### PR TITLE
Fix scrollbar input and retained rendering

### DIFF
--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -104,8 +104,8 @@ pub use fission_core::ui::*;
 // Core action/state types
 pub use fission_core::{
     Action, ActionEnvelope, ActionId, AnimationPropertyId, AnimationRequest, AnimationStartValue,
-    AppState, BuildCtx, FlexDirection, Handler, NodeBuilder, Op, PortalLayer, ReducerContext,
-    Selector, View, Widget, WidgetNodeId,
+    AppState, BuildCtx, EasingFunction, FlexDirection, Handler, NodeBuilder, Op, PortalLayer,
+    ReducerContext, Selector, View, Widget, WidgetNodeId,
 };
 
 // Core event types

--- a/crates/core/fission-core/src/env.rs
+++ b/crates/core/fission-core/src/env.rs
@@ -108,6 +108,7 @@ pub struct GestureState {
     pub target_node: Option<NodeId>,
     pub dragging_payload: Option<Vec<u8>>,
     pub pressed_button: Option<crate::event::PointerButton>,
+    pub scrollbar_drag: Option<crate::scrollbar::ScrollbarDragState>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/core/fission-core/src/input/gesture.rs
+++ b/crates/core/fission-core/src/input/gesture.rs
@@ -1,5 +1,9 @@
 use super::{ControllerContext, InputController};
 use crate::event::{InputEvent, PointerEvent};
+use crate::scrollbar::{
+    scrollbar_drag_offset, scrollbar_drag_offset_with_grab, scrollbar_geometry_for_node,
+    scrollbar_hit_test, scrollbar_point_for_node, ScrollbarDragState, ScrollbarHitKind,
+};
 use crate::{ActionEnvelope, ActionId, ActionInput};
 use fission_ir::op::RichTextAnnotation;
 use fission_ir::{semantics::ActionTrigger, NodeId, Op};
@@ -17,6 +21,32 @@ impl InputController for GestureController {
                         ctx.gesture.last_point = Some(*point);
                         ctx.gesture.is_panning = false;
                         ctx.gesture.pressed_button = Some(button.clone());
+                        ctx.gesture.scrollbar_drag = None;
+
+                        if matches!(button, crate::event::PointerButton::Primary) {
+                            if let Some(hit) =
+                                scrollbar_hit_test(ctx.ir, ctx.layout, ctx.scroll, *point)
+                            {
+                                let pointer_to_thumb_start = match hit.kind {
+                                    ScrollbarHitKind::Thumb => hit.pointer_to_thumb_start,
+                                    ScrollbarHitKind::Rail => hit.geometry.thumb_extent() * 0.5,
+                                };
+                                let new_offset = match hit.kind {
+                                    ScrollbarHitKind::Thumb => hit.geometry.offset,
+                                    ScrollbarHitKind::Rail => {
+                                        scrollbar_drag_offset(hit.geometry, hit.layout_point)
+                                    }
+                                };
+                                ctx.scroll.set_offset(hit.geometry.node_id, new_offset);
+                                ctx.gesture.target_node = Some(hit.geometry.node_id);
+                                ctx.gesture.dragging_payload = None;
+                                ctx.gesture.scrollbar_drag = Some(ScrollbarDragState {
+                                    node_id: hit.geometry.node_id,
+                                    pointer_to_thumb_start,
+                                });
+                                return true;
+                            }
+                        }
 
                         if let Some(hit) = crate::hit_test::hit_test_with_scroll(
                             ctx.ir, ctx.layout, ctx.scroll, *point,
@@ -29,6 +59,29 @@ impl InputController for GestureController {
                         }
                     }
                     PointerEvent::Move { point, .. } => {
+                        if let Some(drag) = ctx.gesture.scrollbar_drag {
+                            if let Some(geometry) = scrollbar_geometry_for_node(
+                                ctx.ir,
+                                ctx.layout,
+                                ctx.scroll,
+                                drag.node_id,
+                            ) {
+                                let new_offset = scrollbar_drag_offset_with_grab(
+                                    geometry,
+                                    scrollbar_point_for_node(
+                                        ctx.ir,
+                                        ctx.scroll,
+                                        drag.node_id,
+                                        *point,
+                                    ),
+                                    drag.pointer_to_thumb_start,
+                                );
+                                ctx.scroll.set_offset(drag.node_id, new_offset);
+                            }
+                            ctx.gesture.last_point = Some(*point);
+                            return true;
+                        }
+
                         if let Some(start) = ctx.gesture.start_point {
                             let dx = point.x - start.x;
                             let dy = point.y - start.y;
@@ -82,6 +135,7 @@ impl InputController for GestureController {
                         }
                     }
                     PointerEvent::Up { point, .. } => {
+                        let scrollbar_drag = ctx.gesture.scrollbar_drag.take();
                         let mut handled = false;
                         let was_secondary = matches!(
                             ctx.gesture.pressed_button,
@@ -196,6 +250,10 @@ impl InputController for GestureController {
                         ctx.gesture.is_panning = false;
                         ctx.gesture.dragging_payload = None;
                         ctx.gesture.pressed_button = None;
+                        if scrollbar_drag.is_some() {
+                            ctx.gesture.target_node = None;
+                            return true;
+                        }
                         return handled;
                     }
                     _ => {}

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod lowering;
 pub mod media;
 pub mod registry;
 pub mod runtime;
+pub mod scrollbar;
 pub mod time;
 pub mod ui;
 

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -8,8 +8,8 @@ use crate::registry::{
 };
 use crate::BoxedReducer;
 use crate::{
-    Clipboard, Clock, CurrentTime, ImeHandler, InputEvent, KeyCode, KeyEvent, PointerEvent,
-    ResourceExecutionContext,
+    Clipboard, Clock, CurrentTime, ImeHandler, InputEvent, KeyCode, KeyEvent, PointerButton,
+    PointerEvent, ResourceExecutionContext,
 };
 use anyhow::{anyhow, Result};
 use fission_diagnostics::prelude as diag;
@@ -636,6 +636,7 @@ impl Runtime {
         use crate::input::slider::SliderController;
         use crate::input::text::TextInputController;
         use crate::input::{ControllerContext, InputController};
+        use crate::scrollbar::scrollbar_hit_test;
         use crate::ui::custom_render::downcast_render_object;
 
         if self.runtime_state.interaction.focused.is_none() {
@@ -684,93 +685,112 @@ impl Runtime {
         // check whether any ancestor carries a custom render object.  The
         // first one that returns `handled = true` short-circuits the entire
         // standard controller chain.
-        if let Some(point) = Self::event_point(&event) {
-            if let Some(hit_node_id) =
-                hit_test_with_scroll(ir, layout, &self.runtime_state.scroll, point)
+        let pointer_targets_scrollbar = match &event {
+            InputEvent::Pointer(PointerEvent::Down { point, button, .. })
+                if matches!(button, PointerButton::Primary) =>
             {
-                // Find the custom render object for this click.  Walk up from the
-                // hit node first; if not found, check all registered render objects
-                // by rect containment (the hit may be on a wrapper node above the
-                // CustomNode's lowered subtree).
-                let mut target_ro: Option<(NodeId, &fission_ir::AnyRenderObject)> = None;
+                scrollbar_hit_test(ir, layout, &self.runtime_state.scroll, *point).is_some()
+            }
+            InputEvent::Pointer(PointerEvent::Move { .. })
+            | InputEvent::Pointer(PointerEvent::Up { .. }) => {
+                self.runtime_state.gesture.scrollbar_drag.is_some()
+            }
+            InputEvent::Pointer(PointerEvent::Scroll { point, .. }) => {
+                scrollbar_hit_test(ir, layout, &self.runtime_state.scroll, *point).is_some()
+            }
+            _ => false,
+        };
+
+        if !pointer_targets_scrollbar {
+            if let Some(point) = Self::event_point(&event) {
+                if let Some(hit_node_id) =
+                    hit_test_with_scroll(ir, layout, &self.runtime_state.scroll, point)
                 {
-                    let mut walk = Some(hit_node_id);
-                    while let Some(nid) = walk {
-                        if let Some(ro) = ir.custom_render_objects.get(&nid) {
-                            target_ro = Some((nid, ro));
-                            break;
-                        }
-                        walk = ir.nodes.get(&nid).and_then(|n| n.parent);
-                    }
-                }
-                if target_ro.is_none() {
-                    for (ro_nid, ro) in &ir.custom_render_objects {
-                        if let Some(rect) = layout.get_node_rect(*ro_nid) {
-                            if rect.contains(point) {
-                                target_ro = Some((*ro_nid, ro));
+                    // Find the custom render object for this click.  Walk up from the
+                    // hit node first; if not found, check all registered render objects
+                    // by rect containment (the hit may be on a wrapper node above the
+                    // CustomNode's lowered subtree).
+                    let mut target_ro: Option<(NodeId, &fission_ir::AnyRenderObject)> = None;
+                    {
+                        let mut walk = Some(hit_node_id);
+                        while let Some(nid) = walk {
+                            if let Some(ro) = ir.custom_render_objects.get(&nid) {
+                                target_ro = Some((nid, ro));
                                 break;
                             }
+                            walk = ir.nodes.get(&nid).and_then(|n| n.parent);
                         }
                     }
-                }
-
-                if let Some((nid, any_ro)) = target_ro {
-                    if let Some(render_obj) = downcast_render_object(any_ro) {
-                        let mut node_rect = layout
-                            .get_node_rect(nid)
-                            .unwrap_or(LayoutRect::new(0.0, 0.0, 0.0, 0.0));
-                        // Adjust node_rect by ancestor scroll offsets so it reflects
-                        // the VISUAL position, matching the screen-coordinate click.
-                        {
-                            let mut walk = ir.nodes.get(&nid).and_then(|n| n.parent);
-                            while let Some(pid) = walk {
-                                if let Some(pnode) = ir.nodes.get(&pid) {
-                                    if let fission_ir::Op::Layout(fission_ir::LayoutOp::Scroll {
-                                        direction,
-                                        ..
-                                    }) = &pnode.op
-                                    {
-                                        let off = self.runtime_state.scroll.get_offset(pid);
-                                        match direction {
-                                            fission_ir::FlexDirection::Row => {
-                                                node_rect.origin.x -= off
-                                            }
-                                            fission_ir::FlexDirection::Column => {
-                                                node_rect.origin.y -= off
-                                            }
-                                        }
-                                    }
-                                    walk = pnode.parent;
-                                } else {
+                    if target_ro.is_none() {
+                        for (ro_nid, ro) in &ir.custom_render_objects {
+                            if let Some(rect) = layout.get_node_rect(*ro_nid) {
+                                if rect.contains(point) {
+                                    target_ro = Some((*ro_nid, ro));
                                     break;
                                 }
                             }
                         }
-                        let result = render_obj.handle_event(nid, &event, node_rect);
-                        if result.handled {
-                            // Set focus to this node so keyboard events route here
-                            if matches!(event, InputEvent::Pointer(PointerEvent::Down { .. })) {
-                                let old_focused_id = self.runtime_state.interaction.focused;
-                                if Some(nid) != old_focused_id {
-                                    self.clear_text_pending_on_blur(old_focused_id, Some(nid));
-                                    self.dispatch_custom_blur_actions(ir, old_focused_id)?;
-                                }
-                                self.runtime_state.interaction.set_focused(Some(nid));
-                                if let Some(ime_handler) = &self.ime_handler {
-                                    let accepts_text = render_obj.accepts_text_input();
-                                    ime_handler.set_ime_allowed(accepts_text);
-                                    if accepts_text {
-                                        if let Some(rect) = render_obj.ime_cursor_area(node_rect) {
-                                            ime_handler.set_ime_cursor_area(rect);
+                    }
+
+                    if let Some((nid, any_ro)) = target_ro {
+                        if let Some(render_obj) = downcast_render_object(any_ro) {
+                            let mut node_rect = layout
+                                .get_node_rect(nid)
+                                .unwrap_or(LayoutRect::new(0.0, 0.0, 0.0, 0.0));
+                            // Adjust node_rect by ancestor scroll offsets so it reflects
+                            // the VISUAL position, matching the screen-coordinate click.
+                            {
+                                let mut walk = ir.nodes.get(&nid).and_then(|n| n.parent);
+                                while let Some(pid) = walk {
+                                    if let Some(pnode) = ir.nodes.get(&pid) {
+                                        if let fission_ir::Op::Layout(
+                                            fission_ir::LayoutOp::Scroll { direction, .. },
+                                        ) = &pnode.op
+                                        {
+                                            let off = self.runtime_state.scroll.get_offset(pid);
+                                            match direction {
+                                                fission_ir::FlexDirection::Row => {
+                                                    node_rect.origin.x -= off
+                                                }
+                                                fission_ir::FlexDirection::Column => {
+                                                    node_rect.origin.y -= off
+                                                }
+                                            }
                                         }
+                                        walk = pnode.parent;
+                                    } else {
+                                        break;
                                     }
                                 }
                             }
-                            // Dispatch any actions the render object produced.
-                            for (target, envelope) in result.actions {
-                                self.dispatch(envelope, target)?;
+                            let result = render_obj.handle_event(nid, &event, node_rect);
+                            if result.handled {
+                                // Set focus to this node so keyboard events route here
+                                if matches!(event, InputEvent::Pointer(PointerEvent::Down { .. })) {
+                                    let old_focused_id = self.runtime_state.interaction.focused;
+                                    if Some(nid) != old_focused_id {
+                                        self.clear_text_pending_on_blur(old_focused_id, Some(nid));
+                                        self.dispatch_custom_blur_actions(ir, old_focused_id)?;
+                                    }
+                                    self.runtime_state.interaction.set_focused(Some(nid));
+                                    if let Some(ime_handler) = &self.ime_handler {
+                                        let accepts_text = render_obj.accepts_text_input();
+                                        ime_handler.set_ime_allowed(accepts_text);
+                                        if accepts_text {
+                                            if let Some(rect) =
+                                                render_obj.ime_cursor_area(node_rect)
+                                            {
+                                                ime_handler.set_ime_cursor_area(rect);
+                                            }
+                                        }
+                                    }
+                                }
+                                // Dispatch any actions the render object produced.
+                                for (target, envelope) in result.actions {
+                                    self.dispatch(envelope, target)?;
+                                }
+                                return Ok(());
                             }
-                            return Ok(());
                         }
                     }
                 }
@@ -856,9 +876,12 @@ impl Runtime {
                         point.x, point.y, delta.x, delta.y
                     );
                 }
-                if let Some(hit_node_id) =
-                    hit_test_with_scroll(ir, layout, &self.runtime_state.scroll, point)
-                {
+                let hit_node_id = scrollbar_hit_test(ir, layout, &self.runtime_state.scroll, point)
+                    .map(|hit| hit.geometry.node_id)
+                    .or_else(|| {
+                        hit_test_with_scroll(ir, layout, &self.runtime_state.scroll, point)
+                    });
+                if let Some(hit_node_id) = hit_node_id {
                     if trace_scroll {
                         eprintln!("[scroll-trace] hit_node={}", hit_node_id.as_u128());
                     }

--- a/crates/core/fission-core/src/scrollbar.rs
+++ b/crates/core/fission-core/src/scrollbar.rs
@@ -1,0 +1,464 @@
+use crate::env::ScrollStateMap;
+use fission_ir::{CoreIR, FlexDirection, LayoutOp, NodeId, Op};
+use fission_layout::{LayoutPoint, LayoutRect, LayoutSnapshot};
+
+pub const SCROLLBAR_INSET: f32 = 2.0;
+pub const SCROLLBAR_THICKNESS: f32 = 6.0;
+pub const SCROLLBAR_MIN_THUMB: f32 = 24.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollbarAxis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScrollbarGeometry {
+    pub node_id: NodeId,
+    pub axis: ScrollbarAxis,
+    pub rail_rect: LayoutRect,
+    pub thumb_rect: LayoutRect,
+    pub offset: f32,
+    pub max_offset: f32,
+    pub track_travel: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollbarHitKind {
+    Thumb,
+    Rail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScrollbarHit {
+    pub geometry: ScrollbarGeometry,
+    pub kind: ScrollbarHitKind,
+    pub pointer_to_thumb_start: f32,
+    pub layout_point: LayoutPoint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScrollbarDragState {
+    pub node_id: NodeId,
+    pub pointer_to_thumb_start: f32,
+}
+
+pub fn scrollbar_geometry_for_node(
+    ir: &CoreIR,
+    layout: &LayoutSnapshot,
+    scroll_map: &ScrollStateMap,
+    node_id: NodeId,
+) -> Option<ScrollbarGeometry> {
+    let node = ir.nodes.get(&node_id)?;
+    let Op::Layout(LayoutOp::Scroll {
+        direction,
+        show_scrollbar,
+        ..
+    }) = &node.op
+    else {
+        return None;
+    };
+    if !show_scrollbar {
+        return None;
+    }
+
+    let geom = layout.get_node_geometry(node_id)?;
+    let rect = geom.rect;
+    let (axis, viewport_extent, content_extent, rail_rect) = match direction {
+        FlexDirection::Column => {
+            let rail_extent = (rect.size.height - SCROLLBAR_INSET * 2.0).max(0.0);
+            (
+                ScrollbarAxis::Vertical,
+                rect.size.height,
+                geom.content_size.height,
+                LayoutRect::new(
+                    rect.origin.x + rect.size.width - SCROLLBAR_THICKNESS - SCROLLBAR_INSET,
+                    rect.origin.y + SCROLLBAR_INSET,
+                    SCROLLBAR_THICKNESS,
+                    rail_extent,
+                ),
+            )
+        }
+        FlexDirection::Row => {
+            let rail_extent = (rect.size.width - SCROLLBAR_INSET * 2.0).max(0.0);
+            (
+                ScrollbarAxis::Horizontal,
+                rect.size.width,
+                geom.content_size.width,
+                LayoutRect::new(
+                    rect.origin.x + SCROLLBAR_INSET,
+                    rect.origin.y + rect.size.height - SCROLLBAR_THICKNESS - SCROLLBAR_INSET,
+                    rail_extent,
+                    SCROLLBAR_THICKNESS,
+                ),
+            )
+        }
+    };
+
+    if viewport_extent <= 0.0 || content_extent <= viewport_extent + 0.5 {
+        return None;
+    }
+
+    let rail_extent = axis_extent(axis, rail_rect);
+    if rail_extent <= 0.0 {
+        return None;
+    }
+
+    let max_offset = (content_extent - viewport_extent).max(0.0);
+    let offset = scroll_map.get_offset(node_id).clamp(0.0, max_offset);
+    let min_thumb = SCROLLBAR_MIN_THUMB.min(rail_extent);
+    let thumb_extent =
+        ((viewport_extent / content_extent) * rail_extent).clamp(min_thumb, rail_extent);
+    let track_travel = (rail_extent - thumb_extent).max(0.0);
+    let thumb_start = axis_start(axis, rail_rect)
+        + if max_offset > 0.0 && track_travel > 0.0 {
+            (offset / max_offset) * track_travel
+        } else {
+            0.0
+        };
+
+    let thumb_rect = match axis {
+        ScrollbarAxis::Vertical => LayoutRect::new(
+            rail_rect.origin.x,
+            thumb_start,
+            SCROLLBAR_THICKNESS,
+            thumb_extent,
+        ),
+        ScrollbarAxis::Horizontal => LayoutRect::new(
+            thumb_start,
+            rail_rect.origin.y,
+            thumb_extent,
+            SCROLLBAR_THICKNESS,
+        ),
+    };
+
+    Some(ScrollbarGeometry {
+        node_id,
+        axis,
+        rail_rect,
+        thumb_rect,
+        offset,
+        max_offset,
+        track_travel,
+    })
+}
+
+pub fn scrollbar_hit_test(
+    ir: &CoreIR,
+    layout: &LayoutSnapshot,
+    scroll_map: &ScrollStateMap,
+    point: LayoutPoint,
+) -> Option<ScrollbarHit> {
+    let root = ir.root?;
+    scrollbar_hit_test_recursive(root, ir, layout, scroll_map, point)
+}
+
+pub fn scrollbar_drag_offset(geometry: ScrollbarGeometry, point: LayoutPoint) -> f32 {
+    scrollbar_drag_offset_with_grab(geometry, point, geometry.thumb_extent() * 0.5)
+}
+
+pub fn scrollbar_point_for_node(
+    ir: &CoreIR,
+    scroll_map: &ScrollStateMap,
+    node_id: NodeId,
+    mut point: LayoutPoint,
+) -> LayoutPoint {
+    let mut current = ir.nodes.get(&node_id).and_then(|node| node.parent);
+    while let Some(parent_id) = current {
+        let Some(parent) = ir.nodes.get(&parent_id) else {
+            break;
+        };
+        if let Op::Layout(LayoutOp::Scroll { direction, .. }) = &parent.op {
+            let offset = scroll_map.get_offset(parent_id);
+            match direction {
+                FlexDirection::Column => point.y += offset,
+                FlexDirection::Row => point.x += offset,
+            }
+        }
+        current = parent.parent;
+    }
+    point
+}
+
+pub fn scrollbar_drag_offset_with_grab(
+    geometry: ScrollbarGeometry,
+    point: LayoutPoint,
+    pointer_to_thumb_start: f32,
+) -> f32 {
+    if geometry.track_travel <= 0.0 || geometry.max_offset <= 0.0 {
+        return 0.0;
+    }
+    let rail_start = axis_start(geometry.axis, geometry.rail_rect);
+    let pointer_axis = point_axis(geometry.axis, point);
+    let requested_thumb_start = pointer_axis - pointer_to_thumb_start;
+    let normalized = ((requested_thumb_start - rail_start) / geometry.track_travel).clamp(0.0, 1.0);
+    normalized * geometry.max_offset
+}
+
+impl ScrollbarGeometry {
+    pub fn thumb_extent(self) -> f32 {
+        axis_extent(self.axis, self.thumb_rect)
+    }
+}
+
+fn scrollbar_hit_test_recursive(
+    node_id: NodeId,
+    ir: &CoreIR,
+    layout: &LayoutSnapshot,
+    scroll_map: &ScrollStateMap,
+    point: LayoutPoint,
+) -> Option<ScrollbarHit> {
+    let node = ir.nodes.get(&node_id)?;
+    let geom = layout.get_node_geometry(node_id)?;
+    let is_clip_container = matches!(
+        node.op,
+        Op::Layout(LayoutOp::Clip { .. }) | Op::Layout(LayoutOp::Scroll { .. })
+    );
+    if is_clip_container && !geom.rect.contains(point) {
+        return None;
+    }
+
+    if let Some(geometry) = scrollbar_geometry_for_node(ir, layout, scroll_map, node_id) {
+        if geometry.thumb_rect.contains(point) {
+            return Some(ScrollbarHit {
+                geometry,
+                kind: ScrollbarHitKind::Thumb,
+                pointer_to_thumb_start: point_axis(geometry.axis, point)
+                    - axis_start(geometry.axis, geometry.thumb_rect),
+                layout_point: point,
+            });
+        }
+        if geometry.rail_rect.contains(point) {
+            return Some(ScrollbarHit {
+                geometry,
+                kind: ScrollbarHitKind::Rail,
+                pointer_to_thumb_start: geometry.thumb_extent() * 0.5,
+                layout_point: point,
+            });
+        }
+    }
+
+    let mut child_point = point;
+    if let Op::Layout(LayoutOp::Scroll { direction, .. }) = &node.op {
+        let offset = scroll_map.get_offset(node_id);
+        match direction {
+            FlexDirection::Column => child_point.y += offset,
+            FlexDirection::Row => child_point.x += offset,
+        }
+    }
+
+    for child_id in node.children.iter().rev() {
+        if let Some(hit) =
+            scrollbar_hit_test_recursive(*child_id, ir, layout, scroll_map, child_point)
+        {
+            return Some(hit);
+        }
+    }
+
+    None
+}
+
+fn axis_start(axis: ScrollbarAxis, rect: LayoutRect) -> f32 {
+    match axis {
+        ScrollbarAxis::Horizontal => rect.origin.x,
+        ScrollbarAxis::Vertical => rect.origin.y,
+    }
+}
+
+fn axis_extent(axis: ScrollbarAxis, rect: LayoutRect) -> f32 {
+    match axis {
+        ScrollbarAxis::Horizontal => rect.size.width,
+        ScrollbarAxis::Vertical => rect.size.height,
+    }
+}
+
+fn point_axis(axis: ScrollbarAxis, point: LayoutPoint) -> f32 {
+    match axis {
+        ScrollbarAxis::Horizontal => point.x,
+        ScrollbarAxis::Vertical => point.y,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        scrollbar_drag_offset_with_grab, scrollbar_geometry_for_node, scrollbar_hit_test,
+        scrollbar_point_for_node, ScrollbarAxis, ScrollbarHitKind,
+    };
+    use crate::env::ScrollStateMap;
+    use fission_ir::{CompositeStyle, CoreIR, CoreNode, FlexDirection, LayoutOp, NodeId, Op};
+    use fission_layout::{LayoutNodeGeometry, LayoutPoint, LayoutRect, LayoutSize, LayoutSnapshot};
+
+    #[test]
+    fn vertical_scrollbar_geometry_tracks_offset_inside_viewport() {
+        let (ir, mut layout, scroll) = scroll_tree();
+        layout.nodes.insert(
+            scroll,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(10.0, 20.0, 100.0, 200.0),
+                content_size: LayoutSize::new(100.0, 600.0),
+            },
+        );
+        let mut scroll_map = ScrollStateMap::default();
+        scroll_map.set_offset(scroll, 200.0);
+
+        let geometry =
+            scrollbar_geometry_for_node(&ir, &layout, &scroll_map, scroll).expect("scrollbar");
+
+        assert_eq!(geometry.axis, ScrollbarAxis::Vertical);
+        assert_eq!(geometry.rail_rect.origin.x, 102.0);
+        assert_eq!(geometry.rail_rect.origin.y, 22.0);
+        assert!(geometry.thumb_rect.origin.y > geometry.rail_rect.origin.y);
+        assert!(geometry.thumb_rect.bottom() <= geometry.rail_rect.bottom());
+    }
+
+    #[test]
+    fn scrollbar_hit_test_prioritizes_thumb_chrome() {
+        let (ir, mut layout, scroll) = scroll_tree();
+        layout.nodes.insert(
+            scroll,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(0.0, 0.0, 100.0, 200.0),
+                content_size: LayoutSize::new(100.0, 600.0),
+            },
+        );
+
+        let hit = scrollbar_hit_test(
+            &ir,
+            &layout,
+            &ScrollStateMap::default(),
+            LayoutPoint::new(97.0, 8.0),
+        )
+        .expect("scrollbar hit");
+
+        assert_eq!(hit.kind, ScrollbarHitKind::Thumb);
+        assert_eq!(hit.geometry.node_id, scroll);
+    }
+
+    #[test]
+    fn scrollbar_drag_maps_thumb_position_to_offset() {
+        let (ir, mut layout, scroll) = scroll_tree();
+        layout.nodes.insert(
+            scroll,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(0.0, 0.0, 100.0, 200.0),
+                content_size: LayoutSize::new(100.0, 600.0),
+            },
+        );
+        let geometry =
+            scrollbar_geometry_for_node(&ir, &layout, &ScrollStateMap::default(), scroll).unwrap();
+
+        let offset = scrollbar_drag_offset_with_grab(geometry, LayoutPoint::new(97.0, 198.0), 0.0);
+
+        assert!((offset - geometry.max_offset).abs() <= 0.01);
+    }
+
+    #[test]
+    fn nested_scrollbar_hit_uses_target_layout_coordinates() {
+        let parent = NodeId::derived(71, &[0]);
+        let child = NodeId::derived(71, &[1]);
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            child,
+            Op::Layout(LayoutOp::Scroll {
+                direction: FlexDirection::Row,
+                show_scrollbar: true,
+                width: Some(100.0),
+                height: Some(50.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 0.0,
+            }),
+            vec![],
+        );
+        ir.add_node(
+            parent,
+            Op::Layout(LayoutOp::Scroll {
+                direction: FlexDirection::Column,
+                show_scrollbar: true,
+                width: Some(120.0),
+                height: Some(120.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 0.0,
+            }),
+            vec![child],
+        );
+        ir.set_root(parent);
+
+        let mut layout = LayoutSnapshot::new(LayoutSize::new(120.0, 120.0));
+        layout.nodes.insert(
+            parent,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(0.0, 0.0, 120.0, 120.0),
+                content_size: LayoutSize::new(120.0, 320.0),
+            },
+        );
+        layout.nodes.insert(
+            child,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(0.0, 160.0, 100.0, 50.0),
+                content_size: LayoutSize::new(300.0, 50.0),
+            },
+        );
+        let mut scroll_map = ScrollStateMap::default();
+        scroll_map.set_offset(parent, 100.0);
+
+        let visual_rail_point = LayoutPoint::new(50.0, 104.0);
+        let hit =
+            scrollbar_hit_test(&ir, &layout, &scroll_map, visual_rail_point).expect("child rail");
+
+        assert_eq!(hit.geometry.node_id, child);
+        assert_eq!(hit.kind, ScrollbarHitKind::Rail);
+        assert_eq!(
+            hit.layout_point,
+            scrollbar_point_for_node(&ir, &scroll_map, child, visual_rail_point)
+        );
+        assert!(
+            hit.geometry.rail_rect.contains(hit.layout_point),
+            "hit point must be in the target scrollbar's layout coordinate space"
+        );
+    }
+
+    fn scroll_tree() -> (CoreIR, LayoutSnapshot, NodeId) {
+        let scroll = NodeId::derived(70, &[1]);
+        let mut ir = CoreIR::default();
+        ir.nodes.insert(
+            scroll,
+            CoreNode {
+                id: scroll,
+                parent: None,
+                children: Vec::new(),
+                op: Op::Layout(LayoutOp::Scroll {
+                    direction: FlexDirection::Column,
+                    show_scrollbar: true,
+                    width: Some(100.0),
+                    height: Some(200.0),
+                    min_width: None,
+                    max_width: None,
+                    min_height: None,
+                    max_height: None,
+                    padding: [0.0; 4],
+                    flex_grow: 0.0,
+                    flex_shrink: 0.0,
+                }),
+                composite: CompositeStyle::default(),
+                hash: 0,
+            },
+        );
+        ir.set_root(scroll);
+        (
+            ir,
+            LayoutSnapshot::new(LayoutSize::new(100.0, 200.0)),
+            scroll,
+        )
+    }
+}

--- a/crates/core/fission-core/tests/scrollbar_input.rs
+++ b/crates/core/fission-core/tests/scrollbar_input.rs
@@ -1,0 +1,276 @@
+use fission_core::env::{
+    Clipboard, GestureState, InteractionStateMap, ScrollStateMap, TextEditStateMap,
+};
+use fission_core::event::{InputEvent, PointerButton, PointerEvent};
+use fission_core::input::gesture::GestureController;
+use fission_core::input::{ControllerContext, InputController};
+use fission_core::scrollbar::scrollbar_geometry_for_node;
+use fission_core::Runtime;
+use fission_ir::{CompositeStyle, CoreIR, CoreNode, FlexDirection, LayoutOp, NodeId, Op};
+use fission_layout::{LayoutNodeGeometry, LayoutPoint, LayoutRect, LayoutSize, LayoutSnapshot};
+use std::sync::Arc;
+
+#[derive(Default)]
+struct NoClipboard;
+
+impl Clipboard for NoClipboard {
+    fn get_text(&self) -> Option<String> {
+        None
+    }
+
+    fn set_text(&self, _text: &str) {}
+}
+
+#[test]
+fn dragging_scrollbar_thumb_updates_scroll_offset_directly() {
+    let (ir, layout, scroll) = scroll_tree(FlexDirection::Column);
+
+    let mut text_edit = TextEditStateMap::default();
+    let mut interaction = InteractionStateMap::default();
+    let mut scroll_map = ScrollStateMap::default();
+    let mut gesture = GestureState::default();
+    let clipboard: Arc<dyn Clipboard> = Arc::new(NoClipboard);
+    let mut controller = GestureController;
+
+    let geometry =
+        scrollbar_geometry_for_node(&ir, &layout, &scroll_map, scroll).expect("scrollbar");
+    let down = LayoutPoint::new(
+        geometry.thumb_rect.origin.x + 1.0,
+        geometry.thumb_rect.origin.y + 4.0,
+    );
+    let move_to = LayoutPoint::new(down.x, geometry.rail_rect.bottom() - 1.0);
+
+    let mut ctx = ControllerContext {
+        ir: &ir,
+        layout: &layout,
+        text_edit: &mut text_edit,
+        interaction: &mut interaction,
+        scroll: &mut scroll_map,
+        gesture: &mut gesture,
+        clipboard: Some(&clipboard),
+        measurer: None,
+        dispatched_actions: Vec::new(),
+    };
+
+    assert!(controller.handle_event(
+        &mut ctx,
+        &InputEvent::Pointer(PointerEvent::Down {
+            point: down,
+            button: PointerButton::Primary,
+            modifiers: 0,
+        })
+    ));
+    assert!(ctx.gesture.scrollbar_drag.is_some());
+
+    assert!(controller.handle_event(
+        &mut ctx,
+        &InputEvent::Pointer(PointerEvent::Move {
+            point: move_to,
+            modifiers: 0,
+        })
+    ));
+    assert!(ctx.scroll.get_offset(scroll) > 0.0);
+
+    assert!(controller.handle_event(
+        &mut ctx,
+        &InputEvent::Pointer(PointerEvent::Up {
+            point: move_to,
+            button: PointerButton::Primary,
+            modifiers: 0,
+        })
+    ));
+    assert!(ctx.gesture.scrollbar_drag.is_none());
+}
+
+#[test]
+fn dragging_nested_scrollbar_uses_visual_pointer_coordinates() {
+    let parent = NodeId::derived(82, &[0]);
+    let child = NodeId::derived(82, &[1]);
+    let mut ir = CoreIR::new();
+    ir.add_node(
+        child,
+        Op::Layout(LayoutOp::Scroll {
+            direction: FlexDirection::Row,
+            show_scrollbar: true,
+            width: Some(100.0),
+            height: Some(50.0),
+            min_width: None,
+            max_width: None,
+            min_height: None,
+            max_height: None,
+            padding: [0.0; 4],
+            flex_grow: 0.0,
+            flex_shrink: 0.0,
+        }),
+        vec![],
+    );
+    ir.add_node(
+        parent,
+        Op::Layout(LayoutOp::Scroll {
+            direction: FlexDirection::Column,
+            show_scrollbar: true,
+            width: Some(120.0),
+            height: Some(120.0),
+            min_width: None,
+            max_width: None,
+            min_height: None,
+            max_height: None,
+            padding: [0.0; 4],
+            flex_grow: 0.0,
+            flex_shrink: 0.0,
+        }),
+        vec![child],
+    );
+    ir.set_root(parent);
+
+    let mut layout = LayoutSnapshot::new(LayoutSize::new(120.0, 120.0));
+    layout.nodes.insert(
+        parent,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(0.0, 0.0, 120.0, 120.0),
+            content_size: LayoutSize::new(120.0, 320.0),
+        },
+    );
+    layout.nodes.insert(
+        child,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(0.0, 160.0, 100.0, 50.0),
+            content_size: LayoutSize::new(300.0, 50.0),
+        },
+    );
+
+    let mut text_edit = TextEditStateMap::default();
+    let mut interaction = InteractionStateMap::default();
+    let mut scroll_map = ScrollStateMap::default();
+    scroll_map.set_offset(parent, 100.0);
+    let mut gesture = GestureState::default();
+    let clipboard: Arc<dyn Clipboard> = Arc::new(NoClipboard);
+    let mut controller = GestureController;
+    let mut ctx = ControllerContext {
+        ir: &ir,
+        layout: &layout,
+        text_edit: &mut text_edit,
+        interaction: &mut interaction,
+        scroll: &mut scroll_map,
+        gesture: &mut gesture,
+        clipboard: Some(&clipboard),
+        measurer: None,
+        dispatched_actions: Vec::new(),
+    };
+
+    assert!(controller.handle_event(
+        &mut ctx,
+        &InputEvent::Pointer(PointerEvent::Down {
+            point: LayoutPoint::new(50.0, 104.0),
+            button: PointerButton::Primary,
+            modifiers: 0,
+        })
+    ));
+    assert!(controller.handle_event(
+        &mut ctx,
+        &InputEvent::Pointer(PointerEvent::Move {
+            point: LayoutPoint::new(98.0, 104.0),
+            modifiers: 0,
+        })
+    ));
+
+    assert!(
+        ctx.scroll.get_offset(child) > 100.0,
+        "nested horizontal scrollbar should drag in its own layout coordinates"
+    );
+    assert_eq!(ctx.scroll.get_offset(parent), 100.0);
+}
+
+#[test]
+fn wheel_scroll_on_vertical_scrollbar_rail_updates_scroll_offset() {
+    let (ir, layout, scroll) = scroll_tree(FlexDirection::Column);
+    let mut runtime = Runtime::default();
+    let geometry = scrollbar_geometry_for_node(&ir, &layout, &runtime.runtime_state.scroll, scroll)
+        .expect("scrollbar");
+
+    runtime
+        .handle_input(
+            InputEvent::Pointer(PointerEvent::Scroll {
+                point: LayoutPoint::new(
+                    geometry.rail_rect.origin.x + 1.0,
+                    geometry.rail_rect.origin.y + 80.0,
+                ),
+                delta: LayoutPoint::new(0.0, 90.0),
+                modifiers: 0,
+            }),
+            &ir,
+            &layout,
+        )
+        .expect("scroll rail wheel");
+
+    assert!(runtime.runtime_state.scroll.get_offset(scroll) > 0.0);
+}
+
+#[test]
+fn wheel_scroll_on_horizontal_scrollbar_rail_updates_scroll_offset() {
+    let (ir, layout, scroll) = scroll_tree(FlexDirection::Row);
+    let mut runtime = Runtime::default();
+    let geometry = scrollbar_geometry_for_node(&ir, &layout, &runtime.runtime_state.scroll, scroll)
+        .expect("scrollbar");
+
+    runtime
+        .handle_input(
+            InputEvent::Pointer(PointerEvent::Scroll {
+                point: LayoutPoint::new(
+                    geometry.rail_rect.origin.x + 80.0,
+                    geometry.rail_rect.origin.y + 1.0,
+                ),
+                delta: LayoutPoint::new(90.0, 0.0),
+                modifiers: 0,
+            }),
+            &ir,
+            &layout,
+        )
+        .expect("scroll rail wheel");
+
+    assert!(runtime.runtime_state.scroll.get_offset(scroll) > 0.0);
+}
+
+fn scroll_tree(direction: FlexDirection) -> (CoreIR, LayoutSnapshot, NodeId) {
+    let scroll = NodeId::derived(81, &[1]);
+    let mut ir = CoreIR::default();
+    ir.nodes.insert(
+        scroll,
+        CoreNode {
+            id: scroll,
+            parent: None,
+            children: Vec::new(),
+            op: Op::Layout(LayoutOp::Scroll {
+                direction,
+                show_scrollbar: true,
+                width: Some(100.0),
+                height: Some(200.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 0.0,
+            }),
+            composite: CompositeStyle::default(),
+            hash: 0,
+        },
+    );
+    ir.set_root(scroll);
+
+    let mut layout = LayoutSnapshot::new(LayoutSize::new(100.0, 200.0));
+    let content_size = match direction {
+        FlexDirection::Column => LayoutSize::new(100.0, 600.0),
+        FlexDirection::Row => LayoutSize::new(500.0, 200.0),
+    };
+    layout.nodes.insert(
+        scroll,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(0.0, 0.0, 100.0, 200.0),
+            content_size,
+        },
+    );
+
+    (ir, layout, scroll)
+}

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -1315,6 +1315,25 @@ fn sync_window_cursor(window: &Window, runtime: &Runtime) {
     window.set_cursor_icon(cursor_icon_for(runtime.runtime_state.interaction.cursor()));
 }
 
+const LINE_SCROLL_POINTS: f32 = 50.0;
+
+fn normalize_winit_scroll_delta(delta: &MouseScrollDelta, scale_factor: f64) -> (f32, f32) {
+    let scale_factor = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+    match delta {
+        // Fission scroll offsets increase down/right. Winit reports positive
+        // wheel lines upward/leftward; the OS has already applied any natural
+        // scrolling preference before the event reaches us.
+        MouseScrollDelta::LineDelta(x, y) => (-x * LINE_SCROLL_POINTS, -y * LINE_SCROLL_POINTS),
+        MouseScrollDelta::PixelDelta(p) => {
+            (-(p.x / scale_factor) as f32, -(p.y / scale_factor) as f32)
+        }
+    }
+}
+
 /// Handle cursor/mouse move — shared by WindowEvent::CursorMoved and TestEvent::MouseMove.
 fn handle_cursor_moved(
     x: f32,
@@ -3973,13 +3992,8 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                     let point_x = (position.x / scale_factor) as f32;
                                     let point_y = (position.y / scale_factor) as f32;
 
-                                    let (dx, dy) = match delta {
-                                        MouseScrollDelta::LineDelta(x, y) => (-x * 50.0, -y * 50.0),
-                                        MouseScrollDelta::PixelDelta(p) => (
-                                            -(p.x / scale_factor) as f32,
-                                            -(p.y / scale_factor) as f32,
-                                        ),
-                                    };
+                                    let (dx, dy) =
+                                        normalize_winit_scroll_delta(&delta, scale_factor);
 
                                     if std::env::var("FISSION_SCROLL_TRACE").ok().as_deref() == Some("1") {
                                         eprintln!(
@@ -4533,9 +4547,10 @@ mod tests {
         animation_redraw_interval, clamp_copy_extent_to_texture, cursor_icon_for,
         downscale_rgba_box, layout_size_to_image_dimensions, logical_viewport_to_physical_size,
         logical_viewport_to_render_target_size, native_window_size_for_logical_viewport,
-        normalize_scale_factor, physical_size_to_layout_size, repeating_animation_redraw_interval,
-        resize_is_unsettled, resolve_build_viewport, sync_tracked_target_texture_size_to_surface,
-        texture_plans_fit_device_limits, LiveResizeController, WindowViewportState,
+        normalize_scale_factor, normalize_winit_scroll_delta, physical_size_to_layout_size,
+        repeating_animation_redraw_interval, resize_is_unsettled, resolve_build_viewport,
+        sync_tracked_target_texture_size_to_surface, texture_plans_fit_device_limits,
+        LiveResizeController, WindowViewportState,
     };
     use crate::pipeline::CompositorTexturePlan;
     use crate::InvalidationSet;
@@ -4545,7 +4560,8 @@ mod tests {
     use fission_layout::{LayoutRect, LayoutSize};
     use std::collections::HashMap;
     use std::time::Duration;
-    use winit::dpi::PhysicalSize;
+    use winit::dpi::{PhysicalPosition, PhysicalSize};
+    use winit::event::MouseScrollDelta;
     use winit::window::CursorIcon;
 
     #[test]
@@ -4560,6 +4576,21 @@ mod tests {
         assert_eq!(
             cursor_icon_for(MouseCursor::VerticalText),
             CursorIcon::VerticalText
+        );
+    }
+
+    #[test]
+    fn winit_scroll_delta_normalizes_to_positive_down_and_right() {
+        assert_eq!(
+            normalize_winit_scroll_delta(&MouseScrollDelta::LineDelta(-1.0, -2.0), 1.0),
+            (50.0, 100.0)
+        );
+        assert_eq!(
+            normalize_winit_scroll_delta(
+                &MouseScrollDelta::PixelDelta(PhysicalPosition::new(-20.0, -40.0)),
+                2.0,
+            ),
+            (10.0, 20.0)
         );
     }
 

--- a/crates/shell/fission-shell-winit/src/pipeline.rs
+++ b/crates/shell/fission-shell-winit/src/pipeline.rs
@@ -4,6 +4,7 @@ use fission_core::diff::diff_ir;
 use fission_core::env::{AnimationStateMap, Env, VideoStateMap, WebStateMap};
 use fission_core::lowering::build_layout_tree;
 use fission_core::registry::AnimationPropertyId;
+use fission_core::scrollbar::scrollbar_geometry_for_node;
 use fission_core::ui::custom_render::downcast_render_object;
 use fission_core::{LayoutPoint, ScrollStateMap};
 use fission_diagnostics::prelude as diag;
@@ -129,6 +130,12 @@ struct TransformBinding {
 }
 
 #[derive(Debug, Clone)]
+struct ScrollbarBinding {
+    node_path: Vec<usize>,
+    node_id: NodeId,
+}
+
+#[derive(Debug, Clone)]
 struct ScrollTransform {
     node_id: NodeId,
     direction: FlexDirection,
@@ -138,6 +145,7 @@ struct ScrollTransform {
 struct RetainedDynamicOps {
     opacity: Vec<OpacityBinding>,
     transform: Vec<TransformBinding>,
+    scrollbar: Vec<ScrollbarBinding>,
 }
 
 #[derive(Debug, Clone)]
@@ -762,6 +770,24 @@ impl Pipeline {
                     compose_dynamic_layer_transform(binding, scroll_map, animation_map);
             }
         }
+
+        let Some(ir) = self.prev_ir.as_ref() else {
+            return;
+        };
+        let Some(snapshot) = self.last_snapshot.as_ref() else {
+            return;
+        };
+        for binding in &self.retained_dynamic_ops.scrollbar {
+            let Some(scrollbar) = build_scrollbar_paint(ir, binding.node_id, snapshot, scroll_map)
+            else {
+                continue;
+            };
+            if let Some(RenderNode::Paint(list)) =
+                render_node_mut_at_path(scene, &binding.node_path)
+            {
+                *list = scrollbar;
+            }
+        }
     }
 
     pub fn retained_scene(&self) -> Option<&RenderScene> {
@@ -836,6 +862,32 @@ fn layer_mut_at_path<'a>(
     let (root_index, tail) = path.split_first()?;
     let node = scene.roots.get_mut(*root_index)?;
     layer_mut_in_node(node, tail)
+}
+
+fn render_node_mut_at_path<'a>(
+    scene: &'a mut RenderScene,
+    path: &[usize],
+) -> Option<&'a mut RenderNode> {
+    let (root_index, tail) = path.split_first()?;
+    let node = scene.roots.get_mut(*root_index)?;
+    render_node_mut_in_node(node, tail)
+}
+
+fn render_node_mut_in_node<'a>(
+    node: &'a mut RenderNode,
+    path: &[usize],
+) -> Option<&'a mut RenderNode> {
+    if path.is_empty() {
+        return Some(node);
+    }
+    match node {
+        RenderNode::Layer(layer) => {
+            let (child_index, tail) = path.split_first()?;
+            let child = layer.children.get_mut(*child_index)?;
+            render_node_mut_in_node(child, tail)
+        }
+        RenderNode::Paint(_) => None,
+    }
 }
 
 fn layer_mut_in_node<'a>(node: &'a mut RenderNode, path: &[usize]) -> Option<&'a mut RenderLayer> {
@@ -1539,7 +1591,8 @@ fn generate_render_layer_recursive(
         Op::Layout(LayoutOp::Transform { transform }) => Some(*transform),
         _ => None,
     };
-    let has_dynamic_transform = needs_dynamic_transform || scroll.is_some();
+    let has_own_transform = needs_dynamic_transform || layout_transform.is_some();
+    let has_dynamic_transform = has_own_transform || scroll.is_some();
     let has_dynamic_style = emit_opacity_layer || has_dynamic_transform || has_runtime_clip;
     let has_dynamic_children = node.children.iter().any(|child| {
         runtime_dynamic_subtrees
@@ -1571,7 +1624,7 @@ fn generate_render_layer_recursive(
             layer_path: layer_path.clone(),
             rect,
             layout_transform,
-            scroll: scroll.clone(),
+            scroll: None,
             translate_x: node.composite.translate_x.clone(),
             translate_y: node.composite.translate_y.clone(),
             scale: node.composite.scale.clone(),
@@ -1581,9 +1634,6 @@ fn generate_render_layer_recursive(
         animation_map,
     ) {
         layer.style.transform = Some(transform);
-    }
-    if scroll.is_some() {
-        layer.style.transform_clip = false;
     }
 
     let local_hash = local_paint_hash(node);
@@ -1622,12 +1672,12 @@ fn generate_render_layer_recursive(
             });
         }
     }
-    if has_dynamic_transform {
+    if has_own_transform {
         bindings.transform.push(TransformBinding {
             layer_path: layer_path.clone(),
             rect,
             layout_transform,
-            scroll,
+            scroll: None,
             translate_x: node.composite.translate_x.clone(),
             translate_y: node.composite.translate_y.clone(),
             scale: node.composite.scale.clone(),
@@ -1635,32 +1685,98 @@ fn generate_render_layer_recursive(
         });
     }
 
-    for child in &node.children {
-        let child_index = layer.children.len();
-        let mut child_path = layer_path.clone();
-        child_path.push(child_index);
-        if let Some(child_layer) = generate_render_layer_recursive(
-            *child,
-            ir,
-            snapshot,
+    if let Some(scroll) = scroll {
+        let content_index = layer.children.len();
+        let mut content_path = layer_path.clone();
+        content_path.push(content_index);
+        let mut content_layer = RenderLayer::new(rect);
+        content_layer.style.transform = compose_dynamic_layer_transform(
+            &TransformBinding {
+                layer_path: content_path.clone(),
+                rect,
+                layout_transform: None,
+                scroll: Some(scroll.clone()),
+                translate_x: None,
+                translate_y: None,
+                scale: None,
+                rotation: None,
+            },
             scroll_map,
             animation_map,
-            paint_cache,
-            boundary_cache,
-            runtime_dynamic_subtrees,
-            miss_count,
-            hit_count,
-            scene_cache_allowed,
-            visited,
-            bindings,
-            child_path,
-        ) {
-            layer.children.push(RenderNode::Layer(child_layer));
+        );
+        content_layer.style.transform_clip = false;
+        bindings.transform.push(TransformBinding {
+            layer_path: content_path.clone(),
+            rect,
+            layout_transform: None,
+            scroll: Some(scroll),
+            translate_x: None,
+            translate_y: None,
+            scale: None,
+            rotation: None,
+        });
+
+        for child in &node.children {
+            let child_index = content_layer.children.len();
+            let mut child_path = content_path.clone();
+            child_path.push(child_index);
+            if let Some(child_layer) = generate_render_layer_recursive(
+                *child,
+                ir,
+                snapshot,
+                scroll_map,
+                animation_map,
+                paint_cache,
+                boundary_cache,
+                runtime_dynamic_subtrees,
+                miss_count,
+                hit_count,
+                scene_cache_allowed,
+                visited,
+                bindings,
+                child_path,
+            ) {
+                content_layer.children.push(RenderNode::Layer(child_layer));
+            }
+        }
+
+        if !content_layer.children.is_empty() {
+            layer.children.push(RenderNode::Layer(content_layer));
+        }
+    } else {
+        for child in &node.children {
+            let child_index = layer.children.len();
+            let mut child_path = layer_path.clone();
+            child_path.push(child_index);
+            if let Some(child_layer) = generate_render_layer_recursive(
+                *child,
+                ir,
+                snapshot,
+                scroll_map,
+                animation_map,
+                paint_cache,
+                boundary_cache,
+                runtime_dynamic_subtrees,
+                miss_count,
+                hit_count,
+                scene_cache_allowed,
+                visited,
+                bindings,
+                child_path,
+            ) {
+                layer.children.push(RenderNode::Layer(child_layer));
+            }
         }
     }
 
-    if let Some(scrollbar_rail) = build_scrollbar_rail_paint(node_id, node, rect, snapshot) {
-        layer.children.push(RenderNode::Paint(scrollbar_rail));
+    if let Some(scrollbar) = build_scrollbar_paint(ir, node_id, snapshot, scroll_map) {
+        let mut scrollbar_path = layer_path.clone();
+        scrollbar_path.push(layer.children.len());
+        layer.children.push(RenderNode::Paint(scrollbar));
+        bindings.scrollbar.push(ScrollbarBinding {
+            node_path: scrollbar_path,
+            node_id,
+        });
     }
 
     if can_use_boundary_cache {
@@ -2010,78 +2126,46 @@ fn build_local_paint_list(
     }
 }
 
-fn build_scrollbar_rail_paint(
+fn build_scrollbar_paint(
+    ir: &CoreIR,
     node_id: NodeId,
-    node: &fission_ir::CoreNode,
-    rect: LayoutRect,
     snapshot: &LayoutSnapshot,
+    scroll_map: &ScrollStateMap,
 ) -> Option<DisplayList> {
-    let Op::Layout(LayoutOp::Scroll {
-        direction,
-        show_scrollbar,
-        ..
-    }) = &node.op
-    else {
-        return None;
-    };
-    if !show_scrollbar {
-        return None;
-    }
-
-    let content_id = *node.children.first()?;
-    let content_rect = snapshot.nodes.get(&content_id)?.rect;
+    let geometry = scrollbar_geometry_for_node(ir, snapshot, scroll_map, node_id)?;
     let rail_fill = Some(Fill::Solid(RenderColor {
         r: 160,
         g: 168,
         b: 180,
-        a: 110,
+        a: 80,
     }));
-    let inset = 2.0;
-    let thickness = 6.0;
-    let mut list = DisplayList::new(rect);
+    let thumb_fill = Some(Fill::Solid(RenderColor {
+        r: 82,
+        g: 91,
+        b: 108,
+        a: 190,
+    }));
+    let mut list = DisplayList::new(geometry.rail_rect);
+    let corner_radius = fission_core::scrollbar::SCROLLBAR_THICKNESS / 2.0;
 
-    match direction {
-        FlexDirection::Column => {
-            if content_rect.size.height <= rect.size.height + 0.5 {
-                return None;
-            }
-            let rail_rect = LayoutRect::new(
-                rect.origin.x + rect.size.width - thickness - inset,
-                rect.origin.y + inset,
-                thickness,
-                (rect.size.height - inset * 2.0).max(0.0),
-            );
-            list.push(DisplayOp::DrawRect {
-                rect: rail_rect,
-                fill: rail_fill,
-                stroke: None,
-                corner_radius: thickness / 2.0,
-                shadow: None,
-                bounds: rail_rect,
-                node_id: Some(node_id),
-            });
-        }
-        FlexDirection::Row => {
-            if content_rect.size.width <= rect.size.width + 0.5 {
-                return None;
-            }
-            let rail_rect = LayoutRect::new(
-                rect.origin.x + inset,
-                rect.origin.y + rect.size.height - thickness - inset,
-                (rect.size.width - inset * 2.0).max(0.0),
-                thickness,
-            );
-            list.push(DisplayOp::DrawRect {
-                rect: rail_rect,
-                fill: rail_fill,
-                stroke: None,
-                corner_radius: thickness / 2.0,
-                shadow: None,
-                bounds: rail_rect,
-                node_id: Some(node_id),
-            });
-        }
-    }
+    list.push(DisplayOp::DrawRect {
+        rect: geometry.rail_rect,
+        fill: rail_fill,
+        stroke: None,
+        corner_radius,
+        shadow: None,
+        bounds: geometry.rail_rect,
+        node_id: Some(node_id),
+    });
+    list.push(DisplayOp::DrawRect {
+        rect: geometry.thumb_rect,
+        fill: thumb_fill,
+        stroke: None,
+        corner_radius,
+        shadow: None,
+        bounds: geometry.thumb_rect,
+        node_id: Some(node_id),
+    });
 
     Some(list)
 }
@@ -3046,17 +3130,18 @@ mod tests {
             )
             .unwrap();
 
-        fn find_scroll_layer(
+        fn find_layer_by_node(
             node: &fission_render::RenderNode,
+            node_id: NodeId,
         ) -> Option<&fission_render::RenderLayer> {
             match node {
                 fission_render::RenderNode::Paint(_) => None,
                 fission_render::RenderNode::Layer(layer) => {
-                    if !layer.style.transform_clip && layer.style.clip.is_some() {
+                    if layer.node_id == Some(node_id) {
                         return Some(layer);
                     }
                     for child in &layer.children {
-                        if let Some(found) = find_scroll_layer(child) {
+                        if let Some(found) = find_layer_by_node(child, node_id) {
                             return Some(found);
                         }
                     }
@@ -3067,17 +3152,173 @@ mod tests {
 
         let scroll_layer = pipeline
             .retained_scene()
-            .and_then(|scene| scene.roots.iter().find_map(find_scroll_layer))
+            .and_then(|scene| {
+                scene
+                    .roots
+                    .iter()
+                    .find_map(|node| find_layer_by_node(node, scroll))
+            })
             .expect("expected a retained scroll layer");
+        assert!(
+            scroll_layer.style.transform.is_none(),
+            "scrollbar chrome must not inherit the content scroll transform"
+        );
         let transform = scroll_layer
-            .style
-            .transform
-            .expect("scroll layer should carry a compositor transform");
+            .children
+            .iter()
+            .find_map(|child| match child {
+                fission_render::RenderNode::Layer(layer) => layer.style.transform,
+                fission_render::RenderNode::Paint(_) => None,
+            })
+            .expect("scroll content layer should carry a compositor transform");
         assert!(
             (transform[13] + 180.0).abs() <= 0.01,
-            "expected retained scroll transform to patch to -180, got {}",
+            "expected retained content transform to patch to -180, got {}",
             transform[13]
         );
+    }
+
+    #[test]
+    fn scrollbar_thumb_patches_after_scroll_offset_changes() {
+        let mut ir = CoreIR::new();
+        let fill = NodeId::derived(18, &[0]);
+        let content = NodeId::derived(18, &[1]);
+        let scroll = NodeId::derived(18, &[2]);
+        let root = NodeId::derived(18, &[3]);
+
+        ir.add_node(
+            fill,
+            Op::Paint(PaintOp::DrawRect {
+                fill: Some(Fill::Solid(Color {
+                    r: 120,
+                    g: 120,
+                    b: 220,
+                    a: 255,
+                })),
+                stroke: None,
+                corner_radius: 0.0,
+                shadow: None,
+            }),
+            vec![],
+        );
+        ir.add_node(
+            content,
+            Op::Layout(LayoutOp::Box {
+                width: Some(320.0),
+                height: Some(640.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0, 0.0, 0.0, 0.0],
+                flex_grow: 0.0,
+                flex_shrink: 0.0,
+                aspect_ratio: None,
+            }),
+            vec![fill],
+        );
+        ir.add_node(
+            scroll,
+            Op::Layout(LayoutOp::Scroll {
+                direction: fission_ir::FlexDirection::Column,
+                show_scrollbar: true,
+                width: Some(320.0),
+                height: Some(240.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0, 0.0, 0.0, 0.0],
+                flex_grow: 0.0,
+                flex_shrink: 0.0,
+            }),
+            vec![content],
+        );
+        ir.add_node(
+            root,
+            Op::Layout(LayoutOp::Box {
+                width: Some(320.0),
+                height: Some(240.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0, 0.0, 0.0, 0.0],
+                flex_grow: 0.0,
+                flex_shrink: 0.0,
+                aspect_ratio: None,
+            }),
+            vec![scroll],
+        );
+        ir.set_root(root);
+
+        let mut pipeline = Pipeline::new();
+        let mut layout_engine = LayoutEngine::new();
+        let scroll0 = ScrollStateMap::default();
+        pipeline.replace_ir(ir, &Env::default());
+        pipeline
+            .ensure_layout(
+                LayoutRect::new(0.0, 0.0, 320.0, 240.0),
+                &mut layout_engine,
+                &scroll0,
+            )
+            .unwrap();
+        pipeline
+            .prepare_current(
+                LayoutSize::new(320.0, 240.0),
+                LayoutSize::new(320.0, 240.0),
+                false,
+                &scroll0,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+        let initial_thumb_y = scrollbar_thumb_y(pipeline.retained_scene().unwrap(), scroll)
+            .expect("initial scrollbar thumb");
+
+        let mut scroll1 = ScrollStateMap::default();
+        scroll1.set_offset(scroll, 200.0);
+        pipeline
+            .prepare_current(
+                LayoutSize::new(320.0, 240.0),
+                LayoutSize::new(320.0, 240.0),
+                false,
+                &scroll1,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+        let moved_thumb_y = scrollbar_thumb_y(pipeline.retained_scene().unwrap(), scroll)
+            .expect("moved scrollbar thumb");
+
+        assert!(
+            moved_thumb_y > initial_thumb_y,
+            "body scroll must patch the retained scrollbar thumb, before={initial_thumb_y}, after={moved_thumb_y}"
+        );
+
+        fn scrollbar_thumb_y(scene: &fission_render::RenderScene, scroll: NodeId) -> Option<f32> {
+            fn find(node: &fission_render::RenderNode, scroll: NodeId) -> Option<f32> {
+                match node {
+                    fission_render::RenderNode::Paint(list) => list.ops.iter().find_map(|op| {
+                        if let fission_render::DisplayOp::DrawRect { rect, node_id, .. } = op {
+                            if *node_id == Some(scroll)
+                                && (rect.width() - 6.0).abs() <= 0.01
+                                && rect.height() < 200.0
+                            {
+                                return Some(rect.origin.y);
+                            }
+                        }
+                        None
+                    }),
+                    fission_render::RenderNode::Layer(layer) => {
+                        layer.children.iter().find_map(|child| find(child, scroll))
+                    }
+                }
+            }
+            scene.roots.iter().find_map(|root| find(root, scroll))
+        }
     }
 
     #[test]

--- a/examples/animation-gallery/src/main.rs
+++ b/examples/animation-gallery/src/main.rs
@@ -1,11 +1,10 @@
-use fission::prelude::fission_reducer;
-use fission_core::ui::{
-    Button, ButtonVariant, Column, Composite, Container, Node, Row, Scroll, Text,
-};
-use fission_core::{
+use fission::prelude::*;
+use fission::{
     op::Color as IrColor, with_reducer, AnimationPropertyId, AnimationRequest, AnimationStartValue,
-    AppState, BuildCtx, EasingFunction, FlexDirection, View, Widget, WidgetNodeId,
+    AppState, BuildCtx, Button, ButtonVariant, Column, Composite, Container, FlexDirection, Node,
+    Row, Scroll, Text, View, Widget, WidgetNodeId,
 };
+use fission_core::EasingFunction;
 use fission_shell_desktop::DesktopApp;
 use fission_widgets::{Transition, Wrap};
 use lazy_static::lazy_static;


### PR DESCRIPTION
## Summary

- Add a shared scrollbar geometry/hit-testing model in `fission-core` so scrollbars use the same rail/thumb math for input and rendering.
- Route scrollbar pointer/wheel events through runtime-owned scroll handling instead of letting custom render nodes or content hit-testing steal the events.
- Patch retained scrollbar paint from `ScrollStateMap` during shell rendering so body scrolling updates the visible thumb without a full scene rebuild.
- Normalize winit scroll deltas into Fission's positive down/right offset model and update the animation gallery to use the public Fission facade exports.

## Behavior Fixed

- Two-finger/body scrolling now moves the scrollbar thumb.
- Wheel/two-finger scrolling on vertical and horizontal scrollbar rails targets the owning scroll node.
- Thumb dragging maps directly to scroll offset and handles nested/translated scrollbars correctly.
- Retained scroll layers keep content transforms separate from viewport scrollbar chrome.

## Tests

- `cargo test -p fission-core`
- `cargo test -p fission-shell-winit scroll`
- `cargo check -p animation-gallery`
- `git diff --check`

## Notes

No large binary/assets are included in this PR; the largest new/changed blobs are source files.
