### PR TITLE
Expand DSP component theming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,6 +4099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "todo-design-system"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fission",
+ "fission-design-system-codegen",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/authoring/fission-charts/src/chart.rs
+++ b/crates/authoring/fission-charts/src/chart.rs
@@ -421,9 +421,32 @@ impl ChartTheme {
         theme.axis_line = colors.text_secondary;
         theme.label = colors.text_secondary;
         theme.title = colors.text_primary;
-        theme.palette[0] = colors.primary;
-        theme.palette[1] = colors.secondary;
+        if env.theme.tokens.data_visualization.palette.is_empty() {
+            theme.palette[0] = colors.primary;
+            theme.palette[1] = colors.secondary;
+        } else {
+            theme.palette = env.theme.tokens.data_visualization.palette.clone();
+        }
         theme
+    }
+}
+
+#[cfg(test)]
+mod chart_theme_tests {
+    use super::*;
+
+    #[test]
+    fn chart_theme_uses_generated_data_visualization_palette() {
+        let mut env = fission_core::Env::default();
+        env.theme.tokens.data_visualization.palette = vec![
+            color(1, 2, 3, 255),
+            color(4, 5, 6, 255),
+            color(7, 8, 9, 255),
+        ];
+
+        let theme = ChartTheme::from_env(&env);
+
+        assert_eq!(theme.palette, env.theme.tokens.data_visualization.palette);
     }
 }
 

--- a/crates/authoring/fission-widgets/src/badge.rs
+++ b/crates/authoring/fission-widgets/src/badge.rs
@@ -1,5 +1,5 @@
-use fission_core::op::Color;
-use fission_core::ui::{Align, Container, Node, Text};
+use fission_core::op::{Color, Fill};
+use fission_core::ui::{Align, BadgeTone, ComponentSize, Container, Node, Text};
 use fission_core::{BuildCtx, View, Widget};
 use serde::{Deserialize, Serialize};
 
@@ -22,27 +22,46 @@ pub struct Badge {
     pub text: String,
     pub color: Option<Color>,
     pub text_color: Option<Color>,
+    pub tone: BadgeTone,
+    pub size: ComponentSize,
 }
 
 impl<S: fission_core::AppState> Widget<S> for Badge {
     fn build(&self, _ctx: &mut BuildCtx<S>, view: &View<S>) -> Node {
         let theme = &view.env.theme.components.badge;
         let tokens = &view.env.theme.tokens;
-        let bg_color = self.color.unwrap_or(tokens.colors.secondary);
-        let text_color = self.text_color.unwrap_or(tokens.colors.on_secondary);
+        let style = theme.resolve(self.tone, self.size);
+        let bg_fill = self
+            .color
+            .map(Fill::Solid)
+            .or_else(|| style.background.clone())
+            .unwrap_or(Fill::Solid(tokens.colors.secondary));
+        let text_color = self
+            .text_color
+            .unwrap_or(style.text_color.unwrap_or(tokens.colors.on_secondary));
+        let padding_x = style.padding_x.unwrap_or(10.0);
+        let padding_y = style.padding_y.unwrap_or(2.0);
+        let border = style.border.clone();
 
-        Container::new(
+        let mut badge = Container::new(
             Align::new(
                 Text::new(self.text.clone())
-                    .size(13.0)
+                    .size(style.font_size.unwrap_or(theme.font_size))
+                    .weight(style.font_weight.unwrap_or(theme.font_weight))
+                    .line_height(style.line_height.unwrap_or(20.0))
                     .color(text_color)
                     .into_node(),
             )
             .into_node(),
         )
-        .bg(bg_color)
-        .border_radius(theme.radius)
-        .padding_all(5.0)
-        .into_node()
+        .bg_fill(bg_fill)
+        .border_radius(style.radius.unwrap_or(theme.radius))
+        .padding([padding_x, padding_x, padding_y, padding_y]);
+        if let Some(border) = border {
+            if let Fill::Solid(color) = border.fill {
+                badge = badge.border(color, border.width);
+            }
+        }
+        badge.into_node()
     }
 }

--- a/crates/authoring/fission-widgets/src/card.rs
+++ b/crates/authoring/fission-widgets/src/card.rs
@@ -1,4 +1,5 @@
-use fission_core::ui::{Container, Node};
+use fission_core::op::Fill;
+use fission_core::ui::{CardPattern, Container, Node};
 use fission_core::{BuildCtx, View, Widget};
 use serde::{Deserialize, Serialize};
 
@@ -10,18 +11,24 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Card {
     pub child: Box<Node>,
+    pub pattern: CardPattern,
+    pub interactive: bool,
 }
 
 impl Default for Card {
     fn default() -> Self {
         Self {
             child: Box::new(fission_core::ui::Row::default().into()),
+            pattern: CardPattern::Raised,
+            interactive: false,
         }
     }
 }
 
 impl<S: fission_core::AppState> Widget<S> for Card {
     fn build(&self, _ctx: &mut BuildCtx<S>, view: &View<S>) -> Node {
+        let theme = &view.env.theme.components.card;
+        let style = theme.resolve(self.pattern, self.interactive);
         let tokens = &view.env.theme.tokens;
         let default_shadow = fission_core::op::BoxShadow {
             color: fission_core::op::Color {
@@ -34,11 +41,24 @@ impl<S: fission_core::AppState> Widget<S> for Card {
             offset: (0.0, 1.0),
         };
 
-        Container::new(*self.child.clone())
-            .bg(tokens.colors.surface)
-            .border_radius(tokens.radii.medium)
-            .shadow(tokens.elevations.level1.unwrap_or(default_shadow))
-            .padding_all(tokens.spacing.m)
-            .into_node()
+        let mut card = Container::new(*self.child.clone())
+            .bg_fill(
+                style
+                    .background
+                    .clone()
+                    .unwrap_or(Fill::Solid(tokens.colors.surface)),
+            )
+            .border_radius(style.radius.unwrap_or(theme.radius))
+            .shadows(style.outer_shadows())
+            .padding(style.padding_box(theme.padding, theme.padding));
+        if let Some(border) = style.border {
+            if let Fill::Solid(color) = border.fill {
+                card = card.border(color, border.width);
+            }
+        }
+        if style.shadows.is_empty() {
+            card = card.shadow(tokens.elevations.level1.unwrap_or(default_shadow));
+        }
+        card.into_node()
     }
 }

--- a/crates/authoring/fission-widgets/src/modal.rs
+++ b/crates/authoring/fission-widgets/src/modal.rs
@@ -70,6 +70,7 @@ impl<S: fission_core::AppState> Widget<S> for Modal {
 
         let theme = &view.env.theme.components.modal;
         let tokens = &view.env.theme.tokens;
+        let container_style = &theme.container_style;
         let viewport = view.viewport_size();
         let horizontal_margin = 24.0;
         let max_dialog_width = if viewport.width.is_finite() && viewport.width > 0.0 {
@@ -82,12 +83,14 @@ impl<S: fission_core::AppState> Widget<S> for Modal {
         // Dimmed backdrop
         let backdrop =
             Container::new(fission_core::ui::widgets::spacer::Spacer::default().into_node())
-                .bg(Color {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                    a: 220,
-                })
+                .bg_fill(theme.scrim_style.background.clone().unwrap_or(
+                    fission_core::op::Fill::Solid(Color {
+                        r: 0,
+                        g: 0,
+                        b: 0,
+                        a: 220,
+                    }),
+                ))
                 .flex_grow(1.0)
                 .into_node();
 
@@ -104,9 +107,9 @@ impl<S: fission_core::AppState> Widget<S> for Modal {
             action_buttons.push(
                 Button {
                     variant: if action.is_primary {
-                        ButtonVariant::Filled
+                        ButtonVariant::Primary
                     } else {
-                        ButtonVariant::Outline
+                        ButtonVariant::SecondaryGray
                     },
                     child: Some(Box::new(
                         Text::new(action.label.clone())
@@ -174,11 +177,19 @@ impl<S: fission_core::AppState> Widget<S> for Modal {
                 }
                 .into_node(),
             )
-            .bg(theme.bg_color)
-            .border_radius(theme.radius);
+            .bg_fill(
+                container_style
+                    .background
+                    .clone()
+                    .unwrap_or(fission_core::op::Fill::Solid(theme.bg_color)),
+            )
+            .border_radius(container_style.radius.unwrap_or(theme.radius))
+            .shadows(container_style.outer_shadows());
 
-        if let Some(s) = theme.shadow {
-            modal_card_builder = modal_card_builder.shadow(s);
+        if container_style.shadows.is_empty() {
+            if let Some(s) = theme.shadow {
+                modal_card_builder = modal_card_builder.shadow(s);
+            }
         }
 
         let modal_card = modal_card_builder

--- a/crates/authoring/fission-widgets/src/progress.rs
+++ b/crates/authoring/fission-widgets/src/progress.rs
@@ -1,3 +1,4 @@
+use fission_core::op::Fill;
 use fission_core::ui::{Container, GridItem, Node};
 use fission_core::{BuildCtx, View, Widget};
 use serde::{Deserialize, Serialize};
@@ -19,19 +20,33 @@ impl<S: fission_core::AppState> Widget<S> for ProgressBar {
     fn build(&self, _ctx: &mut BuildCtx<S>, view: &View<S>) -> Node {
         let theme = &view.env.theme.components.progress;
 
+        let height = theme.track_style.height.unwrap_or(theme.height);
+        let radius = theme.track_style.radius.unwrap_or(theme.radius);
         let track =
             Container::new(fission_core::ui::widgets::spacer::Spacer::default().into_node())
-                .height(theme.height)
-                .bg(theme.track_color)
-                .border_radius(theme.height / 2.0)
+                .height(height)
+                .bg_fill(
+                    theme
+                        .track_style
+                        .background
+                        .clone()
+                        .unwrap_or(Fill::Solid(theme.track_color)),
+                )
+                .border_radius(radius)
                 .into_node();
 
         let progress_pct = (self.value * 100.0).clamp(0.0, 100.0);
 
         let bar = Container::new(fission_core::ui::widgets::spacer::Spacer::default().into_node())
-            .height(theme.height)
-            .bg(theme.bar_color)
-            .border_radius(theme.height / 2.0)
+            .height(theme.fill_style.height.unwrap_or(height))
+            .bg_fill(
+                theme
+                    .fill_style
+                    .background
+                    .clone()
+                    .unwrap_or(Fill::Solid(theme.bar_color)),
+            )
+            .border_radius(theme.fill_style.radius.unwrap_or(radius))
             .into_node();
 
         let bar_grid = fission_core::ui::Grid {
@@ -39,7 +54,7 @@ impl<S: fission_core::AppState> Widget<S> for ProgressBar {
                 fission_ir::op::GridTrack::Percent(progress_pct),
                 fission_ir::op::GridTrack::Fr(1.0),
             ],
-            rows: vec![fission_ir::op::GridTrack::Points(theme.height)],
+            rows: vec![fission_ir::op::GridTrack::Points(height)],
             children: vec![GridItem {
                 col_start: fission_ir::op::GridPlacement::Line(1),
                 child: Box::new(bar),
@@ -57,7 +72,7 @@ impl<S: fission_core::AppState> Widget<S> for ProgressBar {
             }
             .into_node(),
         )
-        .height(theme.height)
+        .height(height)
         .flex_grow(1.0)
         .into_node()
     }

--- a/crates/authoring/fission-widgets/src/tabs.rs
+++ b/crates/authoring/fission-widgets/src/tabs.rs
@@ -1,5 +1,7 @@
 use crate::stack::{HStack, VStack};
-use fission_core::ui::{Button, ButtonVariant, Container, Node, Text};
+use fission_core::ui::{
+    Button, ButtonVariant, ComponentSize, ComponentState, Container, Node, Text,
+};
 use fission_core::{ActionEnvelope, BuildCtx, View, Widget};
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +34,7 @@ pub struct TabItem {
 pub struct Tabs {
     pub active_index: usize,
     pub items: Vec<TabItem>,
+    pub size: ComponentSize,
 }
 
 impl<S: fission_core::AppState> Widget<S> for Tabs {
@@ -41,11 +44,18 @@ impl<S: fission_core::AppState> Widget<S> for Tabs {
 
         for (i, item) in self.items.iter().enumerate() {
             let is_active = i == self.active_index;
-            let color = if is_active {
+            let state = if is_active {
+                ComponentState::Active
+            } else {
+                ComponentState::Default
+            };
+            let style = theme.resolve_tab(self.size, state);
+            let color = style.text_color.unwrap_or(if is_active {
                 theme.active_color
             } else {
                 theme.inactive_color
-            };
+            });
+            let border = style.border.clone();
 
             let tab_button = VStack {
                 spacing: Some(0.0),
@@ -54,13 +64,19 @@ impl<S: fission_core::AppState> Widget<S> for Tabs {
                         variant: ButtonVariant::Ghost,
                         child: Some(Box::new(
                             Text::new(item.title.clone())
-                                .size(14.0)
+                                .size(style.font_size.unwrap_or(14.0))
+                                .weight(style.font_weight.unwrap_or(400))
                                 .color(color)
                                 .into_node(),
                         )),
                         on_press: item.on_press.clone(),
-                        height: Some(38.0),
-                        padding: Some([10.0, 10.0, 0.0, 0.0]),
+                        height: style.height.or(Some(38.0)),
+                        padding: Some([
+                            10.0,
+                            10.0,
+                            style.padding_y.unwrap_or(0.0),
+                            style.padding_y.unwrap_or(0.0),
+                        ]),
                         ..Default::default()
                     }
                     .into_node(),
@@ -68,8 +84,16 @@ impl<S: fission_core::AppState> Widget<S> for Tabs {
                         Container::new(
                             fission_core::ui::widgets::spacer::Spacer::default().into_node(),
                         )
-                        .height(theme.indicator_height)
-                        .bg(theme.active_color)
+                        .height(
+                            border
+                                .as_ref()
+                                .map(|border| border.width)
+                                .unwrap_or(theme.indicator_height),
+                        )
+                        .bg(match border.map(|border| border.fill) {
+                            Some(fission_core::op::Fill::Solid(color)) => color,
+                            _ => theme.active_color,
+                        })
                         .into_node()
                     } else {
                         fission_core::ui::widgets::spacer::Spacer::default().into_node()
@@ -88,8 +112,30 @@ impl<S: fission_core::AppState> Widget<S> for Tabs {
             }
             .into_node(),
         )
-        .bg(theme.background)
-        .border(theme.divider_color, 1.0)
+        .bg_fill(
+            theme
+                .track_style
+                .background
+                .clone()
+                .unwrap_or(fission_core::op::Fill::Solid(theme.background)),
+        )
+        .border(
+            theme
+                .track_style
+                .border
+                .as_ref()
+                .and_then(|border| match &border.fill {
+                    fission_core::op::Fill::Solid(color) => Some(*color),
+                    _ => None,
+                })
+                .unwrap_or(theme.divider_color),
+            theme
+                .track_style
+                .border
+                .as_ref()
+                .map(|border| border.width)
+                .unwrap_or(1.0),
+        )
         .padding_all(2.0)
         .into_node();
 

--- a/crates/authoring/fission-widgets/src/tooltip.rs
+++ b/crates/authoring/fission-widgets/src/tooltip.rs
@@ -36,16 +36,23 @@ impl<S: fission_core::AppState> Widget<S> for Tooltip {
             .into_node();
 
         if show_tooltip {
+            let style = &theme.style;
             let tooltip_card = Container::new(
                 Text::new(self.text.clone())
-                    .size(theme.font_size)
-                    .color(theme.text_color)
-                    .max_width(220.0)
+                    .size(style.font_size.unwrap_or(theme.font_size))
+                    .color(style.text_color.unwrap_or(theme.text_color))
+                    .max_width(style.max_width.unwrap_or(theme.max_width))
                     .into_node(),
             )
-            .bg(theme.bg_color)
-            .padding_all(8.0)
-            .border_radius(theme.radius)
+            .bg_fill(
+                style
+                    .background
+                    .clone()
+                    .unwrap_or(fission_core::op::Fill::Solid(theme.bg_color)),
+            )
+            .padding(style.padding_box(theme.padding_x, theme.padding_y))
+            .border_radius(style.radius.unwrap_or(theme.radius))
+            .shadows(style.outer_shadows())
             .into_node();
 
             let flyout_node = crate::flyout(

--- a/crates/authoring/fission-widgets/tests/theme_alignment.rs
+++ b/crates/authoring/fission-widgets/tests/theme_alignment.rs
@@ -96,10 +96,22 @@ fn rect_center(rect: fission_layout::LayoutRect) -> (f32, f32) {
     )
 }
 
+fn find_text_paint(ir: &CoreIR, expected: &str) -> Option<NodeId> {
+    ir.nodes.iter().find_map(|(id, node)| match &node.op {
+        Op::Paint(PaintOp::DrawText { text, .. }) if text == expected => Some(*id),
+        Op::Paint(PaintOp::DrawRichText { runs, .. })
+            if runs.iter().map(|run| run.text.as_str()).collect::<String>() == expected =>
+        {
+            Some(*id)
+        }
+        _ => None,
+    })
+}
+
 #[test]
-fn badge_background_uses_theme_secondary() {
+fn badge_background_uses_generated_brand_tone() {
     let mut tokens = Tokens::default();
-    tokens.colors.secondary = Color {
+    tokens.colors.primary_subtle = Color {
         r: 7,
         g: 11,
         b: 13,
@@ -124,7 +136,7 @@ fn badge_background_uses_theme_secondary() {
             ..
         }) = &node.op
         {
-            if *color == env.theme.tokens.colors.secondary {
+            if *color == env.theme.tokens.colors.primary_subtle {
                 found = true;
                 break;
             }
@@ -133,7 +145,7 @@ fn badge_background_uses_theme_secondary() {
 
     assert!(
         found,
-        "expected badge background to use theme secondary color"
+        "expected badge background to use generated brand tone"
     );
 }
 
@@ -205,18 +217,7 @@ fn badge_text_centered() {
     );
     let parents = parent_map(&ir);
 
-    let text_paint_id = ir
-        .nodes
-        .iter()
-        .find_map(|(id, node)| {
-            if let Op::Paint(PaintOp::DrawText { text, .. }) = &node.op {
-                if text == "1" {
-                    return Some(*id);
-                }
-            }
-            None
-        })
-        .expect("badge text paint");
+    let text_paint_id = find_text_paint(&ir, "1").expect("badge text paint");
 
     let text_layout_id = parents
         .get(&text_paint_id)

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -151,11 +151,14 @@ pub mod prelude {
     pub use fission_core::{
         Action, ActionEnvelope, ActionId, AnimationPropertyId, AnimationRequest,
         AnimationStartValue, AppState, BuildCtx, Effects, FlexDirection, Handler, NodeBuilder, Op,
-        PortalLayer, ReducerContext, Selector, View, Widget, WidgetNodeId,
+        PortalLayer, ReducerContext, Selector, View, Widget, WidgetNodeId, WindowEnv, WindowTitle,
     };
 
     // Layout
     pub use fission_layout::{LayoutPoint, LayoutRect, LayoutSize};
+
+    // Design systems and generated themes.
+    pub use fission_theme::*;
 
     // IR
     pub use fission_ir::op as ir_op;

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -96,7 +96,8 @@ pub use registry::{
 };
 pub use time::{Clock, CurrentTime};
 pub use ui::{
-    Builder, Button, Column, CustomEventResult, CustomHitResult, CustomNode, CustomRenderObject,
+    BadgeTone, Builder, Button, ButtonHierarchy, CardPattern, Column, ComponentSize,
+    ComponentState, CustomEventResult, CustomHitResult, CustomNode, CustomRenderObject,
     LayoutBuilder, Lower, LowerDyn, Node, Row, Text,
 };
 pub use view::{Selector, View, Widget};

--- a/crates/core/fission-core/src/ui/mod.rs
+++ b/crates/core/fission-core/src/ui/mod.rs
@@ -7,8 +7,9 @@ pub use custom_render::{CustomEventResult, CustomHitResult, CustomRenderObject};
 pub use node::{CustomNode, Node};
 pub use traits::{Lower, LowerDyn};
 pub use widgets::{
-    Align, Builder, Button, ButtonContentAlign, ButtonVariant, Checkbox, Column, Composite,
-    Container, FocusScope, GestureDetector, Grid, GridItem, Icon, Image, LayoutBuilder, LazyColumn,
-    Overlay, Positioned, Radio, RichText, RichTextRun, Row, SafeArea, Scroll, Slider, Spacer,
-    Switch, Text, TextContent, TextFontStyle, TextInput, TextRunStyle, Video, ZStack,
+    Align, BadgeTone, Builder, Button, ButtonContentAlign, ButtonHierarchy, ButtonVariant,
+    CardPattern, Checkbox, Column, ComponentSize, ComponentState, Composite, Container, FocusScope,
+    GestureDetector, Grid, GridItem, Icon, Image, LayoutBuilder, LazyColumn, Overlay, Positioned,
+    Radio, RichText, RichTextRun, Row, SafeArea, Scroll, Slider, Spacer, Switch, Text, TextContent,
+    TextFontStyle, TextInput, TextRunStyle, Video, ZStack,
 };

--- a/crates/core/fission-core/src/ui/widgets/button.rs
+++ b/crates/core/fission-core/src/ui/widgets/button.rs
@@ -6,6 +6,7 @@ use fission_ir::{
     op::{BoxShadow, Color as IrColor, Fill, LayoutOp, Op, PaintOp, Stroke},
     ActionEntry, ActionSet, NodeId, Role, Semantics,
 };
+use fission_theme::{ButtonHierarchy, ComponentSize, ComponentState};
 use serde::{Deserialize, Serialize};
 
 /// Visual style variant for a [`Button`].
@@ -32,6 +33,37 @@ pub enum ButtonVariant {
     Outline,
     /// No background, no border.
     Ghost,
+    /// DSP primary hierarchy.
+    Primary,
+    /// DSP secondary colour hierarchy.
+    SecondaryColor,
+    /// DSP secondary gray hierarchy.
+    SecondaryGray,
+    /// DSP tertiary colour hierarchy.
+    TertiaryColor,
+    /// DSP tertiary gray hierarchy.
+    TertiaryGray,
+    /// DSP link colour hierarchy.
+    LinkColor,
+    /// DSP link gray hierarchy.
+    LinkGray,
+    /// DSP destructive hierarchy.
+    Destructive,
+}
+
+impl ButtonVariant {
+    fn hierarchy(self) -> ButtonHierarchy {
+        match self {
+            ButtonVariant::Filled | ButtonVariant::Primary => ButtonHierarchy::Primary,
+            ButtonVariant::Outline | ButtonVariant::SecondaryGray => ButtonHierarchy::SecondaryGray,
+            ButtonVariant::Ghost | ButtonVariant::TertiaryGray => ButtonHierarchy::TertiaryGray,
+            ButtonVariant::SecondaryColor => ButtonHierarchy::SecondaryColor,
+            ButtonVariant::TertiaryColor => ButtonHierarchy::TertiaryColor,
+            ButtonVariant::LinkColor => ButtonHierarchy::LinkColor,
+            ButtonVariant::LinkGray => ButtonHierarchy::LinkGray,
+            ButtonVariant::Destructive => ButtonHierarchy::Destructive,
+        }
+    }
 }
 
 /// Horizontal alignment of a [`Button`]'s child content.
@@ -95,6 +127,9 @@ pub struct Button {
     pub style: Option<ButtonStyleOverride>,
     /// Visual variant (Filled, Outline, or Ghost).
     pub variant: ButtonVariant,
+    /// Design-system size slot.
+    #[serde(default)]
+    pub size: ComponentSize,
     /// Optional fill override for the button background.
     pub background_fill: Option<Fill>,
     /// Optional text color override for direct `Text` children.
@@ -159,6 +194,7 @@ impl Default for Button {
             padding: None,
             style: None,
             variant: ButtonVariant::Filled,
+            size: ComponentSize::Md,
             background_fill: None,
             text_color: None,
             content_align: ButtonContentAlign::Center,
@@ -178,7 +214,11 @@ struct ButtonStyleResolved {
     height: f32,
     corner_radius: f32,
     shadow: Option<BoxShadow>,
+    shadows: Vec<BoxShadow>,
     stroke: Option<Stroke>,
+    font_size: f32,
+    font_weight: u16,
+    line_height: Option<f32>,
 }
 
 impl Button {
@@ -194,98 +234,77 @@ impl Button {
         let is_hovered = interaction.is_hovered(self_id) && !self.disabled;
         let is_pressed = interaction.is_pressed(self_id) && !self.disabled;
         let is_focused = interaction.is_focused(self_id) && !self.disabled;
-
-        let (background_fill, text_color, border_stroke) = if self.disabled {
-            (
-                if self.variant == ButtonVariant::Filled {
-                    Some(Fill::Solid(tokens.border))
-                } else {
-                    None
-                }, // Grey bg or transparent
-                tokens.text_secondary, // Grey text
-                if self.variant == ButtonVariant::Outline {
-                    Some(Stroke {
-                        fill: Fill::Solid(tokens.border),
-                        width: 1.0,
-                        dash_array: None,
-                        line_cap: fission_ir::op::LineCap::Butt,
-                        line_join: fission_ir::op::LineJoin::Miter,
-                    })
-                } else {
-                    None
-                },
-            )
+        let component_state = if self.disabled {
+            ComponentState::Disabled
+        } else if is_pressed {
+            ComponentState::Active
+        } else if is_focused {
+            ComponentState::Focus
+        } else if is_hovered {
+            ComponentState::Hover
         } else {
-            match self.variant {
-                ButtonVariant::Filled => (
-                    Some(
-                        self.background_fill
-                            .clone()
-                            .unwrap_or(Fill::Solid(tokens.primary)),
-                    ),
-                    tokens.on_primary,
-                    if is_focused {
-                        default_style.focus_stroke.clone()
-                    } else {
-                        None
-                    },
-                ),
-                ButtonVariant::Outline => (
-                    if is_hovered {
-                        Some(
-                            self.background_fill
-                                .clone()
-                                .unwrap_or(Fill::Solid(tokens.surface)),
-                        )
-                    } else {
-                        self.background_fill.clone()
-                    },
-                    tokens.primary,
-                    Some(Stroke {
-                        fill: Fill::Solid(tokens.border),
-                        width: 1.0,
-                        dash_array: None,
-                        line_cap: fission_ir::op::LineCap::Butt,
-                        line_join: fission_ir::op::LineJoin::Miter,
-                    }),
-                ),
-                ButtonVariant::Ghost => (
-                    if is_hovered {
-                        Some(
-                            self.background_fill
-                                .clone()
-                                .unwrap_or(Fill::Solid(tokens.surface)),
-                        )
-                    } else {
-                        self.background_fill.clone()
-                    },
-                    tokens.primary,
-                    None,
-                ),
-            }
+            ComponentState::Default
         };
+        let component_style =
+            default_style.resolve(self.variant.hierarchy(), self.size, component_state);
 
-        let shadow = if self.variant == ButtonVariant::Filled {
-            if is_pressed {
-                default_style.elevation_pressed
-            } else if is_hovered {
-                default_style.elevation_hover
+        let stroke = component_style
+            .border
+            .clone()
+            .or_else(|| component_style.inset_border())
+            .map(|border| Stroke {
+                fill: border.fill,
+                width: border.width,
+                dash_array: None,
+                line_cap: fission_ir::op::LineCap::Butt,
+                line_join: fission_ir::op::LineJoin::Miter,
+            })
+            .or_else(|| {
+                if is_focused {
+                    default_style.focus_stroke.clone()
+                } else {
+                    None
+                }
+            });
+        let shadows = component_style.outer_shadows();
+        let shadow = shadows.first().copied().or_else(|| {
+            if matches!(self.variant, ButtonVariant::Filled | ButtonVariant::Primary) {
+                if is_pressed {
+                    default_style.elevation_pressed
+                } else if is_hovered {
+                    default_style.elevation_hover
+                } else {
+                    default_style.elevation_rest
+                }
             } else {
-                default_style.elevation_rest
+                None
             }
-        } else {
-            None
-        };
+        });
 
         ButtonStyleResolved {
-            background_fill,
-            text_color: self.text_color.unwrap_or(text_color),
-            padding_horizontal: default_style.padding_horizontal,
-            padding_vertical: default_style.padding_vertical,
-            height: default_style.height,
-            corner_radius: default_style.radius,
+            background_fill: self
+                .background_fill
+                .clone()
+                .or_else(|| component_style.background.clone()),
+            text_color: self
+                .text_color
+                .unwrap_or(component_style.text_color.unwrap_or(tokens.primary)),
+            padding_horizontal: component_style
+                .padding_x
+                .unwrap_or(default_style.padding_horizontal),
+            padding_vertical: component_style
+                .padding_y
+                .unwrap_or(default_style.padding_vertical),
+            height: component_style.height.unwrap_or(default_style.height),
+            corner_radius: component_style.radius.unwrap_or(default_style.radius),
             shadow,
-            stroke: border_stroke,
+            shadows,
+            stroke,
+            font_size: component_style.font_size.unwrap_or(default_style.text_size),
+            font_weight: component_style
+                .font_weight
+                .unwrap_or(default_style.font_weight),
+            line_height: component_style.line_height,
         }
     }
 
@@ -334,17 +353,6 @@ impl Lower for Button {
 
         cx.push_scope(layout_node_id);
 
-        let background_id = NodeBuilder::new(
-            cx.next_node_id(),
-            Op::Paint(PaintOp::DrawRect {
-                fill: resolved_style.background_fill,
-                stroke: resolved_style.stroke,
-                corner_radius: resolved_style.corner_radius,
-                shadow: resolved_style.shadow,
-            }),
-        )
-        .build(cx);
-
         let mut button_builder = NodeBuilder::new(
             layout_node_id,
             Op::Layout(LayoutOp::Box {
@@ -369,11 +377,43 @@ impl Lower for Button {
                 aspect_ratio: None,
             }),
         );
+
+        for shadow in &resolved_style.shadows {
+            let shadow_id = NodeBuilder::new(
+                cx.next_node_id(),
+                Op::Paint(PaintOp::DrawRect {
+                    fill: None,
+                    stroke: None,
+                    corner_radius: resolved_style.corner_radius,
+                    shadow: Some(*shadow),
+                }),
+            )
+            .build(cx);
+            button_builder.add_child(shadow_id);
+        }
+
+        let background_id = NodeBuilder::new(
+            cx.next_node_id(),
+            Op::Paint(PaintOp::DrawRect {
+                fill: resolved_style.background_fill,
+                stroke: resolved_style.stroke,
+                corner_radius: resolved_style.corner_radius,
+                shadow: if resolved_style.shadows.is_empty() {
+                    resolved_style.shadow
+                } else {
+                    None
+                },
+            }),
+        )
+        .build(cx);
         button_builder.add_child(background_id);
 
         if let Some(child_widget) = &self.child {
             let child_id = if let Node::Text(mut text_widget) = *child_widget.clone() {
                 text_widget.color = Some(resolved_style.text_color);
+                text_widget.font_size = Some(resolved_style.font_size);
+                text_widget.font_weight = Some(resolved_style.font_weight);
+                text_widget.line_height = resolved_style.line_height;
                 text_widget.lower(cx)
             } else {
                 child_widget.lower(cx)

--- a/crates/core/fission-core/src/ui/widgets/container.rs
+++ b/crates/core/fission-core/src/ui/widgets/container.rs
@@ -64,6 +64,8 @@ pub struct Container {
     pub border_radius: f32,
     /// Optional drop shadow.
     pub shadow: Option<BoxShadow>,
+    /// Additional shadows drawn behind the container in order.
+    pub shadows: Vec<BoxShadow>,
 }
 
 impl Default for Container {
@@ -86,6 +88,7 @@ impl Default for Container {
             border_width: 0.0,
             border_radius: 0.0,
             shadow: None,
+            shadows: Vec::new(),
         }
     }
 }
@@ -186,6 +189,11 @@ impl Container {
         self
     }
 
+    pub fn shadows(mut self, shadows: Vec<BoxShadow>) -> Self {
+        self.shadows = shadows;
+        self
+    }
+
     pub fn into_node(self) -> Node {
         Node::Container(self)
     }
@@ -203,7 +211,21 @@ impl Lower for Container {
             || self.background_color.is_some()
             || self.border_color.is_some()
             || self.shadow.is_some()
+            || !self.shadows.is_empty()
         {
+            for shadow in &self.shadows {
+                let paint = NodeBuilder::new(
+                    cx.next_node_id(),
+                    Op::Paint(PaintOp::DrawRect {
+                        fill: None,
+                        stroke: None,
+                        corner_radius: self.border_radius,
+                        shadow: Some(*shadow),
+                    }),
+                )
+                .build(cx);
+                children_ids.push(paint);
+            }
             let paint = NodeBuilder::new(
                 cx.next_node_id(),
                 Op::Paint(PaintOp::DrawRect {

--- a/crates/core/fission-core/src/ui/widgets/mod.rs
+++ b/crates/core/fission-core/src/ui/widgets/mod.rs
@@ -31,6 +31,7 @@ pub use checkbox::Checkbox;
 pub use column::Column;
 pub use composite::Composite;
 pub use container::Container;
+pub use fission_theme::{BadgeTone, ButtonHierarchy, CardPattern, ComponentSize, ComponentState};
 pub use grid::{Grid, GridItem};
 pub use icon::Icon;
 pub use image::Image;

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -16,6 +16,7 @@ use fission_ir::{
     },
     AnyRenderObject, FlexDirection, FlexWrap, NodeId, Role, Semantics,
 };
+use fission_theme::{ComponentSize, ComponentState};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use unicode_segmentation::UnicodeSegmentation;
@@ -296,6 +297,9 @@ pub struct TextInput {
     pub width: Option<f32>,
     /// Fixed height in layout points.
     pub height: Option<f32>,
+    /// Design-system size slot.
+    #[serde(default)]
+    pub size: ComponentSize,
     /// Custom content padding `[left, right, top, bottom]`.
     pub padding: Option<[f32; 4]>,
     /// When `true`, the input accepts newlines and scrolls vertically.
@@ -783,6 +787,7 @@ impl Default for TextInput {
             on_tap_outside: None,
             width: None,
             height: None,
+            size: ComponentSize::Md,
             padding: None,
             multiline: false,
             autofocus: false,
@@ -1082,35 +1087,89 @@ impl Lower for TextInput {
 
         let theme = &cx.env.theme.components.text_input;
         let tokens = &cx.env.theme.tokens;
+        let component_state = if !self.enabled {
+            ComponentState::Disabled
+        } else if self.error_text.is_some() {
+            ComponentState::Error
+        } else if is_focused {
+            ComponentState::Focus
+        } else {
+            ComponentState::Default
+        };
+        let component_style = theme.resolve(self.size, component_state);
 
         let text_scale = self.text_scale.unwrap_or(1.0).max(0.0);
-        let font_size = self.font_size.unwrap_or(theme.font_size) * text_scale;
-        let text_color = self.text_color.unwrap_or(theme.text_color);
+        let font_size = self
+            .font_size
+            .unwrap_or(component_style.font_size.unwrap_or(theme.font_size))
+            * text_scale;
+        let text_color = self
+            .text_color
+            .unwrap_or(component_style.text_color.unwrap_or(theme.text_color));
         let selection_color = self
             .selection_color
             .unwrap_or(tokens.colors.primary.with_alpha(52));
         let selection_text_color = self.selection_text_color.unwrap_or(text_color);
-        let placeholder_color = self.placeholder_color.unwrap_or(theme.placeholder_color);
+        let placeholder_color = self.placeholder_color.unwrap_or(
+            theme
+                .placeholder_style
+                .text_color
+                .unwrap_or(theme.placeholder_color),
+        );
         let cursor_color = self.cursor_color.unwrap_or(theme.focus_color);
         let cursor_width = self.cursor_width.unwrap_or(2.0);
-        let font_weight = self.font_weight.unwrap_or(400);
-        let line_height = self.line_height.map(|value| value * text_scale);
+        let font_weight = self
+            .font_weight
+            .unwrap_or(component_style.font_weight.unwrap_or(theme.font_weight));
+        let line_height = self
+            .line_height
+            .or(component_style.line_height)
+            .map(|value| value * text_scale);
         let letter_spacing = self.letter_spacing.unwrap_or(0.0) * text_scale;
+        let style_border = component_style.border.clone();
         let border_color = if is_focused {
-            self.focus_border_color.unwrap_or(theme.focus_color)
+            self.focus_border_color.unwrap_or_else(|| {
+                style_border
+                    .as_ref()
+                    .and_then(|border| match &border.fill {
+                        Fill::Solid(color) => Some(*color),
+                        _ => None,
+                    })
+                    .unwrap_or(theme.focus_color)
+            })
         } else {
-            self.border_color.unwrap_or(theme.border_color)
+            self.border_color.unwrap_or_else(|| {
+                style_border
+                    .as_ref()
+                    .and_then(|border| match &border.fill {
+                        Fill::Solid(color) => Some(*color),
+                        _ => None,
+                    })
+                    .unwrap_or(theme.border_color)
+            })
         };
         let border_width = if is_focused {
-            self.focus_border_width
-                .unwrap_or(self.border_width.unwrap_or(2.0))
+            self.focus_border_width.unwrap_or(
+                style_border
+                    .as_ref()
+                    .map(|border| border.width)
+                    .unwrap_or(2.0),
+            )
         } else {
-            self.border_width.unwrap_or(theme.border_width)
+            self.border_width.unwrap_or(
+                style_border
+                    .as_ref()
+                    .map(|border| border.width)
+                    .unwrap_or(theme.border_width),
+            )
         };
-        let border_radius = self.border_radius.unwrap_or(theme.radius);
-        let content_padding = self
-            .padding
-            .unwrap_or([theme.padding_h, theme.padding_h, 4.0, 4.0]);
+        let border_radius = self
+            .border_radius
+            .unwrap_or(component_style.radius.unwrap_or(theme.radius));
+        let content_padding = self.padding.unwrap_or(component_style.padding_box(
+            component_style.padding_x.unwrap_or(theme.padding_h),
+            component_style.padding_y.unwrap_or(4.0),
+        ));
         let base_text_style = fission_ir::op::TextStyle {
             font_size,
             color: text_color,
@@ -1144,6 +1203,7 @@ impl Lower for TextInput {
                         fill: Some(
                             self.background_fill
                                 .clone()
+                                .or_else(|| component_style.background.clone())
                                 .unwrap_or(Fill::Solid(tokens.colors.background)),
                         ),
                         stroke: Some(Stroke {
@@ -1154,7 +1214,7 @@ impl Lower for TextInput {
                             line_join: fission_ir::op::LineJoin::Miter,
                         }),
                         corner_radius: border_radius,
-                        shadow: None,
+                        shadow: component_style.outer_shadows().first().copied(),
                     }),
                 )
                 .build(cx),
@@ -1610,14 +1670,27 @@ impl Lower for TextInput {
                 let label_color = self.label_color.unwrap_or(if is_focused {
                     theme.focus_color
                 } else {
-                    tokens.colors.text_secondary
+                    theme
+                        .label_style
+                        .text_color
+                        .unwrap_or(tokens.colors.text_secondary)
                 });
                 let supporting_color = if self.error_text.is_some() {
                     self.error_color.unwrap_or(tokens.colors.error)
                 } else {
-                    self.helper_color.unwrap_or(tokens.colors.text_secondary)
+                    self.helper_color.unwrap_or(
+                        theme
+                            .helper_style
+                            .text_color
+                            .unwrap_or(tokens.colors.text_secondary),
+                    )
                 };
-                let counter_color = self.counter_color.unwrap_or(tokens.colors.text_secondary);
+                let counter_color = self.counter_color.unwrap_or(
+                    theme
+                        .helper_style
+                        .text_color
+                        .unwrap_or(tokens.colors.text_secondary),
+                );
                 let mut column = NodeBuilder::new(
                     cx.next_node_id(),
                     Op::Layout(LayoutOp::Flex {
@@ -1635,7 +1708,18 @@ impl Lower for TextInput {
                 if let Some(label) = &resolved_label {
                     column.add_child(
                         Text::new(label.clone())
-                            .size(tokens.typography.label_large_size)
+                            .size(
+                                theme
+                                    .label_style
+                                    .font_size
+                                    .unwrap_or(tokens.typography.label_large_size),
+                            )
+                            .weight(
+                                theme
+                                    .label_style
+                                    .font_weight
+                                    .unwrap_or(tokens.typography.font_weight_medium),
+                            )
                             .color(label_color)
                             .lower(cx),
                     );
@@ -1648,7 +1732,12 @@ impl Lower for TextInput {
                     if let Some(supporting_text) = supporting_text {
                         row.children.push(
                             Text::new(supporting_text)
-                                .size(tokens.typography.label_large_size)
+                                .size(
+                                    theme
+                                        .helper_style
+                                        .font_size
+                                        .unwrap_or(tokens.typography.label_large_size),
+                                )
                                 .color(supporting_color)
                                 .into_node(),
                         );
@@ -1663,7 +1752,12 @@ impl Lower for TextInput {
                     if let Some(counter_text) = counter_text {
                         row.children.push(
                             Text::new(counter_text)
-                                .size(tokens.typography.label_large_size)
+                                .size(
+                                    theme
+                                        .helper_style
+                                        .font_size
+                                        .unwrap_or(tokens.typography.label_large_size),
+                                )
                                 .color(counter_color)
                                 .into_node(),
                         );

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -230,6 +230,10 @@ fn button_background_fill_and_text_override_lower() {
     let text_color = paint_ops(&ir)
         .find_map(|op| match op {
             PaintOp::DrawText { text, color, .. } if text == "Continue" => Some(*color),
+            PaintOp::DrawRichText { runs, .. } => runs
+                .iter()
+                .find(|run| run.text == "Continue")
+                .map(|run| run.style.color),
             _ => None,
         })
         .expect("button label");
@@ -504,7 +508,7 @@ fn text_input_lowers_cursor_and_semantics_overrides() {
         })
         .expect("value run");
     assert_eq!(value_run.style.locale.as_deref(), Some("fr-GB"));
-    assert_eq!(value_run.style.font_size, 21.25);
+    assert_eq!(value_run.style.font_size, 20.0);
 }
 
 #[test]

--- a/crates/core/fission-theme/design/default/dsp.json
+++ b/crates/core/fission-theme/design/default/dsp.json
@@ -90,35 +90,35 @@
         "primary": {
           "default":  { "background": "{color.light.primary}",       "color": "{color.light.on_primary}", "border": "none", "box_shadow": "0 1px 2px 0 rgba(10,13,18,0.05), inset 0 0 0 1px rgba(0,0,0,0.18)" },
           "hover":    { "background": "{color.light.primary_hover}" },
-          "active":   { "background": "{color.teal.900}" },
+          "active":   { "background": "{color.light.primary_hover}" },
           "focus":    { "box_shadow": "{elevation.focus}" },
-          "disabled": { "background": "{color.slate.100}", "color": "{color.slate.400}", "box_shadow": "none", "cursor": "not-allowed" }
+          "disabled": { "background": "{color.light.surface_sunken}", "color": "{color.light.text_muted}", "box_shadow": "none", "cursor": "not-allowed" }
         },
         "secondary_color": {
-          "default":  { "background": "{color.light.surface}", "color": "{color.teal.700}",  "border": "1px solid {color.teal.200}",  "box_shadow": "0 1px 2px 0 rgba(10,13,18,0.05)" },
-          "hover":    { "background": "{color.teal.50}", "color": "{color.teal.800}" },
-          "active":   { "background": "{color.teal.100}" }
+          "default":  { "background": "{color.light.surface}", "color": "{color.light.primary}",  "border": "1px solid {color.light.primary_subtle}",  "box_shadow": "0 1px 2px 0 rgba(10,13,18,0.05)" },
+          "hover":    { "background": "{color.light.primary_subtle}", "color": "{color.light.primary_hover}" },
+          "active":   { "background": "{color.light.primary_subtle}" }
         },
         "secondary_gray": {
-          "default":  { "background": "{color.light.surface}", "color": "{color.slate.700}", "border": "1px solid {color.slate.300}", "box_shadow": "0 1px 2px 0 rgba(10,13,18,0.05)" },
-          "hover":    { "background": "{color.slate.50}", "color": "{color.slate.800}" },
-          "active":   { "background": "{color.slate.100}" }
+          "default":  { "background": "{color.light.surface}", "color": "{color.light.text_primary}", "border": "1px solid {color.light.border}", "box_shadow": "0 1px 2px 0 rgba(10,13,18,0.05)" },
+          "hover":    { "background": "{color.light.surface_sunken}", "color": "{color.light.text_primary}" },
+          "active":   { "background": "{color.light.surface_sunken}" }
         },
         "tertiary_color": {
-          "default":  { "background": "transparent", "color": "{color.teal.700}",  "border": "none" },
-          "hover":    { "background": "{color.teal.50}" }
+          "default":  { "background": "transparent", "color": "{color.light.primary}",  "border": "none" },
+          "hover":    { "background": "{color.light.primary_subtle}", "color": "{color.light.primary_hover}" }
         },
         "tertiary_gray": {
-          "default":  { "background": "transparent", "color": "{color.slate.600}", "border": "none" },
-          "hover":    { "background": "{color.slate.100}", "color": "{color.slate.800}" }
+          "default":  { "background": "transparent", "color": "{color.light.text_secondary}", "border": "none" },
+          "hover":    { "background": "{color.light.surface_sunken}", "color": "{color.light.text_primary}" }
         },
         "link_color": {
-          "default":  { "background": "transparent", "color": "{color.teal.700}",  "border": "none", "padding_x": "0", "height": "auto" },
-          "hover":    { "color": "{color.teal.800}", "text_decoration": "underline" }
+          "default":  { "background": "transparent", "color": "{color.light.primary}",  "border": "none", "padding_x": "0", "height": "auto" },
+          "hover":    { "color": "{color.light.primary_hover}", "text_decoration": "underline" }
         },
         "link_gray": {
-          "default":  { "background": "transparent", "color": "{color.slate.600}", "border": "none", "padding_x": "0", "height": "auto" },
-          "hover":    { "color": "{color.slate.800}", "text_decoration": "underline" }
+          "default":  { "background": "transparent", "color": "{color.light.text_secondary}", "border": "none", "padding_x": "0", "height": "auto" },
+          "hover":    { "color": "{color.light.text_primary}", "text_decoration": "underline" }
         },
         "destructive": {
           "$source": "Figma /Buttons/Buttons-Button-destructive",
@@ -143,14 +143,14 @@
         "md": { "height": "40px", "padding_x": "12px" }
       },
       "states": {
-        "default":     { "background": "{color.light.surface}", "border": "1px solid {color.slate.300}", "color": "{color.slate.900}",       "box_shadow": "0 1px 2px 0 rgba(10,13,18,0.05)" },
-        "placeholder": { "color": "{color.slate.500}" },
-        "focus":       { "border": "2px solid {color.teal.700}", "box_shadow": "{elevation.focus}", "padding_x": "11px",   "$comment": "padding shrinks by 1px to compensate for the doubled border so the field doesn't jump" },
-        "error":       { "border": "1px solid {color.semantic.error}", "$helper_color": "{color.semantic.error}" },
-        "disabled":    { "background": "{color.slate.50}",  "color": "{color.slate.500}", "cursor": "not-allowed" }
+        "default":     { "background": "{color.light.surface}", "border": "1px solid {color.light.border}", "color": "{color.light.text_primary}",       "box_shadow": "0 1px 2px 0 rgba(10,13,18,0.05)" },
+        "placeholder": { "color": "{color.light.text_muted}" },
+        "focus":       { "border": "2px solid {color.light.primary}", "box_shadow": "{elevation.focus}", "padding_x": "11px",   "$comment": "padding shrinks by 1px to compensate for the doubled border so the field doesn't jump" },
+        "error":       { "border": "1px solid {color.light.error}", "$helper_color": "{color.light.error}" },
+        "disabled":    { "background": "{color.light.surface_sunken}",  "color": "{color.light.text_secondary}", "cursor": "not-allowed" }
       },
-      "label": { "font_size": "14px", "font_weight": 500, "color": "{color.slate.700}", "margin_bottom": "6px" },
-      "helper_text": { "font_size": "14px", "color": "{color.slate.500}", "margin_top": "6px" },
+      "label": { "font_size": "14px", "font_weight": 500, "color": "{color.light.text_primary}", "margin_bottom": "6px" },
+      "helper_text": { "font_size": "14px", "color": "{color.light.text_muted}", "margin_top": "6px" },
       "css_classes": ["fs-input"]
     },
 
@@ -345,6 +345,20 @@
       "cdn": "https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0",
       "rust_source": "https://github.com/worka-ai/material-design-icons"
     }
+  },
+
+  "data_visualization": {
+    "$description": "Default qualitative chart palette used by Fission charts when an app does not provide a chart-specific palette.",
+    "palette": [
+      "{color.teal.700}",
+      "{color.brand.blue.600}",
+      "{color.semantic.warning}",
+      "{color.semantic.error}",
+      "{color.semantic.success}",
+      "{color.semantic.info}",
+      "{color.brand.orange.600}",
+      "{color.teal.500}"
+    ]
   },
 
   "preview": {

--- a/crates/core/fission-theme/src/lib.rs
+++ b/crates/core/fission-theme/src/lib.rs
@@ -96,6 +96,26 @@ pub struct ShadowLayer {
     pub inset: bool,
 }
 
+impl ShadowLayer {
+    pub fn to_box_shadow(&self) -> BoxShadow {
+        BoxShadow {
+            color: self.color,
+            offset: self.offset,
+            blur_radius: self.blur_radius,
+        }
+    }
+}
+
+fn shadow_layer_from_box(shadow: BoxShadow) -> ShadowLayer {
+    ShadowLayer {
+        color: shadow.color,
+        offset: shadow.offset,
+        blur_radius: shadow.blur_radius,
+        spread_radius: 0.0,
+        inset: false,
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum EasingCurve {
     Linear,
@@ -130,6 +150,194 @@ pub struct DesignAsset {
     pub id: String,
     pub path: String,
     pub format: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComponentSize {
+    Sm,
+    #[default]
+    Md,
+    Lg,
+    Xl,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComponentState {
+    #[default]
+    Default,
+    Hover,
+    Active,
+    Focus,
+    Disabled,
+    Error,
+    Selected,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ButtonHierarchy {
+    #[default]
+    Primary,
+    SecondaryColor,
+    SecondaryGray,
+    TertiaryColor,
+    TertiaryGray,
+    LinkColor,
+    LinkGray,
+    Destructive,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BadgeTone {
+    #[default]
+    Brand,
+    Gray,
+    Success,
+    Warning,
+    Error,
+    Blue,
+    Orange,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CardPattern {
+    Plain,
+    #[default]
+    Raised,
+    Tinted,
+    Elevated,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FeatureIconTone {
+    #[default]
+    Brand,
+    Gray,
+    Blue,
+    Orange,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ComponentBorder {
+    pub fill: Fill,
+    pub width: f32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ComponentMotion {
+    pub duration_ms: u64,
+    pub easing: EasingCurve,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedComponentStyle {
+    pub background: Option<Fill>,
+    pub text_color: Option<Color>,
+    pub border: Option<ComponentBorder>,
+    pub radius: Option<f32>,
+    pub height: Option<f32>,
+    pub width: Option<f32>,
+    pub padding_x: Option<f32>,
+    pub padding_y: Option<f32>,
+    pub padding: Option<[f32; 4]>,
+    pub gap: Option<f32>,
+    pub font_size: Option<f32>,
+    pub font_weight: Option<u16>,
+    pub line_height: Option<f32>,
+    pub letter_spacing: Option<f32>,
+    pub icon_size: Option<f32>,
+    pub max_width: Option<f32>,
+    pub shadows: Vec<ShadowLayer>,
+    pub transition: Option<ComponentMotion>,
+}
+
+impl ResolvedComponentStyle {
+    pub fn merge(&self, overlay: &Self) -> Self {
+        Self {
+            background: overlay
+                .background
+                .clone()
+                .or_else(|| self.background.clone()),
+            text_color: overlay.text_color.or(self.text_color),
+            border: overlay.border.clone().or_else(|| self.border.clone()),
+            radius: overlay.radius.or(self.radius),
+            height: overlay.height.or(self.height),
+            width: overlay.width.or(self.width),
+            padding_x: overlay.padding_x.or(self.padding_x),
+            padding_y: overlay.padding_y.or(self.padding_y),
+            padding: overlay.padding.or(self.padding),
+            gap: overlay.gap.or(self.gap),
+            font_size: overlay.font_size.or(self.font_size),
+            font_weight: overlay.font_weight.or(self.font_weight),
+            line_height: overlay.line_height.or(self.line_height),
+            letter_spacing: overlay.letter_spacing.or(self.letter_spacing),
+            icon_size: overlay.icon_size.or(self.icon_size),
+            max_width: overlay.max_width.or(self.max_width),
+            shadows: if overlay.shadows.is_empty() {
+                self.shadows.clone()
+            } else {
+                overlay.shadows.clone()
+            },
+            transition: overlay
+                .transition
+                .clone()
+                .or_else(|| self.transition.clone()),
+        }
+    }
+
+    pub fn padding_box(&self, fallback_x: f32, fallback_y: f32) -> [f32; 4] {
+        self.padding.unwrap_or([
+            self.padding_x.unwrap_or(fallback_x),
+            self.padding_x.unwrap_or(fallback_x),
+            self.padding_y.unwrap_or(fallback_y),
+            self.padding_y.unwrap_or(fallback_y),
+        ])
+    }
+
+    pub fn outer_shadows(&self) -> Vec<BoxShadow> {
+        self.shadows
+            .iter()
+            .filter(|layer| !layer.inset)
+            .map(ShadowLayer::to_box_shadow)
+            .collect()
+    }
+
+    pub fn inset_border(&self) -> Option<ComponentBorder> {
+        self.shadows
+            .iter()
+            .find(|layer| layer.inset && layer.spread_radius > 0.0)
+            .map(|layer| ComponentBorder {
+                fill: Fill::Solid(layer.color),
+                width: layer.spread_radius,
+            })
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ComponentStateStyles {
+    pub default: ResolvedComponentStyle,
+    pub hover: Option<ResolvedComponentStyle>,
+    pub active: Option<ResolvedComponentStyle>,
+    pub focus: Option<ResolvedComponentStyle>,
+    pub disabled: Option<ResolvedComponentStyle>,
+    pub error: Option<ResolvedComponentStyle>,
+    pub selected: Option<ResolvedComponentStyle>,
+}
+
+impl ComponentStateStyles {
+    pub fn resolve(&self, state: ComponentState) -> ResolvedComponentStyle {
+        let overlay = match state {
+            ComponentState::Default => None,
+            ComponentState::Hover => self.hover.as_ref(),
+            ComponentState::Active => self.active.as_ref(),
+            ComponentState::Focus => self.focus.as_ref(),
+            ComponentState::Disabled => self.disabled.as_ref(),
+            ComponentState::Error => self.error.as_ref(),
+            ComponentState::Selected => self.selected.as_ref(),
+        };
+        overlay
+            .map(|style| self.default.merge(style))
+            .unwrap_or_else(|| self.default.clone())
+    }
 }
 
 /// Semantic color palette for the application.
@@ -703,6 +911,68 @@ impl Default for MotionTokens {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DataVisualizationTokens {
+    pub palette: Vec<Color>,
+}
+
+impl Default for DataVisualizationTokens {
+    fn default() -> Self {
+        Self {
+            palette: vec![
+                Color {
+                    r: 20,
+                    g: 184,
+                    b: 166,
+                    a: 255,
+                },
+                Color {
+                    r: 77,
+                    g: 166,
+                    b: 224,
+                    a: 255,
+                },
+                Color {
+                    r: 245,
+                    g: 158,
+                    b: 11,
+                    a: 255,
+                },
+                Color {
+                    r: 244,
+                    g: 63,
+                    b: 94,
+                    a: 255,
+                },
+                Color {
+                    r: 132,
+                    g: 204,
+                    b: 22,
+                    a: 255,
+                },
+                Color {
+                    r: 14,
+                    g: 165,
+                    b: 233,
+                    a: 255,
+                },
+                Color {
+                    r: 168,
+                    g: 85,
+                    b: 247,
+                    a: 255,
+                },
+                Color {
+                    r: 249,
+                    g: 115,
+                    b: 22,
+                    a: 255,
+                },
+            ],
+        }
+    }
+}
+
 /// The complete set of primitive design tokens.
 ///
 /// Combines [`ColorTokens`], [`SpacingTokens`], [`TypographyTokens`],
@@ -716,6 +986,7 @@ pub struct Tokens {
     pub radii: RadiusTokens,
     pub elevations: ElevationTokens,
     pub motion: MotionTokens,
+    pub data_visualization: DataVisualizationTokens,
 }
 
 impl Tokens {
@@ -727,6 +998,7 @@ impl Tokens {
             radii: RadiusTokens::default(),
             elevations: ElevationTokens::default(),
             motion: MotionTokens::default(),
+            data_visualization: DataVisualizationTokens::default(),
         }
     }
 }
@@ -748,10 +1020,124 @@ pub struct ButtonTheme {
     pub elevation_hover: Option<BoxShadow>,
     pub elevation_pressed: Option<BoxShadow>,
     pub focus_stroke: Option<Stroke>,
+    pub icon_size: f32,
+    pub font_weight: u16,
+    pub line_height: f32,
+    pub transition: Option<ComponentMotion>,
+    pub sizes: Vec<(ComponentSize, ResolvedComponentStyle)>,
+    pub hierarchies: Vec<(ButtonHierarchy, ComponentStateStyles)>,
 }
 
 impl ButtonTheme {
     pub fn from_tokens(tokens: &Tokens) -> Self {
+        let transition = Some(ComponentMotion {
+            duration_ms: tokens.motion.duration_fast_ms,
+            easing: tokens.motion.easing_standard.clone(),
+        });
+        let size_md = ResolvedComponentStyle {
+            height: Some(40.0),
+            padding_x: Some(14.0),
+            padding_y: Some(tokens.spacing.s),
+            gap: Some(4.0),
+            font_size: Some(tokens.typography.label_large_size),
+            font_weight: Some(tokens.typography.font_weight_semibold),
+            line_height: Some(20.0),
+            icon_size: Some(20.0),
+            ..ResolvedComponentStyle::default()
+        };
+        let primary = ComponentStateStyles {
+            default: ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.primary)),
+                text_color: Some(tokens.colors.on_primary),
+                border: None,
+                shadows: tokens
+                    .elevations
+                    .level1
+                    .map(shadow_layer_from_box)
+                    .into_iter()
+                    .collect(),
+                transition: transition.clone(),
+                ..ResolvedComponentStyle::default()
+            },
+            hover: Some(ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.primary_hover)),
+                shadows: tokens
+                    .elevations
+                    .level2
+                    .map(shadow_layer_from_box)
+                    .into_iter()
+                    .collect(),
+                ..ResolvedComponentStyle::default()
+            }),
+            active: Some(ResolvedComponentStyle {
+                shadows: tokens
+                    .elevations
+                    .level0
+                    .map(shadow_layer_from_box)
+                    .into_iter()
+                    .collect(),
+                ..ResolvedComponentStyle::default()
+            }),
+            focus: Some(ResolvedComponentStyle {
+                shadows: tokens
+                    .elevations
+                    .focus
+                    .map(shadow_layer_from_box)
+                    .into_iter()
+                    .collect(),
+                ..ResolvedComponentStyle::default()
+            }),
+            disabled: Some(ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.border)),
+                text_color: Some(tokens.colors.text_secondary),
+                shadows: Vec::new(),
+                ..ResolvedComponentStyle::default()
+            }),
+            ..ComponentStateStyles::default()
+        };
+        let secondary_gray = ComponentStateStyles {
+            default: ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.surface)),
+                text_color: Some(tokens.colors.text_primary),
+                border: Some(ComponentBorder {
+                    fill: Fill::Solid(tokens.colors.border),
+                    width: 1.0,
+                }),
+                transition: transition.clone(),
+                ..ResolvedComponentStyle::default()
+            },
+            hover: Some(ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.surface_sunken)),
+                ..ResolvedComponentStyle::default()
+            }),
+            disabled: Some(ResolvedComponentStyle {
+                text_color: Some(tokens.colors.text_secondary),
+                border: Some(ComponentBorder {
+                    fill: Fill::Solid(tokens.colors.border),
+                    width: 1.0,
+                }),
+                ..ResolvedComponentStyle::default()
+            }),
+            ..ComponentStateStyles::default()
+        };
+        let tertiary_gray = ComponentStateStyles {
+            default: ResolvedComponentStyle {
+                background: None,
+                text_color: Some(tokens.colors.primary),
+                border: None,
+                transition,
+                ..ResolvedComponentStyle::default()
+            },
+            hover: Some(ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.surface_sunken)),
+                ..ResolvedComponentStyle::default()
+            }),
+            disabled: Some(ResolvedComponentStyle {
+                text_color: Some(tokens.colors.text_secondary),
+                ..ResolvedComponentStyle::default()
+            }),
+            ..ComponentStateStyles::default()
+        };
         Self {
             height: 42.0,
             padding_horizontal: tokens.spacing.m,
@@ -768,7 +1154,140 @@ impl ButtonTheme {
                 line_cap: fission_ir::op::LineCap::Butt,
                 line_join: fission_ir::op::LineJoin::Miter,
             }),
+            icon_size: 20.0,
+            font_weight: tokens.typography.font_weight_semibold,
+            line_height: 20.0,
+            transition: Some(ComponentMotion {
+                duration_ms: tokens.motion.duration_fast_ms,
+                easing: tokens.motion.easing_standard.clone(),
+            }),
+            sizes: vec![
+                (
+                    ComponentSize::Sm,
+                    ResolvedComponentStyle {
+                        height: Some(36.0),
+                        padding_x: Some(12.0),
+                        padding_y: Some(tokens.spacing.xs),
+                        gap: Some(4.0),
+                        font_size: Some(tokens.typography.font_size_sm),
+                        line_height: Some(20.0),
+                        icon_size: Some(18.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (ComponentSize::Md, size_md),
+                (
+                    ComponentSize::Lg,
+                    ResolvedComponentStyle {
+                        height: Some(44.0),
+                        padding_x: Some(16.0),
+                        padding_y: Some(tokens.spacing.s),
+                        gap: Some(6.0),
+                        font_size: Some(tokens.typography.font_size_base),
+                        line_height: Some(24.0),
+                        icon_size: Some(20.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    ComponentSize::Xl,
+                    ResolvedComponentStyle {
+                        height: Some(48.0),
+                        padding_x: Some(18.0),
+                        padding_y: Some(tokens.spacing.s),
+                        gap: Some(6.0),
+                        font_size: Some(tokens.typography.font_size_base),
+                        line_height: Some(24.0),
+                        icon_size: Some(20.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+            ],
+            hierarchies: vec![
+                (ButtonHierarchy::Primary, primary.clone()),
+                (ButtonHierarchy::SecondaryColor, secondary_gray.clone()),
+                (ButtonHierarchy::SecondaryGray, secondary_gray),
+                (ButtonHierarchy::TertiaryColor, tertiary_gray.clone()),
+                (ButtonHierarchy::TertiaryGray, tertiary_gray.clone()),
+                (ButtonHierarchy::LinkColor, tertiary_gray.clone()),
+                (ButtonHierarchy::LinkGray, tertiary_gray.clone()),
+                (
+                    ButtonHierarchy::Destructive,
+                    ComponentStateStyles {
+                        default: ResolvedComponentStyle {
+                            background: Some(Fill::Solid(tokens.colors.error)),
+                            text_color: Some(tokens.colors.on_error),
+                            ..primary.default.clone()
+                        },
+                        hover: Some(ResolvedComponentStyle {
+                            background: Some(Fill::Solid(tokens.colors.error.with_alpha(230))),
+                            ..ResolvedComponentStyle::default()
+                        }),
+                        ..primary
+                    },
+                ),
+            ],
         }
+    }
+
+    pub fn size_style(&self, size: ComponentSize) -> ResolvedComponentStyle {
+        self.sizes
+            .iter()
+            .find(|(candidate, _)| *candidate == size)
+            .map(|(_, style)| style.clone())
+            .or_else(|| {
+                self.sizes
+                    .iter()
+                    .find(|(candidate, _)| *candidate == ComponentSize::Md)
+                    .map(|(_, style)| style.clone())
+            })
+            .unwrap_or_else(|| ResolvedComponentStyle {
+                height: Some(self.height),
+                padding_x: Some(self.padding_horizontal),
+                padding_y: Some(self.padding_vertical),
+                radius: Some(self.radius),
+                font_size: Some(self.text_size),
+                font_weight: Some(self.font_weight),
+                line_height: Some(self.line_height),
+                icon_size: Some(self.icon_size),
+                ..ResolvedComponentStyle::default()
+            })
+    }
+
+    pub fn hierarchy_style(&self, hierarchy: ButtonHierarchy) -> ComponentStateStyles {
+        self.hierarchies
+            .iter()
+            .find(|(candidate, _)| *candidate == hierarchy)
+            .map(|(_, styles)| styles.clone())
+            .or_else(|| {
+                self.hierarchies
+                    .iter()
+                    .find(|(candidate, _)| *candidate == ButtonHierarchy::Primary)
+                    .map(|(_, styles)| styles.clone())
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn resolve(
+        &self,
+        hierarchy: ButtonHierarchy,
+        size: ComponentSize,
+        state: ComponentState,
+    ) -> ResolvedComponentStyle {
+        let base = ResolvedComponentStyle {
+            height: Some(self.height),
+            padding_x: Some(self.padding_horizontal),
+            padding_y: Some(self.padding_vertical),
+            radius: Some(self.radius),
+            font_size: Some(self.text_size),
+            font_weight: Some(self.font_weight),
+            line_height: Some(self.line_height),
+            icon_size: Some(self.icon_size),
+            transition: self.transition.clone(),
+            ..ResolvedComponentStyle::default()
+        };
+        base.merge(&self.size_style(size))
+            .merge(&self.hierarchy_style(hierarchy).resolve(state))
     }
 }
 
@@ -787,6 +1306,13 @@ pub struct TextInputTheme {
     pub focus_color: Color,
     pub text_color: Color,
     pub placeholder_color: Color,
+    pub line_height: f32,
+    pub font_weight: u16,
+    pub sizes: Vec<(ComponentSize, ResolvedComponentStyle)>,
+    pub states: ComponentStateStyles,
+    pub placeholder_style: ResolvedComponentStyle,
+    pub label_style: ResolvedComponentStyle,
+    pub helper_style: ResolvedComponentStyle,
 }
 
 impl TextInputTheme {
@@ -801,7 +1327,123 @@ impl TextInputTheme {
             focus_color: tokens.colors.primary,
             text_color: tokens.colors.text_primary,
             placeholder_color: tokens.colors.text_secondary,
+            line_height: 24.0,
+            font_weight: tokens.typography.font_weight_regular,
+            sizes: vec![
+                (
+                    ComponentSize::Sm,
+                    ResolvedComponentStyle {
+                        height: Some(36.0),
+                        padding_x: Some(12.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    ComponentSize::Md,
+                    ResolvedComponentStyle {
+                        height: Some(40.0),
+                        padding_x: Some(12.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+            ],
+            states: ComponentStateStyles {
+                default: ResolvedComponentStyle {
+                    background: Some(Fill::Solid(tokens.colors.surface)),
+                    text_color: Some(tokens.colors.text_primary),
+                    border: Some(ComponentBorder {
+                        fill: Fill::Solid(tokens.colors.border),
+                        width: 1.0,
+                    }),
+                    shadows: tokens
+                        .elevations
+                        .level1
+                        .map(shadow_layer_from_box)
+                        .into_iter()
+                        .collect(),
+                    ..ResolvedComponentStyle::default()
+                },
+                focus: Some(ResolvedComponentStyle {
+                    border: Some(ComponentBorder {
+                        fill: Fill::Solid(tokens.colors.focus_ring),
+                        width: 2.0,
+                    }),
+                    shadows: tokens
+                        .elevations
+                        .focus
+                        .map(shadow_layer_from_box)
+                        .into_iter()
+                        .collect(),
+                    padding_x: Some(11.0),
+                    ..ResolvedComponentStyle::default()
+                }),
+                error: Some(ResolvedComponentStyle {
+                    border: Some(ComponentBorder {
+                        fill: Fill::Solid(tokens.colors.error),
+                        width: 1.0,
+                    }),
+                    ..ResolvedComponentStyle::default()
+                }),
+                disabled: Some(ResolvedComponentStyle {
+                    background: Some(Fill::Solid(tokens.colors.surface_sunken)),
+                    text_color: Some(tokens.colors.text_secondary),
+                    ..ResolvedComponentStyle::default()
+                }),
+                ..ComponentStateStyles::default()
+            },
+            placeholder_style: ResolvedComponentStyle {
+                text_color: Some(tokens.colors.text_muted),
+                ..ResolvedComponentStyle::default()
+            },
+            label_style: ResolvedComponentStyle {
+                font_size: Some(tokens.typography.font_size_base),
+                font_weight: Some(tokens.typography.font_weight_medium),
+                text_color: Some(tokens.colors.text_primary),
+                ..ResolvedComponentStyle::default()
+            },
+            helper_style: ResolvedComponentStyle {
+                font_size: Some(tokens.typography.font_size_base),
+                text_color: Some(tokens.colors.text_muted),
+                ..ResolvedComponentStyle::default()
+            },
         }
+    }
+
+    pub fn size_style(&self, size: ComponentSize) -> ResolvedComponentStyle {
+        self.sizes
+            .iter()
+            .find(|(candidate, _)| *candidate == size)
+            .map(|(_, style)| style.clone())
+            .or_else(|| {
+                self.sizes
+                    .iter()
+                    .find(|(candidate, _)| *candidate == ComponentSize::Md)
+                    .map(|(_, style)| style.clone())
+            })
+            .unwrap_or_else(|| ResolvedComponentStyle {
+                height: Some(self.height),
+                padding_x: Some(self.padding_h),
+                ..ResolvedComponentStyle::default()
+            })
+    }
+
+    pub fn resolve(&self, size: ComponentSize, state: ComponentState) -> ResolvedComponentStyle {
+        let base = ResolvedComponentStyle {
+            height: Some(self.height),
+            padding_x: Some(self.padding_h),
+            radius: Some(self.radius),
+            font_size: Some(self.font_size),
+            line_height: Some(self.line_height),
+            font_weight: Some(self.font_weight),
+            text_color: Some(self.text_color),
+            border: Some(ComponentBorder {
+                fill: Fill::Solid(self.border_color),
+                width: self.border_width,
+            }),
+            ..ResolvedComponentStyle::default()
+        };
+        base.merge(&self.size_style(size))
+            .merge(&self.states.resolve(state))
     }
 }
 
@@ -931,6 +1573,9 @@ impl AlertTheme {
 pub struct BadgeTheme {
     pub radius: f32,
     pub font_size: f32,
+    pub font_weight: u16,
+    pub sizes: Vec<(ComponentSize, ResolvedComponentStyle)>,
+    pub tones: Vec<(BadgeTone, ResolvedComponentStyle)>,
 }
 
 impl BadgeTheme {
@@ -938,7 +1583,111 @@ impl BadgeTheme {
         Self {
             radius: tokens.radii.full,
             font_size: 10.0,
+            font_weight: tokens.typography.font_weight_medium,
+            sizes: vec![
+                (
+                    ComponentSize::Sm,
+                    ResolvedComponentStyle {
+                        height: Some(20.0),
+                        padding_x: Some(8.0),
+                        font_size: Some(tokens.typography.font_size_xs),
+                        line_height: Some(18.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    ComponentSize::Md,
+                    ResolvedComponentStyle {
+                        height: Some(24.0),
+                        padding_x: Some(10.0),
+                        font_size: Some(tokens.typography.font_size_base),
+                        line_height: Some(20.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+            ],
+            tones: vec![
+                (
+                    BadgeTone::Brand,
+                    badge_tone(
+                        tokens.colors.primary_subtle,
+                        tokens.colors.primary,
+                        tokens.colors.primary,
+                    ),
+                ),
+                (
+                    BadgeTone::Gray,
+                    badge_tone(
+                        tokens.colors.surface_sunken,
+                        tokens.colors.border,
+                        tokens.colors.text_primary,
+                    ),
+                ),
+                (
+                    BadgeTone::Success,
+                    badge_tone(
+                        tokens.colors.success.with_alpha(26),
+                        tokens.colors.success.with_alpha(80),
+                        tokens.colors.success,
+                    ),
+                ),
+                (
+                    BadgeTone::Warning,
+                    badge_tone(
+                        tokens.colors.warning.with_alpha(26),
+                        tokens.colors.warning.with_alpha(80),
+                        tokens.colors.warning,
+                    ),
+                ),
+                (
+                    BadgeTone::Error,
+                    badge_tone(
+                        tokens.colors.error.with_alpha(26),
+                        tokens.colors.error.with_alpha(80),
+                        tokens.colors.error,
+                    ),
+                ),
+                (
+                    BadgeTone::Blue,
+                    badge_tone(
+                        tokens.colors.info.with_alpha(26),
+                        tokens.colors.info.with_alpha(80),
+                        tokens.colors.info,
+                    ),
+                ),
+                (
+                    BadgeTone::Orange,
+                    badge_tone(
+                        tokens.colors.warning.with_alpha(26),
+                        tokens.colors.warning.with_alpha(80),
+                        tokens.colors.warning,
+                    ),
+                ),
+            ],
         }
+    }
+
+    pub fn resolve(&self, tone: BadgeTone, size: ComponentSize) -> ResolvedComponentStyle {
+        let base = ResolvedComponentStyle {
+            radius: Some(self.radius),
+            font_size: Some(self.font_size),
+            font_weight: Some(self.font_weight),
+            ..ResolvedComponentStyle::default()
+        };
+        let size_style = find_size_style(&self.sizes, size);
+        let tone_style = self
+            .tones
+            .iter()
+            .find(|(candidate, _)| *candidate == tone)
+            .map(|(_, style)| style.clone())
+            .or_else(|| {
+                self.tones
+                    .iter()
+                    .find(|(candidate, _)| *candidate == BadgeTone::Brand)
+                    .map(|(_, style)| style.clone())
+            })
+            .unwrap_or_default();
+        base.merge(&size_style).merge(&tone_style)
     }
 }
 
@@ -950,6 +1699,9 @@ pub struct TabsTheme {
     pub indicator_height: f32,
     pub background: Color,
     pub divider_color: Color,
+    pub sizes: Vec<(ComponentSize, ResolvedComponentStyle)>,
+    pub states: ComponentStateStyles,
+    pub track_style: ResolvedComponentStyle,
 }
 
 impl TabsTheme {
@@ -960,7 +1712,74 @@ impl TabsTheme {
             indicator_height: 3.0,
             background: tokens.colors.background,
             divider_color: tokens.colors.border.with_alpha(120),
+            sizes: vec![
+                (
+                    ComponentSize::Sm,
+                    ResolvedComponentStyle {
+                        padding_y: Some(10.0),
+                        font_size: Some(tokens.typography.font_size_base),
+                        line_height: Some(20.0),
+                        height: Some(40.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    ComponentSize::Md,
+                    ResolvedComponentStyle {
+                        padding_y: Some(12.0),
+                        font_size: Some(tokens.typography.font_size_base),
+                        line_height: Some(20.0),
+                        height: Some(44.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+            ],
+            states: ComponentStateStyles {
+                default: ResolvedComponentStyle {
+                    text_color: Some(tokens.colors.text_secondary),
+                    border: Some(ComponentBorder {
+                        fill: Fill::Solid(Color {
+                            r: 0,
+                            g: 0,
+                            b: 0,
+                            a: 0,
+                        }),
+                        width: 2.0,
+                    }),
+                    ..ResolvedComponentStyle::default()
+                },
+                hover: Some(ResolvedComponentStyle {
+                    text_color: Some(tokens.colors.text_primary),
+                    ..ResolvedComponentStyle::default()
+                }),
+                active: Some(ResolvedComponentStyle {
+                    text_color: Some(tokens.colors.primary),
+                    border: Some(ComponentBorder {
+                        fill: Fill::Solid(tokens.colors.primary),
+                        width: 2.0,
+                    }),
+                    font_weight: Some(tokens.typography.font_weight_semibold),
+                    ..ResolvedComponentStyle::default()
+                }),
+                ..ComponentStateStyles::default()
+            },
+            track_style: ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.background)),
+                border: Some(ComponentBorder {
+                    fill: Fill::Solid(tokens.colors.border.with_alpha(120)),
+                    width: 1.0,
+                }),
+                ..ResolvedComponentStyle::default()
+            },
         }
+    }
+
+    pub fn resolve_tab(
+        &self,
+        size: ComponentSize,
+        state: ComponentState,
+    ) -> ResolvedComponentStyle {
+        find_size_style(&self.sizes, size).merge(&self.states.resolve(state))
     }
 }
 
@@ -973,6 +1792,9 @@ pub struct ModalTheme {
     pub radius: f32,
     pub shadow: Option<BoxShadow>,
     pub max_width: f32,
+    pub container_style: ResolvedComponentStyle,
+    pub scrim_style: ResolvedComponentStyle,
+    pub scrim_blur: f32,
 }
 
 impl ModalTheme {
@@ -982,6 +1804,28 @@ impl ModalTheme {
             radius: tokens.radii.large,
             shadow: tokens.elevations.level3,
             max_width: 600.0,
+            container_style: ResolvedComponentStyle {
+                background: Some(Fill::Solid(tokens.colors.surface)),
+                radius: Some(tokens.radii.large),
+                max_width: Some(600.0),
+                shadows: tokens
+                    .elevations
+                    .level3
+                    .map(shadow_layer_from_box)
+                    .into_iter()
+                    .collect(),
+                ..ResolvedComponentStyle::default()
+            },
+            scrim_style: ResolvedComponentStyle {
+                background: Some(Fill::Solid(Color {
+                    r: 15,
+                    g: 23,
+                    b: 42,
+                    a: 153,
+                })),
+                ..ResolvedComponentStyle::default()
+            },
+            scrim_blur: 4.0,
         }
     }
 }
@@ -1010,6 +1854,9 @@ pub struct ProgressTheme {
     pub height: f32,
     pub track_color: Color,
     pub bar_color: Color,
+    pub radius: f32,
+    pub track_style: ResolvedComponentStyle,
+    pub fill_style: ResolvedComponentStyle,
 }
 
 impl ProgressTheme {
@@ -1018,6 +1865,19 @@ impl ProgressTheme {
             height: 8.0,
             track_color: tokens.colors.border,
             bar_color: tokens.colors.primary,
+            radius: tokens.radii.full,
+            track_style: ResolvedComponentStyle {
+                height: Some(8.0),
+                radius: Some(tokens.radii.full),
+                background: Some(Fill::Solid(tokens.colors.border)),
+                ..ResolvedComponentStyle::default()
+            },
+            fill_style: ResolvedComponentStyle {
+                height: Some(8.0),
+                radius: Some(tokens.radii.full),
+                background: Some(Fill::Solid(tokens.colors.primary)),
+                ..ResolvedComponentStyle::default()
+            },
         }
     }
 }
@@ -1029,6 +1889,10 @@ pub struct TooltipTheme {
     pub text_color: Color,
     pub radius: f32,
     pub font_size: f32,
+    pub padding_x: f32,
+    pub padding_y: f32,
+    pub max_width: f32,
+    pub style: ResolvedComponentStyle,
 }
 
 impl TooltipTheme {
@@ -1043,8 +1907,255 @@ impl TooltipTheme {
             text_color: Color::WHITE,
             radius: tokens.radii.small,
             font_size: 12.0,
+            padding_x: 10.0,
+            padding_y: 8.0,
+            max_width: 240.0,
+            style: ResolvedComponentStyle {
+                background: Some(Fill::Solid(Color {
+                    r: 50,
+                    g: 50,
+                    b: 50,
+                    a: 255,
+                })),
+                text_color: Some(Color::WHITE),
+                radius: Some(tokens.radii.small),
+                font_size: Some(12.0),
+                padding_x: Some(10.0),
+                padding_y: Some(8.0),
+                max_width: Some(240.0),
+                shadows: tokens
+                    .elevations
+                    .level2
+                    .map(shadow_layer_from_box)
+                    .into_iter()
+                    .collect(),
+                ..ResolvedComponentStyle::default()
+            },
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CardTheme {
+    pub padding: f32,
+    pub radius: f32,
+    pub default_pattern: CardPattern,
+    pub patterns: Vec<(CardPattern, ResolvedComponentStyle)>,
+    pub hover_style: ResolvedComponentStyle,
+}
+
+impl CardTheme {
+    pub fn from_tokens(tokens: &Tokens) -> Self {
+        let base_border = ComponentBorder {
+            fill: Fill::Solid(tokens.colors.border),
+            width: 1.0,
+        };
+        Self {
+            padding: tokens.spacing.l,
+            radius: tokens.radii.xl,
+            default_pattern: CardPattern::Raised,
+            patterns: vec![
+                (
+                    CardPattern::Plain,
+                    ResolvedComponentStyle {
+                        background: Some(Fill::Solid(tokens.colors.surface)),
+                        border: Some(base_border.clone()),
+                        radius: Some(tokens.radii.xl),
+                        padding_x: Some(tokens.spacing.l),
+                        padding_y: Some(tokens.spacing.l),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    CardPattern::Raised,
+                    ResolvedComponentStyle {
+                        background: Some(Fill::Solid(tokens.colors.surface)),
+                        border: Some(base_border.clone()),
+                        radius: Some(tokens.radii.xl),
+                        padding_x: Some(tokens.spacing.l),
+                        padding_y: Some(tokens.spacing.l),
+                        shadows: tokens
+                            .elevations
+                            .level2
+                            .map(shadow_layer_from_box)
+                            .into_iter()
+                            .collect(),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    CardPattern::Tinted,
+                    ResolvedComponentStyle {
+                        background: Some(Fill::Solid(tokens.colors.primary_subtle)),
+                        border: Some(ComponentBorder {
+                            fill: Fill::Solid(tokens.colors.primary.with_alpha(80)),
+                            width: 1.0,
+                        }),
+                        radius: Some(tokens.radii.xl),
+                        padding_x: Some(tokens.spacing.l),
+                        padding_y: Some(tokens.spacing.l),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    CardPattern::Elevated,
+                    ResolvedComponentStyle {
+                        background: Some(Fill::Solid(tokens.colors.surface)),
+                        border: Some(base_border),
+                        radius: Some(tokens.radii.xl),
+                        padding_x: Some(tokens.spacing.l),
+                        padding_y: Some(tokens.spacing.l),
+                        shadows: tokens
+                            .elevations
+                            .level1
+                            .map(shadow_layer_from_box)
+                            .into_iter()
+                            .collect(),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+            ],
+            hover_style: ResolvedComponentStyle {
+                shadows: tokens
+                    .elevations
+                    .level2
+                    .map(shadow_layer_from_box)
+                    .into_iter()
+                    .collect(),
+                ..ResolvedComponentStyle::default()
+            },
+        }
+    }
+
+    pub fn resolve(&self, pattern: CardPattern, hovered: bool) -> ResolvedComponentStyle {
+        let base = self
+            .patterns
+            .iter()
+            .find(|(candidate, _)| *candidate == pattern)
+            .map(|(_, style)| style.clone())
+            .or_else(|| {
+                self.patterns
+                    .iter()
+                    .find(|(candidate, _)| *candidate == self.default_pattern)
+                    .map(|(_, style)| style.clone())
+            })
+            .unwrap_or_default();
+        if hovered {
+            base.merge(&self.hover_style)
+        } else {
+            base
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FeatureIconTheme {
+    pub sizes: Vec<(ComponentSize, ResolvedComponentStyle)>,
+    pub tones: Vec<(FeatureIconTone, ResolvedComponentStyle)>,
+    pub shadow: Option<BoxShadow>,
+}
+
+impl FeatureIconTheme {
+    pub fn from_tokens(tokens: &Tokens) -> Self {
+        Self {
+            sizes: vec![
+                (
+                    ComponentSize::Md,
+                    ResolvedComponentStyle {
+                        width: Some(40.0),
+                        height: Some(40.0),
+                        radius: Some(tokens.radii.medium),
+                        icon_size: Some(20.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    ComponentSize::Lg,
+                    ResolvedComponentStyle {
+                        width: Some(48.0),
+                        height: Some(48.0),
+                        radius: Some(10.0),
+                        icon_size: Some(24.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+                (
+                    ComponentSize::Xl,
+                    ResolvedComponentStyle {
+                        width: Some(56.0),
+                        height: Some(56.0),
+                        radius: Some(12.0),
+                        icon_size: Some(28.0),
+                        ..ResolvedComponentStyle::default()
+                    },
+                ),
+            ],
+            tones: vec![
+                (
+                    FeatureIconTone::Brand,
+                    badge_tone(
+                        tokens.colors.primary_subtle,
+                        tokens.colors.primary.with_alpha(40),
+                        tokens.colors.primary,
+                    ),
+                ),
+                (
+                    FeatureIconTone::Gray,
+                    badge_tone(
+                        tokens.colors.surface_sunken,
+                        tokens.colors.border,
+                        tokens.colors.text_primary,
+                    ),
+                ),
+                (
+                    FeatureIconTone::Blue,
+                    badge_tone(
+                        tokens.colors.info.with_alpha(26),
+                        tokens.colors.info.with_alpha(80),
+                        tokens.colors.info,
+                    ),
+                ),
+                (
+                    FeatureIconTone::Orange,
+                    badge_tone(
+                        tokens.colors.warning.with_alpha(26),
+                        tokens.colors.warning.with_alpha(80),
+                        tokens.colors.warning,
+                    ),
+                ),
+            ],
+            shadow: tokens.elevations.level1,
+        }
+    }
+}
+
+fn badge_tone(background: Color, border: Color, text_color: Color) -> ResolvedComponentStyle {
+    ResolvedComponentStyle {
+        background: Some(Fill::Solid(background)),
+        text_color: Some(text_color),
+        border: Some(ComponentBorder {
+            fill: Fill::Solid(border),
+            width: 1.0,
+        }),
+        ..ResolvedComponentStyle::default()
+    }
+}
+
+fn find_size_style(
+    styles: &[(ComponentSize, ResolvedComponentStyle)],
+    size: ComponentSize,
+) -> ResolvedComponentStyle {
+    styles
+        .iter()
+        .find(|(candidate, _)| *candidate == size)
+        .map(|(_, style)| style.clone())
+        .or_else(|| {
+            styles
+                .iter()
+                .find(|(candidate, _)| *candidate == ComponentSize::Md)
+                .map(|(_, style)| style.clone())
+        })
+        .unwrap_or_default()
 }
 
 /// Aggregates all per-component visual themes.
@@ -1066,6 +2177,8 @@ pub struct ComponentTheme {
     pub tree_view: TreeViewTheme,
     pub progress: ProgressTheme,
     pub tooltip: TooltipTheme,
+    pub card: CardTheme,
+    pub feature_icon: FeatureIconTheme,
 }
 
 impl ComponentTheme {
@@ -1084,6 +2197,8 @@ impl ComponentTheme {
             tree_view: TreeViewTheme::from_tokens(tokens),
             progress: ProgressTheme::from_tokens(tokens),
             tooltip: TooltipTheme::from_tokens(tokens),
+            card: CardTheme::from_tokens(tokens),
+            feature_icon: FeatureIconTheme::from_tokens(tokens),
         }
     }
 }

--- a/crates/core/fission-theme/tests/design_system.rs
+++ b/crates/core/fission-theme/tests/design_system.rs
@@ -1,4 +1,7 @@
-use fission_theme::{DesignMode, DesignSystem, FissionDefaultDesignSystem, Theme};
+use fission_theme::{
+    BadgeTone, ButtonHierarchy, CardPattern, ComponentSize, ComponentState, DesignMode,
+    DesignSystem, FissionDefaultDesignSystem, Theme,
+};
 
 #[test]
 fn default_theme_is_generated_from_bundled_dsp() {
@@ -43,4 +46,105 @@ fn generated_design_system_exposes_components_patterns_and_assets() {
         .logos
         .iter()
         .any(|asset| asset.id == "wordmark.dark"));
+}
+
+#[test]
+fn generated_theme_resolves_dsp_component_model() {
+    let theme = Theme::default();
+
+    let primary_button = theme.components.button.resolve(
+        ButtonHierarchy::Primary,
+        ComponentSize::Md,
+        ComponentState::Default,
+    );
+    let hover_button = theme.components.button.resolve(
+        ButtonHierarchy::Primary,
+        ComponentSize::Md,
+        ComponentState::Hover,
+    );
+    let destructive_button = theme.components.button.resolve(
+        ButtonHierarchy::Destructive,
+        ComponentSize::Lg,
+        ComponentState::Default,
+    );
+    assert_ne!(primary_button.background, hover_button.background);
+    assert!(destructive_button.background.is_some());
+    assert_eq!(destructive_button.height, Some(44.0));
+
+    let focused_input = theme
+        .components
+        .text_input
+        .resolve(ComponentSize::Md, ComponentState::Focus);
+    assert_eq!(
+        focused_input.border.as_ref().map(|border| border.width),
+        Some(2.0)
+    );
+
+    let badge = theme
+        .components
+        .badge
+        .resolve(BadgeTone::Success, ComponentSize::Sm);
+    assert_eq!(badge.height, Some(20.0));
+    assert!(badge.border.is_some());
+
+    let card = theme.components.card.resolve(CardPattern::Raised, false);
+    assert!(card.background.is_some());
+    assert!(!card.shadows.is_empty());
+
+    assert!(theme.tokens.data_visualization.palette.len() >= 4);
+}
+
+#[test]
+fn generated_dark_input_uses_dark_readable_text_tokens() {
+    let theme = Theme::dark();
+    let input = theme
+        .components
+        .text_input
+        .resolve(ComponentSize::Md, ComponentState::Default);
+
+    assert_eq!(input.text_color, Some(theme.tokens.colors.text_primary));
+    assert_ne!(
+        input.text_color,
+        Some(theme.tokens.colors.background),
+        "dark input text must not collapse to the dark background color"
+    );
+}
+
+#[test]
+fn generated_dark_buttons_use_dark_readable_text_tokens() {
+    let theme = Theme::dark();
+
+    let secondary = theme.components.button.resolve(
+        ButtonHierarchy::SecondaryGray,
+        ComponentSize::Md,
+        ComponentState::Default,
+    );
+    assert_eq!(secondary.text_color, Some(theme.tokens.colors.text_primary));
+    assert_eq!(
+        secondary.border.as_ref().map(|border| &border.fill),
+        Some(&fission_theme::Fill::Solid(theme.tokens.colors.border))
+    );
+
+    let tertiary = theme.components.button.resolve(
+        ButtonHierarchy::TertiaryGray,
+        ComponentSize::Md,
+        ComponentState::Default,
+    );
+    assert_eq!(
+        tertiary.text_color,
+        Some(theme.tokens.colors.text_secondary)
+    );
+
+    let disabled = theme.components.button.resolve(
+        ButtonHierarchy::Primary,
+        ComponentSize::Md,
+        ComponentState::Disabled,
+    );
+    assert_eq!(disabled.text_color, Some(theme.tokens.colors.text_muted));
+    assert_eq!(
+        disabled.background,
+        Some(fission_theme::Fill::Solid(
+            theme.tokens.colors.surface_sunken
+        ))
+    );
 }

--- a/crates/tools/fission-design-system-codegen/src/lib.rs
+++ b/crates/tools/fission-design-system-codegen/src/lib.rs
@@ -160,6 +160,7 @@ impl {krate}::DesignSystem for {type_name} {{
         let radii = self.radius_tokens_expr(krate)?;
         let elevations = self.elevation_tokens_expr(krate)?;
         let motion = self.motion_tokens_expr(krate)?;
+        let data_visualization = self.data_visualization_tokens_expr(krate, mode)?;
         let components = self.component_theme_expr(krate, mode)?;
         Ok(format!(
             r#"{krate}::Theme {{
@@ -170,6 +171,7 @@ impl {krate}::DesignSystem for {type_name} {{
                     radii: {radii},
                     elevations: {elevations},
                     motion: {motion},
+                    data_visualization: {data_visualization},
                 }},
                 components: {components},
                 design_system: {krate}::ResolvedDesignSystem {{
@@ -416,9 +418,23 @@ impl {krate}::DesignSystem for {type_name} {{
         ))
     }
 
+    fn data_visualization_tokens_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let palette = self.palette_expr(krate, mode)?;
+        Ok(format!(
+            "{krate}::DataVisualizationTokens {{ palette: vec![{palette}] }}"
+        ))
+    }
+
     fn component_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
         let button = self.button_theme_expr(krate, mode)?;
         let text_input = self.text_input_theme_expr(krate, mode)?;
+        let badge = self.badge_theme_expr(krate, mode)?;
+        let tabs = self.tabs_theme_expr(krate, mode)?;
+        let modal = self.modal_theme_expr(krate, mode)?;
+        let progress = self.progress_theme_expr(krate, mode)?;
+        let tooltip = self.tooltip_theme_expr(krate, mode)?;
+        let card = self.card_theme_expr(krate, mode)?;
+        let feature_icon = self.feature_icon_theme_expr(krate, mode)?;
         let colors_prefix = match mode {
             Mode::Light => "color.light",
             Mode::Dark => "color.dark",
@@ -432,25 +448,20 @@ impl {krate}::DesignSystem for {type_name} {{
                 timeline: {krate}::TimelineTheme {{ dot_size: 12.0, line_width: 2.0, dot_color: {primary}, line_color: {border} }},
                 segmented_control: {krate}::SegmentedControlTheme {{ bg_color: {surface}, border_color: {border}, radius: {radius_full}, active_bg: {primary}, active_text: {on_primary} }},
                 alert: {krate}::AlertTheme {{ info_bg: {info_bg}, warning_bg: {warning_bg}, error_bg: {error_bg}, success_bg: {success_bg}, radius: {radius_medium} }},
-                badge: {krate}::BadgeTheme {{ radius: {badge_radius}, font_size: {badge_font_size} }},
-                tabs: {krate}::TabsTheme {{ active_color: {primary}, inactive_color: {text_secondary}, indicator_height: {tabs_indicator}, background: {background}, divider_color: {divider}.with_alpha(120) }},
-                modal: {krate}::ModalTheme {{ bg_color: {surface}, radius: {modal_radius}, shadow: {modal_shadow}, max_width: {modal_width} }},
+                badge: {badge},
+                tabs: {tabs},
+                modal: {modal},
                 tree_view: {krate}::TreeViewTheme {{ indent: 16.0, selected_bg: {primary}.with_alpha(52), hover_bg: {surface} }},
-                progress: {krate}::ProgressTheme {{ height: {progress_height}, track_color: {border}, bar_color: {primary} }},
-                tooltip: {krate}::TooltipTheme {{ bg_color: {tooltip_bg}, text_color: {tooltip_text}, radius: {tooltip_radius}, font_size: {tooltip_font_size} }},
+                progress: {progress},
+                tooltip: {tooltip},
+                card: {card},
+                feature_icon: {feature_icon},
             }}"#,
             surface = self.color_expr(krate, &format!("{colors_prefix}.surface"))?,
             border = self.color_expr(krate, &format!("{colors_prefix}.border"))?,
             primary = self.color_expr(krate, &format!("{colors_prefix}.primary"))?,
             on_primary = self.color_expr(krate, &format!("{colors_prefix}.on_primary"))?,
             secondary = self.color_expr(krate, &format!("{colors_prefix}.secondary"))?,
-            background = self.color_expr(krate, &format!("{colors_prefix}.background"))?,
-            divider = self.color_expr_optional(
-                krate,
-                &format!("{colors_prefix}.divider"),
-                &self.resolve_token_string(&format!("{colors_prefix}.border"))?
-            )?,
-            text_secondary = self.color_expr(krate, &format!("{colors_prefix}.text_secondary"))?,
             info_bg = self.color_literal_expr(krate, "#E6F2FF")?,
             warning_bg = self.color_literal_expr(krate, "#FFF4E5")?,
             error_bg = format!(
@@ -461,27 +472,6 @@ impl {krate}::DesignSystem for {type_name} {{
             radius_medium = f32_lit(self.dimension("radius.medium")?),
             radius_full = f32_lit(self.dimension("radius.full")?),
             spacing_s = f32_lit(self.dimension("spacing.s")?),
-            badge_radius = f32_lit(
-                self.dimension_optional("component.badge.radius", self.dimension("radius.full")?)?
-            ),
-            badge_font_size = f32_lit(self.dimension_optional("component.badge.font_size", 10.0)?),
-            tabs_indicator =
-                f32_lit(self.dimension_optional("component.tabs.indicator_height", 3.0)?),
-            modal_radius = f32_lit(
-                self.dimension_optional("component.modal.radius", self.dimension("radius.large")?)?
-            ),
-            modal_shadow = self.shadow_option_expr(krate, "component.modal.shadow")?,
-            modal_width = f32_lit(self.dimension_optional("component.modal.max_width", 600.0)?),
-            progress_height = f32_lit(self.dimension_optional("component.progress.height", 8.0)?),
-            tooltip_bg = self.color_literal_expr(krate, "#323232")?,
-            tooltip_text = self.color_literal_expr(krate, "#FFFFFF")?,
-            tooltip_radius =
-                f32_lit(self.dimension_optional(
-                    "component.tooltip.radius",
-                    self.dimension("radius.small")?
-                )?),
-            tooltip_font_size =
-                f32_lit(self.dimension_optional("component.tooltip.font_size", 12.0)?),
         ))
     }
 
@@ -518,6 +508,12 @@ impl {krate}::DesignSystem for {type_name} {{
                 elevation_hover: {elevation_hover},
                 elevation_pressed: {elevation_pressed},
                 focus_stroke: Some({krate}::Stroke {{ fill: {krate}::Fill::Solid({focus}), width: 2.0, dash_array: None, line_cap: {krate}::LineCap::Round, line_join: {krate}::LineJoin::Round }}),
+                icon_size: {icon_size},
+                font_weight: {font_weight},
+                line_height: {line_height},
+                transition: {transition},
+                sizes: vec![{sizes}],
+                hierarchies: vec![{hierarchies}],
             }}"#,
             height = f32_lit(height),
             padding_h = f32_lit(padding_h),
@@ -532,6 +528,31 @@ impl {krate}::DesignSystem for {type_name} {{
                 krate,
                 &format!("{colors_prefix}.focus_ring"),
                 &self.resolve_token_string(&format!("{colors_prefix}.primary"))?
+            )?,
+            icon_size = f32_lit(self.style_dimension_optional(
+                mode,
+                self.dsp.pointer("/components/button/icon_size"),
+                20.0,
+            )?),
+            font_weight = self.style_u16_optional(
+                mode,
+                self.dsp.pointer("/components/button/font_weight"),
+                600,
+            )?,
+            line_height = f32_lit(
+                self.dsp_dimension_optional("/components/button/sizes/md/line_height", 20.0,)?
+            ),
+            transition = self.motion_option_expr(
+                krate,
+                mode,
+                self.dsp.pointer("/components/button/transition"),
+            )?,
+            sizes = self.size_styles_expr(krate, mode, "/components/button/sizes")?,
+            hierarchies = self.enum_state_styles_expr(
+                krate,
+                mode,
+                "/components/button/hierarchies",
+                button_hierarchy_variant,
             )?,
         ))
     }
@@ -558,17 +579,808 @@ impl {krate}::DesignSystem for {type_name} {{
             self.dimension_optional("component.text_input.font_size", 17.0)?,
         )?;
         Ok(format!(
-            "{krate}::TextInputTheme {{ height: {height}, padding_h: {padding_h}, radius: {radius}, font_size: {font_size}, border_color: {border}, border_width: {border_width}, focus_color: {focus}, text_color: {text}, placeholder_color: {placeholder} }}",
+            r#"{krate}::TextInputTheme {{
+                height: {height},
+                padding_h: {padding_h},
+                radius: {radius},
+                font_size: {font_size},
+                border_color: {border},
+                border_width: {border_width},
+                focus_color: {focus},
+                text_color: {text},
+                placeholder_color: {placeholder},
+                line_height: {line_height},
+                font_weight: {font_weight},
+                sizes: vec![{sizes}],
+                states: {states},
+                placeholder_style: {placeholder_style},
+                label_style: {label_style},
+                helper_style: {helper_style},
+            }}"#,
             height = f32_lit(height),
             padding_h = f32_lit(padding_h),
             radius = f32_lit(radius),
             font_size = f32_lit(font_size),
             border = self.color_expr(krate, &format!("{colors_prefix}.border"))?,
-            border_width = f32_lit(self.dimension_optional("component.text_input.border_width", 1.0)?),
-            focus = self.color_expr_optional(krate, &format!("{colors_prefix}.focus_ring"), &self.resolve_token_string(&format!("{colors_prefix}.primary"))?)?,
+            border_width =
+                f32_lit(self.dimension_optional("component.text_input.border_width", 1.0)?),
+            focus = self.color_expr_optional(
+                krate,
+                &format!("{colors_prefix}.focus_ring"),
+                &self.resolve_token_string(&format!("{colors_prefix}.primary"))?
+            )?,
             text = self.color_expr(krate, &format!("{colors_prefix}.text_primary"))?,
-            placeholder = self.color_expr_optional(krate, &format!("{colors_prefix}.text_muted"), &self.resolve_token_string(&format!("{colors_prefix}.text_secondary"))?)?,
+            placeholder = self.color_expr_optional(
+                krate,
+                &format!("{colors_prefix}.text_muted"),
+                &self.resolve_token_string(&format!("{colors_prefix}.text_secondary"))?
+            )?,
+            line_height =
+                f32_lit(self.dsp_dimension_optional("/components/input/line_height", 24.0)?),
+            font_weight = self.style_u16_optional(
+                mode,
+                self.dsp.pointer("/components/input/font_weight"),
+                400,
+            )?,
+            sizes = self.size_styles_expr(krate, mode, "/components/input/sizes")?,
+            states =
+                self.state_styles_expr(krate, mode, self.dsp.pointer("/components/input/states"))?,
+            placeholder_style = self.style_expr(
+                krate,
+                mode,
+                self.dsp.pointer("/components/input/states/placeholder")
+            )?,
+            label_style =
+                self.style_expr(krate, mode, self.dsp.pointer("/components/input/label"))?,
+            helper_style = self.style_expr(
+                krate,
+                mode,
+                self.dsp.pointer("/components/input/helper_text")
+            )?,
         ))
+    }
+
+    fn badge_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let radius = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/badge/radius"),
+            self.dimension_optional("component.badge.radius", self.dimension("radius.full")?)?,
+        )?;
+        let font_size = self.dsp_dimension_optional(
+            "/components/badge/sizes/md/font_size",
+            self.dimension_optional("component.badge.font_size", 10.0)?,
+        )?;
+        Ok(format!(
+            r#"{krate}::BadgeTheme {{
+                radius: {radius},
+                font_size: {font_size},
+                font_weight: {font_weight},
+                sizes: vec![{sizes}],
+                tones: vec![{tones}],
+            }}"#,
+            radius = f32_lit(radius),
+            font_size = f32_lit(font_size),
+            font_weight = self.style_u16_optional(
+                mode,
+                self.dsp.pointer("/components/badge/font_weight"),
+                500
+            )?,
+            sizes = self.size_styles_expr(krate, mode, "/components/badge/sizes")?,
+            tones =
+                self.enum_styles_expr(krate, mode, "/components/badge/colors", badge_tone_variant)?,
+        ))
+    }
+
+    fn tabs_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let colors_prefix = match mode {
+            Mode::Light => "color.light",
+            Mode::Dark => "color.dark",
+        };
+        let active = self.color_expr(krate, &format!("{colors_prefix}.primary"))?;
+        let inactive = self.color_expr(krate, &format!("{colors_prefix}.text_secondary"))?;
+        let background = self.color_expr(krate, &format!("{colors_prefix}.background"))?;
+        let divider = self.color_expr_optional(
+            krate,
+            &format!("{colors_prefix}.divider"),
+            &self.resolve_token_string(&format!("{colors_prefix}.border"))?,
+        )?;
+        Ok(format!(
+            r#"{krate}::TabsTheme {{
+                active_color: {active},
+                inactive_color: {inactive},
+                indicator_height: {indicator_height},
+                background: {background},
+                divider_color: {divider}.with_alpha(120),
+                sizes: vec![{sizes}],
+                states: {states},
+                track_style: {track},
+            }}"#,
+            indicator_height = f32_lit(self.dsp_dimension_optional(
+                "/components/tabs/sizes/md/indicator_height",
+                self.dimension_optional("component.tabs.indicator_height", 3.0)?
+            )?),
+            sizes = self.size_styles_expr(krate, mode, "/components/tabs/sizes")?,
+            states =
+                self.state_styles_expr(krate, mode, self.dsp.pointer("/components/tabs/states"))?,
+            track = self.style_expr(krate, mode, self.dsp.pointer("/components/tabs/track"))?,
+        ))
+    }
+
+    fn modal_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let bg = self
+            .style_fill_color_expr(
+                krate,
+                mode,
+                self.dsp.pointer("/components/modal/background"),
+            )?
+            .unwrap_or(self.color_expr(krate, &format!("color.{}.surface", mode.color_name()))?);
+        let radius = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/modal/radius"),
+            self.dimension_optional("component.modal.radius", self.dimension("radius.large")?)?,
+        )?;
+        let max_width = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/modal/max_width"),
+            self.dimension_optional("component.modal.max_width", 600.0)?,
+        )?;
+        let shadow = self.shadow_option_expr(krate, "component.modal.shadow")?;
+        let container_style = self.style_expr_for_component(
+            krate,
+            mode,
+            "/components/modal",
+            &["background", "radius", "max_width", "box_shadow"],
+        )?;
+        let scrim_style =
+            self.style_expr(krate, mode, self.dsp.pointer("/components/modal/scrim"))?;
+        let scrim_blur = self
+            .dsp
+            .pointer("/components/modal/scrim/backdrop_filter")
+            .and_then(Value::as_str)
+            .and_then(|value| {
+                value
+                    .strip_prefix("blur(")
+                    .and_then(|v| v.strip_suffix(')'))
+            })
+            .and_then(|value| parse_dimension(value).ok())
+            .unwrap_or(4.0);
+        Ok(format!(
+            r#"{krate}::ModalTheme {{
+                bg_color: {bg},
+                radius: {radius},
+                shadow: {shadow},
+                max_width: {max_width},
+                container_style: {container_style},
+                scrim_style: {scrim_style},
+                scrim_blur: {scrim_blur},
+            }}"#,
+            radius = f32_lit(radius),
+            max_width = f32_lit(max_width),
+            scrim_blur = f32_lit(scrim_blur),
+        ))
+    }
+
+    fn progress_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let height = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/progress_bar/height"),
+            self.dimension_optional("component.progress.height", 8.0)?,
+        )?;
+        let radius = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/progress_bar/radius"),
+            self.dimension("radius.full")?,
+        )?;
+        let track_style = self.style_expr(
+            krate,
+            mode,
+            self.dsp.pointer("/components/progress_bar/track"),
+        )?;
+        let fill_style = self.style_expr(
+            krate,
+            mode,
+            self.dsp.pointer("/components/progress_bar/fill"),
+        )?;
+        let track_color = self
+            .style_fill_color_expr(
+                krate,
+                mode,
+                self.dsp
+                    .pointer("/components/progress_bar/track/background"),
+            )?
+            .unwrap_or_else(|| {
+                self.color_expr(krate, &format!("color.{}.border", mode.color_name()))
+                    .unwrap()
+            });
+        let fill_color = self
+            .style_fill_color_expr(
+                krate,
+                mode,
+                self.dsp.pointer("/components/progress_bar/fill/background"),
+            )?
+            .unwrap_or_else(|| {
+                self.color_expr(krate, &format!("color.{}.primary", mode.color_name()))
+                    .unwrap()
+            });
+        Ok(format!(
+            r#"{krate}::ProgressTheme {{
+                height: {height},
+                track_color: {track_color},
+                bar_color: {fill_color},
+                radius: {radius},
+                track_style: {track_style},
+                fill_style: {fill_style},
+            }}"#,
+            height = f32_lit(height),
+            radius = f32_lit(radius),
+        ))
+    }
+
+    fn tooltip_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let style = self.style_expr_for_component(
+            krate,
+            mode,
+            "/components/tooltip",
+            &[
+                "background",
+                "color",
+                "radius",
+                "font_size",
+                "padding",
+                "max_width",
+                "box_shadow",
+            ],
+        )?;
+        let bg = self
+            .style_fill_color_expr(
+                krate,
+                mode,
+                self.dsp.pointer("/components/tooltip/background"),
+            )?
+            .unwrap_or(self.color_literal_expr(krate, "#323232")?);
+        let text = self
+            .style_fill_color_expr(krate, mode, self.dsp.pointer("/components/tooltip/color"))?
+            .unwrap_or(self.color_literal_expr(krate, "#FFFFFF")?);
+        let radius = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/tooltip/radius"),
+            self.dimension_optional("component.tooltip.radius", self.dimension("radius.small")?)?,
+        )?;
+        let font_size = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/tooltip/font_size"),
+            self.dimension_optional("component.tooltip.font_size", 12.0)?,
+        )?;
+        let (padding_x, padding_y) = self
+            .dsp
+            .pointer("/components/tooltip/padding")
+            .and_then(Value::as_str)
+            .and_then(|raw| self.resolve_refs_in_string_for_mode(raw, mode).ok())
+            .and_then(|raw| parse_padding(&raw).ok())
+            .map(|p| (p[0], p[2]))
+            .unwrap_or((10.0, 8.0));
+        let max_width = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/tooltip/max_width"),
+            240.0,
+        )?;
+        Ok(format!(
+            r#"{krate}::TooltipTheme {{
+                bg_color: {bg},
+                text_color: {text},
+                radius: {radius},
+                font_size: {font_size},
+                padding_x: {padding_x},
+                padding_y: {padding_y},
+                max_width: {max_width},
+                style: {style},
+            }}"#,
+            radius = f32_lit(radius),
+            font_size = f32_lit(font_size),
+            padding_x = f32_lit(padding_x),
+            padding_y = f32_lit(padding_y),
+            max_width = f32_lit(max_width),
+        ))
+    }
+
+    fn card_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let padding = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/card/padding"),
+            self.dimension_optional("component.card.padding", self.dimension("spacing.l")?)?,
+        )?;
+        let radius = self.style_dimension_optional(
+            mode,
+            self.dsp.pointer("/components/card/radius"),
+            self.dimension_optional("component.card.radius", self.dimension("radius.large")?)?,
+        )?;
+        let patterns = self.enum_styles_expr(
+            krate,
+            mode,
+            "/components/card/patterns",
+            card_pattern_variant,
+        )?;
+        let hover = self.style_expr(
+            krate,
+            mode,
+            self.dsp.pointer("/components/card/interaction/hover"),
+        )?;
+        Ok(format!(
+            r#"{krate}::CardTheme {{
+                padding: {padding},
+                radius: {radius},
+                default_pattern: {krate}::CardPattern::Raised,
+                patterns: vec![{patterns}],
+                hover_style: {hover},
+            }}"#,
+            padding = f32_lit(padding),
+            radius = f32_lit(radius),
+        ))
+    }
+
+    fn feature_icon_theme_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        Ok(format!(
+            r#"{krate}::FeatureIconTheme {{
+                sizes: vec![{sizes}],
+                tones: vec![{tones}],
+                shadow: {shadow},
+            }}"#,
+            sizes = self.size_styles_expr(krate, mode, "/components/feature_icon/sizes")?,
+            tones = self.enum_styles_expr(
+                krate,
+                mode,
+                "/components/feature_icon/tones",
+                feature_icon_tone_variant
+            )?,
+            shadow = self.shadow_option_from_value_expr(
+                krate,
+                mode,
+                self.dsp.pointer("/components/feature_icon/box_shadow"),
+            )?,
+        ))
+    }
+
+    fn palette_expr(&self, krate: &str, mode: Mode) -> Result<String> {
+        let mut colors = Vec::new();
+        if let Some(items) = self
+            .dsp
+            .pointer("/data_visualization/palette")
+            .or_else(|| self.dsp.pointer("/charts/palette"))
+            .and_then(Value::as_array)
+        {
+            for item in items {
+                if let Some(color) = self.style_fill_color_expr(krate, mode, Some(item))? {
+                    colors.push(color);
+                }
+            }
+        }
+        if colors.is_empty() {
+            let token_paths = [
+                "color.teal.700",
+                "color.brand.blue.600",
+                "color.semantic.warning",
+                "color.semantic.error",
+                "color.semantic.success",
+                "color.semantic.info",
+                "color.brand.orange.600",
+                "color.teal.500",
+            ];
+            for path in token_paths {
+                if self.tokens.contains(path) {
+                    colors.push(self.color_expr(krate, path)?);
+                }
+            }
+        }
+        if colors.is_empty() {
+            colors = vec![
+                self.color_literal_expr(krate, "#14B8A6")?,
+                self.color_literal_expr(krate, "#4DA6E0")?,
+                self.color_literal_expr(krate, "#F59E0B")?,
+                self.color_literal_expr(krate, "#F43F5E")?,
+            ];
+        }
+        Ok(colors.join(","))
+    }
+
+    fn size_styles_expr(&self, krate: &str, mode: Mode, pointer: &str) -> Result<String> {
+        let Some(obj) = self.dsp.pointer(pointer).and_then(Value::as_object) else {
+            return Ok(String::new());
+        };
+        let mut items = Vec::new();
+        for (name, value) in obj {
+            if let Some(variant) = component_size_variant(krate, name) {
+                items.push(format!(
+                    "({variant}, {})",
+                    self.style_expr(krate, mode, Some(value))?
+                ));
+            }
+        }
+        Ok(items.join(","))
+    }
+
+    fn enum_styles_expr(
+        &self,
+        krate: &str,
+        mode: Mode,
+        pointer: &str,
+        variant: fn(&str, &str) -> Option<String>,
+    ) -> Result<String> {
+        let Some(obj) = self.dsp.pointer(pointer).and_then(Value::as_object) else {
+            return Ok(String::new());
+        };
+        let mut items = Vec::new();
+        for (name, value) in obj {
+            if let Some(variant_expr) = variant(krate, name) {
+                items.push(format!(
+                    "({variant_expr}, {})",
+                    self.style_expr(krate, mode, Some(value))?
+                ));
+            }
+        }
+        Ok(items.join(","))
+    }
+
+    fn enum_state_styles_expr(
+        &self,
+        krate: &str,
+        mode: Mode,
+        pointer: &str,
+        variant: fn(&str, &str) -> Option<String>,
+    ) -> Result<String> {
+        let Some(obj) = self.dsp.pointer(pointer).and_then(Value::as_object) else {
+            return Ok(String::new());
+        };
+        let mut items = Vec::new();
+        for (name, value) in obj {
+            if let Some(variant_expr) = variant(krate, name) {
+                items.push(format!(
+                    "({variant_expr}, {})",
+                    self.state_styles_expr(krate, mode, Some(value))?
+                ));
+            }
+        }
+        Ok(items.join(","))
+    }
+
+    fn state_styles_expr(&self, krate: &str, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let state = |name: &str| -> Result<String> {
+            let expr = value
+                .and_then(|v| v.get(name))
+                .map(|v| self.style_expr(krate, mode, Some(v)))
+                .transpose()?;
+            Ok(expr
+                .map(|expr| format!("Some({expr})"))
+                .unwrap_or_else(|| "None".into()))
+        };
+        let default = value
+            .and_then(|v| v.get("default"))
+            .map(|v| self.style_expr(krate, mode, Some(v)))
+            .transpose()?
+            .unwrap_or_else(|| format!("{krate}::ResolvedComponentStyle::default()"));
+        Ok(format!(
+            r#"{krate}::ComponentStateStyles {{
+                default: {default},
+                hover: {hover},
+                active: {active},
+                focus: {focus},
+                disabled: {disabled},
+                error: {error},
+                selected: {selected},
+            }}"#,
+            hover = state("hover")?,
+            active = state("active")?,
+            focus = state("focus")?,
+            disabled = state("disabled")?,
+            error = state("error")?,
+            selected = state("selected")?,
+        ))
+    }
+
+    fn style_expr_for_component(
+        &self,
+        krate: &str,
+        mode: Mode,
+        pointer: &str,
+        keys: &[&str],
+    ) -> Result<String> {
+        let Some(source) = self.dsp.pointer(pointer).and_then(Value::as_object) else {
+            return self.style_expr(krate, mode, None);
+        };
+        let mut obj = serde_json::Map::new();
+        for key in keys {
+            if let Some(value) = source.get(*key) {
+                obj.insert((*key).to_string(), value.clone());
+            }
+        }
+        self.style_expr(krate, mode, Some(&Value::Object(obj)))
+    }
+
+    fn style_expr(&self, krate: &str, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(value) = value else {
+            return Ok(format!("{krate}::ResolvedComponentStyle::default()"));
+        };
+        let background = self.fill_option_expr(krate, mode, field(value, "background"))?;
+        let text_color = self
+            .style_fill_color_expr(krate, mode, field(value, "color"))?
+            .map(|expr| format!("Some({expr})"))
+            .unwrap_or_else(|| "None".into());
+        let border = self.border_option_expr(
+            krate,
+            mode,
+            field(value, "border").or_else(|| field(value, "border_bottom")),
+        )?;
+        let shadows = self.shadow_layers_expr(
+            krate,
+            mode,
+            field(value, "box_shadow").or_else(|| field(value, "shadow")),
+        )?;
+        let radius = self.style_dimension_option_expr(mode, field(value, "radius"))?;
+        let height = self.style_dimension_option_expr(mode, field(value, "height"))?;
+        let width = self.style_dimension_option_expr(mode, field(value, "width"))?;
+        let size = self.style_dimension_option_expr(mode, field(value, "size"))?;
+        let width = if width == "None" { size.clone() } else { width };
+        let height = if height == "None" { size } else { height };
+        let padding_x = self.style_dimension_option_expr(mode, field(value, "padding_x"))?;
+        let padding_y = self.style_dimension_option_expr(mode, field(value, "padding_y"))?;
+        let padding = self.padding_option_expr(mode, field(value, "padding"))?;
+        let gap = self.style_dimension_option_expr(mode, field(value, "gap"))?;
+        let font_size = self.style_dimension_option_expr(mode, field(value, "font_size"))?;
+        let font_weight = self.style_u16_option_expr(mode, field(value, "font_weight"))?;
+        let line_height = self.style_dimension_option_expr(mode, field(value, "line_height"))?;
+        let letter_spacing =
+            self.style_dimension_option_expr(mode, field(value, "letter_spacing"))?;
+        let icon_size = self.style_dimension_option_expr(mode, field(value, "icon_size"))?;
+        let max_width = self.style_dimension_option_expr(mode, field(value, "max_width"))?;
+        let transition = self.motion_option_expr(krate, mode, field(value, "transition"))?;
+        Ok(format!(
+            r#"{krate}::ResolvedComponentStyle {{
+                background: {background},
+                text_color: {text_color},
+                border: {border},
+                radius: {radius},
+                height: {height},
+                width: {width},
+                padding_x: {padding_x},
+                padding_y: {padding_y},
+                padding: {padding},
+                gap: {gap},
+                font_size: {font_size},
+                font_weight: {font_weight},
+                line_height: {line_height},
+                letter_spacing: {letter_spacing},
+                icon_size: {icon_size},
+                max_width: {max_width},
+                shadows: {shadows},
+                transition: {transition},
+            }}"#
+        ))
+    }
+
+    fn fill_option_expr(&self, krate: &str, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(fill) = self.fill_expr(krate, mode, value)? else {
+            return Ok("None".into());
+        };
+        Ok(format!("Some({fill})"))
+    }
+
+    fn fill_expr(&self, krate: &str, mode: Mode, value: Option<&Value>) -> Result<Option<String>> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok(None);
+        };
+        let raw = raw.trim();
+        if raw.eq_ignore_ascii_case("none") || raw.eq_ignore_ascii_case("auto") {
+            return Ok(None);
+        }
+        if raw.eq_ignore_ascii_case("transparent") {
+            return Ok(Some(format!(
+                "{krate}::Fill::Solid({})",
+                color_expr(krate, 0, 0, 0, 0)
+            )));
+        }
+        if raw.starts_with("linear-gradient(") {
+            let stops = gradient_stops(raw)
+                .into_iter()
+                .enumerate()
+                .map(|(idx, color)| {
+                    let position = if idx == 0 { 0.0 } else { 1.0 };
+                    Ok(format!(
+                        "({}, {})",
+                        f32_lit(position),
+                        self.color_literal_expr(krate, color)?
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            return Ok(Some(format!(
+                "{krate}::Fill::LinearGradient {{ start: (0.0, 0.0), end: (1.0, 1.0), stops: vec![{}] }}",
+                stops.join(",")
+            )));
+        }
+        if raw.starts_with("radial-gradient(") {
+            let colors = gradient_stops(raw);
+            let mut stops = Vec::new();
+            for (idx, color) in colors.iter().enumerate() {
+                let position = if colors.len() <= 1 {
+                    0.0
+                } else {
+                    idx as f32 / (colors.len() - 1) as f32
+                };
+                stops.push(format!(
+                    "({}, {})",
+                    f32_lit(position),
+                    self.color_literal_expr(krate, color)?
+                ));
+            }
+            return Ok(Some(format!(
+                "{krate}::Fill::RadialGradient {{ center: (0.5, 0.5), radius: 1.0, stops: vec![{}] }}",
+                stops.join(",")
+            )));
+        }
+        if parse_color(raw).is_ok() {
+            return Ok(Some(format!(
+                "{krate}::Fill::Solid({})",
+                self.color_literal_expr(krate, raw)?
+            )));
+        }
+        Ok(None)
+    }
+
+    fn style_fill_color_expr(
+        &self,
+        krate: &str,
+        mode: Mode,
+        value: Option<&Value>,
+    ) -> Result<Option<String>> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok(None);
+        };
+        let raw = raw.trim();
+        if raw.eq_ignore_ascii_case("transparent") {
+            return Ok(Some(color_expr(krate, 0, 0, 0, 0)));
+        }
+        if parse_color(raw).is_ok() {
+            return Ok(Some(self.color_literal_expr(krate, raw)?));
+        }
+        Ok(None)
+    }
+
+    fn border_option_expr(&self, krate: &str, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok("None".into());
+        };
+        let raw = raw.trim();
+        if raw.eq_ignore_ascii_case("none") || raw.eq_ignore_ascii_case("transparent") {
+            return Ok("None".into());
+        }
+        let Some((width, color)) = parse_border(raw) else {
+            return Ok("None".into());
+        };
+        Ok(format!(
+            "Some({krate}::ComponentBorder {{ fill: {krate}::Fill::Solid({}), width: {} }})",
+            self.color_literal_expr(krate, color)?,
+            f32_lit(width)
+        ))
+    }
+
+    fn shadow_layers_expr(&self, krate: &str, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok("Vec::new()".into());
+        };
+        let layers = parse_shadow_layers(&raw);
+        let exprs = layers
+            .iter()
+            .map(|layer| shadow_layer_expr(krate, layer))
+            .collect::<Vec<_>>();
+        Ok(format!("vec![{}]", exprs.join(",")))
+    }
+
+    fn shadow_option_from_value_expr(
+        &self,
+        krate: &str,
+        mode: Mode,
+        value: Option<&Value>,
+    ) -> Result<String> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok("None".into());
+        };
+        let layers = parse_shadow_layers(&raw);
+        if let Some(layer) = layers.iter().find(|layer| !layer.inset) {
+            Ok(format!("Some({})", box_shadow_expr(krate, layer)))
+        } else {
+            Ok("None".into())
+        }
+    }
+
+    fn style_dimension_optional(
+        &self,
+        mode: Mode,
+        value: Option<&Value>,
+        fallback: f32,
+    ) -> Result<f32> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok(fallback);
+        };
+        parse_dimension(&raw)
+            .or_else(|_| raw.parse::<f32>())
+            .or(Ok(fallback))
+    }
+
+    fn style_dimension_option_expr(&self, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok("None".into());
+        };
+        if raw == "auto" {
+            return Ok("None".into());
+        }
+        let Ok(dimension) = parse_dimension(&raw).or_else(|_| raw.parse::<f32>()) else {
+            return Ok("None".into());
+        };
+        Ok(format!("Some({})", f32_lit(dimension)))
+    }
+
+    fn style_u16_optional(&self, mode: Mode, value: Option<&Value>, fallback: u16) -> Result<u16> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok(fallback);
+        };
+        Ok(raw.parse::<u16>().unwrap_or(fallback))
+    }
+
+    fn style_u16_option_expr(&self, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok("None".into());
+        };
+        Ok(raw
+            .parse::<u16>()
+            .map(|value| format!("Some({value})"))
+            .unwrap_or_else(|_| "None".into()))
+    }
+
+    fn padding_option_expr(&self, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok("None".into());
+        };
+        let Ok(padding) = parse_padding(&raw) else {
+            return Ok("None".into());
+        };
+        Ok(format!(
+            "Some([{}, {}, {}, {}])",
+            f32_lit(padding[0]),
+            f32_lit(padding[1]),
+            f32_lit(padding[2]),
+            f32_lit(padding[3])
+        ))
+    }
+
+    fn motion_option_expr(&self, krate: &str, mode: Mode, value: Option<&Value>) -> Result<String> {
+        let Some(raw) = self.resolved_value_string(mode, value)? else {
+            return Ok("None".into());
+        };
+        let duration = raw
+            .split_whitespace()
+            .find_map(|part| parse_duration_ms(part).ok())
+            .unwrap_or(self.duration_ms_optional("motion.duration.fast", 160)?);
+        let easing = if raw.contains("cubic-bezier") {
+            let start = raw.find("cubic-bezier").unwrap_or(0);
+            let value = raw[start..].split_whitespace().next().unwrap_or("linear");
+            easing_expr(krate, value.trim_end_matches(','))
+        } else if raw.contains("ease") {
+            format!("{krate}::EasingCurve::Ease")
+        } else {
+            self.easing_expr(krate, "motion.easing.standard")?
+        };
+        Ok(format!(
+            "Some({krate}::ComponentMotion {{ duration_ms: {duration}, easing: {easing} }})"
+        ))
+    }
+
+    fn resolved_value_string(&self, mode: Mode, value: Option<&Value>) -> Result<Option<String>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        match value {
+            Value::String(raw) => Ok(Some(self.resolve_refs_in_string_for_mode(raw, mode)?)),
+            Value::Number(number) => Ok(Some(number.to_string())),
+            _ => Ok(None),
+        }
     }
 
     fn design_tokens_expr(&self, krate: &str) -> Result<String> {
@@ -728,8 +1540,8 @@ impl {krate}::DesignSystem for {type_name} {{
     }
 
     fn design_value_expr(&self, krate: &str, kind: &str, value: &str) -> Result<String> {
-        if kind == "color" || value.trim_start().starts_with('#') {
-            if let Ok((r, g, b, a)) = parse_hex_color(value) {
+        if kind == "color" || value.trim_start().starts_with('#') || value.starts_with("rgb") {
+            if let Ok((r, g, b, a)) = parse_color(value) {
                 return Ok(format!(
                     "{krate}::DesignValue::Color({})",
                     color_expr(krate, r, g, b, a)
@@ -789,8 +1601,7 @@ impl {krate}::DesignSystem for {type_name} {{
     }
 
     fn color_literal_expr(&self, krate: &str, value: &str) -> Result<String> {
-        let (r, g, b, a) =
-            parse_hex_color(value).with_context(|| format!("invalid color {value}"))?;
+        let (r, g, b, a) = parse_color(value).with_context(|| format!("invalid color {value}"))?;
         Ok(color_expr(krate, r, g, b, a))
     }
 
@@ -898,6 +1709,41 @@ impl {krate}::DesignSystem for {type_name} {{
         out.push_str(rest);
         Ok(out)
     }
+
+    fn resolve_refs_in_string_for_mode(&self, raw: &str, mode: Mode) -> Result<String> {
+        let mut out = String::new();
+        let mut rest = raw;
+        while let Some(start) = rest.find('{') {
+            let (before, after_start) = rest.split_at(start);
+            out.push_str(before);
+            let after_start = &after_start[1..];
+            let Some(end) = after_start.find('}') else {
+                bail!("unclosed token reference in {raw}");
+            };
+            let mut token = after_start[..end].to_string();
+            match mode {
+                Mode::Light => {}
+                Mode::Dark => {
+                    if let Some(suffix) = token.strip_prefix("color.light.") {
+                        let dark = format!("color.dark.{suffix}");
+                        if self.tokens.contains(&dark) {
+                            token = dark;
+                        }
+                    }
+                }
+            }
+            if self.tokens.contains(&token) {
+                out.push_str(&self.resolve_token_string(&token)?);
+            } else {
+                out.push('{');
+                out.push_str(&token);
+                out.push('}');
+            }
+            rest = &after_start[end + 1..];
+        }
+        out.push_str(rest);
+        Ok(out)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -910,6 +1756,13 @@ impl Mode {
         match self {
             Self::Light => "Light",
             Self::Dark => "Dark",
+        }
+    }
+
+    fn color_name(self) -> &'static str {
+        match self {
+            Self::Light => "light",
+            Self::Dark => "dark",
         }
     }
 }
@@ -1114,6 +1967,20 @@ fn parse_hex_color(value: &str) -> Result<(u8, u8, u8, u8)> {
     }
 }
 
+fn parse_color(value: &str) -> Result<(u8, u8, u8, u8)> {
+    let value = value.trim();
+    if value.eq_ignore_ascii_case("transparent") {
+        return Ok((0, 0, 0, 0));
+    }
+    if value.starts_with('#') {
+        return parse_hex_color(value);
+    }
+    if value.starts_with("rgb(") || value.starts_with("rgba(") {
+        return parse_rgb_color(value);
+    }
+    bail!("unsupported color value: {value}")
+}
+
 fn parse_rgb_color(value: &str) -> Result<(u8, u8, u8, u8)> {
     let inner = value
         .trim()
@@ -1142,6 +2009,55 @@ fn parse_rgb_color(value: &str) -> Result<(u8, u8, u8, u8)> {
     Ok((r, g, b, a))
 }
 
+fn parse_border(value: &str) -> Option<(f32, &str)> {
+    let mut width = None;
+    let mut color_start = None;
+    for part in value.split_whitespace() {
+        if width.is_none() {
+            if let Ok(px) = parse_dimension(part) {
+                width = Some(px);
+                continue;
+            }
+        }
+        if part.starts_with('#') || part.starts_with("rgb") || part == "transparent" {
+            color_start = value.find(part);
+            break;
+        }
+    }
+    match (width, color_start) {
+        (Some(width), Some(start)) => Some((width, value[start..].trim())),
+        _ => None,
+    }
+}
+
+fn parse_padding(value: &str) -> Result<[f32; 4]> {
+    let parts = value
+        .split_whitespace()
+        .map(parse_dimension)
+        .collect::<Result<Vec<_>>>()?;
+    let (top, right, bottom, left) = match parts.as_slice() {
+        [all] => (*all, *all, *all, *all),
+        [vertical, horizontal] => (*vertical, *horizontal, *vertical, *horizontal),
+        [top, horizontal, bottom] => (*top, *horizontal, *bottom, *horizontal),
+        [top, right, bottom, left, ..] => (*top, *right, *bottom, *left),
+        _ => (0.0, 0.0, 0.0, 0.0),
+    };
+    Ok([left, right, top, bottom])
+}
+
+fn gradient_stops(value: &str) -> Vec<&str> {
+    let inner = value
+        .split_once('(')
+        .and_then(|(_, rest)| rest.strip_suffix(')'))
+        .unwrap_or(value);
+    split_css_layers(inner)
+        .into_iter()
+        .map(str::trim)
+        .filter(|part| part.starts_with('#') || part.starts_with("rgb") || *part == "transparent")
+        .map(|part| part.split_whitespace().next().unwrap_or(part))
+        .collect()
+}
+
 fn parse_dimension(value: &str) -> Result<f32> {
     let trimmed = value.trim().trim_matches('"');
     if let Some(px) = trimmed.strip_suffix("px") {
@@ -1151,6 +2067,72 @@ fn parse_dimension(value: &str) -> Result<f32> {
         return Ok(em.trim().parse()?);
     }
     Ok(trimmed.parse()?)
+}
+
+fn field<'a>(value: &'a Value, name: &str) -> Option<&'a Value> {
+    value.get(name)
+}
+
+fn component_size_variant(krate: &str, name: &str) -> Option<String> {
+    let variant = match name {
+        "sm" => "Sm",
+        "md" => "Md",
+        "lg" => "Lg",
+        "xl" => "Xl",
+        _ => return None,
+    };
+    Some(format!("{krate}::ComponentSize::{variant}"))
+}
+
+fn button_hierarchy_variant(krate: &str, name: &str) -> Option<String> {
+    let variant = match name {
+        "primary" => "Primary",
+        "secondary_color" => "SecondaryColor",
+        "secondary_gray" => "SecondaryGray",
+        "tertiary_color" => "TertiaryColor",
+        "tertiary_gray" => "TertiaryGray",
+        "link_color" => "LinkColor",
+        "link_gray" => "LinkGray",
+        "destructive" => "Destructive",
+        _ => return None,
+    };
+    Some(format!("{krate}::ButtonHierarchy::{variant}"))
+}
+
+fn badge_tone_variant(krate: &str, name: &str) -> Option<String> {
+    let variant = match name {
+        "brand" => "Brand",
+        "gray" => "Gray",
+        "success" => "Success",
+        "warning" => "Warning",
+        "error" => "Error",
+        "blue" => "Blue",
+        "orange" => "Orange",
+        _ => return None,
+    };
+    Some(format!("{krate}::BadgeTone::{variant}"))
+}
+
+fn card_pattern_variant(krate: &str, name: &str) -> Option<String> {
+    let variant = match name {
+        "plain" => "Plain",
+        "raised" => "Raised",
+        "tinted" => "Tinted",
+        "elevated" => "Elevated",
+        _ => return None,
+    };
+    Some(format!("{krate}::CardPattern::{variant}"))
+}
+
+fn feature_icon_tone_variant(krate: &str, name: &str) -> Option<String> {
+    let variant = match name {
+        "brand" => "Brand",
+        "gray" => "Gray",
+        "blue" => "Blue",
+        "orange" => "Orange",
+        _ => return None,
+    };
+    Some(format!("{krate}::FeatureIconTone::{variant}"))
 }
 
 fn parse_duration_ms(value: &str) -> Result<u64> {

--- a/examples/inbox/src/components/email_list.rs
+++ b/examples/inbox/src/components/email_list.rs
@@ -8,6 +8,7 @@ use fission_core::ui::{
 use fission_core::ActionEnvelope;
 use fission_core::{reduce_with, BuildCtx, NodeId, View, Widget, WidgetNodeId};
 use fission_icons::material;
+use fission_theme::ComponentSize;
 use fission_widgets::{
     Badge, DateRangePicker, Divider, DropDown, EmptyState, HStack, Hero, Icon, LazyColumn,
     Pagination, Popover, RangeSlider, SegmentedControl, TabItem, Tabs, Tag, TextInput, VStack,
@@ -362,6 +363,7 @@ impl Widget<InboxState> for EmailList {
                     }
                     .build(ctx, view),
                 ],
+                ..Default::default()
             }
             .build(ctx, view),
         );
@@ -395,6 +397,7 @@ impl Widget<InboxState> for EmailList {
                         }),
                     },
                 ],
+                size: ComponentSize::Sm,
             }
             .build(ctx, view),
         );

--- a/examples/inbox/src/tests/mod.rs
+++ b/examples/inbox/src/tests/mod.rs
@@ -301,11 +301,17 @@ fn find_text_node_rects(h: &TestHarness<InboxState>, needle: &str) -> Vec<Layout
         None => return rects,
     };
     for (node_id, node) in &ir.nodes {
-        if let Op::Paint(PaintOp::DrawText { text, .. }) = &node.op {
-            if text == needle {
-                if let Some(rect) = node_rect(h, *node_id) {
-                    rects.push(rect);
-                }
+        let matches = match &node.op {
+            Op::Paint(PaintOp::DrawText { text, .. }) => text == needle,
+            Op::Paint(PaintOp::DrawRichText { runs, .. }) => {
+                runs.iter().any(|run| run.text == needle)
+                    || runs.iter().map(|run| run.text.as_str()).collect::<String>() == needle
+            }
+            _ => false,
+        };
+        if matches {
+            if let Some(rect) = node_rect(h, *node_id) {
+                rects.push(rect);
             }
         }
     }
@@ -315,10 +321,16 @@ fn find_text_node_rects(h: &TestHarness<InboxState>, needle: &str) -> Vec<Layout
 fn find_text_node_id(h: &TestHarness<InboxState>, needle: &str) -> Option<NodeId> {
     let ir = h.last_ir.as_ref()?;
     for (node_id, node) in &ir.nodes {
-        if let Op::Paint(PaintOp::DrawText { text, .. }) = &node.op {
-            if text == needle {
-                return Some(*node_id);
+        let matches = match &node.op {
+            Op::Paint(PaintOp::DrawText { text, .. }) => text == needle,
+            Op::Paint(PaintOp::DrawRichText { runs, .. }) => {
+                runs.iter().any(|run| run.text == needle)
+                    || runs.iter().map(|run| run.text.as_str()).collect::<String>() == needle
             }
+            _ => false,
+        };
+        if matches {
+            return Some(*node_id);
         }
     }
     None

--- a/examples/todo-design-system/Cargo.toml
+++ b/examples/todo-design-system/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "todo-design-system"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fission = { path = "../../crates/authoring/fission" }
+anyhow = "1.0"
+
+[build-dependencies]
+fission-design-system-codegen = { path = "../../crates/tools/fission-design-system-codegen" }

--- a/examples/todo-design-system/build.rs
+++ b/examples/todo-design-system/build.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let dsp_path = manifest_dir.join("../../crates/core/fission-theme/design/default/dsp.json");
+    fission_design_system_codegen::generate(fission_design_system_codegen::Config {
+        dsp_path,
+        out_file: "todo_design_system.rs".into(),
+        type_name: "TodoDesignSystem".into(),
+        crate_path: "fission::theme".into(),
+    })
+    .expect("failed to generate TodoDesignSystem from DSP JSON");
+}

--- a/examples/todo-design-system/src/main.rs
+++ b/examples/todo-design-system/src/main.rs
@@ -1,0 +1,260 @@
+use fission::prelude::*;
+
+include!(concat!(env!("OUT_DIR"), "/todo_design_system.rs"));
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TodoItem {
+    id: usize,
+    title: String,
+    done: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TodoState {
+    next_id: usize,
+    draft: String,
+    items: Vec<TodoItem>,
+    theme_mode: DesignMode,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            next_id: 4,
+            draft: String::new(),
+            items: vec![
+                TodoItem {
+                    id: 1,
+                    title: "Connect the DSP package".into(),
+                    done: true,
+                },
+                TodoItem {
+                    id: 2,
+                    title: "Use generated component styles".into(),
+                    done: false,
+                },
+                TodoItem {
+                    id: 3,
+                    title: "Ship the themed app".into(),
+                    done: false,
+                },
+            ],
+            theme_mode: DesignMode::Light,
+        }
+    }
+}
+
+impl AppState for TodoState {}
+
+#[fission_reducer(UpdateDraft)]
+fn update_draft(state: &mut TodoState, value: String) {
+    state.draft = value;
+}
+
+#[fission_reducer(AddTodo)]
+fn add_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+    state.items.push(TodoItem {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: usize) {
+    if let Some(item) = state.items.iter_mut().find(|item| item.id == id) {
+        item.done = !item.done;
+    }
+}
+
+#[fission_reducer(ClearDone)]
+fn clear_done(state: &mut TodoState) {
+    state.items.retain(|item| !item.done);
+}
+
+#[fission_reducer(SetThemeMode)]
+fn set_theme_mode(state: &mut TodoState, mode: DesignMode) {
+    state.theme_mode = mode;
+}
+
+struct TodoApp;
+
+impl Widget<TodoState> for TodoApp {
+    fn build(&self, ctx: &mut BuildCtx<TodoState>, view: &View<TodoState>) -> Node {
+        let colors = &view.env.theme.tokens.colors;
+        let spacing = &view.env.theme.tokens.spacing;
+        let done_count = view.state.items.iter().filter(|item| item.done).count();
+        let add = with_reducer!(ctx, AddTodo, add_todo);
+        let update_draft = with_reducer!(ctx, UpdateDraft(String::new()), update_draft);
+        let clear_done = with_reducer!(ctx, ClearDone, clear_done);
+        let light = with_reducer!(ctx, SetThemeMode(DesignMode::Light), set_theme_mode);
+        let dark = with_reducer!(ctx, SetThemeMode(DesignMode::Dark), set_theme_mode);
+
+        let mut todo_rows = Vec::new();
+        for item in &view.state.items {
+            let toggle = with_reducer!(ctx, ToggleTodo(item.id), toggle_todo);
+            todo_rows.push(
+                Container::new(
+                    Row {
+                        gap: Some(12.0),
+                        children: vec![
+                            Checkbox {
+                                checked: item.done,
+                                on_toggle: Some(toggle),
+                                ..Default::default()
+                            }
+                            .into_node(),
+                            Text::new(item.title.clone())
+                                .size(16.0)
+                                .color(if item.done {
+                                    colors.text_secondary
+                                } else {
+                                    colors.text_primary
+                                })
+                                .into_node(),
+                        ],
+                        ..Default::default()
+                    }
+                    .into_node(),
+                )
+                .padding([16.0, 16.0, 12.0, 12.0])
+                .border(colors.border, 1.0)
+                .border_radius(view.env.theme.tokens.radii.medium)
+                .into_node(),
+            );
+        }
+
+        let theme_toggle = Row {
+            gap: Some(8.0),
+            children: vec![
+                Button {
+                    variant: if view.state.theme_mode == DesignMode::Light {
+                        ButtonVariant::Primary
+                    } else {
+                        ButtonVariant::SecondaryGray
+                    },
+                    size: ComponentSize::Sm,
+                    child: Some(Box::new(Text::new("Light").into_node())),
+                    on_press: Some(light),
+                    ..Default::default()
+                }
+                .into_node(),
+                Button {
+                    variant: if view.state.theme_mode == DesignMode::Dark {
+                        ButtonVariant::Primary
+                    } else {
+                        ButtonVariant::SecondaryGray
+                    },
+                    size: ComponentSize::Sm,
+                    child: Some(Box::new(Text::new("Dark").into_node())),
+                    on_press: Some(dark),
+                    ..Default::default()
+                }
+                .into_node(),
+            ],
+            ..Default::default()
+        }
+        .into_node();
+
+        let content = Card {
+            pattern: CardPattern::Raised,
+            child: Box::new(
+                Column {
+                    gap: Some(20.0),
+                    children: vec![
+                        Row {
+                            gap: Some(12.0),
+                            children: vec![
+                                Column {
+                                    gap: Some(6.0),
+                                    children: vec![
+                                        Text::new("Design-system todo")
+                                            .size(32.0)
+                                            .weight(700)
+                                            .into_node(),
+                                        Text::new("This example reads a DSP JSON package at build time and uses the generated Rust theme at runtime.")
+                                            .color(colors.text_secondary)
+                                            .into_node(),
+                                    ],
+                                    flex_grow: 1.0,
+                                    ..Default::default()
+                                }
+                                .into_node(),
+                                Badge {
+                                    text: format!("{} done", done_count),
+                                    tone: BadgeTone::Success,
+                                    ..Default::default()
+                                }
+                                .build(ctx, view),
+                            ],
+                            ..Default::default()
+                        }
+                        .into_node(),
+                        theme_toggle,
+                        Row {
+                            gap: Some(12.0),
+                            children: vec![
+                                TextInput {
+                                    value: view.state.draft.clone(),
+                                    placeholder: Some("Add a task".into()),
+                                    on_change: Some(update_draft),
+                                    width: Some(360.0),
+                                    ..Default::default()
+                                }
+                                .into_node(),
+                                Button {
+                                    variant: ButtonVariant::Primary,
+                                    child: Some(Box::new(Text::new("Add task").into_node())),
+                                    on_press: Some(add),
+                                    ..Default::default()
+                                }
+                                .into_node(),
+                            ],
+                            ..Default::default()
+                        }
+                        .into_node(),
+                        Column {
+                            gap: Some(10.0),
+                            children: todo_rows,
+                            ..Default::default()
+                        }
+                        .into_node(),
+                        Button {
+                            variant: ButtonVariant::TertiaryGray,
+                            child: Some(Box::new(Text::new("Clear completed").into_node())),
+                            on_press: Some(clear_done),
+                            disabled: done_count == 0,
+                            ..Default::default()
+                        }
+                        .into_node(),
+                    ],
+                    ..Default::default()
+                }
+                .into_node(),
+            ),
+            ..Default::default()
+        }
+        .build(ctx, view);
+
+        Container::new(content)
+            .bg(colors.background)
+            .padding_all(spacing.xl)
+            .into_node()
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    DesktopApp::new(TodoApp)
+        .with_design_system::<TodoDesignSystem>(DesignMode::Light)
+        .with_sync_env(|state: &TodoState, env: &mut Env| {
+            env.theme = TodoDesignSystem::theme(state.theme_mode);
+            env.window.title = WindowTitle::plain("Fission Todo - Design System");
+        })
+        .run()
+}

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -481,6 +481,7 @@ impl Widget<GalleryState> for GalleryApp {
                             )),
                         },
                     ],
+                    ..Default::default()
                 }
                 .build(ctx, view),
                 // Breadcrumb
@@ -587,6 +588,7 @@ impl Widget<GalleryState> for GalleryApp {
                         }
                         .into_node(),
                     ),
+                    ..Default::default()
                 }
                 .build(ctx, view),
                 // Accordion

--- a/examples/widget-gallery/tests/visual_audit.rs
+++ b/examples/widget-gallery/tests/visual_audit.rs
@@ -217,6 +217,7 @@ fn build_all_widgets(ctx: &mut BuildCtx<GS>, view: &View<GS>) -> Node {
                         on_press: None,
                     },
                 ],
+                ..Default::default()
             }
             .build(ctx, view),
             Breadcrumb {
@@ -516,20 +517,23 @@ fn progress_bar_partial_fill() {
     let dl = harness.renderer.last_display_list.lock().unwrap();
     let dl = dl.as_ref().unwrap();
 
-    // Find the progress bar: look for a colored rect that's narrower than the track
-    // The track color is theme.progress.track_color (border color ~188,188,188)
-    // The bar color is theme.progress.bar_color (primary ~103,85,143)
+    let progress_theme = &harness.env.theme.components.progress;
+    let expected_height = progress_theme
+        .track_style
+        .height
+        .unwrap_or(progress_theme.height);
+
+    // Find the progress bar by its generated track height; the radius may come
+    // from the active design system and should not be hard-coded in this test.
     let mut bar_rects: Vec<(f32, f32)> = Vec::new();
     for op in &dl.ops {
         if let DisplayOp::DrawRect {
             rect,
             fill: Some(_fill),
-            corner_radius,
             ..
         } = op
         {
-            // Progress bar has corner_radius = height/2 = 4.0
-            if (*corner_radius - 4.0).abs() < 0.5 && rect.height() > 3.0 && rect.height() < 12.0 {
+            if (rect.height() - expected_height).abs() < 0.5 {
                 bar_rects.push((rect.width(), rect.height()));
             }
         }
@@ -541,6 +545,19 @@ fn progress_bar_partial_fill() {
         bar_rects.len() >= 2,
         "expected track + bar rects, found {}",
         bar_rects.len()
+    );
+    let min_width = bar_rects
+        .iter()
+        .map(|(width, _)| *width)
+        .fold(f32::INFINITY, f32::min);
+    let max_width = bar_rects
+        .iter()
+        .map(|(width, _)| *width)
+        .fold(0.0_f32, f32::max);
+    assert!(
+        min_width < max_width,
+        "expected determinate fill to be narrower than track: {:?}",
+        bar_rects
     );
     println!("Progress bar rects: {:?}", bar_rects);
 }

--- a/website/docs/guides/design-system.mdx
+++ b/website/docs/guides/design-system.mdx
@@ -1,0 +1,141 @@
+---
+title: Design system
+sidebar_label: Design system
+description: Use a Design System Package JSON file to generate typed Fission themes at build time.
+---
+
+# Design system
+
+A design system is the set of decisions that makes an application feel coherent: color, typography, spacing, radius, elevation, motion, chart palettes, and the component styles that turn those tokens into real buttons, inputs, badges, cards, tabs, modals, tooltips, and progress indicators.
+
+Fission supports Design System Package JSON files as a build-time input. The app does not parse JSON while it is running. Instead, a build script reads `dsp.json` and `tokens.json`, resolves the token references, and generates ordinary Rust code. Your app then chooses one of the generated themes and writes it into `Env`.
+
+That keeps the hot path simple. Widgets read typed Rust values from `view.env.theme`; they do not search JSON, hash token names, or do string lookups while drawing a frame.
+
+## What gets generated
+
+A DSP package contains two important files:
+
+- `dsp.json`, which describes the package, components, patterns, assets, and where the token file lives.
+- `tokens.json`, which contains primitive and semantic values such as colors, font sizes, spacing, radius, shadows, motion, and chart palettes.
+
+Fission's generator turns those files into a Rust type that implements `DesignSystem`.
+
+```rust
+include!(concat!(env!("OUT_DIR"), "/app_design_system.rs"));
+
+DesktopApp::new(MyApp)
+    .with_design_system::<AppDesignSystem>(DesignMode::Light)
+    .run()?;
+```
+
+`AppDesignSystem` is not hand-written. It is generated during `cargo build`, compiled into your app, and used like any other Rust type.
+
+## Add a DSP package to an app
+
+Create a `design/` folder in your app and place the package files inside it:
+
+```text
+my-app/
+  Cargo.toml
+  build.rs
+  design/
+    dsp.json
+    tokens.json
+  src/
+    main.rs
+```
+
+If you only want to try the workflow first, point your app at Fission's bundled package instead of copying it:
+
+```rust title="build.rs"
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let dsp_path = manifest_dir.join("../../crates/core/fission-theme/design/default/dsp.json");
+
+    fission_design_system_codegen::generate(fission_design_system_codegen::Config {
+        dsp_path,
+        out_file: "app_design_system.rs".into(),
+        type_name: "AppDesignSystem".into(),
+        crate_path: "fission::theme".into(),
+    })
+    .expect("failed to generate design system");
+}
+```
+
+Add the generator as a build dependency:
+
+```toml title="Cargo.toml"
+[dependencies]
+fission = { path = "../../crates/authoring/fission" }
+
+[build-dependencies]
+fission-design-system-codegen = { path = "../../crates/tools/fission-design-system-codegen" }
+```
+
+The generated code uses the public Fission theme API. Your application still imports Fission normally:
+
+```rust title="src/main.rs"
+use fission::prelude::*;
+
+include!(concat!(env!("OUT_DIR"), "/app_design_system.rs"));
+```
+
+## Let the user choose light or dark
+
+Theme choice is product state. If the user can choose light mode or dark mode, keep that choice in `AppState`, then mirror it into `Env` with `.with_sync_env(...)`.
+
+```rust
+DesktopApp::new(MyApp)
+    .with_design_system::<AppDesignSystem>(DesignMode::Light)
+    .with_sync_env(|state: &MyState, env: &mut Env| {
+        env.theme = AppDesignSystem::theme(state.theme_mode);
+        env.window.title = WindowTitle::plain("My Fission App");
+    })
+    .run()?;
+```
+
+`Env` is the environment shared with widgets while they build. Putting the generated `Theme` there means every widget sees the same colors, typography, component sizes, shadows, and motion settings for the current frame.
+
+## What Fission consumes today
+
+The generated theme is not just a bag of metadata. Fission resolves DSP component styles into typed runtime structs.
+
+Buttons consume hierarchy styles such as `primary`, `secondary_color`, `secondary_gray`, `tertiary_color`, `link_color`, and `destructive`. Button sizes such as `sm`, `md`, `lg`, and `xl` map to first-class component size slots. State tables such as `default`, `hover`, `active`, `focus`, and `disabled` resolve into typed style values before the widget renders.
+
+Inputs, badges, tabs, cards, modals, tooltips, and progress bars follow the same model. They read generated component styles for background fills, text colors, borders, radius, padding, font sizes, font weights, line heights, shadows, and state-specific overrides. Charts read the generated data-visualization palette from the theme instead of inventing a separate chart palette.
+
+The important rule is that JSON stops at build time. Runtime code sees Rust values.
+
+## Where to get DSP and token files
+
+You can start from Fission's default package, export from a design tool, or use public token systems as reference material.
+
+- Adobe introduced Design System Package as an open package format for sharing design-system information across tools, including tokens, documentation, snippets, and examples.
+- Google's Material token repository documents Material Design DSP usage and can be used as a reference for a real DSP-style token package.
+- Adobe Spectrum publishes structured design-token data for colors, layout, typography, and component tokens.
+- Tokens Studio and Style Dictionary are useful when your team already manages design tokens in Figma or JSON and needs to transform them for engineering.
+- Token generators such as Tokenry can produce a first pass of primitive and semantic tokens when you are starting from a brand color instead of an existing system.
+
+Useful links:
+
+- [Adobe XD and Design System Package announcement](https://blog.adobe.com/en/publish/2020/10/20/xd-october-2020-update-3d-transforms-libraries-panel-more)
+- [Material Design DSP token repository](https://github.com/material-foundation/material-tokens)
+- [Adobe Spectrum design data tokens](https://opensource.adobe.com/spectrum-design-data/tokens/)
+- [Tokens Studio](https://tokens.studio/)
+- [Style Dictionary design token docs](https://styledictionary.com/info/tokens/)
+- [Tokenry design token generator](https://tokenry.app/)
+
+## Example app
+
+The repository includes `examples/todo-design-system`. It is intentionally small: a todo list, a text input, buttons, badges, a card surface, and a light/dark toggle.
+
+The example's `build.rs` points at Fission's bundled DSP package so the example does not carry a large local copy of the JSON files. In your own app, copy the default package, replace it with your design team's package, or point the generator at a package produced by your design tooling.
+
+Run it with:
+
+```bash
+cargo run -p todo-design-system
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
         'guides/input-events-text-and-env',
         'guides/layout-and-widgets',
         'guides/theming-and-i18n',
+        'guides/design-system',
         'guides/media-animation-portals-and-3d',
         'guides/platform-shells-cli-and-testing',
         'guides/testing-and-diagnostics',


### PR DESCRIPTION
## Summary
- expands the default DSP-backed theme model/codegen into typed component state, size, shadow, border, motion, typography, and chart palette data
- wires generated DSP styles into core/authoring widgets, text inputs, buttons, cards, badges, tabs, modals, progress, tooltips, and charts
- adds a todo design-system example showing app-provided DSP JSON at build time and `with_sync_env` theme/title setup
- adds the Design system guide page and sidebar entry

## Validation
- `cargo test --workspace`
- `cargo test -p inbox --bin inbox`
- `cargo test -p widget-gallery --test visual_audit`
- `npm run typecheck && npm run build:docusaurus` in `website/`
