### PR TITLE
Avoid desktop shell dependencies in site builds

### DIFF
--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -6,6 +6,14 @@ license = "MIT"
 repository = "https://github.com/worka-ai/fission"
 description = "Cross-platform GPU-accelerated UI framework for Rust"
 
+[features]
+default = ["platform-shells"]
+platform-shells = [
+    "dep:fission-shell-desktop",
+    "dep:fission-shell-mobile",
+    "dep:fission-shell-web",
+]
+
 [dependencies]
 fission-core = { path = "../../core/fission-core", version = "0.1.1" }
 fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
@@ -21,10 +29,10 @@ fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.1
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.1.1" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.1.1", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.1.1" }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.1.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.1.1" }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.1.1", optional = true }

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -69,11 +69,14 @@ pub mod icons {
 
 /// Platform shells — desktop, mobile, and web wrappers over the shared runtime.
 pub mod shell {
-    #[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
+    #[cfg(all(
+        feature = "platform-shells",
+        not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
+    ))]
     pub use fission_shell_desktop::*;
-    #[cfg(any(target_os = "android", target_os = "ios"))]
+    #[cfg(all(feature = "platform-shells", any(target_os = "android", target_os = "ios")))]
     pub use fission_shell_mobile::*;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "platform-shells", target_arch = "wasm32"))]
     pub use fission_shell_web::*;
 }
 
@@ -127,11 +130,14 @@ pub use fission_layout::{LayoutPoint, LayoutRect, LayoutSize, LayoutUnit};
 pub use fission_widgets::{HStack, Icon, Spacer, VStack};
 
 // Platform shells
-#[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
+#[cfg(all(
+    feature = "platform-shells",
+    not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
+))]
 pub use fission_shell_desktop::DesktopApp;
-#[cfg(any(target_os = "android", target_os = "ios"))]
+#[cfg(all(feature = "platform-shells", any(target_os = "android", target_os = "ios")))]
 pub use fission_shell_mobile::MobileApp;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "platform-shells", target_arch = "wasm32"))]
 pub use fission_shell_web::WebApp;
 
 // Macros
@@ -173,13 +179,16 @@ pub mod prelude {
     pub use fission_macros::{fission_action, fission_reducer, Action};
 
     // Shell
-    #[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
+    #[cfg(all(
+        feature = "platform-shells",
+        not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
+    ))]
     pub use fission_shell_desktop::DesktopApp;
-    #[cfg(target_os = "android")]
+    #[cfg(all(feature = "platform-shells", target_os = "android"))]
     pub use fission_shell_mobile::AndroidApp;
-    #[cfg(any(target_os = "android", target_os = "ios"))]
+    #[cfg(all(feature = "platform-shells", any(target_os = "android", target_os = "ios")))]
     pub use fission_shell_mobile::MobileApp;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "platform-shells", target_arch = "wasm32"))]
     pub use fission_shell_web::WebApp;
 
     // Serde (commonly needed for actions)

--- a/documentation/Cargo.toml
+++ b/documentation/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-fission = { path = "../crates/authoring/fission" }
+fission = { path = "../crates/authoring/fission", default-features = false }
 fission-shell-site = { path = "../crates/shell/fission-shell-site" }


### PR DESCRIPTION
## Summary
- Make platform shell re-exports in the `fission` facade opt-in through the default `platform-shells` feature.
- Build the documentation site with `fission` default features disabled, so static-site generation does not pull desktop renderer/fontconfig dependencies on Linux CI.

## Context
The main `Publish website` workflow got past the missing `android-activity` submodule issue, then failed in `Check static site routes` because `yeslogic-fontconfig-sys` could not find the system `fontconfig` package. That dependency was being pulled through the desktop shell/rendering path even though the documentation site only needs the Fission authoring/runtime APIs plus the static site shell.

This keeps the normal `fission` default behavior intact for app crates, while allowing site-only crates to opt out of platform shells.

## Verification
- `cargo tree -p fission-documentation -e features | rg "fission-shell-desktop|fission-render-vello|vello|fontconfig|platform-shells" || true`
- `cargo run -p fission-cli --bin fission -- site check --project-dir documentation --release`
- `cargo run -p fission-cli --bin fission -- site build --project-dir documentation --release`
- Verified generated site artifact files exist.
- `cargo check -p fission --no-default-features`
- `cargo check -p fission`
