### PR TITLE
Add NFC platform capability

### DIFF
--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -153,18 +153,22 @@ pub use fission_core::{
     Action, ActionEnvelope, ActionId, ActionScopeId, AnimationPropertyId, AnimationRequest,
     AnimationStartValue, AppState, BuildCtx, CancelAllNotificationsCapability,
     CancelNotificationCapability, CancelNotificationRequest, DeepLink, DeepLinkConfig,
-    DeepLinkReceived, DeepLinkSource, EasingFunction, FlexDirection,
-    GetNotificationSettingsCapability, Handler, NodeBuilder, NotificationActionButton,
-    NotificationError, NotificationId, NotificationPermission, NotificationPermissionRequest,
-    NotificationReceipt, NotificationRequest, NotificationResponse, NotificationResponseReceived,
-    NotificationSchedule, NotificationSettings, NotificationSound, Op, PortalLayer, PushPlatform,
-    PushRegistration, PushRegistrationRequest, ReducerContext, RegisterPushNotificationsCapability,
-    RequestNotificationPermissionCapability, ScheduleNotificationCapability, Selector,
-    SetBadgeCountCapability, SetBadgeCountRequest, ShowNotificationCapability,
-    UnregisterPushNotificationsCapability, View, Widget, WidgetNodeId, CANCEL_ALL_NOTIFICATIONS,
-    CANCEL_NOTIFICATION, GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS,
-    REQUEST_NOTIFICATION_PERMISSION, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION,
-    UNREGISTER_PUSH_NOTIFICATIONS,
+    DeepLinkReceived, DeepLinkSource, EasingFunction, EmulateNfcTagCapability, FlexDirection,
+    GetNfcAvailabilityCapability, GetNotificationSettingsCapability, Handler, NfcAvailability,
+    NfcEffects, NfcEmulationRequest, NfcError, NfcRecord, NfcRecordTypeNameFormat, NfcScanRequest,
+    NfcSessionReceipt, NfcTag, NfcTagDiscovered, NfcTechnology, NfcWriteRequest, NodeBuilder,
+    NotificationActionButton, NotificationError, NotificationId, NotificationPermission,
+    NotificationPermissionRequest, NotificationReceipt, NotificationRequest, NotificationResponse,
+    NotificationResponseReceived, NotificationSchedule, NotificationSettings, NotificationSound,
+    Op, PortalLayer, PushPlatform, PushRegistration, PushRegistrationRequest, ReducerContext,
+    RegisterPushNotificationsCapability, RequestNotificationPermissionCapability,
+    ScanNfcTagCapability, ScheduleNotificationCapability, Selector, SetBadgeCountCapability,
+    SetBadgeCountRequest, ShowNotificationCapability, UnregisterPushNotificationsCapability, View,
+    Widget, WidgetNodeId, WriteNfcTagCapability, CANCEL_ALL_NOTIFICATIONS, CANCEL_NFC_SESSION,
+    CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_NFC_AVAILABILITY, GET_NOTIFICATION_SETTINGS,
+    REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION, SCAN_NFC_TAG,
+    SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
+    WRITE_NFC_TAG,
 };
 
 // Core event types
@@ -190,7 +194,8 @@ pub use fission_widgets::{HStack, Icon, Spacer, VStack};
     not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
 ))]
 pub use fission_shell_desktop::{
-    DesktopApp, MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+    DesktopApp, MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
+    UnsupportedNfcHost, UnsupportedNotificationHost,
 };
 #[cfg(all(
     any(
@@ -202,7 +207,8 @@ pub use fission_shell_desktop::{
     any(target_os = "android", target_os = "ios")
 ))]
 pub use fission_shell_mobile::{
-    MemoryNotificationHost, MobileApp, NotificationHost, UnsupportedNotificationHost,
+    MemoryNfcHost, MemoryNotificationHost, MobileApp, NfcHost, NotificationHost,
+    UnsupportedNfcHost, UnsupportedNotificationHost,
 };
 #[cfg(feature = "terminal-shell")]
 pub use fission_shell_terminal::TerminalApp;
@@ -211,7 +217,8 @@ pub use fission_shell_terminal::TerminalApp;
     target_arch = "wasm32"
 ))]
 pub use fission_shell_web::{
-    MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost, WebApp,
+    MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost, UnsupportedNfcHost,
+    UnsupportedNotificationHost, WebApp,
 };
 
 // Macros
@@ -234,19 +241,24 @@ pub mod prelude {
         Action, ActionEnvelope, ActionId, ActionScopeId, AnimationPropertyId, AnimationRequest,
         AnimationStartValue, AppState, BuildCtx, CancelAllNotificationsCapability,
         CancelNotificationCapability, CancelNotificationRequest, DeepLink, DeepLinkConfig,
-        DeepLinkReceived, DeepLinkSource, Effects, FlexDirection,
-        GetNotificationSettingsCapability, Handler, NodeBuilder, NotificationActionButton,
-        NotificationEffects, NotificationError, NotificationId, NotificationPermission,
-        NotificationPermissionRequest, NotificationReceipt, NotificationRequest,
-        NotificationResponse, NotificationResponseReceived, NotificationSchedule,
-        NotificationSettings, NotificationSound, Op, PortalLayer, PushPlatform, PushRegistration,
+        DeepLinkReceived, DeepLinkSource, Effects, EmulateNfcTagCapability, FlexDirection,
+        GetNfcAvailabilityCapability, GetNotificationSettingsCapability, Handler, NfcAvailability,
+        NfcEffects, NfcEmulationRequest, NfcError, NfcRecord, NfcRecordTypeNameFormat,
+        NfcScanRequest, NfcSessionReceipt, NfcTag, NfcTagDiscovered, NfcTechnology,
+        NfcWriteRequest, NodeBuilder, NotificationActionButton, NotificationEffects,
+        NotificationError, NotificationId, NotificationPermission, NotificationPermissionRequest,
+        NotificationReceipt, NotificationRequest, NotificationResponse,
+        NotificationResponseReceived, NotificationSchedule, NotificationSettings,
+        NotificationSound, Op, PortalLayer, PushPlatform, PushRegistration,
         PushRegistrationRequest, ReducerContext, RegisterPushNotificationsCapability,
-        RequestNotificationPermissionCapability, ScheduleNotificationCapability, Selector,
-        SetBadgeCountCapability, SetBadgeCountRequest, ShowNotificationCapability,
-        UnregisterPushNotificationsCapability, View, Widget, WidgetNodeId, WindowEnv, WindowTitle,
-        CANCEL_ALL_NOTIFICATIONS, CANCEL_NOTIFICATION, GET_NOTIFICATION_SETTINGS,
-        REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION, SCHEDULE_NOTIFICATION,
-        SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
+        RequestNotificationPermissionCapability, ScanNfcTagCapability,
+        ScheduleNotificationCapability, Selector, SetBadgeCountCapability, SetBadgeCountRequest,
+        ShowNotificationCapability, UnregisterPushNotificationsCapability, View, Widget,
+        WidgetNodeId, WindowEnv, WindowTitle, WriteNfcTagCapability, CANCEL_ALL_NOTIFICATIONS,
+        CANCEL_NFC_SESSION, CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_NFC_AVAILABILITY,
+        GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
+        SCAN_NFC_TAG, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION,
+        UNREGISTER_PUSH_NOTIFICATIONS, WRITE_NFC_TAG,
     };
 
     // Layout
@@ -271,7 +283,8 @@ pub mod prelude {
         not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
     ))]
     pub use fission_shell_desktop::{
-        DesktopApp, MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+        DesktopApp, MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
+        UnsupportedNfcHost, UnsupportedNotificationHost,
     };
     #[cfg(all(
         any(feature = "android", feature = "mobile", feature = "platform-shells"),
@@ -288,7 +301,8 @@ pub mod prelude {
         any(target_os = "android", target_os = "ios")
     ))]
     pub use fission_shell_mobile::{
-        MemoryNotificationHost, MobileApp, NotificationHost, UnsupportedNotificationHost,
+        MemoryNfcHost, MemoryNotificationHost, MobileApp, NfcHost, NotificationHost,
+        UnsupportedNfcHost, UnsupportedNotificationHost,
     };
     #[cfg(feature = "site")]
     pub use fission_shell_site::*;
@@ -299,7 +313,8 @@ pub mod prelude {
         target_arch = "wasm32"
     ))]
     pub use fission_shell_web::{
-        MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost, WebApp,
+        MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost, UnsupportedNfcHost,
+        UnsupportedNotificationHost, WebApp,
     };
 
     // Serde (commonly needed for actions)

--- a/crates/authoring/fission/tests/platform_api.rs
+++ b/crates/authoring/fission/tests/platform_api.rs
@@ -33,6 +33,7 @@ impl Widget<PlatformApiState> for PlatformApiApp {
 fn facade_exports_notifications_and_deep_links() {
     let _app = DesktopApp::new(PlatformApiApp)
         .with_notification_host(MemoryNotificationHost)
+        .with_nfc_host(MemoryNfcHost::default())
         .with_deep_link_config(
             DeepLinkConfig::new()
                 .scheme("fission")
@@ -49,4 +50,9 @@ fn facade_exports_notifications_and_deep_links() {
         .on_notification_response(
             on_notification_response as fn(&mut PlatformApiState, NotificationResponseReceived),
         );
+
+    let _scan = NfcScanRequest {
+        technologies: vec![NfcTechnology::Ndef],
+        ..Default::default()
+    };
 }

--- a/crates/core/fission-core/src/context.rs
+++ b/crates/core/fission-core/src/context.rs
@@ -20,6 +20,10 @@ use crate::platform::{
     GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
     SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
 };
+use crate::platform_nfc::{
+    NfcEmulationRequest, NfcScanRequest, NfcWriteRequest, CANCEL_NFC_SESSION, EMULATE_NFC_TAG,
+    GET_NFC_AVAILABILITY, SCAN_NFC_TAG, WRITE_NFC_TAG,
+};
 use crate::registry::{ActionRegistry, IntoHandler};
 use std::marker::PhantomData;
 
@@ -159,6 +163,10 @@ impl<'a, S: AppState> Effects<'a, S> {
 
     pub fn notifications(&mut self) -> NotificationEffects<'_, 'a, S> {
         NotificationEffects { effects: self }
+    }
+
+    pub fn nfc(&mut self) -> NfcEffects<'_, 'a, S> {
+        NfcEffects { effects: self }
     }
 
     pub fn app<J: JobSpec>(
@@ -323,6 +331,33 @@ impl<'a, 'b, S: AppState> NotificationEffects<'a, 'b, S> {
 
     pub fn unregister_push(self) -> EffectBuilder<'a, 'b, S> {
         self.effects.capability(UNREGISTER_PUSH_NOTIFICATIONS, ())
+    }
+}
+
+/// Convenience builder for standard NFC host capabilities.
+pub struct NfcEffects<'a, 'b, S: AppState> {
+    effects: &'a mut Effects<'b, S>,
+}
+
+impl<'a, 'b, S: AppState> NfcEffects<'a, 'b, S> {
+    pub fn availability(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(GET_NFC_AVAILABILITY, ())
+    }
+
+    pub fn scan_tag(self, request: NfcScanRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(SCAN_NFC_TAG, request)
+    }
+
+    pub fn write_tag(self, request: NfcWriteRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(WRITE_NFC_TAG, request)
+    }
+
+    pub fn emulate_tag(self, request: NfcEmulationRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(EMULATE_NFC_TAG, request)
+    }
+
+    pub fn cancel_session(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(CANCEL_NFC_SESSION, ())
     }
 }
 

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -52,6 +52,7 @@ pub mod input;
 pub mod lowering;
 pub mod media;
 pub mod platform;
+pub mod platform_nfc;
 pub mod registry;
 pub mod runtime;
 pub mod scrollbar;
@@ -73,7 +74,7 @@ pub use capability::{
     OperationCapability, PickOpenFilesCapability, PickOpenFilesError, PickOpenFilesRequest,
     PickOpenFilesResult, PickedFile, OPEN_URL, PICK_OPEN_FILES,
 };
-pub use context::{Effects, NotificationEffects, ReducerContext}; // New
+pub use context::{Effects, NfcEffects, NotificationEffects, ReducerContext}; // New
 pub use effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect};
 pub use env::{
     Clipboard, Env, ImeHandler, InteractionStateMap, RuntimeState, ScrollStateMap, WindowEnv,
@@ -101,6 +102,13 @@ pub use platform::{
     UnregisterPushNotificationsCapability, CANCEL_ALL_NOTIFICATIONS, CANCEL_NOTIFICATION,
     GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
     SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS,
+};
+pub use platform_nfc::{
+    CancelNfcSessionCapability, EmulateNfcTagCapability, GetNfcAvailabilityCapability,
+    NfcAvailability, NfcEmulationRequest, NfcError, NfcRecord, NfcRecordTypeNameFormat,
+    NfcScanRequest, NfcSessionReceipt, NfcTag, NfcTagDiscovered, NfcTechnology, NfcWriteRequest,
+    ScanNfcTagCapability, WriteNfcTagCapability, CANCEL_NFC_SESSION, EMULATE_NFC_TAG,
+    GET_NFC_AVAILABILITY, SCAN_NFC_TAG, WRITE_NFC_TAG,
 };
 pub use registry::{
     ActionRegistry, AnimationPropertyId, AnimationRequest, AnimationStartValue, BuildCtx,

--- a/crates/core/fission-core/src/platform_nfc.rs
+++ b/crates/core/fission-core/src/platform_nfc.rs
@@ -1,0 +1,265 @@
+//! NFC host capabilities.
+//!
+//! The core crate only defines portable typed requests, results, and capability
+//! identities. Shells decide which platform NFC APIs can satisfy them.
+
+use crate::action::{Action, ActionId};
+use crate::capability::{CapabilityType, OperationCapability};
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+
+/// NFC operation support reported by the active shell.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcAvailability {
+    pub supported: bool,
+    pub enabled: bool,
+    pub read: bool,
+    pub write: bool,
+    pub card_emulation: bool,
+}
+
+/// NFC technology family requested by an app or discovered on a tag.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NfcTechnology {
+    IsoDep,
+    NfcA,
+    NfcB,
+    NfcF,
+    NfcV,
+    Ndef,
+    MifareClassic,
+    MifareUltralight,
+    Felica,
+    Other(String),
+}
+
+/// NFC Forum NDEF type-name-format value.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NfcRecordTypeNameFormat {
+    Empty,
+    #[default]
+    WellKnown,
+    MimeMedia,
+    AbsoluteUri,
+    External,
+    Unknown,
+    Unchanged,
+    Reserved(u8),
+}
+
+/// Portable NDEF-like record payload.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcRecord {
+    pub type_name_format: NfcRecordTypeNameFormat,
+    pub type_name: Vec<u8>,
+    pub id: Vec<u8>,
+    pub payload: Vec<u8>,
+}
+
+impl NfcRecord {
+    pub fn text(language: impl Into<String>, text: impl Into<String>) -> Self {
+        let language = language.into();
+        let text = text.into();
+        let mut payload = Vec::with_capacity(1 + language.len() + text.len());
+        payload.push(language.len().min(63) as u8);
+        payload.extend_from_slice(language.as_bytes());
+        payload.extend_from_slice(text.as_bytes());
+        Self {
+            type_name_format: NfcRecordTypeNameFormat::WellKnown,
+            type_name: b"T".to_vec(),
+            id: Vec::new(),
+            payload,
+        }
+    }
+
+    pub fn uri(uri: impl Into<String>) -> Self {
+        let uri = uri.into();
+        let mut payload = Vec::with_capacity(1 + uri.len());
+        payload.push(0);
+        payload.extend_from_slice(uri.as_bytes());
+        Self {
+            type_name_format: NfcRecordTypeNameFormat::WellKnown,
+            type_name: b"U".to_vec(),
+            id: Vec::new(),
+            payload,
+        }
+    }
+}
+
+/// A tag returned by a scan operation.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcTag {
+    pub id: Option<Vec<u8>>,
+    pub technologies: Vec<NfcTechnology>,
+    pub records: Vec<NfcRecord>,
+    pub raw_payload: Option<Vec<u8>>,
+}
+
+/// One-shot NFC read request.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcScanRequest {
+    pub technologies: Vec<NfcTechnology>,
+    pub message: Option<String>,
+    pub timeout_ms: Option<u64>,
+    pub read_multiple_records: bool,
+}
+
+/// NFC write request. Hosts may require the user to tap a writable tag after
+/// this operation starts.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcWriteRequest {
+    pub records: Vec<NfcRecord>,
+    pub message: Option<String>,
+    pub timeout_ms: Option<u64>,
+    pub make_read_only: bool,
+}
+
+/// NFC card-emulation request for hosts that support it.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcEmulationRequest {
+    pub records: Vec<NfcRecord>,
+    pub message: Option<String>,
+    pub timeout_ms: Option<u64>,
+}
+
+/// Receipt for write/emulation/session operations.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcSessionReceipt {
+    pub session_id: Option<String>,
+    pub completed: bool,
+}
+
+/// Portable NFC error payload.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcError {
+    pub code: String,
+    pub message: String,
+}
+
+impl NfcError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn unsupported(operation: impl Into<String>) -> Self {
+        Self::new(
+            "unsupported",
+            format!(
+                "NFC operation `{}` is not supported by this host",
+                operation.into()
+            ),
+        )
+    }
+}
+
+pub struct GetNfcAvailabilityCapability;
+impl OperationCapability for GetNfcAvailabilityCapability {
+    type Request = ();
+    type Ok = NfcAvailability;
+    type Err = NfcError;
+}
+
+pub struct ScanNfcTagCapability;
+impl OperationCapability for ScanNfcTagCapability {
+    type Request = NfcScanRequest;
+    type Ok = NfcTag;
+    type Err = NfcError;
+}
+
+pub struct WriteNfcTagCapability;
+impl OperationCapability for WriteNfcTagCapability {
+    type Request = NfcWriteRequest;
+    type Ok = NfcSessionReceipt;
+    type Err = NfcError;
+}
+
+pub struct EmulateNfcTagCapability;
+impl OperationCapability for EmulateNfcTagCapability {
+    type Request = NfcEmulationRequest;
+    type Ok = NfcSessionReceipt;
+    type Err = NfcError;
+}
+
+pub struct CancelNfcSessionCapability;
+impl OperationCapability for CancelNfcSessionCapability {
+    type Request = ();
+    type Ok = ();
+    type Err = NfcError;
+}
+
+pub const GET_NFC_AVAILABILITY: CapabilityType<GetNfcAvailabilityCapability> =
+    CapabilityType::new("fission.nfc.get_availability");
+pub const SCAN_NFC_TAG: CapabilityType<ScanNfcTagCapability> =
+    CapabilityType::new("fission.nfc.scan_tag");
+pub const WRITE_NFC_TAG: CapabilityType<WriteNfcTagCapability> =
+    CapabilityType::new("fission.nfc.write_tag");
+pub const EMULATE_NFC_TAG: CapabilityType<EmulateNfcTagCapability> =
+    CapabilityType::new("fission.nfc.emulate_tag");
+pub const CANCEL_NFC_SESSION: CapabilityType<CancelNfcSessionCapability> =
+    CapabilityType::new("fission.nfc.cancel_session");
+
+/// Built-in action for host-delivered NFC tag events.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NfcTagDiscovered {
+    pub tag: NfcTag,
+}
+
+impl Action for NfcTagDiscovered {
+    fn static_id() -> ActionId {
+        lazy_static! {
+            static ref ID: ActionId = ActionId::from_name("fission_core::NfcTagDiscovered");
+        }
+        *ID
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nfc_records_round_trip() {
+        let records = vec![
+            NfcRecord::text("en", "Tap received"),
+            NfcRecord::uri("https://fission.rs/docs"),
+        ];
+        let bytes = serde_json::to_vec(&records).unwrap();
+        let decoded: Vec<NfcRecord> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, records);
+    }
+
+    #[test]
+    fn nfc_scan_request_round_trips() {
+        let request = NfcScanRequest {
+            technologies: vec![NfcTechnology::Ndef, NfcTechnology::IsoDep],
+            message: Some("Hold near the tag".into()),
+            timeout_ms: Some(30_000),
+            read_multiple_records: true,
+        };
+
+        let bytes = serde_json::to_vec(&request).unwrap();
+        let decoded: NfcScanRequest = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
+    fn nfc_inbound_action_round_trips() {
+        let action = NfcTagDiscovered {
+            tag: NfcTag {
+                id: Some(vec![1, 2, 3, 4]),
+                technologies: vec![NfcTechnology::Ndef],
+                records: vec![NfcRecord::uri("fission://open/1")],
+                raw_payload: None,
+            },
+        };
+
+        let envelope: crate::ActionEnvelope = action.clone().into();
+        let decoded: NfcTagDiscovered = serde_json::from_slice(&envelope.payload).unwrap();
+
+        assert_eq!(decoded, action);
+    }
+}

--- a/crates/core/fission-core/tests/platform_effects.rs
+++ b/crates/core/fission-core/tests/platform_effects.rs
@@ -3,6 +3,7 @@ use fission_core::{
     DeepLinkReceived, Effect, Effects, NotificationId, NotificationRequest, NotificationResponse,
     NotificationResponseReceived, SHOW_NOTIFICATION,
 };
+use fission_core::{NfcRecord, NfcScanRequest, NfcTechnology, SCAN_NFC_TAG};
 
 #[derive(Debug, Default)]
 struct TestState;
@@ -53,4 +54,33 @@ fn deep_link_config_and_inbound_actions_are_public_api() {
         },
     };
     let _: fission_core::ActionEnvelope = response_action.into();
+}
+
+#[test]
+fn nfc_convenience_builder_emits_capability_effect() {
+    let mut registry = ActionRegistry::<TestState>::new();
+    let mut effects = Effects::new(7, &mut registry);
+
+    effects.nfc().scan_tag(NfcScanRequest {
+        technologies: vec![NfcTechnology::Ndef],
+        message: Some("Tap a tag".into()),
+        timeout_ms: Some(5_000),
+        read_multiple_records: true,
+    });
+
+    assert_eq!(effects.out.len(), 1);
+    assert_eq!(effects.out[0].req_id, 7);
+    let Effect::Capability(CapabilityInvocationPayload::Operation(op)) = &effects.out[0].effect
+    else {
+        panic!("expected NFC capability effect");
+    };
+    assert_eq!(op.capability_name, SCAN_NFC_TAG.name);
+    let decoded: NfcScanRequest = serde_json::from_slice(&op.request).unwrap();
+    assert_eq!(decoded.technologies, vec![NfcTechnology::Ndef]);
+}
+
+#[test]
+fn nfc_records_are_public_api() {
+    let record = NfcRecord::uri("fission://open/1");
+    assert_eq!(record.type_name, b"U".to_vec());
 }

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -6,8 +6,8 @@ use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
-    test_control, InvalidationSet, MemoryNotificationHost, NotificationHost, Pipeline,
-    UnsupportedNotificationHost,
+    test_control, InvalidationSet, MemoryNfcHost, MemoryNotificationHost, NfcHost,
+    NotificationHost, Pipeline, UnsupportedNfcHost, UnsupportedNotificationHost,
 };
 
 pub struct DesktopApp<S: AppState, W: Widget<S>> {
@@ -89,6 +89,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> DesktopApp<S, W> {
         H: NotificationHost,
     {
         self.inner = self.inner.with_notification_host(host);
+        self
+    }
+
+    pub fn with_nfc_host<H>(mut self, host: H) -> Self
+    where
+        H: NfcHost,
+    {
+        self.inner = self.inner.with_nfc_host(host);
         self
     }
 

--- a/crates/shell/fission-shell-mobile/src/lib.rs
+++ b/crates/shell/fission-shell-mobile/src/lib.rs
@@ -4,7 +4,8 @@ use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
-    MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+    MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost, UnsupportedNfcHost,
+    UnsupportedNotificationHost,
 };
 
 #[cfg(target_os = "android")]
@@ -89,6 +90,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> MobileApp<S, W> {
         H: NotificationHost,
     {
         self.inner = self.inner.with_notification_host(host);
+        self
+    }
+
+    pub fn with_nfc_host<H>(mut self, host: H) -> Self
+    where
+        H: NfcHost,
+    {
+        self.inner = self.inner.with_nfc_host(host);
         self
     }
 

--- a/crates/shell/fission-shell-web/src/lib.rs
+++ b/crates/shell/fission-shell-web/src/lib.rs
@@ -4,7 +4,8 @@ use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
-    MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost,
+    MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost, UnsupportedNfcHost,
+    UnsupportedNotificationHost,
 };
 
 pub struct WebApp<S: AppState, W: Widget<S>> {
@@ -82,6 +83,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WebApp<S, W> {
         H: NotificationHost,
     {
         self.inner = self.inner.with_notification_host(host);
+        self
+    }
+
+    pub fn with_nfc_host<H>(mut self, host: H) -> Self
+    where
+        H: NfcHost,
+    {
+        self.inner = self.inner.with_nfc_host(host);
         self
     }
 

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -89,6 +89,8 @@ mod ime;
 use ime::{DesktopImeHandler, TextInputConfig};
 mod notifications;
 pub use notifications::{MemoryNotificationHost, NotificationHost, UnsupportedNotificationHost};
+mod nfc;
+pub use nfc::{MemoryNfcHost, NfcHost, UnsupportedNfcHost};
 pub mod test_control;
 
 use fission_core::action::ActionEnvelope;
@@ -151,6 +153,7 @@ fn register_builtin_operation_capabilities(async_registry: &mut AsyncRegistry) {
         async_registry,
         Arc::new(UnsupportedNotificationHost),
     );
+    nfc::register_nfc_capabilities(async_registry, Arc::new(UnsupportedNfcHost));
 }
 
 fn collect_startup_deep_links(config: &DeepLinkConfig) -> Vec<DeepLink> {
@@ -2402,6 +2405,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
         H: NotificationHost,
     {
         notifications::register_notification_capabilities(&mut self.async_registry, Arc::new(host));
+        self
+    }
+
+    pub fn with_nfc_host<H>(mut self, host: H) -> Self
+    where
+        H: NfcHost,
+    {
+        nfc::register_nfc_capabilities(&mut self.async_registry, Arc::new(host));
         self
     }
 

--- a/crates/shell/fission-shell-winit/src/nfc.rs
+++ b/crates/shell/fission-shell-winit/src/nfc.rs
@@ -1,0 +1,164 @@
+use fission_core::{
+    NfcAvailability, NfcEmulationRequest, NfcError, NfcRecord, NfcScanRequest, NfcSessionReceipt,
+    NfcTag, NfcTechnology, NfcWriteRequest, CANCEL_NFC_SESSION, EMULATE_NFC_TAG,
+    GET_NFC_AVAILABILITY, SCAN_NFC_TAG, WRITE_NFC_TAG,
+};
+use fission_shell::async_host::AsyncRegistry;
+use std::sync::Arc;
+
+/// Host-side NFC provider used by shell capability registration.
+pub trait NfcHost: Send + Sync + 'static {
+    fn availability(&self) -> Result<NfcAvailability, NfcError>;
+    fn scan_tag(&self, request: NfcScanRequest) -> Result<NfcTag, NfcError>;
+    fn write_tag(&self, request: NfcWriteRequest) -> Result<NfcSessionReceipt, NfcError>;
+    fn emulate_tag(&self, request: NfcEmulationRequest) -> Result<NfcSessionReceipt, NfcError>;
+    fn cancel_session(&self) -> Result<(), NfcError>;
+}
+
+/// Default provider used when the active shell has no NFC integration.
+#[derive(Debug, Default)]
+pub struct UnsupportedNfcHost;
+
+impl NfcHost for UnsupportedNfcHost {
+    fn availability(&self) -> Result<NfcAvailability, NfcError> {
+        Ok(NfcAvailability::default())
+    }
+
+    fn scan_tag(&self, _request: NfcScanRequest) -> Result<NfcTag, NfcError> {
+        Err(NfcError::unsupported("scan_tag"))
+    }
+
+    fn write_tag(&self, _request: NfcWriteRequest) -> Result<NfcSessionReceipt, NfcError> {
+        Err(NfcError::unsupported("write_tag"))
+    }
+
+    fn emulate_tag(&self, _request: NfcEmulationRequest) -> Result<NfcSessionReceipt, NfcError> {
+        Err(NfcError::unsupported("emulate_tag"))
+    }
+
+    fn cancel_session(&self) -> Result<(), NfcError> {
+        Err(NfcError::unsupported("cancel_session"))
+    }
+}
+
+/// In-process NFC host for smoke tests and non-OS environments.
+#[derive(Debug, Clone)]
+pub struct MemoryNfcHost {
+    tag: NfcTag,
+}
+
+impl MemoryNfcHost {
+    pub fn new(tag: NfcTag) -> Self {
+        Self { tag }
+    }
+}
+
+impl Default for MemoryNfcHost {
+    fn default() -> Self {
+        Self {
+            tag: NfcTag {
+                id: Some(vec![0xF1, 0x55, 0x10, 0x01]),
+                technologies: vec![NfcTechnology::Ndef],
+                records: vec![NfcRecord::uri("fission://memory-nfc")],
+                raw_payload: None,
+            },
+        }
+    }
+}
+
+impl NfcHost for MemoryNfcHost {
+    fn availability(&self) -> Result<NfcAvailability, NfcError> {
+        Ok(NfcAvailability {
+            supported: true,
+            enabled: true,
+            read: true,
+            write: true,
+            card_emulation: true,
+        })
+    }
+
+    fn scan_tag(&self, _request: NfcScanRequest) -> Result<NfcTag, NfcError> {
+        Ok(self.tag.clone())
+    }
+
+    fn write_tag(&self, request: NfcWriteRequest) -> Result<NfcSessionReceipt, NfcError> {
+        Ok(NfcSessionReceipt {
+            session_id: Some(format!("memory-nfc-write-{}", request.records.len())),
+            completed: true,
+        })
+    }
+
+    fn emulate_tag(&self, request: NfcEmulationRequest) -> Result<NfcSessionReceipt, NfcError> {
+        Ok(NfcSessionReceipt {
+            session_id: Some(format!("memory-nfc-emulate-{}", request.records.len())),
+            completed: true,
+        })
+    }
+
+    fn cancel_session(&self) -> Result<(), NfcError> {
+        Ok(())
+    }
+}
+
+pub(crate) fn register_nfc_capabilities(
+    async_registry: &mut AsyncRegistry,
+    host: Arc<dyn NfcHost>,
+) {
+    let availability_host = host.clone();
+    async_registry.register_operation_capability(GET_NFC_AVAILABILITY, move |(), _| {
+        let host = availability_host.clone();
+        async move { host.availability() }
+    });
+
+    let scan_host = host.clone();
+    async_registry.register_operation_capability(SCAN_NFC_TAG, move |request, _| {
+        let host = scan_host.clone();
+        async move { host.scan_tag(request) }
+    });
+
+    let write_host = host.clone();
+    async_registry.register_operation_capability(WRITE_NFC_TAG, move |request, _| {
+        let host = write_host.clone();
+        async move { host.write_tag(request) }
+    });
+
+    let emulate_host = host.clone();
+    async_registry.register_operation_capability(EMULATE_NFC_TAG, move |request, _| {
+        let host = emulate_host.clone();
+        async move { host.emulate_tag(request) }
+    });
+
+    async_registry.register_operation_capability(CANCEL_NFC_SESSION, move |(), _| {
+        let host = host.clone();
+        async move { host.cancel_session() }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_host_reports_unavailable() {
+        let host = UnsupportedNfcHost;
+        let availability = host.availability().unwrap();
+
+        assert!(!availability.supported);
+        assert!(host.scan_tag(NfcScanRequest::default()).is_err());
+    }
+
+    #[test]
+    fn memory_host_scans_and_writes() {
+        let host = MemoryNfcHost::default();
+        let tag = host.scan_tag(NfcScanRequest::default()).unwrap();
+        assert_eq!(tag.technologies, vec![NfcTechnology::Ndef]);
+
+        let receipt = host
+            .write_tag(NfcWriteRequest {
+                records: vec![NfcRecord::text("en", "ok")],
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(receipt.completed);
+    }
+}

--- a/crates/tools/cargo-fission/src/cli.rs
+++ b/crates/tools/cargo-fission/src/cli.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use fission_command_core::{DistributionProvider, Target};
+use fission_command_core::{DistributionProvider, PlatformCapability, Target};
 use fission_command_package as package;
 use fission_command_release as release;
 use std::path::PathBuf;
@@ -35,6 +35,14 @@ pub(crate) enum Command {
     AddTarget {
         #[arg(value_enum)]
         targets: Vec<Target>,
+        /// Project directory; defaults to the current working directory.
+        #[arg(long, default_value = ".")]
+        project_dir: PathBuf,
+    },
+    /// Add one or more host capabilities and update platform config where possible.
+    AddCapability {
+        #[arg(value_enum)]
+        capabilities: Vec<PlatformCapability>,
         /// Project directory; defaults to the current working directory.
         #[arg(long, default_value = ".")]
         project_dir: PathBuf,

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -37,6 +37,10 @@ where
             targets,
             project_dir,
         } => fission_command_core::add_targets(&project_dir, &targets),
+        Command::AddCapability {
+            capabilities,
+            project_dir,
+        } => fission_command_core::add_capabilities(&project_dir, &capabilities),
         Command::Doctor {
             targets,
             project_dir,
@@ -357,6 +361,45 @@ mod tests {
         assert!(std::fs::read_to_string(dir.join("platforms/web/README.md"))
             .unwrap()
             .contains("fission run --target web"));
+    }
+
+    #[test]
+    fn add_capability_updates_project_and_platform_config() {
+        let dir = unique_dir("capability");
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+        run([
+            "fission",
+            "add-target",
+            "ios",
+            "android",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+        run([
+            "fission",
+            "add-capability",
+            "nfc",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let project = read_project_config(&dir).unwrap();
+        assert!(project
+            .capabilities
+            .contains(&fission_command_core::PlatformCapability::Nfc));
+
+        let android_manifest =
+            std::fs::read_to_string(dir.join("platforms/android/AndroidManifest.xml")).unwrap();
+        assert!(android_manifest.contains("android.permission.NFC"));
+        assert!(android_manifest.contains("android.hardware.nfc"));
+
+        let ios_info = std::fs::read_to_string(dir.join("platforms/ios/Info.plist")).unwrap();
+        assert!(ios_info.contains("NFCReaderUsageDescription"));
+        let ios_entitlements =
+            std::fs::read_to_string(dir.join("platforms/ios/Entitlements.plist")).unwrap();
+        assert!(ios_entitlements.contains("com.apple.developer.nfc.readersession.formats"));
     }
 
     #[test]

--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -20,6 +20,20 @@ pub enum Target {
     Windows,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PlatformCapability {
+    Nfc,
+}
+
+impl PlatformCapability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Nfc => "nfc",
+        }
+    }
+}
+
 impl Target {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -91,6 +105,8 @@ impl DistributionProvider {
 pub struct FissionProject {
     pub app: AppConfig,
     pub targets: BTreeSet<Target>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub capabilities: BTreeSet<PlatformCapability>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -164,6 +180,7 @@ pub fn init_project(
     for target in targets {
         scaffold_target_with_policy(root, &project, target, write_policy)?;
     }
+    apply_platform_capability_config(root, &project)?;
 
     Ok(())
 }
@@ -212,10 +229,14 @@ fn initial_project_config(
         app: AppConfig {
             name: normalized_name.clone(),
             app_id: app_id
-                .or_else(|| existing.map(|project| project.app.app_id))
+                .or_else(|| existing.as_ref().map(|project| project.app.app_id.clone()))
                 .unwrap_or_else(|| format!("com.example.{}", normalized_name.replace('-', "_"))),
         },
         targets,
+        capabilities: existing
+            .as_ref()
+            .map(|project| project.capabilities.clone())
+            .unwrap_or_default(),
     })
 }
 
@@ -262,6 +283,7 @@ pub fn add_targets(project_dir: &Path, targets: &[Target]) -> Result<()> {
         };
         scaffold_target_with_policy(project_dir, &project, *target, write_policy)?;
     }
+    apply_platform_capability_config(project_dir, &project)?;
     write_project_config(project_dir, &project)?;
     update_cargo_fission_features(project_dir, &project)?;
     write_file_with_policy(
@@ -269,6 +291,89 @@ pub fn add_targets(project_dir: &Path, targets: &[Target]) -> Result<()> {
         &render_project_readme(&project),
         WritePolicy::PreserveExisting,
     )?;
+    Ok(())
+}
+
+pub fn add_capabilities(project_dir: &Path, capabilities: &[PlatformCapability]) -> Result<()> {
+    if capabilities.is_empty() {
+        bail!("no capabilities provided");
+    }
+    let mut project = read_project_config(project_dir)?;
+    for capability in capabilities {
+        project.capabilities.insert(*capability);
+    }
+    write_project_config(project_dir, &project)?;
+    apply_platform_capability_config(project_dir, &project)?;
+    Ok(())
+}
+
+fn apply_platform_capability_config(root: &Path, project: &FissionProject) -> Result<()> {
+    if project.capabilities.is_empty() {
+        return Ok(());
+    }
+    if project.targets.contains(&Target::Android) {
+        apply_android_capability_config(root, project)?;
+    }
+    if project.targets.contains(&Target::Ios) {
+        apply_ios_capability_config(root, project)?;
+    }
+    Ok(())
+}
+
+fn apply_android_capability_config(root: &Path, project: &FissionProject) -> Result<()> {
+    let path = root.join("platforms/android/AndroidManifest.xml");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let capabilities = render_android_capability_manifest_entries(project);
+    if capabilities.is_empty() || existing.contains("android.permission.NFC") {
+        return Ok(());
+    }
+    let marker = r#"    <uses-permission android:name="android.permission.INTERNET" />"#;
+    let updated = if existing.contains(marker) {
+        existing.replacen(marker, &format!("{marker}\n{capabilities}"), 1)
+    } else {
+        existing.replacen("<uses-sdk", &format!("{capabilities}\n    <uses-sdk"), 1)
+    };
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn apply_ios_capability_config(root: &Path, project: &FissionProject) -> Result<()> {
+    let info_path = root.join("platforms/ios/Info.plist");
+    if info_path.exists() {
+        let existing = fs::read_to_string(&info_path)
+            .with_context(|| format!("failed to read {}", info_path.display()))?;
+        if project.capabilities.contains(&PlatformCapability::Nfc)
+            && !existing.contains("NFCReaderUsageDescription")
+        {
+            let entry = "  <key>NFCReaderUsageDescription</key>\n  <string>This app uses NFC to scan nearby tags when you request it.</string>\n";
+            let updated = existing.replacen("</dict>", &format!("{entry}</dict>"), 1);
+            fs::write(&info_path, updated)
+                .with_context(|| format!("failed to write {}", info_path.display()))?;
+        }
+    }
+
+    if project.capabilities.contains(&PlatformCapability::Nfc) {
+        let entitlements_path = root.join("platforms/ios/Entitlements.plist");
+        if entitlements_path.exists() {
+            let existing = fs::read_to_string(&entitlements_path)
+                .with_context(|| format!("failed to read {}", entitlements_path.display()))?;
+            if !existing.contains("com.apple.developer.nfc.readersession.formats") {
+                let entry = "  <key>com.apple.developer.nfc.readersession.formats</key>\n  <array>\n    <string>NDEF</string>\n  </array>\n";
+                let updated = existing.replacen("</dict>", &format!("{entry}</dict>"), 1);
+                fs::write(&entitlements_path, updated)
+                    .with_context(|| format!("failed to write {}", entitlements_path.display()))?;
+            }
+        } else {
+            write_file_with_policy(
+                &entitlements_path,
+                IOS_NFC_ENTITLEMENTS_PLIST,
+                WritePolicy::PreserveExisting,
+            )?;
+        }
+    }
     Ok(())
 }
 
@@ -414,6 +519,7 @@ fn scaffold_target_with_policy(
                     "Override `ANDROID_HOME`, `ANDROID_NDK`, `ANDROID_MIN_API_LEVEL`, `ANDROID_TARGET_API_LEVEL`, `ANDROID_AVD_NAME`, or `ANDROID_SYSTEM_IMAGE` if your local SDK setup differs.",
                     "Set `ANDROID_EMULATOR_HEADLESS=1` for background/CI runs, or `ANDROID_EMULATOR_RESTART=1` to relaunch a hidden emulator visibly.",
                     "The generated package uses `assets/app-icon.png` as its default launcher icon.",
+                    "Run `fission add-capability nfc --project-dir .` to add NFC manifest permission and feature declarations.",
                     "Set `FISSION_TEST_CONTROL_PORT=<host-port>` before `run-emulator.sh`; the script forwards it to the fixed in-app device port.",
                 ],
             )
@@ -433,6 +539,7 @@ fn scaffold_target_with_policy(
                     "Run `fission test --target ios --project-dir .` for a simulator launch plus test-control health check.",
                     "Run `./platforms/ios/run-sim.sh` from the project root to build, install, and launch the app on the first available iPhone simulator.",
                     "The generated bundle uses `assets/app-icon.png` as its default app icon.",
+                    "Run `fission add-capability nfc --project-dir .` to add the NFC usage description and entitlements file.",
                     "Set `FISSION_TEST_CONTROL_PORT=<port>` before `run-sim.sh` to expose the in-app test control server on the host.",
                     "Set `IOS_SIM_DEVICE_ID=<udid>` if you want a specific simulator device.",
                     "Set `IOS_SIM_HEADLESS=1` for CI or background-only simulator runs; otherwise the script opens Simulator visibly.",
@@ -510,6 +617,13 @@ fn scaffold_ios_bundle(
     let test_script = render_ios_test_script();
 
     write_file_with_policy(&root.join("platforms/ios/Info.plist"), &plist, write_policy)?;
+    if project.capabilities.contains(&PlatformCapability::Nfc) {
+        write_file_with_policy(
+            &root.join("platforms/ios/Entitlements.plist"),
+            IOS_NFC_ENTITLEMENTS_PLIST,
+            write_policy,
+        )?;
+    }
     write_file_with_policy(
         &root.join("platforms/ios/package-sim.sh"),
         &package_script,
@@ -734,7 +848,7 @@ fn render_project_readme(project: &FissionProject) -> String {
         targets.push_str(&format!("- `{}`\n", target.as_str()));
     }
     format!(
-        "# {}\n\nGenerated by `fission init`.\n\n## Targets\n\n{}\n## Commands\n\n- `fission doctor --project-dir .` -- check local SDKs, browsers, emulators, and Rust targets\n- `fission devices --project-dir .` -- list runnable desktop, browser, simulator, emulator, and device targets\n- `fission run --project-dir .` -- launch the desktop app and attach to output\n- `fission run --target web --project-dir .` -- launch the web app and attach to the local server\n- `fission run --target ios --project-dir .` -- build, install, launch, and attach to simulator logs\n- `fission run --target android --project-dir .` -- build, install, launch, and attach to Android logs\n- `fission run --target <target> --device <id> --detach --project-dir .` -- launch without attaching\n- `fission logs --target <target> --device <id> --project-dir . --follow` -- attach later where supported\n- `fission build --target <target> --project-dir . --release` -- build a target without launching it\n- `fission test --target <target> --project-dir .` -- run the generated platform smoke test\n- `fission add-target web ios android --project-dir .` -- scaffold more targets\n- `cat platforms/<target>/README.md` -- inspect target-specific prerequisites and environment variables\n\n## Assets\n\n- `assets/app-icon.png` is the default app icon seed copied from Fission's `docs/fission_logo.png`\n\n## Status\n\nDesktop, web, iOS simulator, and Android emulator workflows are runnable through `fission run`. The platform scripts remain checked in so CI and advanced users can call the lower-level build, run, and smoke-test steps directly when needed.\n",
+        "# {}\n\nGenerated by `fission init`.\n\n## Targets\n\n{}\n## Commands\n\n- `fission doctor --project-dir .` -- check local SDKs, browsers, emulators, and Rust targets\n- `fission devices --project-dir .` -- list runnable desktop, browser, simulator, emulator, and device targets\n- `fission run --project-dir .` -- launch the desktop app and attach to output\n- `fission run --target web --project-dir .` -- launch the web app and attach to the local server\n- `fission run --target ios --project-dir .` -- build, install, launch, and attach to simulator logs\n- `fission run --target android --project-dir .` -- build, install, launch, and attach to Android logs\n- `fission run --target <target> --device <id> --detach --project-dir .` -- launch without attaching\n- `fission logs --target <target> --device <id> --project-dir . --follow` -- attach later where supported\n- `fission build --target <target> --project-dir . --release` -- build a target without launching it\n- `fission test --target <target> --project-dir .` -- run the generated platform smoke test\n- `fission add-target web ios android --project-dir .` -- scaffold more targets\n- `fission add-capability nfc --project-dir .` -- declare host capabilities and update platform config where possible\n- `cat platforms/<target>/README.md` -- inspect target-specific prerequisites and environment variables\n\n## Assets\n\n- `assets/app-icon.png` is the default app icon seed copied from Fission's `docs/fission_logo.png`\n\n## Status\n\nDesktop, web, iOS simulator, and Android emulator workflows are runnable through `fission run`. The platform scripts remain checked in so CI and advanced users can call the lower-level build, run, and smoke-test steps directly when needed.\n",
         project.app.name, targets
     )
 }
@@ -789,6 +903,7 @@ fn android_library_name(project: &FissionProject) -> String {
 }
 
 fn render_ios_plist(project: &FissionProject, executable: &str) -> String {
+    let capability_entries = render_ios_info_plist_capability_entries(project);
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -818,6 +933,7 @@ fn render_ios_plist(project: &FissionProject, executable: &str) -> String {
   <true/>
   <key>MinimumOSVersion</key>
   <string>18.0</string>
+{capability_entries}
   <key>UIDeviceFamily</key>
   <array>
     <integer>1</integer>
@@ -829,7 +945,16 @@ fn render_ios_plist(project: &FissionProject, executable: &str) -> String {
         display_name = ios_bundle_name(project),
         executable = executable,
         bundle_id = project.app.app_id,
+        capability_entries = capability_entries,
     )
+}
+
+fn render_ios_info_plist_capability_entries(project: &FissionProject) -> String {
+    if project.capabilities.contains(&PlatformCapability::Nfc) {
+        "  <key>NFCReaderUsageDescription</key>\n  <string>This app uses NFC to scan nearby tags when you request it.</string>\n".to_string()
+    } else {
+        String::new()
+    }
 }
 
 fn render_ios_package_script(
@@ -988,12 +1113,14 @@ PY
 }
 
 fn render_android_manifest(project: &FissionProject) -> String {
+    let capability_entries = render_android_capability_manifest_entries(project);
     format!(
         r#"<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{app_id}">
 
     <uses-permission android:name="android.permission.INTERNET" />
+{capability_entries}
 
     <uses-sdk
         android:minSdkVersion="24"
@@ -1025,8 +1152,32 @@ fn render_android_manifest(project: &FissionProject) -> String {
         app_id = project.app.app_id,
         label = ios_bundle_name(project),
         lib_name = android_library_name(project),
+        capability_entries = capability_entries,
     )
 }
+
+fn render_android_capability_manifest_entries(project: &FissionProject) -> String {
+    let mut out = String::new();
+    if project.capabilities.contains(&PlatformCapability::Nfc) {
+        out.push_str("    <uses-permission android:name=\"android.permission.NFC\" />\n");
+        out.push_str(
+            "    <uses-feature android:name=\"android.hardware.nfc\" android:required=\"false\" />\n",
+        );
+    }
+    out
+}
+
+const IOS_NFC_ENTITLEMENTS_PLIST: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.developer.nfc.readersession.formats</key>
+  <array>
+    <string>NDEF</string>
+  </array>
+</dict>
+</plist>
+"#;
 
 fn render_android_package_script(project: &FissionProject) -> String {
     let lib_name = android_library_name(project);


### PR DESCRIPTION
## Summary

Adds the first platform capability after notifications/deep links: NFC. This PR is stacked on `feature/notifications-deeplinks` so the diff stays scoped to the NFC API and its project configuration support.

## What changed

- Adds typed NFC capability models in `fission-core`:
  - `NfcAvailability`, `NfcTechnology`, `NfcRecord`, `NfcTag`
  - scan, write, emulation, cancellation request/result types
  - portable `NfcError`
  - `NfcTagDiscovered` inbound action
- Adds NFC capability identities:
  - `GET_NFC_AVAILABILITY`
  - `SCAN_NFC_TAG`
  - `WRITE_NFC_TAG`
  - `EMULATE_NFC_TAG`
  - `CANCEL_NFC_SESSION`
- Adds `Effects::nfc()` convenience builder for reducers.
- Adds shell host abstraction in `fission-shell-winit`:
  - `NfcHost`
  - `UnsupportedNfcHost`
  - `MemoryNfcHost`
  - async capability registration.
- Exposes `.with_nfc_host(...)` through desktop, mobile, web, and the `fission` facade/prelude.
- Adds CLI project configuration support:
  - `fission add-capability nfc --project-dir .`
  - `capabilities = ["nfc"]` in `fission.toml`
  - Android manifest patching for NFC permission/feature declarations
  - iOS `NFCReaderUsageDescription` and `Entitlements.plist` generation.

## Verification

- `cargo test -p fission-core --locked nfc`
- `cargo test -p fission-shell-winit --locked nfc`
- `cargo test -p fission --features desktop --locked --test platform_api`
- `cargo test -p cargo-fission --locked add_capability_updates_project_and_platform_config`
- `cargo check -p fission-shell-desktop -p fission-shell-web -p fission-shell-mobile --locked`
- `cargo check -p fission-shell-web --target wasm32-unknown-unknown --locked`
- `cargo check -p fission-shell-mobile --target aarch64-apple-ios-sim --locked`
