### PR TITLE
[codex] harden winit platform backends

### DIFF
--- a/crates/shell/fission-shell-winit/src/ime.rs
+++ b/crates/shell/fission-shell-winit/src/ime.rs
@@ -220,7 +220,10 @@ mod macos {
         config: Option<&TextInputConfig>,
         active_view_id: &mut Option<usize>,
     ) {
-        let view = ns_view_from_window(window);
+        let Some(view) = ns_view_from_window(window) else {
+            clear_text_input_traits(active_view_id.take());
+            return;
+        };
         ensure_trait_bridge(view);
 
         let view_id = view as usize;
@@ -261,13 +264,11 @@ mod macos {
         }
     }
 
-    fn ns_view_from_window(window: &Window) -> id {
-        let handle = window
-            .window_handle()
-            .expect("window handle unavailable on macOS");
+    fn ns_view_from_window(window: &Window) -> Option<id> {
+        let handle = window.window_handle().ok()?;
         match handle.as_raw() {
-            RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr() as id,
-            other => panic!("expected AppKit window handle, got {other:?}"),
+            RawWindowHandle::AppKit(handle) => Some(handle.ns_view.as_ptr() as id),
+            _ => None,
         }
     }
 

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -47,7 +47,7 @@ use fission_render_vello::{RetainedSceneCache, VelloRenderer, VelloTextMeasurer}
 use fission_shell::async_host::{
     AsyncMessage, AsyncRegistry, RunningServiceHandle, ServiceControlMessage,
 };
-use fission_shell::{VideoBackend, VideoEvent, VideoPlayer};
+use fission_shell::{VideoEvent, VideoPlayer};
 use fission_theme::fonts;
 use fontique::{Blob, Collection, CollectionOptions, FontInfoOverride, SourceCache};
 
@@ -75,15 +75,9 @@ pub use pipeline::{InvalidationSet, Pipeline};
 mod software_renderer;
 use software_renderer::SoftwareRenderer;
 mod video_backend;
-#[cfg(target_os = "macos")]
-use video_backend::MacVideoBackend;
-#[cfg(not(target_os = "macos"))]
-use video_backend::MockVideoBackend;
+use video_backend::create_video_backend;
 mod web_backend;
-#[cfg(target_os = "macos")]
-use web_backend::MacWebBackend;
-#[cfg(not(target_os = "macos"))]
-use web_backend::MockWebBackend;
+use web_backend::PlatformWebBackend;
 
 mod clipboard;
 use clipboard::DesktopClipboard;
@@ -2841,14 +2835,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
         let mut active_services: HashMap<ServiceKey, ActiveServiceHandle> = HashMap::new();
         let mut service_bindings: HashMap<ServiceBindingKey, ServiceBindings> = HashMap::new();
 
-        #[cfg(target_os = "macos")]
-        let video_backend: Arc<dyn VideoBackend> = Arc::new(MacVideoBackend::new(&platform_window));
-        #[cfg(not(target_os = "macos"))]
-        let video_backend: Arc<dyn VideoBackend> = Arc::new(MockVideoBackend::new());
-        #[cfg(target_os = "macos")]
-        let web_backend = MacWebBackend::new(&platform_window);
-        #[cfg(not(target_os = "macos"))]
-        let web_backend = MockWebBackend::new();
+        #[cfg(not(target_os = "android"))]
+        let video_backend = create_video_backend(Some(&platform_window));
+        #[cfg(target_os = "android")]
+        let video_backend = create_video_backend(platform_window.as_deref());
+        #[cfg(not(target_os = "android"))]
+        let web_backend = PlatformWebBackend::new(Some(&platform_window));
+        #[cfg(target_os = "android")]
+        let web_backend = PlatformWebBackend::new(platform_window.as_deref());
         let mut players: HashMap<WidgetNodeId, ActivePlayer> = HashMap::new();
 
         let mut last_cursor_position: Option<PhysicalPosition<f64>> = None;

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -876,3 +876,34 @@ mod mock {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{create_video_backend, VideoEvent};
+    use fission_ir::WidgetNodeId;
+    use fission_render::LayoutRect;
+    use fission_shell::VideoSurfaceFrame;
+
+    #[test]
+    fn video_backend_without_window_uses_safe_fallback() {
+        let backend = create_video_backend(None);
+        let mut player = backend.create_player("");
+
+        assert!(player.surface_id() > 0);
+
+        backend.present_surfaces(&[VideoSurfaceFrame {
+            widget_id: WidgetNodeId::explicit("fallback-video"),
+            surface_id: player.surface_id(),
+            rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
+        }]);
+        backend.present_surfaces(&[]);
+
+        let events = player.poll_events();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, VideoEvent::Error(_))),
+            "missing source should surface a recoverable error event"
+        );
+    }
+}

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -1,12 +1,27 @@
 #![allow(unexpected_cfgs)]
 
 use fission_shell::{VideoBackend, VideoEvent, VideoPlayer};
+use std::sync::Arc;
+use winit::window::Window;
 
 #[cfg(target_os = "macos")]
 pub use mac::MacVideoBackend;
 
-#[cfg(not(target_os = "macos"))]
 pub use mock::MockVideoBackend;
+
+pub fn create_video_backend(window: Option<&Window>) -> Arc<dyn VideoBackend> {
+    #[cfg(target_os = "macos")]
+    if let Some(window) = window {
+        if let Some(backend) = MacVideoBackend::try_new(window) {
+            return Arc::new(backend);
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = window;
+
+    Arc::new(MockVideoBackend::new())
+}
 
 #[cfg(target_os = "macos")]
 #[allow(unexpected_cfgs)]
@@ -65,24 +80,24 @@ mod mac {
     }
 
     pub struct MacVideoBackend {
-        view: RetainedId,
+        view: Option<RetainedId>,
         layers: Mutex<HashMap<WidgetNodeId, VideoLayer>>,
         registry: Arc<PlayerRegistry>,
     }
 
     impl MacVideoBackend {
-        pub fn new(window: &Window) -> Self {
-            let ns_view = ns_view_from_window(window);
-            Self {
-                view: unsafe { RetainedId::new(ns_view) },
+        pub fn try_new(window: &Window) -> Option<Self> {
+            let ns_view = ns_view_from_window(window)?;
+            Some(Self {
+                view: Some(unsafe { RetainedId::new(ns_view) }),
                 layers: Mutex::new(HashMap::new()),
                 registry: Arc::new(PlayerRegistry::new()),
-            }
+            })
         }
 
-        fn ensure_layer_backing(&self) -> LayerContext {
+        fn ensure_layer_backing(&self) -> Option<LayerContext> {
             unsafe {
-                let view = self.view.as_id();
+                let view = self.view.as_ref()?.as_id();
                 let wants_layer: bool = msg_send![view, wantsLayer];
                 if !wants_layer {
                     let () = msg_send![view, setWantsLayer: YES];
@@ -103,11 +118,11 @@ mod mac {
 
                 let bounds: CGRect = msg_send![view, bounds];
 
-                LayerContext {
+                Some(LayerContext {
                     parent_view: view,
                     scale_factor: if scale == 0.0 { 1.0 } else { scale },
                     bounds_height: bounds.size.height,
-                }
+                })
             }
         }
 
@@ -127,13 +142,11 @@ mod mac {
         }
     }
 
-    fn ns_view_from_window(window: &Window) -> id {
-        let handle = window
-            .window_handle()
-            .expect("window handle unavailable on macOS");
+    fn ns_view_from_window(window: &Window) -> Option<id> {
+        let handle = window.window_handle().ok()?;
         match handle.as_raw() {
-            RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr() as id,
-            other => panic!("expected AppKit window handle, got {other:?}"),
+            RawWindowHandle::AppKit(handle) => Some(handle.ns_view.as_ptr() as id),
+            _ => None,
         }
     }
 
@@ -172,7 +185,15 @@ mod mac {
                 return;
             }
 
-            let ctx = self.ensure_layer_backing();
+            let Some(ctx) = self.ensure_layer_backing() else {
+                for layer in layers.values() {
+                    unsafe {
+                        layer.detach();
+                    }
+                }
+                layers.clear();
+                return;
+            };
             let mut seen = HashSet::new();
             for frame in frames {
                 seen.insert(frame.widget_id);
@@ -579,7 +600,6 @@ mod mac {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
 mod mock {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
     use std::path::{Path, PathBuf};

--- a/crates/shell/fission-shell-winit/src/web_backend.rs
+++ b/crates/shell/fission-shell-winit/src/web_backend.rs
@@ -285,3 +285,22 @@ mod mock {
         pub fn present_surfaces(&self, _frames: &[WebSurfaceFrame]) {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{PlatformWebBackend, WebSurfaceFrame};
+    use fission_ir::WidgetNodeId;
+    use fission_render::LayoutRect;
+
+    #[test]
+    fn web_backend_without_window_uses_safe_fallback() {
+        let backend = PlatformWebBackend::new(None);
+        backend.present_surfaces(&[WebSurfaceFrame {
+            widget_id: WidgetNodeId::explicit("fallback-web"),
+            url: "https://example.invalid".to_string(),
+            user_agent: Some("fission-test".to_string()),
+            rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
+        }]);
+        backend.present_surfaces(&[]);
+    }
+}

--- a/crates/shell/fission-shell-winit/src/web_backend.rs
+++ b/crates/shell/fission-shell-winit/src/web_backend.rs
@@ -2,6 +2,7 @@
 
 use fission_ir::WidgetNodeId;
 use fission_render::LayoutRect;
+use winit::window::Window;
 
 #[derive(Clone, Debug)]
 pub struct WebSurfaceFrame {
@@ -14,8 +15,37 @@ pub struct WebSurfaceFrame {
 #[cfg(target_os = "macos")]
 pub use mac::MacWebBackend;
 
-#[cfg(not(target_os = "macos"))]
 pub use mock::MockWebBackend;
+
+pub enum PlatformWebBackend {
+    #[cfg(target_os = "macos")]
+    Native(MacWebBackend),
+    Mock(MockWebBackend),
+}
+
+impl PlatformWebBackend {
+    pub fn new(window: Option<&Window>) -> Self {
+        #[cfg(target_os = "macos")]
+        if let Some(window) = window {
+            if let Some(backend) = MacWebBackend::try_new(window) {
+                return Self::Native(backend);
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        let _ = window;
+
+        Self::Mock(MockWebBackend::new())
+    }
+
+    pub fn present_surfaces(&self, frames: &[WebSurfaceFrame]) {
+        match self {
+            #[cfg(target_os = "macos")]
+            Self::Native(backend) => backend.present_surfaces(frames),
+            Self::Mock(backend) => backend.present_surfaces(frames),
+        }
+    }
+}
 
 #[cfg(target_os = "macos")]
 #[allow(unexpected_cfgs)]
@@ -62,17 +92,17 @@ mod mac {
     }
 
     pub struct MacWebBackend {
-        view: RetainedId,
+        view: Option<RetainedId>,
         views: Mutex<HashMap<WidgetNodeId, WebViewEntry>>,
     }
 
     impl MacWebBackend {
-        pub fn new(window: &Window) -> Self {
-            let ns_view = ns_view_from_window(window);
-            Self {
-                view: unsafe { RetainedId::retain(ns_view) },
+        pub fn try_new(window: &Window) -> Option<Self> {
+            let ns_view = ns_view_from_window(window)?;
+            Some(Self {
+                view: Some(unsafe { RetainedId::retain(ns_view) }),
                 views: Mutex::new(HashMap::new()),
-            }
+            })
         }
 
         pub fn present_surfaces(&self, frames: &[WebSurfaceFrame]) {
@@ -85,7 +115,13 @@ mod mac {
                 return;
             }
 
-            let ctx = self.context();
+            let Some(ctx) = self.context() else {
+                for view in views.values() {
+                    view.detach();
+                }
+                views.clear();
+                return;
+            };
             let mut seen = HashSet::new();
             for frame in frames {
                 seen.insert(frame.widget_id);
@@ -105,14 +141,14 @@ mod mac {
             });
         }
 
-        fn context(&self) -> ViewContext {
+        fn context(&self) -> Option<ViewContext> {
             unsafe {
-                let parent_view = self.view.as_id();
+                let parent_view = self.view.as_ref()?.as_id();
                 let bounds: CGRect = msg_send![parent_view, bounds];
-                ViewContext {
+                Some(ViewContext {
                     parent_view,
                     bounds_height: bounds.size.height,
-                }
+                })
             }
         }
     }
@@ -208,13 +244,11 @@ mod mac {
         }
     }
 
-    fn ns_view_from_window(window: &Window) -> id {
-        let handle = window
-            .window_handle()
-            .expect("window handle unavailable on macOS");
+    fn ns_view_from_window(window: &Window) -> Option<id> {
+        let handle = window.window_handle().ok()?;
         match handle.as_raw() {
-            RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr() as id,
-            other => panic!("expected AppKit window handle, got {other:?}"),
+            RawWindowHandle::AppKit(handle) => Some(handle.ns_view.as_ptr() as id),
+            _ => None,
         }
     }
 
@@ -238,7 +272,6 @@ mod mac {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
 mod mock {
     use super::WebSurfaceFrame;
 


### PR DESCRIPTION
## Summary

Hardens the winit shell against missing or non-AppKit native window handles.

- Makes macOS IME trait configuration no-op safely when no AppKit view is available
- Adds safe mock fallbacks for native video and web overlay backends
- Adds regression coverage for no-window video and web backend construction

## Why

The shell previously assumed AppKit handles in places that can be reached by cross-platform or background/test shell paths. That made platform integration brittle and could panic instead of falling back to deterministic mock behavior.

## Impact

Desktop/macOS behavior continues to use native backends when an AppKit view exists. Other paths now degrade to mock backends instead of crashing.

## Validation

- `cargo test -p fission-shell-winit --lib --locked -- --nocapture`

