### PR TITLE
Add clipboard platform capability

### DIFF
--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -180,6 +180,13 @@ pub use fission_core::{
     DecodeBarcodeImageCapability, ScanBarcodeCapability, CANCEL_BARCODE_SCAN, DECODE_BARCODE_IMAGE,
     SCAN_BARCODE,
 };
+pub use fission_core::{
+    ClearClipboardCapability, ClipboardContent, ClipboardEffects, ClipboardError, ClipboardItem,
+    ClipboardText, ClipboardWriteTextRequest, ReadClipboardContentCapability,
+    ReadClipboardTextCapability, WriteClipboardContentCapability, WriteClipboardTextCapability,
+    CLEAR_CLIPBOARD, READ_CLIPBOARD_CONTENT, READ_CLIPBOARD_TEXT, WRITE_CLIPBOARD_CONTENT,
+    WRITE_CLIPBOARD_TEXT,
+};
 
 // Core event types
 pub use fission_core::event::{InputEvent, KeyCode, KeyEvent, PointerButton, PointerEvent};
@@ -204,9 +211,9 @@ pub use fission_widgets::{HStack, Icon, Spacer, VStack};
     not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
 ))]
 pub use fission_shell_desktop::{
-    BarcodeScannerHost, BiometricHost, DesktopApp, MemoryBarcodeScannerHost, MemoryBiometricHost,
-    MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
-    UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
+    BarcodeScannerHost, BiometricHost, ClipboardHost, DesktopApp, MemoryBarcodeScannerHost,
+    MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, NfcHost,
+    NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
     UnsupportedNotificationHost,
 };
 #[cfg(all(
@@ -219,10 +226,10 @@ pub use fission_shell_desktop::{
     any(target_os = "android", target_os = "ios")
 ))]
 pub use fission_shell_mobile::{
-    BarcodeScannerHost, BiometricHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
-    MemoryNfcHost, MemoryNotificationHost, MobileApp, NfcHost, NotificationHost,
-    UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
-    UnsupportedNotificationHost,
+    BarcodeScannerHost, BiometricHost, ClipboardHost, MemoryBarcodeScannerHost,
+    MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, MobileApp,
+    NfcHost, NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost,
+    UnsupportedNfcHost, UnsupportedNotificationHost,
 };
 #[cfg(feature = "terminal-shell")]
 pub use fission_shell_terminal::TerminalApp;
@@ -231,9 +238,9 @@ pub use fission_shell_terminal::TerminalApp;
     target_arch = "wasm32"
 ))]
 pub use fission_shell_web::{
-    BarcodeScannerHost, BiometricHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
-    MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
-    UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
+    BarcodeScannerHost, BiometricHost, ClipboardHost, MemoryBarcodeScannerHost,
+    MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, NfcHost,
+    NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
     UnsupportedNotificationHost, WebApp,
 };
 
@@ -286,6 +293,13 @@ pub mod prelude {
         CancelBarcodeScanCapability, DecodeBarcodeImageCapability, ScanBarcodeCapability,
         CANCEL_BARCODE_SCAN, DECODE_BARCODE_IMAGE, SCAN_BARCODE,
     };
+    pub use fission_core::{
+        ClearClipboardCapability, ClipboardContent, ClipboardEffects, ClipboardError,
+        ClipboardItem, ClipboardText, ClipboardWriteTextRequest, ReadClipboardContentCapability,
+        ReadClipboardTextCapability, WriteClipboardContentCapability, WriteClipboardTextCapability,
+        CLEAR_CLIPBOARD, READ_CLIPBOARD_CONTENT, READ_CLIPBOARD_TEXT, WRITE_CLIPBOARD_CONTENT,
+        WRITE_CLIPBOARD_TEXT,
+    };
 
     // Layout
     pub use fission_layout::{LayoutPoint, LayoutRect, LayoutSize};
@@ -309,10 +323,10 @@ pub mod prelude {
         not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
     ))]
     pub use fission_shell_desktop::{
-        BarcodeScannerHost, BiometricHost, DesktopApp, MemoryBarcodeScannerHost,
-        MemoryBiometricHost, MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
-        UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
-        UnsupportedNotificationHost,
+        BarcodeScannerHost, BiometricHost, ClipboardHost, DesktopApp, MemoryBarcodeScannerHost,
+        MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, NfcHost,
+        NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost,
+        UnsupportedNfcHost, UnsupportedNotificationHost,
     };
     #[cfg(all(
         any(feature = "android", feature = "mobile", feature = "platform-shells"),
@@ -329,10 +343,10 @@ pub mod prelude {
         any(target_os = "android", target_os = "ios")
     ))]
     pub use fission_shell_mobile::{
-        BarcodeScannerHost, BiometricHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
-        MemoryNfcHost, MemoryNotificationHost, MobileApp, NfcHost, NotificationHost,
-        UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
-        UnsupportedNotificationHost,
+        BarcodeScannerHost, BiometricHost, ClipboardHost, MemoryBarcodeScannerHost,
+        MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, MobileApp,
+        NfcHost, NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost,
+        UnsupportedNfcHost, UnsupportedNotificationHost,
     };
     #[cfg(feature = "site")]
     pub use fission_shell_site::*;
@@ -343,10 +357,10 @@ pub mod prelude {
         target_arch = "wasm32"
     ))]
     pub use fission_shell_web::{
-        BarcodeScannerHost, BiometricHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
-        MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
-        UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
-        UnsupportedNotificationHost, WebApp,
+        BarcodeScannerHost, BiometricHost, ClipboardHost, MemoryBarcodeScannerHost,
+        MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, NfcHost,
+        NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost,
+        UnsupportedNfcHost, UnsupportedNotificationHost, WebApp,
     };
 
     // Serde (commonly needed for actions)

--- a/crates/authoring/fission/tests/platform_api.rs
+++ b/crates/authoring/fission/tests/platform_api.rs
@@ -36,6 +36,7 @@ fn facade_exports_notifications_and_deep_links() {
         .with_nfc_host(MemoryNfcHost::default())
         .with_biometric_host(MemoryBiometricHost::default())
         .with_barcode_scanner_host(MemoryBarcodeScannerHost::default())
+        .with_clipboard_host(MemoryClipboardHost::default())
         .with_deep_link_config(
             DeepLinkConfig::new()
                 .scheme("fission")
@@ -65,5 +66,8 @@ fn facade_exports_notifications_and_deep_links() {
     let _barcode = BarcodeScanRequest {
         formats: vec![BarcodeFormat::QrCode],
         ..Default::default()
+    };
+    let _clipboard = ClipboardWriteTextRequest {
+        text: "copied".into(),
     };
 }

--- a/crates/core/fission-core/src/context.rs
+++ b/crates/core/fission-core/src/context.rs
@@ -28,6 +28,10 @@ use crate::platform_biometric::{
     BiometricAuthenticateRequest, AUTHENTICATE_BIOMETRIC, CANCEL_BIOMETRIC_AUTHENTICATION,
     GET_BIOMETRIC_AVAILABILITY,
 };
+use crate::platform_clipboard::{
+    ClipboardContent, ClipboardWriteTextRequest, CLEAR_CLIPBOARD, READ_CLIPBOARD_CONTENT,
+    READ_CLIPBOARD_TEXT, WRITE_CLIPBOARD_CONTENT, WRITE_CLIPBOARD_TEXT,
+};
 use crate::platform_nfc::{
     NfcEmulationRequest, NfcScanRequest, NfcWriteRequest, CANCEL_NFC_SESSION, EMULATE_NFC_TAG,
     GET_NFC_AVAILABILITY, SCAN_NFC_TAG, WRITE_NFC_TAG,
@@ -183,6 +187,10 @@ impl<'a, S: AppState> Effects<'a, S> {
 
     pub fn barcode_scanner(&mut self) -> BarcodeScannerEffects<'_, 'a, S> {
         BarcodeScannerEffects { effects: self }
+    }
+
+    pub fn clipboard(&mut self) -> ClipboardEffects<'_, 'a, S> {
+        ClipboardEffects { effects: self }
     }
 
     pub fn app<J: JobSpec>(
@@ -412,6 +420,33 @@ impl<'a, 'b, S: AppState> BarcodeScannerEffects<'a, 'b, S> {
 
     pub fn cancel_scan(self) -> EffectBuilder<'a, 'b, S> {
         self.effects.capability(CANCEL_BARCODE_SCAN, ())
+    }
+}
+
+/// Convenience builder for standard clipboard host capabilities.
+pub struct ClipboardEffects<'a, 'b, S: AppState> {
+    effects: &'a mut Effects<'b, S>,
+}
+
+impl<'a, 'b, S: AppState> ClipboardEffects<'a, 'b, S> {
+    pub fn read_text(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(READ_CLIPBOARD_TEXT, ())
+    }
+
+    pub fn write_text(self, request: ClipboardWriteTextRequest) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(WRITE_CLIPBOARD_TEXT, request)
+    }
+
+    pub fn read_content(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(READ_CLIPBOARD_CONTENT, ())
+    }
+
+    pub fn write_content(self, request: ClipboardContent) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(WRITE_CLIPBOARD_CONTENT, request)
+    }
+
+    pub fn clear(self) -> EffectBuilder<'a, 'b, S> {
+        self.effects.capability(CLEAR_CLIPBOARD, ())
     }
 }
 

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -54,6 +54,7 @@ pub mod media;
 pub mod platform;
 pub mod platform_barcode;
 pub mod platform_biometric;
+pub mod platform_clipboard;
 pub mod platform_nfc;
 pub mod registry;
 pub mod runtime;
@@ -77,8 +78,8 @@ pub use capability::{
     PickOpenFilesResult, PickedFile, OPEN_URL, PICK_OPEN_FILES,
 };
 pub use context::{
-    BarcodeScannerEffects, BiometricEffects, Effects, NfcEffects, NotificationEffects,
-    ReducerContext,
+    BarcodeScannerEffects, BiometricEffects, ClipboardEffects, Effects, NfcEffects,
+    NotificationEffects, ReducerContext,
 }; // New
 pub use effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect};
 pub use env::{
@@ -119,6 +120,12 @@ pub use platform_biometric::{
     BiometricAvailability, BiometricError, BiometricKind, BiometricStrength,
     CancelBiometricAuthenticationCapability, GetBiometricAvailabilityCapability,
     AUTHENTICATE_BIOMETRIC, CANCEL_BIOMETRIC_AUTHENTICATION, GET_BIOMETRIC_AVAILABILITY,
+};
+pub use platform_clipboard::{
+    ClearClipboardCapability, ClipboardContent, ClipboardError, ClipboardItem, ClipboardText,
+    ClipboardWriteTextRequest, ReadClipboardContentCapability, ReadClipboardTextCapability,
+    WriteClipboardContentCapability, WriteClipboardTextCapability, CLEAR_CLIPBOARD,
+    READ_CLIPBOARD_CONTENT, READ_CLIPBOARD_TEXT, WRITE_CLIPBOARD_CONTENT, WRITE_CLIPBOARD_TEXT,
 };
 pub use platform_nfc::{
     CancelNfcSessionCapability, EmulateNfcTagCapability, GetNfcAvailabilityCapability,

--- a/crates/core/fission-core/src/platform_clipboard.rs
+++ b/crates/core/fission-core/src/platform_clipboard.rs
@@ -1,0 +1,126 @@
+//! Clipboard host capabilities.
+
+use crate::capability::{CapabilityType, OperationCapability};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardText {
+    pub text: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardWriteTextRequest {
+    pub text: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardItem {
+    pub content_type: String,
+    pub bytes: Vec<u8>,
+    pub suggested_name: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardContent {
+    pub items: Vec<ClipboardItem>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardError {
+    pub code: String,
+    pub message: String,
+}
+
+impl ClipboardError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn unsupported(operation: impl Into<String>) -> Self {
+        Self::new(
+            "unsupported",
+            format!(
+                "clipboard operation `{}` is not supported by this host",
+                operation.into()
+            ),
+        )
+    }
+}
+
+pub struct ReadClipboardTextCapability;
+impl OperationCapability for ReadClipboardTextCapability {
+    type Request = ();
+    type Ok = ClipboardText;
+    type Err = ClipboardError;
+}
+
+pub struct WriteClipboardTextCapability;
+impl OperationCapability for WriteClipboardTextCapability {
+    type Request = ClipboardWriteTextRequest;
+    type Ok = ();
+    type Err = ClipboardError;
+}
+
+pub struct ReadClipboardContentCapability;
+impl OperationCapability for ReadClipboardContentCapability {
+    type Request = ();
+    type Ok = ClipboardContent;
+    type Err = ClipboardError;
+}
+
+pub struct WriteClipboardContentCapability;
+impl OperationCapability for WriteClipboardContentCapability {
+    type Request = ClipboardContent;
+    type Ok = ();
+    type Err = ClipboardError;
+}
+
+pub struct ClearClipboardCapability;
+impl OperationCapability for ClearClipboardCapability {
+    type Request = ();
+    type Ok = ();
+    type Err = ClipboardError;
+}
+
+pub const READ_CLIPBOARD_TEXT: CapabilityType<ReadClipboardTextCapability> =
+    CapabilityType::new("fission.clipboard.read_text");
+pub const WRITE_CLIPBOARD_TEXT: CapabilityType<WriteClipboardTextCapability> =
+    CapabilityType::new("fission.clipboard.write_text");
+pub const READ_CLIPBOARD_CONTENT: CapabilityType<ReadClipboardContentCapability> =
+    CapabilityType::new("fission.clipboard.read_content");
+pub const WRITE_CLIPBOARD_CONTENT: CapabilityType<WriteClipboardContentCapability> =
+    CapabilityType::new("fission.clipboard.write_content");
+pub const CLEAR_CLIPBOARD: CapabilityType<ClearClipboardCapability> =
+    CapabilityType::new("fission.clipboard.clear");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clipboard_text_round_trips() {
+        let request = ClipboardWriteTextRequest {
+            text: "copy me".into(),
+        };
+        let bytes = serde_json::to_vec(&request).unwrap();
+        let decoded: ClipboardWriteTextRequest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
+    fn clipboard_content_round_trips() {
+        let content = ClipboardContent {
+            items: vec![ClipboardItem {
+                content_type: "text/plain".into(),
+                bytes: b"copy me".to_vec(),
+                suggested_name: None,
+            }],
+        };
+        let bytes = serde_json::to_vec(&content).unwrap();
+        let decoded: ClipboardContent = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, content);
+    }
+}

--- a/crates/core/fission-core/tests/platform_effects.rs
+++ b/crates/core/fission-core/tests/platform_effects.rs
@@ -5,6 +5,7 @@ use fission_core::{
 };
 use fission_core::{BarcodeFormat, BarcodeScanRequest, SCAN_BARCODE};
 use fission_core::{BiometricAuthenticateRequest, AUTHENTICATE_BIOMETRIC};
+use fission_core::{ClipboardWriteTextRequest, WRITE_CLIPBOARD_TEXT};
 use fission_core::{NfcRecord, NfcScanRequest, NfcTechnology, SCAN_NFC_TAG};
 
 #[derive(Debug, Default)]
@@ -130,4 +131,24 @@ fn barcode_convenience_builder_emits_capability_effect() {
     assert_eq!(op.capability_name, SCAN_BARCODE.name);
     let decoded: BarcodeScanRequest = serde_json::from_slice(&op.request).unwrap();
     assert_eq!(decoded.formats, vec![BarcodeFormat::QrCode]);
+}
+
+#[test]
+fn clipboard_convenience_builder_emits_capability_effect() {
+    let mut registry = ActionRegistry::<TestState>::new();
+    let mut effects = Effects::new(17, &mut registry);
+
+    effects.clipboard().write_text(ClipboardWriteTextRequest {
+        text: "copied".into(),
+    });
+
+    assert_eq!(effects.out.len(), 1);
+    assert_eq!(effects.out[0].req_id, 17);
+    let Effect::Capability(CapabilityInvocationPayload::Operation(op)) = &effects.out[0].effect
+    else {
+        panic!("expected clipboard capability effect");
+    };
+    assert_eq!(op.capability_name, WRITE_CLIPBOARD_TEXT.name);
+    let decoded: ClipboardWriteTextRequest = serde_json::from_slice(&op.request).unwrap();
+    assert_eq!(decoded.text, "copied");
 }

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -6,10 +6,10 @@ use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
-    test_control, BarcodeScannerHost, BiometricHost, InvalidationSet, MemoryBarcodeScannerHost,
-    MemoryBiometricHost, MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
-    Pipeline, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
-    UnsupportedNotificationHost,
+    test_control, BarcodeScannerHost, BiometricHost, ClipboardHost, InvalidationSet,
+    MemoryBarcodeScannerHost, MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost,
+    MemoryNotificationHost, NfcHost, NotificationHost, Pipeline, UnsupportedBarcodeScannerHost,
+    UnsupportedBiometricHost, UnsupportedNfcHost, UnsupportedNotificationHost,
 };
 
 pub struct DesktopApp<S: AppState, W: Widget<S>> {
@@ -115,6 +115,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> DesktopApp<S, W> {
         H: BarcodeScannerHost,
     {
         self.inner = self.inner.with_barcode_scanner_host(host);
+        self
+    }
+
+    pub fn with_clipboard_host<H>(mut self, host: H) -> Self
+    where
+        H: ClipboardHost,
+    {
+        self.inner = self.inner.with_clipboard_host(host);
         self
     }
 

--- a/crates/shell/fission-shell-mobile/src/lib.rs
+++ b/crates/shell/fission-shell-mobile/src/lib.rs
@@ -4,9 +4,9 @@ use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
-    BarcodeScannerHost, BiometricHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
-    MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
-    UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
+    BarcodeScannerHost, BiometricHost, ClipboardHost, MemoryBarcodeScannerHost,
+    MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, NfcHost,
+    NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
     UnsupportedNotificationHost,
 };
 
@@ -116,6 +116,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> MobileApp<S, W> {
         H: BarcodeScannerHost,
     {
         self.inner = self.inner.with_barcode_scanner_host(host);
+        self
+    }
+
+    pub fn with_clipboard_host<H>(mut self, host: H) -> Self
+    where
+        H: ClipboardHost,
+    {
+        self.inner = self.inner.with_clipboard_host(host);
         self
     }
 

--- a/crates/shell/fission-shell-web/src/lib.rs
+++ b/crates/shell/fission-shell-web/src/lib.rs
@@ -4,9 +4,9 @@ use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
-    BarcodeScannerHost, BiometricHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
-    MemoryNfcHost, MemoryNotificationHost, NfcHost, NotificationHost,
-    UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
+    BarcodeScannerHost, BiometricHost, ClipboardHost, MemoryBarcodeScannerHost,
+    MemoryBiometricHost, MemoryClipboardHost, MemoryNfcHost, MemoryNotificationHost, NfcHost,
+    NotificationHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedNfcHost,
     UnsupportedNotificationHost,
 };
 
@@ -109,6 +109,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WebApp<S, W> {
         H: BarcodeScannerHost,
     {
         self.inner = self.inner.with_barcode_scanner_host(host);
+        self
+    }
+
+    pub fn with_clipboard_host<H>(mut self, host: H) -> Self
+    where
+        H: ClipboardHost,
+    {
+        self.inner = self.inner.with_clipboard_host(host);
         self
     }
 

--- a/crates/shell/fission-shell-winit/src/clipboard.rs
+++ b/crates/shell/fission-shell-winit/src/clipboard.rs
@@ -1,4 +1,9 @@
 use fission_core::env::Clipboard;
+use fission_core::{
+    ClipboardContent, ClipboardError, ClipboardText, ClipboardWriteTextRequest, CLEAR_CLIPBOARD,
+    READ_CLIPBOARD_CONTENT, READ_CLIPBOARD_TEXT, WRITE_CLIPBOARD_CONTENT, WRITE_CLIPBOARD_TEXT,
+};
+use fission_shell::async_host::AsyncRegistry;
 use std::sync::{Arc, Mutex};
 
 #[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
@@ -43,5 +48,180 @@ impl Clipboard for DesktopClipboard {
                 let _ = cb.set_text(text);
             }
         }
+    }
+}
+
+/// Host-side clipboard provider used by shell capability registration.
+pub trait ClipboardHost: Send + Sync + 'static {
+    fn read_text(&self) -> Result<ClipboardText, ClipboardError>;
+    fn write_text(&self, request: ClipboardWriteTextRequest) -> Result<(), ClipboardError>;
+    fn read_content(&self) -> Result<ClipboardContent, ClipboardError>;
+    fn write_content(&self, request: ClipboardContent) -> Result<(), ClipboardError>;
+    fn clear(&self) -> Result<(), ClipboardError>;
+}
+
+impl ClipboardHost for DesktopClipboard {
+    fn read_text(&self) -> Result<ClipboardText, ClipboardError> {
+        Ok(ClipboardText {
+            text: self.get_text(),
+        })
+    }
+
+    fn write_text(&self, request: ClipboardWriteTextRequest) -> Result<(), ClipboardError> {
+        self.set_text(&request.text);
+        Ok(())
+    }
+
+    fn read_content(&self) -> Result<ClipboardContent, ClipboardError> {
+        let text = self.get_text().unwrap_or_default();
+        Ok(ClipboardContent {
+            items: if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![fission_core::ClipboardItem {
+                    content_type: "text/plain".into(),
+                    bytes: text.into_bytes(),
+                    suggested_name: None,
+                }]
+            },
+        })
+    }
+
+    fn write_content(&self, request: ClipboardContent) -> Result<(), ClipboardError> {
+        if let Some(item) = request
+            .items
+            .iter()
+            .find(|item| item.content_type.starts_with("text/plain"))
+        {
+            if let Ok(text) = String::from_utf8(item.bytes.clone()) {
+                self.set_text(&text);
+                return Ok(());
+            }
+        }
+        Err(ClipboardError::unsupported("write_content_non_text"))
+    }
+
+    fn clear(&self) -> Result<(), ClipboardError> {
+        self.set_text("");
+        Ok(())
+    }
+}
+
+/// In-process clipboard host for tests and non-OS environments.
+#[derive(Debug, Default)]
+pub struct MemoryClipboardHost {
+    content: Arc<Mutex<ClipboardContent>>,
+}
+
+impl ClipboardHost for MemoryClipboardHost {
+    fn read_text(&self) -> Result<ClipboardText, ClipboardError> {
+        let content = self.content.lock().map_err(|_| {
+            ClipboardError::new("lock_poisoned", "memory clipboard lock was poisoned")
+        })?;
+        let text = content
+            .items
+            .iter()
+            .find(|item| item.content_type.starts_with("text/plain"))
+            .and_then(|item| String::from_utf8(item.bytes.clone()).ok());
+        Ok(ClipboardText { text })
+    }
+
+    fn write_text(&self, request: ClipboardWriteTextRequest) -> Result<(), ClipboardError> {
+        let mut content = self.content.lock().map_err(|_| {
+            ClipboardError::new("lock_poisoned", "memory clipboard lock was poisoned")
+        })?;
+        *content = ClipboardContent {
+            items: vec![fission_core::ClipboardItem {
+                content_type: "text/plain".into(),
+                bytes: request.text.into_bytes(),
+                suggested_name: None,
+            }],
+        };
+        Ok(())
+    }
+
+    fn read_content(&self) -> Result<ClipboardContent, ClipboardError> {
+        self.content
+            .lock()
+            .map(|content| content.clone())
+            .map_err(|_| ClipboardError::new("lock_poisoned", "memory clipboard lock was poisoned"))
+    }
+
+    fn write_content(&self, request: ClipboardContent) -> Result<(), ClipboardError> {
+        let mut content = self.content.lock().map_err(|_| {
+            ClipboardError::new("lock_poisoned", "memory clipboard lock was poisoned")
+        })?;
+        *content = request;
+        Ok(())
+    }
+
+    fn clear(&self) -> Result<(), ClipboardError> {
+        let mut content = self.content.lock().map_err(|_| {
+            ClipboardError::new("lock_poisoned", "memory clipboard lock was poisoned")
+        })?;
+        content.items.clear();
+        Ok(())
+    }
+}
+
+pub(crate) fn register_clipboard_capabilities(
+    async_registry: &mut AsyncRegistry,
+    host: Arc<dyn ClipboardHost>,
+) {
+    let read_text_host = host.clone();
+    async_registry.register_operation_capability(READ_CLIPBOARD_TEXT, move |(), _| {
+        let host = read_text_host.clone();
+        async move { host.read_text() }
+    });
+
+    let write_text_host = host.clone();
+    async_registry.register_operation_capability(WRITE_CLIPBOARD_TEXT, move |request, _| {
+        let host = write_text_host.clone();
+        async move { host.write_text(request) }
+    });
+
+    let read_content_host = host.clone();
+    async_registry.register_operation_capability(READ_CLIPBOARD_CONTENT, move |(), _| {
+        let host = read_content_host.clone();
+        async move { host.read_content() }
+    });
+
+    let write_content_host = host.clone();
+    async_registry.register_operation_capability(WRITE_CLIPBOARD_CONTENT, move |request, _| {
+        let host = write_content_host.clone();
+        async move { host.write_content(request) }
+    });
+
+    async_registry.register_operation_capability(CLEAR_CLIPBOARD, move |(), _| {
+        let host = host.clone();
+        async move { host.clear() }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_clipboard_reads_and_writes_text() {
+        let host = MemoryClipboardHost::default();
+        host.write_text(ClipboardWriteTextRequest {
+            text: "copied".into(),
+        })
+        .unwrap();
+        assert_eq!(host.read_text().unwrap().text.as_deref(), Some("copied"));
+        host.clear().unwrap();
+        assert_eq!(host.read_text().unwrap().text, None);
+    }
+
+    #[test]
+    fn desktop_clipboard_host_supports_text_content() {
+        let host = DesktopClipboard::new();
+        host.write_text(ClipboardWriteTextRequest {
+            text: "copied".into(),
+        })
+        .unwrap();
+        let content = ClipboardHost::read_content(&host).unwrap();
+        assert_eq!(content.items[0].content_type, "text/plain");
     }
 }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -85,6 +85,7 @@ use web_backend::MockWebBackend;
 
 mod clipboard;
 use clipboard::DesktopClipboard;
+pub use clipboard::{ClipboardHost, MemoryClipboardHost};
 mod barcode;
 pub use barcode::{BarcodeScannerHost, MemoryBarcodeScannerHost, UnsupportedBarcodeScannerHost};
 mod biometric;
@@ -163,6 +164,7 @@ fn register_builtin_operation_capabilities(async_registry: &mut AsyncRegistry) {
         async_registry,
         Arc::new(UnsupportedBarcodeScannerHost),
     );
+    clipboard::register_clipboard_capabilities(async_registry, Arc::new(DesktopClipboard::new()));
 }
 
 fn collect_startup_deep_links(config: &DeepLinkConfig) -> Vec<DeepLink> {
@@ -2438,6 +2440,14 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
         H: BarcodeScannerHost,
     {
         barcode::register_barcode_scanner_capabilities(&mut self.async_registry, Arc::new(host));
+        self
+    }
+
+    pub fn with_clipboard_host<H>(mut self, host: H) -> Self
+    where
+        H: ClipboardHost,
+    {
+        clipboard::register_clipboard_capabilities(&mut self.async_registry, Arc::new(host));
         self
     }
 


### PR DESCRIPTION
## Summary

Adds clipboard access as a typed host capability. This PR is stacked on `feature/capability-barcode-scanner` and keeps the existing text-input clipboard backend intact while exposing app-level clipboard effects through the standard capability path.

## What changed

- Adds typed clipboard models in `fission-core`:
  - `ClipboardText`, `ClipboardWriteTextRequest`
  - `ClipboardItem`, `ClipboardContent`
  - portable `ClipboardError`
- Adds capability identities:
  - `READ_CLIPBOARD_TEXT`
  - `WRITE_CLIPBOARD_TEXT`
  - `READ_CLIPBOARD_CONTENT`
  - `WRITE_CLIPBOARD_CONTENT`
  - `CLEAR_CLIPBOARD`
- Adds `Effects::clipboard()` convenience builder.
- Extends the winit clipboard backend with host capability registration:
  - `ClipboardHost`
  - `MemoryClipboardHost`
  - `DesktopClipboard` implements `ClipboardHost`
- Exposes `.with_clipboard_host(...)` through desktop, mobile, web, and the `fission` facade/prelude.

## Platform config

No manifest/plist entries are required for the generic clipboard capability in the current scaffold. Shells still decide what clipboard operations are available on the active platform.

## Verification

- `cargo test -p fission-core --locked clipboard`
- `cargo test -p fission-shell-winit --locked clipboard`
- `cargo test -p fission --features desktop --locked --test platform_api`
- `cargo check -p fission-shell-desktop -p fission-shell-web -p fission-shell-mobile --locked`
- `cargo check -p fission-shell-web --target wasm32-unknown-unknown --locked`
- `cargo check -p fission-shell-mobile --target aarch64-apple-ios-sim --locked`
