### PR TITLE
Fix CI submodule checkout

### DIFF
--- a/.github/workflows/platform-checks.yml
+++ b/.github/workflows/platform-checks.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -64,6 +68,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -106,6 +112,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "third_party/android-activity"]
 	path = third_party/android-activity
-	url = git@github.com:worka-ai/android-activity.git
+	url = https://github.com/worka-ai/android-activity.git
 	branch = worka


### PR DESCRIPTION
## Summary

- Fixes the CI failures on merged PR #22 and the `main` website publish run caused by missing `third_party/android-activity` submodule checkout.
- Enables recursive submodule checkout in both GitHub workflows that invoke Cargo: `platform-checks.yml` and `publish-website.yml`.
- Changes the android-activity submodule URL from SSH to HTTPS so GitHub Actions can fetch it without an SSH key.

## Failure confirmed with GH CLI

- `Publish website` main run `26177744184` failed in `Check static site routes` before compilation because Cargo could not read `third_party/android-activity/android-activity/Cargo.toml`.
- `Platform checks` main run `26177744137` failed in all jobs for the same root cause before the actual platform checks could run.

## Verification

- `git submodule sync --recursive`
- `cargo run -p fission-cli --bin fission -- site check --project-dir documentation --release`
- `cargo test -p fission-cli`
