### PR TITLE
Add notification capabilities and deep-link lifecycle actions

### DIFF
--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -151,8 +151,20 @@ pub use fission_core::ui::*;
 // Core action/state types
 pub use fission_core::{
     Action, ActionEnvelope, ActionId, ActionScopeId, AnimationPropertyId, AnimationRequest,
-    AnimationStartValue, AppState, BuildCtx, EasingFunction, FlexDirection, Handler, NodeBuilder,
-    Op, PortalLayer, ReducerContext, Selector, View, Widget, WidgetNodeId,
+    AnimationStartValue, AppState, BuildCtx, CancelAllNotificationsCapability,
+    CancelNotificationCapability, CancelNotificationRequest, DeepLink, DeepLinkConfig,
+    DeepLinkReceived, DeepLinkSource, EasingFunction, FlexDirection,
+    GetNotificationSettingsCapability, Handler, NodeBuilder, NotificationActionButton,
+    NotificationError, NotificationId, NotificationPermission, NotificationPermissionRequest,
+    NotificationReceipt, NotificationRequest, NotificationResponse, NotificationResponseReceived,
+    NotificationSchedule, NotificationSettings, NotificationSound, Op, PortalLayer, PushPlatform,
+    PushRegistration, PushRegistrationRequest, ReducerContext, RegisterPushNotificationsCapability,
+    RequestNotificationPermissionCapability, ScheduleNotificationCapability, Selector,
+    SetBadgeCountCapability, SetBadgeCountRequest, ShowNotificationCapability,
+    UnregisterPushNotificationsCapability, View, Widget, WidgetNodeId, CANCEL_ALL_NOTIFICATIONS,
+    CANCEL_NOTIFICATION, GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS,
+    REQUEST_NOTIFICATION_PERMISSION, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION,
+    UNREGISTER_PUSH_NOTIFICATIONS,
 };
 
 // Core event types
@@ -177,7 +189,9 @@ pub use fission_widgets::{HStack, Icon, Spacer, VStack};
     any(feature = "desktop", feature = "platform-shells"),
     not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
 ))]
-pub use fission_shell_desktop::DesktopApp;
+pub use fission_shell_desktop::{
+    DesktopApp, MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+};
 #[cfg(all(
     any(
         feature = "android",
@@ -187,14 +201,18 @@ pub use fission_shell_desktop::DesktopApp;
     ),
     any(target_os = "android", target_os = "ios")
 ))]
-pub use fission_shell_mobile::MobileApp;
+pub use fission_shell_mobile::{
+    MemoryNotificationHost, MobileApp, NotificationHost, UnsupportedNotificationHost,
+};
 #[cfg(feature = "terminal-shell")]
 pub use fission_shell_terminal::TerminalApp;
 #[cfg(all(
     any(feature = "web", feature = "platform-shells"),
     target_arch = "wasm32"
 ))]
-pub use fission_shell_web::WebApp;
+pub use fission_shell_web::{
+    MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost, WebApp,
+};
 
 // Macros
 pub use fission_macros::{fission_action, fission_reducer, Action as ActionDerive};
@@ -214,8 +232,21 @@ pub mod prelude {
     pub use fission_core::{reduce, reduce_with, with_reducer};
     pub use fission_core::{
         Action, ActionEnvelope, ActionId, ActionScopeId, AnimationPropertyId, AnimationRequest,
-        AnimationStartValue, AppState, BuildCtx, Effects, FlexDirection, Handler, NodeBuilder, Op,
-        PortalLayer, ReducerContext, Selector, View, Widget, WidgetNodeId, WindowEnv, WindowTitle,
+        AnimationStartValue, AppState, BuildCtx, CancelAllNotificationsCapability,
+        CancelNotificationCapability, CancelNotificationRequest, DeepLink, DeepLinkConfig,
+        DeepLinkReceived, DeepLinkSource, Effects, FlexDirection,
+        GetNotificationSettingsCapability, Handler, NodeBuilder, NotificationActionButton,
+        NotificationEffects, NotificationError, NotificationId, NotificationPermission,
+        NotificationPermissionRequest, NotificationReceipt, NotificationRequest,
+        NotificationResponse, NotificationResponseReceived, NotificationSchedule,
+        NotificationSettings, NotificationSound, Op, PortalLayer, PushPlatform, PushRegistration,
+        PushRegistrationRequest, ReducerContext, RegisterPushNotificationsCapability,
+        RequestNotificationPermissionCapability, ScheduleNotificationCapability, Selector,
+        SetBadgeCountCapability, SetBadgeCountRequest, ShowNotificationCapability,
+        UnregisterPushNotificationsCapability, View, Widget, WidgetNodeId, WindowEnv, WindowTitle,
+        CANCEL_ALL_NOTIFICATIONS, CANCEL_NOTIFICATION, GET_NOTIFICATION_SETTINGS,
+        REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION, SCHEDULE_NOTIFICATION,
+        SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
     };
 
     // Layout
@@ -239,7 +270,9 @@ pub mod prelude {
         any(feature = "desktop", feature = "platform-shells"),
         not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
     ))]
-    pub use fission_shell_desktop::DesktopApp;
+    pub use fission_shell_desktop::{
+        DesktopApp, MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+    };
     #[cfg(all(
         any(feature = "android", feature = "mobile", feature = "platform-shells"),
         target_os = "android"
@@ -254,7 +287,9 @@ pub mod prelude {
         ),
         any(target_os = "android", target_os = "ios")
     ))]
-    pub use fission_shell_mobile::MobileApp;
+    pub use fission_shell_mobile::{
+        MemoryNotificationHost, MobileApp, NotificationHost, UnsupportedNotificationHost,
+    };
     #[cfg(feature = "site")]
     pub use fission_shell_site::*;
     #[cfg(feature = "terminal-shell")]
@@ -263,7 +298,9 @@ pub mod prelude {
         any(feature = "web", feature = "platform-shells"),
         target_arch = "wasm32"
     ))]
-    pub use fission_shell_web::WebApp;
+    pub use fission_shell_web::{
+        MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost, WebApp,
+    };
 
     // Serde (commonly needed for actions)
     pub use serde::{Deserialize, Serialize};

--- a/crates/authoring/fission/tests/platform_api.rs
+++ b/crates/authoring/fission/tests/platform_api.rs
@@ -1,0 +1,52 @@
+#![cfg(all(
+    feature = "desktop",
+    not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
+))]
+
+use fission::prelude::*;
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+struct PlatformApiState {
+    last_link: Option<String>,
+    last_notification: Option<String>,
+}
+
+impl AppState for PlatformApiState {}
+
+fn on_deep_link(state: &mut PlatformApiState, action: DeepLinkReceived) {
+    state.last_link = Some(action.link.url);
+}
+
+fn on_notification_response(state: &mut PlatformApiState, action: NotificationResponseReceived) {
+    state.last_notification = Some(action.response.notification_id.0);
+}
+
+struct PlatformApiApp;
+
+impl Widget<PlatformApiState> for PlatformApiApp {
+    fn build(&self, _ctx: &mut BuildCtx<PlatformApiState>, _view: &View<PlatformApiState>) -> Node {
+        Text::new("platform api").into_node()
+    }
+}
+
+#[test]
+fn facade_exports_notifications_and_deep_links() {
+    let _app = DesktopApp::new(PlatformApiApp)
+        .with_notification_host(MemoryNotificationHost)
+        .with_deep_link_config(
+            DeepLinkConfig::new()
+                .scheme("fission")
+                .domain("example.com"),
+        )
+        .with_startup_deep_link(DeepLink::new("fission://open/1").cold_start(true))
+        .with_startup_notification_response(NotificationResponse {
+            notification_id: NotificationId::new("n1"),
+            action_id: Some("open".into()),
+            deep_link: Some("fission://open/1".into()),
+            user_text: None,
+        })
+        .on_deep_link(on_deep_link as fn(&mut PlatformApiState, DeepLinkReceived))
+        .on_notification_response(
+            on_notification_response as fn(&mut PlatformApiState, NotificationResponseReceived),
+        );
+}

--- a/crates/core/fission-core/src/context.rs
+++ b/crates/core/fission-core/src/context.rs
@@ -14,6 +14,12 @@ use crate::capability::{
     CapabilityInvocationPayload, CapabilityType, OperationCapability, OperationCapabilityInvocation,
 };
 use crate::effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect};
+use crate::platform::{
+    CancelNotificationRequest, NotificationPermissionRequest, NotificationRequest,
+    PushRegistrationRequest, SetBadgeCountRequest, CANCEL_ALL_NOTIFICATIONS, CANCEL_NOTIFICATION,
+    GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
+    SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
+};
 use crate::registry::{ActionRegistry, IntoHandler};
 use std::marker::PhantomData;
 
@@ -151,6 +157,10 @@ impl<'a, S: AppState> Effects<'a, S> {
         }
     }
 
+    pub fn notifications(&mut self) -> NotificationEffects<'_, 'a, S> {
+        NotificationEffects { effects: self }
+    }
+
     pub fn app<J: JobSpec>(
         &mut self,
         job: JobRef<J>,
@@ -265,6 +275,54 @@ impl<'a, S: AppState> Effects<'a, S> {
         self.add(Effect::Runtime(RuntimeEffect::ReleaseResource {
             resource_id,
         }));
+    }
+}
+
+/// Convenience builder for the standard notification host capabilities.
+pub struct NotificationEffects<'a, 'b, S: AppState> {
+    effects: &'a mut Effects<'b, S>,
+}
+
+impl<'a, 'b, S: AppState> NotificationEffects<'a, 'b, S> {
+    pub fn request_permission(
+        self,
+        request: NotificationPermissionRequest,
+    ) -> EffectBuilder<'a, 'b, S> {
+        self.effects
+            .capability(REQUEST_NOTIFICATION_PERMISSION, request)
+    }
+
+    pub fn settings(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(GET_NOTIFICATION_SETTINGS, ())
+    }
+
+    pub fn show(self, request: NotificationRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(SHOW_NOTIFICATION, request)
+    }
+
+    pub fn schedule(self, request: NotificationRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(SCHEDULE_NOTIFICATION, request)
+    }
+
+    pub fn cancel(self, request: CancelNotificationRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(CANCEL_NOTIFICATION, request)
+    }
+
+    pub fn cancel_all(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(CANCEL_ALL_NOTIFICATIONS, ())
+    }
+
+    pub fn set_badge_count(self, request: SetBadgeCountRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(SET_BADGE_COUNT, request)
+    }
+
+    pub fn register_push(self, request: PushRegistrationRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects
+            .capability(REGISTER_PUSH_NOTIFICATIONS, request)
+    }
+
+    pub fn unregister_push(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(UNREGISTER_PUSH_NOTIFICATIONS, ())
     }
 }
 

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod hit_test;
 pub mod input;
 pub mod lowering;
 pub mod media;
+pub mod platform;
 pub mod registry;
 pub mod runtime;
 pub mod scrollbar;
@@ -72,7 +73,7 @@ pub use capability::{
     OperationCapability, PickOpenFilesCapability, PickOpenFilesError, PickOpenFilesRequest,
     PickOpenFilesResult, PickedFile, OPEN_URL, PICK_OPEN_FILES,
 };
-pub use context::{Effects, ReducerContext}; // New
+pub use context::{Effects, NotificationEffects, ReducerContext}; // New
 pub use effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect};
 pub use env::{
     Clipboard, Env, ImeHandler, InteractionStateMap, RuntimeState, ScrollStateMap, WindowEnv,
@@ -88,6 +89,19 @@ pub use fission_layout::{
     LayoutSnapshot, LayoutUnit, TextMeasurer,
 };
 pub use lowering::{LoweringContext, NodeBuilder};
+pub use platform::{
+    CancelAllNotificationsCapability, CancelNotificationCapability, CancelNotificationRequest,
+    DeepLink, DeepLinkConfig, DeepLinkReceived, DeepLinkSource, GetNotificationSettingsCapability,
+    NotificationActionButton, NotificationError, NotificationId, NotificationPermission,
+    NotificationPermissionRequest, NotificationReceipt, NotificationRequest, NotificationResponse,
+    NotificationResponseReceived, NotificationSchedule, NotificationSettings, NotificationSound,
+    PushPlatform, PushRegistration, PushRegistrationRequest, RegisterPushNotificationsCapability,
+    RequestNotificationPermissionCapability, ScheduleNotificationCapability,
+    SetBadgeCountCapability, SetBadgeCountRequest, ShowNotificationCapability,
+    UnregisterPushNotificationsCapability, CANCEL_ALL_NOTIFICATIONS, CANCEL_NOTIFICATION,
+    GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
+    SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
+};
 pub use registry::{
     ActionRegistry, AnimationPropertyId, AnimationRequest, AnimationStartValue, BuildCtx,
     EasingFunction, Handler, JobResource, PortalLayer, RawActionHandler, ResourceKey,

--- a/crates/core/fission-core/src/platform.rs
+++ b/crates/core/fission-core/src/platform.rs
@@ -1,0 +1,567 @@
+//! Platform services shared by Fission shells.
+//!
+//! Notifications are modelled as typed host capabilities. Deep links and
+//! notification responses are inbound lifecycle actions dispatched by shells.
+
+use crate::action::{Action, ActionId};
+use crate::capability::{CapabilityType, OperationCapability};
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a local or scheduled notification.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NotificationId(pub String);
+
+impl NotificationId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+/// Permission state reported by the host notification system.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NotificationPermission {
+    Granted,
+    Denied,
+    Provisional,
+    #[default]
+    NotDetermined,
+    Unsupported,
+}
+
+/// Request sent when an app asks the host to request notification permission.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationPermissionRequest {
+    pub alerts: bool,
+    pub badge: bool,
+    pub sound: bool,
+    pub provisional: bool,
+}
+
+/// Current notification settings known to the host.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationSettings {
+    pub permission: NotificationPermission,
+    pub alerts: bool,
+    pub badge: bool,
+    pub sound: bool,
+    pub scheduling: bool,
+    pub push: bool,
+}
+
+impl Default for NotificationSettings {
+    fn default() -> Self {
+        Self {
+            permission: NotificationPermission::NotDetermined,
+            alerts: false,
+            badge: false,
+            sound: false,
+            scheduling: false,
+            push: false,
+        }
+    }
+}
+
+/// Portable notification error payload returned by hosts.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationError {
+    pub code: String,
+    pub message: String,
+}
+
+impl NotificationError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn unsupported(operation: impl Into<String>) -> Self {
+        Self::new(
+            "unsupported",
+            format!(
+                "notification operation `{}` is not supported by this host",
+                operation.into()
+            ),
+        )
+    }
+}
+
+/// Notification sound policy.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NotificationSound {
+    #[default]
+    Default,
+    Silent,
+    Named(String),
+}
+
+/// Portable scheduling request.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NotificationSchedule {
+    #[default]
+    Immediate,
+    AtUnixMillis(u64),
+    AfterMillis(u64),
+}
+
+/// Action button exposed by a notification.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationActionButton {
+    pub id: String,
+    pub title: String,
+    pub destructive: bool,
+    pub foreground: bool,
+    pub text_input: bool,
+}
+
+/// Request to show or schedule a notification.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationRequest {
+    pub id: NotificationId,
+    pub title: String,
+    pub body: String,
+    pub subtitle: Option<String>,
+    pub badge: Option<u32>,
+    pub sound: NotificationSound,
+    pub deep_link: Option<String>,
+    pub actions: Vec<NotificationActionButton>,
+    pub schedule: NotificationSchedule,
+}
+
+/// Success payload for show/schedule notification operations.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationReceipt {
+    pub id: NotificationId,
+    pub scheduled: bool,
+    pub delivered: bool,
+}
+
+/// Request to cancel one notification.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CancelNotificationRequest {
+    pub id: NotificationId,
+}
+
+/// Request to set or clear the app badge.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SetBadgeCountRequest {
+    pub count: Option<u32>,
+}
+
+/// Request to register for remote/push notifications.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PushRegistrationRequest {
+    pub app_server_key: Option<String>,
+    pub sender_id: Option<String>,
+    pub topics: Vec<String>,
+}
+
+/// Push provider used by a host registration.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PushPlatform {
+    Apple,
+    Android,
+    Web,
+    Windows,
+    Other(String),
+}
+
+/// Push registration returned by the host.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PushRegistration {
+    pub platform: PushPlatform,
+    pub token: String,
+    pub endpoint: Option<String>,
+    pub p256dh_key: Option<String>,
+    pub auth_secret: Option<String>,
+}
+
+pub struct RequestNotificationPermissionCapability;
+impl OperationCapability for RequestNotificationPermissionCapability {
+    type Request = NotificationPermissionRequest;
+    type Ok = NotificationSettings;
+    type Err = NotificationError;
+}
+
+pub struct GetNotificationSettingsCapability;
+impl OperationCapability for GetNotificationSettingsCapability {
+    type Request = ();
+    type Ok = NotificationSettings;
+    type Err = NotificationError;
+}
+
+pub struct ShowNotificationCapability;
+impl OperationCapability for ShowNotificationCapability {
+    type Request = NotificationRequest;
+    type Ok = NotificationReceipt;
+    type Err = NotificationError;
+}
+
+pub struct ScheduleNotificationCapability;
+impl OperationCapability for ScheduleNotificationCapability {
+    type Request = NotificationRequest;
+    type Ok = NotificationReceipt;
+    type Err = NotificationError;
+}
+
+pub struct CancelNotificationCapability;
+impl OperationCapability for CancelNotificationCapability {
+    type Request = CancelNotificationRequest;
+    type Ok = ();
+    type Err = NotificationError;
+}
+
+pub struct CancelAllNotificationsCapability;
+impl OperationCapability for CancelAllNotificationsCapability {
+    type Request = ();
+    type Ok = ();
+    type Err = NotificationError;
+}
+
+pub struct SetBadgeCountCapability;
+impl OperationCapability for SetBadgeCountCapability {
+    type Request = SetBadgeCountRequest;
+    type Ok = ();
+    type Err = NotificationError;
+}
+
+pub struct RegisterPushNotificationsCapability;
+impl OperationCapability for RegisterPushNotificationsCapability {
+    type Request = PushRegistrationRequest;
+    type Ok = PushRegistration;
+    type Err = NotificationError;
+}
+
+pub struct UnregisterPushNotificationsCapability;
+impl OperationCapability for UnregisterPushNotificationsCapability {
+    type Request = ();
+    type Ok = ();
+    type Err = NotificationError;
+}
+
+pub const REQUEST_NOTIFICATION_PERMISSION: CapabilityType<RequestNotificationPermissionCapability> =
+    CapabilityType::new("fission.notifications.request_permission");
+pub const GET_NOTIFICATION_SETTINGS: CapabilityType<GetNotificationSettingsCapability> =
+    CapabilityType::new("fission.notifications.get_settings");
+pub const SHOW_NOTIFICATION: CapabilityType<ShowNotificationCapability> =
+    CapabilityType::new("fission.notifications.show");
+pub const SCHEDULE_NOTIFICATION: CapabilityType<ScheduleNotificationCapability> =
+    CapabilityType::new("fission.notifications.schedule");
+pub const CANCEL_NOTIFICATION: CapabilityType<CancelNotificationCapability> =
+    CapabilityType::new("fission.notifications.cancel");
+pub const CANCEL_ALL_NOTIFICATIONS: CapabilityType<CancelAllNotificationsCapability> =
+    CapabilityType::new("fission.notifications.cancel_all");
+pub const SET_BADGE_COUNT: CapabilityType<SetBadgeCountCapability> =
+    CapabilityType::new("fission.notifications.set_badge_count");
+pub const REGISTER_PUSH_NOTIFICATIONS: CapabilityType<RegisterPushNotificationsCapability> =
+    CapabilityType::new("fission.notifications.register_push");
+pub const UNREGISTER_PUSH_NOTIFICATIONS: CapabilityType<UnregisterPushNotificationsCapability> =
+    CapabilityType::new("fission.notifications.unregister_push");
+
+/// Source that delivered an inbound deep link.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeepLinkSource {
+    CustomScheme,
+    UniversalLink,
+    AppLink,
+    WebUrl,
+    Notification,
+    External,
+    Unknown,
+}
+
+/// Inbound URL delivered by the host shell.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeepLink {
+    pub url: String,
+    pub cold_start: bool,
+    pub source: DeepLinkSource,
+}
+
+impl DeepLink {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            cold_start: false,
+            source: DeepLinkSource::Unknown,
+        }
+    }
+
+    pub fn cold_start(mut self, cold_start: bool) -> Self {
+        self.cold_start = cold_start;
+        self
+    }
+
+    pub fn source(mut self, source: DeepLinkSource) -> Self {
+        self.source = source;
+        self
+    }
+}
+
+/// Declarative runtime filter for inbound deep links.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeepLinkConfig {
+    pub schemes: Vec<String>,
+    pub domains: Vec<String>,
+    pub path_prefixes: Vec<String>,
+}
+
+impl DeepLinkConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.schemes.push(normalize_scheme(scheme.into()));
+        self
+    }
+
+    pub fn domain(mut self, domain: impl Into<String>) -> Self {
+        self.domains.push(normalize_domain(domain.into()));
+        self
+    }
+
+    pub fn path_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.path_prefixes
+            .push(normalize_path_prefix(prefix.into()));
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.schemes.is_empty() && self.domains.is_empty() && self.path_prefixes.is_empty()
+    }
+
+    pub fn matches(&self, url: &str) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        let Some(parts) = ParsedUrl::parse(url) else {
+            return false;
+        };
+        let scheme_matches = self
+            .schemes
+            .iter()
+            .any(|scheme| scheme == &normalize_scheme(parts.scheme));
+        let domain_matches = parts.host.as_deref().is_some_and(|host| {
+            let host = normalize_domain(host.to_string());
+            self.domains.iter().any(|domain| domain == &host)
+        });
+        let path_matches = self.path_prefixes.is_empty()
+            || self
+                .path_prefixes
+                .iter()
+                .any(|prefix| parts.path.starts_with(prefix));
+
+        (scheme_matches || domain_matches) && path_matches
+    }
+
+    pub fn source_for(&self, url: &str) -> DeepLinkSource {
+        let Some(parts) = ParsedUrl::parse(url) else {
+            return DeepLinkSource::Unknown;
+        };
+        if parts.scheme == "http" || parts.scheme == "https" {
+            if parts.host.as_deref().is_some_and(|host| {
+                let host = normalize_domain(host.to_string());
+                self.domains.iter().any(|domain| domain == &host)
+            }) {
+                return DeepLinkSource::UniversalLink;
+            }
+            return DeepLinkSource::WebUrl;
+        }
+        if self
+            .schemes
+            .iter()
+            .any(|scheme| scheme == &normalize_scheme(parts.scheme))
+        {
+            DeepLinkSource::CustomScheme
+        } else {
+            DeepLinkSource::External
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ParsedUrl<'a> {
+    scheme: &'a str,
+    host: Option<&'a str>,
+    path: String,
+}
+
+impl<'a> ParsedUrl<'a> {
+    fn parse(url: &'a str) -> Option<Self> {
+        let (scheme, rest) = url.split_once(':')?;
+        if scheme.is_empty() {
+            return None;
+        }
+        let mut host = None;
+        let mut path = String::from("/");
+        if let Some(authority_and_path) = rest.strip_prefix("//") {
+            let authority_end = authority_and_path
+                .find(['/', '?', '#'])
+                .unwrap_or(authority_and_path.len());
+            let authority = &authority_and_path[..authority_end];
+            if !authority.is_empty() {
+                let host_without_userinfo = authority.rsplit('@').next().unwrap_or(authority);
+                let host_without_port = host_without_userinfo
+                    .split_once(':')
+                    .map(|(h, _)| h)
+                    .unwrap_or(host_without_userinfo);
+                if !host_without_port.is_empty() {
+                    host = Some(host_without_port);
+                }
+            }
+            let remainder = &authority_and_path[authority_end..];
+            if remainder.starts_with('/') {
+                path = remainder
+                    .split(['?', '#'])
+                    .next()
+                    .unwrap_or("/")
+                    .to_string();
+            }
+        } else if rest.starts_with('/') {
+            path = rest.split(['?', '#']).next().unwrap_or("/").to_string();
+        }
+        Some(Self { scheme, host, path })
+    }
+}
+
+fn normalize_scheme(value: impl AsRef<str>) -> String {
+    value
+        .as_ref()
+        .trim()
+        .trim_end_matches(':')
+        .to_ascii_lowercase()
+}
+
+fn normalize_domain(value: impl AsRef<str>) -> String {
+    value
+        .as_ref()
+        .trim()
+        .trim_end_matches('.')
+        .to_ascii_lowercase()
+}
+
+fn normalize_path_prefix(value: impl AsRef<str>) -> String {
+    let value = value.as_ref().trim();
+    if value.is_empty() || value == "/" {
+        "/".to_string()
+    } else if value.starts_with('/') {
+        value.to_string()
+    } else {
+        format!("/{value}")
+    }
+}
+
+/// Built-in action dispatched by shells when a deep link is received.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeepLinkReceived {
+    pub link: DeepLink,
+}
+
+impl Action for DeepLinkReceived {
+    fn static_id() -> ActionId {
+        lazy_static! {
+            static ref ID: ActionId = ActionId::from_name("fission_core::DeepLinkReceived");
+        }
+        *ID
+    }
+}
+
+/// Response from the OS/browser after a user interacted with a notification.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationResponse {
+    pub notification_id: NotificationId,
+    pub action_id: Option<String>,
+    pub deep_link: Option<String>,
+    pub user_text: Option<String>,
+}
+
+/// Built-in action dispatched by shells when a notification response arrives.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationResponseReceived {
+    pub response: NotificationResponse,
+}
+
+impl Action for NotificationResponseReceived {
+    fn static_id() -> ActionId {
+        lazy_static! {
+            static ref ID: ActionId =
+                ActionId::from_name("fission_core::NotificationResponseReceived");
+        }
+        *ID
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notification_request_round_trips() {
+        let request = NotificationRequest {
+            id: NotificationId::new("sync"),
+            title: "Sync complete".into(),
+            body: "All files are up to date".into(),
+            subtitle: Some("Workspace".into()),
+            badge: Some(2),
+            sound: NotificationSound::Named("done".into()),
+            deep_link: Some("fission://sync/results".into()),
+            actions: vec![NotificationActionButton {
+                id: "open".into(),
+                title: "Open".into(),
+                foreground: true,
+                ..Default::default()
+            }],
+            schedule: NotificationSchedule::AfterMillis(500),
+        };
+
+        let bytes = serde_json::to_vec(&request).unwrap();
+        let decoded: NotificationRequest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
+    fn deep_link_config_matches_schemes_domains_and_paths() {
+        let config = DeepLinkConfig::new()
+            .scheme("Fission")
+            .domain("Example.COM")
+            .path_prefix("/tasks");
+
+        assert!(config.matches("fission://open/tasks/42"));
+        assert!(config.matches("https://example.com/tasks/42?from=email"));
+        assert!(!config.matches("https://example.com/projects/42"));
+        assert!(!config.matches("other://open/tasks/42"));
+    }
+
+    #[test]
+    fn built_in_actions_round_trip() {
+        let link = DeepLinkReceived {
+            link: DeepLink::new("fission://task/1")
+                .cold_start(true)
+                .source(DeepLinkSource::CustomScheme),
+        };
+        let envelope: crate::ActionEnvelope = link.clone().into();
+        assert_eq!(envelope.id, DeepLinkReceived::static_id());
+        assert_eq!(
+            serde_json::from_slice::<DeepLinkReceived>(&envelope.payload).unwrap(),
+            link
+        );
+
+        let response = NotificationResponseReceived {
+            response: NotificationResponse {
+                notification_id: NotificationId::new("task"),
+                action_id: Some("open".into()),
+                deep_link: Some("fission://task/1".into()),
+                user_text: None,
+            },
+        };
+        let envelope: crate::ActionEnvelope = response.clone().into();
+        assert_eq!(envelope.id, NotificationResponseReceived::static_id());
+        assert_eq!(
+            serde_json::from_slice::<NotificationResponseReceived>(&envelope.payload).unwrap(),
+            response
+        );
+    }
+}

--- a/crates/core/fission-core/tests/platform_effects.rs
+++ b/crates/core/fission-core/tests/platform_effects.rs
@@ -1,0 +1,56 @@
+use fission_core::{
+    ActionRegistry, AppState, CapabilityInvocationPayload, DeepLink, DeepLinkConfig,
+    DeepLinkReceived, Effect, Effects, NotificationId, NotificationRequest, NotificationResponse,
+    NotificationResponseReceived, SHOW_NOTIFICATION,
+};
+
+#[derive(Debug, Default)]
+struct TestState;
+impl AppState for TestState {}
+
+#[test]
+fn notification_convenience_builder_emits_capability_effect() {
+    let mut registry = ActionRegistry::<TestState>::new();
+    let mut effects = Effects::new(42, &mut registry);
+
+    effects.notifications().show(NotificationRequest {
+        id: NotificationId::new("n1"),
+        title: "Title".into(),
+        body: "Body".into(),
+        ..Default::default()
+    });
+
+    assert_eq!(effects.out.len(), 1);
+    assert_eq!(effects.out[0].req_id, 42);
+    let Effect::Capability(CapabilityInvocationPayload::Operation(op)) = &effects.out[0].effect
+    else {
+        panic!("expected notification capability effect");
+    };
+    assert_eq!(op.capability_name, SHOW_NOTIFICATION.name);
+    let decoded: NotificationRequest = serde_json::from_slice(&op.request).unwrap();
+    assert_eq!(decoded.id, NotificationId::new("n1"));
+}
+
+#[test]
+fn deep_link_config_and_inbound_actions_are_public_api() {
+    let config = DeepLinkConfig::new()
+        .scheme("fission")
+        .domain("example.com");
+    assert!(config.matches("fission://open/tasks/1"));
+    assert!(config.matches("https://example.com/tasks/1"));
+
+    let link_action = DeepLinkReceived {
+        link: DeepLink::new("fission://open/tasks/1").cold_start(true),
+    };
+    let _: fission_core::ActionEnvelope = link_action.into();
+
+    let response_action = NotificationResponseReceived {
+        response: NotificationResponse {
+            notification_id: NotificationId::new("n1"),
+            action_id: Some("open".into()),
+            deep_link: Some("fission://open/tasks/1".into()),
+            user_text: None,
+        },
+    };
+    let _: fission_core::ActionEnvelope = response_action.into();
+}

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -5,7 +5,10 @@ use fission_core::{Action, ActionId, AppState, Env, Widget};
 use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
-pub use fission_shell_winit::{test_control, InvalidationSet, Pipeline};
+pub use fission_shell_winit::{
+    test_control, InvalidationSet, MemoryNotificationHost, NotificationHost, Pipeline,
+    UnsupportedNotificationHost,
+};
 
 pub struct DesktopApp<S: AppState, W: Widget<S>> {
     inner: WinitApp<S, W>,
@@ -81,8 +84,66 @@ impl<S: AppState + Default, W: Widget<S> + 'static> DesktopApp<S, W> {
         self
     }
 
+    pub fn with_notification_host<H>(mut self, host: H) -> Self
+    where
+        H: NotificationHost,
+    {
+        self.inner = self.inner.with_notification_host(host);
+        self
+    }
+
     pub fn with_startup_action<A: Action>(mut self, action: A) -> Self {
         self.inner = self.inner.with_startup_action(action);
+        self
+    }
+
+    pub fn with_deep_link_config(mut self, config: fission_core::DeepLinkConfig) -> Self {
+        self.inner = self.inner.with_deep_link_config(config);
+        self
+    }
+
+    pub fn with_deep_link_scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.inner = self.inner.with_deep_link_scheme(scheme);
+        self
+    }
+
+    pub fn with_deep_link_domain(mut self, domain: impl Into<String>) -> Self {
+        self.inner = self.inner.with_deep_link_domain(domain);
+        self
+    }
+
+    pub fn with_startup_deep_link(mut self, link: fission_core::DeepLink) -> Self {
+        self.inner = self.inner.with_startup_deep_link(link);
+        self
+    }
+
+    pub fn with_startup_notification_response(
+        mut self,
+        response: fission_core::NotificationResponse,
+    ) -> Self {
+        self.inner = self.inner.with_startup_notification_response(response);
+        self
+    }
+
+    pub fn on_deep_link<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, fission_core::DeepLinkReceived>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.inner = self.inner.on_deep_link(handler);
+        self
+    }
+
+    pub fn on_notification_response<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, fission_core::NotificationResponseReceived>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.inner = self.inner.on_notification_response(handler);
         self
     }
 

--- a/crates/shell/fission-shell-mobile/src/lib.rs
+++ b/crates/shell/fission-shell-mobile/src/lib.rs
@@ -3,6 +3,10 @@ use fission_core::{Action, AppState, Env, Widget};
 use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
+pub use fission_shell_winit::{
+    MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+};
+
 #[cfg(target_os = "android")]
 pub use winit::platform::android::activity::AndroidApp;
 
@@ -77,6 +81,64 @@ impl<S: AppState + Default, W: Widget<S> + 'static> MobileApp<S, W> {
         F: FnOnce(&mut AsyncRegistry),
     {
         self.inner = self.inner.with_async(configure);
+        self
+    }
+
+    pub fn with_notification_host<H>(mut self, host: H) -> Self
+    where
+        H: NotificationHost,
+    {
+        self.inner = self.inner.with_notification_host(host);
+        self
+    }
+
+    pub fn with_deep_link_config(mut self, config: fission_core::DeepLinkConfig) -> Self {
+        self.inner = self.inner.with_deep_link_config(config);
+        self
+    }
+
+    pub fn with_deep_link_scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.inner = self.inner.with_deep_link_scheme(scheme);
+        self
+    }
+
+    pub fn with_deep_link_domain(mut self, domain: impl Into<String>) -> Self {
+        self.inner = self.inner.with_deep_link_domain(domain);
+        self
+    }
+
+    pub fn with_startup_deep_link(mut self, link: fission_core::DeepLink) -> Self {
+        self.inner = self.inner.with_startup_deep_link(link);
+        self
+    }
+
+    pub fn with_startup_notification_response(
+        mut self,
+        response: fission_core::NotificationResponse,
+    ) -> Self {
+        self.inner = self.inner.with_startup_notification_response(response);
+        self
+    }
+
+    pub fn on_deep_link<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, fission_core::DeepLinkReceived>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.inner = self.inner.on_deep_link(handler);
+        self
+    }
+
+    pub fn on_notification_response<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, fission_core::NotificationResponseReceived>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.inner = self.inner.on_notification_response(handler);
         self
     }
 

--- a/crates/shell/fission-shell-web/src/lib.rs
+++ b/crates/shell/fission-shell-web/src/lib.rs
@@ -3,6 +3,10 @@ use fission_core::{Action, AppState, Env, Widget};
 use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
+pub use fission_shell_winit::{
+    MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+};
+
 pub struct WebApp<S: AppState, W: Widget<S>> {
     inner: WinitApp<S, W>,
 }
@@ -70,6 +74,64 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WebApp<S, W> {
         F: FnOnce(&mut AsyncRegistry),
     {
         self.inner = self.inner.with_async(configure);
+        self
+    }
+
+    pub fn with_notification_host<H>(mut self, host: H) -> Self
+    where
+        H: NotificationHost,
+    {
+        self.inner = self.inner.with_notification_host(host);
+        self
+    }
+
+    pub fn with_deep_link_config(mut self, config: fission_core::DeepLinkConfig) -> Self {
+        self.inner = self.inner.with_deep_link_config(config);
+        self
+    }
+
+    pub fn with_deep_link_scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.inner = self.inner.with_deep_link_scheme(scheme);
+        self
+    }
+
+    pub fn with_deep_link_domain(mut self, domain: impl Into<String>) -> Self {
+        self.inner = self.inner.with_deep_link_domain(domain);
+        self
+    }
+
+    pub fn with_startup_deep_link(mut self, link: fission_core::DeepLink) -> Self {
+        self.inner = self.inner.with_startup_deep_link(link);
+        self
+    }
+
+    pub fn with_startup_notification_response(
+        mut self,
+        response: fission_core::NotificationResponse,
+    ) -> Self {
+        self.inner = self.inner.with_startup_notification_response(response);
+        self
+    }
+
+    pub fn on_deep_link<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, fission_core::DeepLinkReceived>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.inner = self.inner.on_deep_link(handler);
+        self
+    }
+
+    pub fn on_notification_response<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, fission_core::NotificationResponseReceived>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.inner = self.inner.on_notification_response(handler);
         self
     }
 

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -29,9 +29,10 @@ use fission_core::env::VideoStatus;
 use fission_core::lowering::LoweringContext;
 use fission_core::ui::custom_render::downcast_render_object;
 use fission_core::{
-    Action, ActionId, AppState, BuildCtx, Env, InputEvent, KeyCode, KeyEvent as FissionKeyEvent,
-    OpenUrlRequest, PointerButton, PointerEvent, Runtime, RuntimeEffect, ServiceBindings, View,
-    Widget, OPEN_URL,
+    Action, ActionId, ActionRegistry, AppState, BuildCtx, DeepLink, DeepLinkConfig,
+    DeepLinkReceived, Env, InputEvent, KeyCode, KeyEvent as FissionKeyEvent, NotificationResponse,
+    NotificationResponseReceived, OpenUrlRequest, PointerButton, PointerEvent, Runtime,
+    RuntimeEffect, ServiceBindings, View, Widget, OPEN_URL,
 };
 use fission_core::{ActionInput, CapabilityInvocationPayload, Effect};
 use fission_diagnostics::prelude as diag;
@@ -86,6 +87,8 @@ mod clipboard;
 use clipboard::DesktopClipboard;
 mod ime;
 use ime::{DesktopImeHandler, TextInputConfig};
+mod notifications;
+pub use notifications::{MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost};
 pub mod test_control;
 
 use fission_core::action::ActionEnvelope;
@@ -144,6 +147,54 @@ fn register_builtin_operation_capabilities(async_registry: &mut AsyncRegistry) {
             Ok(())
         },
     );
+    notifications::register_notification_capabilities(
+        async_registry,
+        Arc::new(UnsupportedNotificationHost),
+    );
+}
+
+fn collect_startup_deep_links(config: &DeepLinkConfig) -> Vec<DeepLink> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let mut env_values = Vec::new();
+    if let Ok(value) = std::env::var("FISSION_DEEP_LINK_URL") {
+        env_values.push(value);
+    }
+    if let Ok(value) = std::env::var("FISSION_DEEP_LINKS") {
+        env_values.extend(
+            value
+                .split('\n')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+        );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    if let Some(window) = web_sys::window() {
+        if let Ok(href) = window.location().href() {
+            env_values.push(href);
+        }
+    }
+
+    collect_startup_deep_links_from(config, args, env_values)
+}
+
+fn collect_startup_deep_links_from(
+    config: &DeepLinkConfig,
+    args: impl IntoIterator<Item = String>,
+    env_values: impl IntoIterator<Item = String>,
+) -> Vec<DeepLink> {
+    let mut links = Vec::new();
+    for url in env_values.into_iter().chain(args) {
+        if config.matches(&url) {
+            links.push(
+                DeepLink::new(url.clone())
+                    .cold_start(true)
+                    .source(config.source_for(&url)),
+            );
+        }
+    }
+    links
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -2207,6 +2258,9 @@ pub struct WinitApp<S: AppState, W: Widget<S>> {
     effect_result_rx: mpsc::Receiver<AsyncMessage>,
     async_registry: AsyncRegistry,
     startup_action: Option<ActionEnvelope>,
+    deep_link_config: DeepLinkConfig,
+    startup_deep_links: Vec<DeepLink>,
+    startup_notification_responses: Vec<NotificationResponse>,
     _phantom: std::marker::PhantomData<S>,
 }
 
@@ -2261,6 +2315,9 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
             effect_result_rx,
             async_registry,
             startup_action: None,
+            deep_link_config: DeepLinkConfig::default(),
+            startup_deep_links: Vec::new(),
+            startup_notification_responses: Vec::new(),
             _phantom: std::marker::PhantomData,
         }
     }
@@ -2340,8 +2397,64 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
         self
     }
 
+    pub fn with_notification_host<H>(mut self, host: H) -> Self
+    where
+        H: NotificationHost,
+    {
+        notifications::register_notification_capabilities(&mut self.async_registry, Arc::new(host));
+        self
+    }
+
     pub fn with_startup_action<A: Action>(mut self, action: A) -> Self {
         self.startup_action = Some(action.into());
+        self
+    }
+
+    pub fn with_deep_link_config(mut self, config: DeepLinkConfig) -> Self {
+        self.deep_link_config = config;
+        self
+    }
+
+    pub fn with_deep_link_scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.deep_link_config = self.deep_link_config.scheme(scheme);
+        self
+    }
+
+    pub fn with_deep_link_domain(mut self, domain: impl Into<String>) -> Self {
+        self.deep_link_config = self.deep_link_config.domain(domain);
+        self
+    }
+
+    pub fn with_startup_deep_link(mut self, link: DeepLink) -> Self {
+        self.startup_deep_links.push(link);
+        self
+    }
+
+    pub fn with_startup_notification_response(mut self, response: NotificationResponse) -> Self {
+        self.startup_notification_responses.push(response);
+        self
+    }
+
+    pub fn on_deep_link<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, DeepLinkReceived> + Send + Sync + 'static,
+    {
+        let mut registry = ActionRegistry::<S>::new();
+        registry.register(handler);
+        self.runtime.absorb_persistent_registry(registry);
+        self
+    }
+
+    pub fn on_notification_response<H>(mut self, handler: H) -> Self
+    where
+        H: fission_core::registry::IntoHandler<S, NotificationResponseReceived>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let mut registry = ActionRegistry::<S>::new();
+        registry.register(handler);
+        self.runtime.absorb_persistent_registry(registry);
         self
     }
 
@@ -2436,7 +2549,20 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
         #[cfg(not(target_os = "android"))]
         platform_window.request_redraw();
 
+        let mut startup_deep_links = self.startup_deep_links.clone();
+        startup_deep_links.extend(collect_startup_deep_links(&self.deep_link_config));
+        let startup_notification_responses = self.startup_notification_responses.clone();
+
         let mut runtime = self.runtime;
+        for link in startup_deep_links {
+            runtime.dispatch(DeepLinkReceived { link }.into(), NodeId::derived(0, &[0]))?;
+        }
+        for response in startup_notification_responses {
+            runtime.dispatch(
+                NotificationResponseReceived { response }.into(),
+                NodeId::derived(0, &[0]),
+            )?;
+        }
         let mut layout_engine = self.layout_engine;
         let root_widget = self.root_widget;
         let mut env = self.env;
@@ -5175,10 +5301,11 @@ fn native_window_size_for_logical_viewport(size: LayoutSize) -> winit::dpi::Logi
 #[cfg(test)]
 mod tests {
     use super::{
-        animation_redraw_interval, clamp_copy_extent_to_texture, cursor_icon_for,
-        downscale_rgba_box, layout_size_to_image_dimensions, logical_viewport_to_physical_size,
-        logical_viewport_to_render_target_size, native_window_size_for_logical_viewport,
-        normalize_scale_factor, normalize_winit_scroll_delta, physical_position_to_layout_point,
+        animation_redraw_interval, clamp_copy_extent_to_texture, collect_startup_deep_links_from,
+        cursor_icon_for, downscale_rgba_box, layout_size_to_image_dimensions,
+        logical_viewport_to_physical_size, logical_viewport_to_render_target_size,
+        native_window_size_for_logical_viewport, normalize_scale_factor,
+        normalize_winit_scroll_delta, physical_position_to_layout_point,
         physical_size_to_layout_size, repeating_animation_redraw_interval, resize_is_unsettled,
         resolve_build_viewport, sync_tracked_target_texture_size_to_surface,
         texture_plans_fit_device_limits, LiveResizeController, WindowViewportState,
@@ -5186,7 +5313,7 @@ mod tests {
     use crate::pipeline::CompositorTexturePlan;
     use crate::InvalidationSet;
     use fission_core::env::{ActiveAnimation, AnimationStateMap};
-    use fission_core::{AnimationPropertyId, WidgetNodeId};
+    use fission_core::{AnimationPropertyId, DeepLinkConfig, WidgetNodeId};
     use fission_ir::semantics::MouseCursor;
     use fission_layout::{LayoutRect, LayoutSize};
     use std::collections::HashMap;
@@ -5637,5 +5764,29 @@ mod tests {
         ];
         let downscaled = downscale_rgba_box(&rgba, 2, 2, 1, 1).expect("downscale");
         assert_eq!(downscaled, vec![40, 50, 60, 255]);
+    }
+
+    #[test]
+    fn startup_deep_link_collection_filters_to_declared_config() {
+        let config = DeepLinkConfig::new()
+            .scheme("fission")
+            .domain("example.com")
+            .path_prefix("/tasks");
+
+        let links = collect_startup_deep_links_from(
+            &config,
+            vec![
+                "--ignored".to_string(),
+                "fission://open/tasks/1".to_string(),
+                "other://open/tasks/1".to_string(),
+            ],
+            vec!["https://example.com/tasks/2?source=email".to_string()],
+        );
+
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].url, "https://example.com/tasks/2?source=email");
+        assert!(links[0].cold_start);
+        assert_eq!(links[1].url, "fission://open/tasks/1");
+        assert!(links[1].cold_start);
     }
 }

--- a/crates/shell/fission-shell-winit/src/notifications.rs
+++ b/crates/shell/fission-shell-winit/src/notifications.rs
@@ -1,0 +1,274 @@
+use fission_core::{
+    CancelNotificationRequest, NotificationError, NotificationPermission,
+    NotificationPermissionRequest, NotificationReceipt, NotificationRequest, NotificationSchedule,
+    NotificationSettings, PushPlatform, PushRegistration, PushRegistrationRequest,
+    SetBadgeCountRequest, CANCEL_ALL_NOTIFICATIONS, CANCEL_NOTIFICATION, GET_NOTIFICATION_SETTINGS,
+    REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION, SCHEDULE_NOTIFICATION,
+    SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
+};
+use fission_shell::async_host::AsyncRegistry;
+use std::sync::Arc;
+
+/// Host-side notification provider used by the shell capability registry.
+pub trait NotificationHost: Send + Sync + 'static {
+    fn request_permission(
+        &self,
+        request: NotificationPermissionRequest,
+    ) -> Result<NotificationSettings, NotificationError>;
+
+    fn settings(&self) -> Result<NotificationSettings, NotificationError>;
+
+    fn show(&self, request: NotificationRequest) -> Result<NotificationReceipt, NotificationError>;
+
+    fn schedule(
+        &self,
+        request: NotificationRequest,
+    ) -> Result<NotificationReceipt, NotificationError>;
+
+    fn cancel(&self, request: CancelNotificationRequest) -> Result<(), NotificationError>;
+
+    fn cancel_all(&self) -> Result<(), NotificationError>;
+
+    fn set_badge_count(&self, request: SetBadgeCountRequest) -> Result<(), NotificationError>;
+
+    fn register_push(
+        &self,
+        request: PushRegistrationRequest,
+    ) -> Result<PushRegistration, NotificationError>;
+
+    fn unregister_push(&self) -> Result<(), NotificationError>;
+}
+
+/// Default provider used until a shell installs a platform-specific host.
+#[derive(Debug, Default)]
+pub struct UnsupportedNotificationHost;
+
+impl NotificationHost for UnsupportedNotificationHost {
+    fn request_permission(
+        &self,
+        _request: NotificationPermissionRequest,
+    ) -> Result<NotificationSettings, NotificationError> {
+        Ok(NotificationSettings {
+            permission: NotificationPermission::Unsupported,
+            ..Default::default()
+        })
+    }
+
+    fn settings(&self) -> Result<NotificationSettings, NotificationError> {
+        Ok(NotificationSettings {
+            permission: NotificationPermission::Unsupported,
+            ..Default::default()
+        })
+    }
+
+    fn show(
+        &self,
+        _request: NotificationRequest,
+    ) -> Result<NotificationReceipt, NotificationError> {
+        Err(NotificationError::unsupported("show"))
+    }
+
+    fn schedule(
+        &self,
+        _request: NotificationRequest,
+    ) -> Result<NotificationReceipt, NotificationError> {
+        Err(NotificationError::unsupported("schedule"))
+    }
+
+    fn cancel(&self, _request: CancelNotificationRequest) -> Result<(), NotificationError> {
+        Err(NotificationError::unsupported("cancel"))
+    }
+
+    fn cancel_all(&self) -> Result<(), NotificationError> {
+        Err(NotificationError::unsupported("cancel_all"))
+    }
+
+    fn set_badge_count(&self, _request: SetBadgeCountRequest) -> Result<(), NotificationError> {
+        Err(NotificationError::unsupported("set_badge_count"))
+    }
+
+    fn register_push(
+        &self,
+        _request: PushRegistrationRequest,
+    ) -> Result<PushRegistration, NotificationError> {
+        Err(NotificationError::unsupported("register_push"))
+    }
+
+    fn unregister_push(&self) -> Result<(), NotificationError> {
+        Err(NotificationError::unsupported("unregister_push"))
+    }
+}
+
+/// Minimal in-process host useful for smoke tests and non-OS environments.
+#[derive(Debug, Default)]
+pub struct MemoryNotificationHost;
+
+impl NotificationHost for MemoryNotificationHost {
+    fn request_permission(
+        &self,
+        request: NotificationPermissionRequest,
+    ) -> Result<NotificationSettings, NotificationError> {
+        Ok(NotificationSettings {
+            permission: NotificationPermission::Granted,
+            alerts: request.alerts,
+            badge: request.badge,
+            sound: request.sound,
+            scheduling: true,
+            push: false,
+        })
+    }
+
+    fn settings(&self) -> Result<NotificationSettings, NotificationError> {
+        Ok(NotificationSettings {
+            permission: NotificationPermission::Granted,
+            alerts: true,
+            badge: true,
+            sound: true,
+            scheduling: true,
+            push: false,
+        })
+    }
+
+    fn show(&self, request: NotificationRequest) -> Result<NotificationReceipt, NotificationError> {
+        Ok(NotificationReceipt {
+            id: request.id,
+            scheduled: false,
+            delivered: true,
+        })
+    }
+
+    fn schedule(
+        &self,
+        request: NotificationRequest,
+    ) -> Result<NotificationReceipt, NotificationError> {
+        Ok(NotificationReceipt {
+            id: request.id,
+            scheduled: !matches!(request.schedule, NotificationSchedule::Immediate),
+            delivered: matches!(request.schedule, NotificationSchedule::Immediate),
+        })
+    }
+
+    fn cancel(&self, _request: CancelNotificationRequest) -> Result<(), NotificationError> {
+        Ok(())
+    }
+
+    fn cancel_all(&self) -> Result<(), NotificationError> {
+        Ok(())
+    }
+
+    fn set_badge_count(&self, _request: SetBadgeCountRequest) -> Result<(), NotificationError> {
+        Ok(())
+    }
+
+    fn register_push(
+        &self,
+        _request: PushRegistrationRequest,
+    ) -> Result<PushRegistration, NotificationError> {
+        Ok(PushRegistration {
+            platform: PushPlatform::Other("memory".into()),
+            token: "memory-push-token".into(),
+            endpoint: None,
+            p256dh_key: None,
+            auth_secret: None,
+        })
+    }
+
+    fn unregister_push(&self) -> Result<(), NotificationError> {
+        Ok(())
+    }
+}
+
+pub(crate) fn register_notification_capabilities(
+    async_registry: &mut AsyncRegistry,
+    host: Arc<dyn NotificationHost>,
+) {
+    let request_host = host.clone();
+    async_registry.register_operation_capability(
+        REQUEST_NOTIFICATION_PERMISSION,
+        move |request, _| {
+            let host = request_host.clone();
+            async move { host.request_permission(request) }
+        },
+    );
+
+    let settings_host = host.clone();
+    async_registry.register_operation_capability(GET_NOTIFICATION_SETTINGS, move |(), _| {
+        let host = settings_host.clone();
+        async move { host.settings() }
+    });
+
+    let show_host = host.clone();
+    async_registry.register_operation_capability(SHOW_NOTIFICATION, move |request, _| {
+        let host = show_host.clone();
+        async move { host.show(request) }
+    });
+
+    let schedule_host = host.clone();
+    async_registry.register_operation_capability(SCHEDULE_NOTIFICATION, move |request, _| {
+        let host = schedule_host.clone();
+        async move { host.schedule(request) }
+    });
+
+    let cancel_host = host.clone();
+    async_registry.register_operation_capability(CANCEL_NOTIFICATION, move |request, _| {
+        let host = cancel_host.clone();
+        async move { host.cancel(request) }
+    });
+
+    let cancel_all_host = host.clone();
+    async_registry.register_operation_capability(CANCEL_ALL_NOTIFICATIONS, move |(), _| {
+        let host = cancel_all_host.clone();
+        async move { host.cancel_all() }
+    });
+
+    let badge_host = host.clone();
+    async_registry.register_operation_capability(SET_BADGE_COUNT, move |request, _| {
+        let host = badge_host.clone();
+        async move { host.set_badge_count(request) }
+    });
+
+    let push_host = host.clone();
+    async_registry.register_operation_capability(REGISTER_PUSH_NOTIFICATIONS, move |request, _| {
+        let host = push_host.clone();
+        async move { host.register_push(request) }
+    });
+
+    async_registry.register_operation_capability(UNREGISTER_PUSH_NOTIFICATIONS, move |(), _| {
+        let host = host.clone();
+        async move { host.unregister_push() }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fission_core::NotificationId;
+
+    #[test]
+    fn unsupported_host_reports_permission_without_panicking() {
+        let host = UnsupportedNotificationHost;
+        let settings = host
+            .request_permission(NotificationPermissionRequest::default())
+            .unwrap();
+        assert_eq!(settings.permission, NotificationPermission::Unsupported);
+        assert_eq!(
+            host.show(NotificationRequest::default()).unwrap_err().code,
+            "unsupported"
+        );
+    }
+
+    #[test]
+    fn memory_host_returns_receipts() {
+        let host = MemoryNotificationHost;
+        let receipt = host
+            .show(NotificationRequest {
+                id: NotificationId::new("n1"),
+                title: "Title".into(),
+                body: "Body".into(),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(receipt.id, NotificationId::new("n1"));
+        assert!(receipt.delivered);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds typed notification host capabilities for permission, settings, show, schedule, cancel, badge, and push registration operations.
- Adds inbound deep-link and notification-response lifecycle actions wired through desktop, mobile, and web shell builders.
- Exposes the public API through the `fission` facade and prelude, with unsupported and memory notification hosts for platform integration and tests.

## Tests
- `cargo test -p fission-core --locked platform`
- `cargo test -p fission-core --locked --test platform_effects`
- `cargo test -p fission-shell-winit --locked`
- `cargo test -p fission --features desktop --locked --test platform_api`
- `cargo check -p fission-shell-desktop --locked`
- `cargo check -p fission-shell-web --locked`
- `cargo check -p fission-shell-mobile --locked`
- `cargo check -p fission-shell-web --target wasm32-unknown-unknown --locked`
- `cargo check -p fission-shell-mobile --target aarch64-apple-ios-sim --locked`

Android target check is blocked locally by the missing `aarch64-linux-android-clang` toolchain binary.
