### PR TITLE
Prepare Fission 0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fission"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2172,7 +2172,7 @@ source = "git+https://github.com/wez/finl_unicode.git?branch=no_std#a1892f262455
 
 [[package]]
 name = "fission"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "fission-3d",
  "fission-charts",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "fission-3d"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "fission-charts"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "fission-core",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-package"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-release"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-run"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-command-core",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-site"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-shell-site",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-ui"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "fission-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "fission-credentials"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "fission-design-system-codegen"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "fission-diagnostics"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.10.0",
  "once_cell",
@@ -2388,14 +2388,14 @@ dependencies = [
 
 [[package]]
 name = "fission-i18n"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fission-icons"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "heck 0.4.1",
  "serde_json",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "fission-ir"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "serde",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "fission-layout"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "fission-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-ir",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render-vello"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "fission-semantics"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "fission-ir",
  "serde",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-desktop"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-mobile"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-site"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-terminal"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-web"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-winit"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test-driver"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2635,14 +2635,14 @@ dependencies = [
 
 [[package]]
 name = "fission-text-engine"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "fission-theme"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "fission-design-system-codegen",
  "fission-ir",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "fission-widgets"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fission
 
 [![Crates.io](https://img.shields.io/crates/v/fission.svg)](https://crates.io/crates/fission)
-[![docs.rs](https://docs.rs/fission/badge.svg)](https://docs.rs/fission)
+[![Docs](https://img.shields.io/badge/docs-fission.rs-0f766e.svg)](https://fission.rs)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/worka-ai/fission/actions/workflows/ci.yml/badge.svg)](https://github.com/worka-ai/fission/actions/workflows/ci.yml)
 

--- a/crates/authoring/fission-charts/Cargo.toml
+++ b/crates/authoring/fission-charts/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
 name = "fission-charts"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
+license = "MIT"
+repository = "https://github.com/worka-ai/fission"
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+description = "Native chart widgets and data visualization primitives for Fission applications"
+readme = "README.md"
 [dependencies]
 chrono = "0.4.44"
-fission-core = { path = "../../core/fission-core" }
-fission-ir = { path = "../../core/fission-ir" }
-fission-layout = { path = "../../core/fission-layout" }
-fission-widgets = { path = "../fission-widgets" }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/authoring/fission-charts/README.md
+++ b/crates/authoring/fission-charts/README.md
@@ -6,7 +6,7 @@ Chart widgets and data-visualization primitives for Fission applications.
 
 ```toml
 [dependencies]
-fission = { version = "0.1.1", features = ["desktop", "charts"] }
+fission = { version = "0.2.0", features = ["desktop", "charts"] }
 ```
 
 Most application code should import from `fission::prelude::*` and `fission::charts::*` rather than depending on this crate directly. Depend on `fission-charts` only when you are extending the chart layer itself.

--- a/crates/authoring/fission-icons/Cargo.toml
+++ b/crates/authoring/fission-icons/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-icons"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Icons"
+description = "Icon primitives and bundled icons for Fission applications"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 
 [build-dependencies]

--- a/crates/authoring/fission-macros/Cargo.toml
+++ b/crates/authoring/fission-macros/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-macros"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Macros"
+description = "Procedural macros for Fission actions, reducers, and ergonomic app authoring"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [lib]
 proc-macro = true
 

--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-widgets"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Widgets"
+description = "Portable widget catalog for Fission applications"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [features]
 default = []
 terminal = [
@@ -16,22 +19,22 @@ terminal = [
 ]
 
 [dependencies]
-fission-macros = { path = "../fission-macros", version = "0.1.1" }
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
-fission-icons = { path = "../fission-icons", version = "0.1.1" }
+fission-macros = { path = "../fission-macros", version = "0.2.0" }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
+fission-icons = { path = "../fission-icons", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.1.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.2.0" }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 
 [dev-dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Cross-platform GPU-accelerated UI framework for Rust"
+description = "Production-focused Rust application framework for desktop, web, mobile, terminal, and static HTML apps"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [features]
 default = []
 charts = ["dep:fission-charts"]
@@ -33,29 +36,29 @@ three-d = [
 web = ["dep:fission-shell-web"]
 
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-3d = { path = "../../core/fission-3d", version = "0.1.1", optional = true }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-text-engine = { path = "../../core/fission-text-engine", version = "0.1.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.1.1" }
-fission-widgets = { path = "../fission-widgets", version = "0.1.1" }
-fission-macros = { path = "../fission-macros", version = "0.1.1" }
-fission-icons = { path = "../fission-icons", version = "0.1.1" }
-fission-charts = { path = "../fission-charts", version = "0.1.1", optional = true }
-fission-render = { path = "../../rendering/fission-render", version = "0.1.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.1.1" }
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.1.1", optional = true }
-fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.1.1", optional = true }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.1.1", optional = true }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-3d = { path = "../../core/fission-3d", version = "0.2.0", optional = true }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-text-engine = { path = "../../core/fission-text-engine", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.2.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.2.0" }
+fission-macros = { path = "../fission-macros", version = "0.2.0" }
+fission-icons = { path = "../fission-icons", version = "0.2.0" }
+fission-charts = { path = "../fission-charts", version = "0.2.0", optional = true }
+fission-render = { path = "../../rendering/fission-render", version = "0.2.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.2.0" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.2.0", optional = true }
+fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.2.0", optional = true }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.2.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.1.1", optional = true }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.2.0", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.1.1", optional = true }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.2.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.1.1", optional = true }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.2.0", optional = true }

--- a/crates/authoring/fission/README.md
+++ b/crates/authoring/fission/README.md
@@ -1,7 +1,7 @@
 # Fission
 
 [![Crates.io](https://img.shields.io/crates/v/fission.svg)](https://crates.io/crates/fission)
-[![docs.rs](https://docs.rs/fission/badge.svg)](https://docs.rs/fission)
+[![Docs](https://img.shields.io/badge/docs-fission.rs-0f766e.svg)](https://fission.rs)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/worka-ai/fission/blob/main/LICENSE)
 
 Fission is a production-focused Rust application framework for building GPU-accelerated apps across desktop, web, Android, iOS, terminal interfaces, and static HTML sites.
@@ -15,7 +15,7 @@ This crate is the public facade. Application code should normally depend on `fis
 
 ```toml
 [dependencies]
-fission = { version = "0.1.1", features = ["desktop"] }
+fission = { version = "0.2.0", features = ["desktop"] }
 ```
 
 For the full developer workflow, install the Fission command:

--- a/crates/core/fission-3d/Cargo.toml
+++ b/crates/core/fission-3d/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
 name = "fission-3d"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
+license = "MIT"
+repository = "https://github.com/worka-ai/fission"
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+description = "3D scene primitives and rendering data types for Fission applications"
+readme = "README.md"
 [dependencies]
-fission-core = { path = "../fission-core" }
-fission-ir = { path = "../fission-ir" }
+fission-core = { path = "../fission-core", version = "0.2.0" }
+fission-ir = { path = "../fission-ir", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 wgpu = "26.0"
 bytemuck = { version = "1.18", features = ["derive"] }

--- a/crates/core/fission-3d/README.md
+++ b/crates/core/fission-3d/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-fission = { version = "0.1.1", features = ["desktop", "three-d"] }
+fission = { version = "0.2.0", features = ["desktop", "three-d"] }
 ```
 
 Use this crate directly only when you are extending the framework's 3D model or renderer integration.

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -1,19 +1,22 @@
 [package]
 name = "fission-core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Core"
+description = "Core runtime, state, actions, effects, resources, input, and UI model for Fission"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.1.1" }
-fission-layout = { path = "../fission-layout", version = "0.1.1" }
-fission-semantics = { path = "../fission-semantics", version = "0.1.1" }
-fission-theme = { path = "../fission-theme", version = "0.1.1" }
-fission-i18n = { path = "../fission-i18n", version = "0.1.1" }
-fission-text-engine = { path = "../fission-text-engine", version = "0.1.0" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.1.1" }
+fission-ir = { path = "../fission-ir", version = "0.2.0" }
+fission-layout = { path = "../fission-layout", version = "0.2.0" }
+fission-semantics = { path = "../fission-semantics", version = "0.2.0" }
+fission-theme = { path = "../fission-theme", version = "0.2.0" }
+fission-i18n = { path = "../fission-i18n", version = "0.2.0" }
+fission-text-engine = { path = "../fission-text-engine", version = "0.2.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -22,6 +25,6 @@ lazy_static = "1.4"
 blake3 = "1.5"
 unicode-segmentation = "1.10"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.1.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.2.0" }
 
 [dev-dependencies]

--- a/crates/core/fission-i18n/Cargo.toml
+++ b/crates/core/fission-i18n/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "fission-i18n"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "I18N"
+description = "Internationalization primitives for Fission applications"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/core/fission-ir/Cargo.toml
+++ b/crates/core/fission-ir/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-ir"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Ir"
+description = "Intermediate representation and display-list primitives for Fission rendering"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 blake3 = "1.5"

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "fission-layout"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Layout"
+description = "Layout engine primitives for Fission widget trees"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.1.1" }
+fission-ir = { path = "../fission-ir", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.1.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.2.0" }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/Cargo.toml
+++ b/crates/core/fission-semantics/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "fission-semantics"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Semantics"
+description = "Accessibility and semantics primitives for Fission UI trees"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.1.1" }
+fission-ir = { path = "../fission-ir", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/README.md
+++ b/crates/core/fission-semantics/README.md
@@ -38,4 +38,4 @@ assert!(!sem.disabled);
 
 ## License
 
-MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation.
+MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation at https://fission.rs.

--- a/crates/core/fission-text-engine/Cargo.toml
+++ b/crates/core/fission-text-engine/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "fission-text-engine"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
+license = "MIT"
+repository = "https://github.com/worka-ai/fission"
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+description = "Text shaping, editing, and measurement primitives for Fission"
+readme = "README.md"
 [dependencies]
 ropey = "1.6"
 

--- a/crates/core/fission-text-engine/README.md
+++ b/crates/core/fission-text-engine/README.md
@@ -23,7 +23,7 @@ assert_eq!(buffer.to_string(), "hello world");
 
 ## Documentation
 
-Start with the Fission text and input guides at [fission.rs](https://fission.rs). API documentation is available on docs.rs for crate-level details.
+Start with the Fission text and input guides at [fission.rs](https://fission.rs). API documentation and guides are available at https://fission.rs.
 
 ## License
 

--- a/crates/core/fission-theme/Cargo.toml
+++ b/crates/core/fission-theme/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fission-theme"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Design tokens and theming for the Fission UI framework"
+description = "Design tokens, Design System Package codegen output, and component themes for Fission"
 include = [
     "src/**/*",
     "design/**/*",
@@ -15,9 +15,12 @@ include = [
     "fonts/Noto_Sans/static/NotoSans-Regular.ttf",
 ]
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.1.1" }
+fission-ir = { path = "../fission-ir", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.1.1" }
+fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.2.0" }

--- a/crates/core/fission-theme/design/default/dsp.json
+++ b/crates/core/fission-theme/design/default/dsp.json
@@ -4,7 +4,7 @@
 
   "$package": {
     "name": "fission-design-system",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Visual language for Fission — a cross-platform, GPU-accelerated UI framework for Rust. Mirrors the Material 3 token architecture used by the `fission-theme` crate; brand identity from the docs site (teal) + logo (orange/blue).",
     "license": "MIT",
     "framework": {

--- a/crates/core/fission-theme/design/default/tokens.json
+++ b/crates/core/fission-theme/design/default/tokens.json
@@ -3,7 +3,7 @@
   "$description": "Fission Design System tokens. Mirrors the Material Design 3 token architecture used by Fission's own `fission-theme` crate. Primitive tokens (color.*, spacing.*, typography.*, radius.*, elevation.*) cascade into semantic and component tokens.",
   "$meta": {
     "name": "Fission Design System",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "framework": "fission (worka-ai/fission)",
     "license": "MIT"
   },

--- a/crates/rendering/fission-render-skia/Cargo.toml
+++ b/crates/rendering/fission-render-skia/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "fission-render-skia"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Render Skia"
+description = "Skia renderer backend for Fission display lists"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.1.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
+fission-render = { path = "../fission-render", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
 skia-safe = { version = "0.75", features = ["textlayout"] }
 anyhow = "1.0"
 once_cell = "1"

--- a/crates/rendering/fission-render-skia/README.md
+++ b/crates/rendering/fission-render-skia/README.md
@@ -46,4 +46,4 @@ unavailable.
 
 ## License
 
-MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation.
+MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation at https://fission.rs.

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -1,19 +1,22 @@
 [package]
 name = "fission-render-vello"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Render Vello"
+description = "Vello renderer backend for Fission display lists"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.1.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
+fission-render = { path = "../fission-render", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
 anyhow = "1.0"
 vello = { version = "0.6.0", features = ["wgpu"] }
 parley = "0.7.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.1.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.2.0" }
 image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"

--- a/crates/rendering/fission-render-vello/README.md
+++ b/crates/rendering/fission-render-vello/README.md
@@ -54,4 +54,4 @@ Used in production by `fission-shell-desktop`.
 
 ## License
 
-MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation.
+MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation at https://fission.rs.

--- a/crates/rendering/fission-render/Cargo.toml
+++ b/crates/rendering/fission-render/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "fission-render"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Render"
+description = "Renderer trait and display-list conversion layer for Fission"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -1,27 +1,33 @@
 [package]
 name = "fission-shell-desktop"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
+license = "MIT"
+repository = "https://github.com/worka-ai/fission"
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+description = "Desktop shell wrapper for Fission applications"
+readme = "README.md"
 [features]
 default = []
 tray = ["fission-shell-winit/tray"]
 three-d = ["fission-shell-winit/three-d"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell" }
-fission-shell-winit = { path = "../fission-shell-winit", default-features = false }
-fission-core = { path = "../../core/fission-core" }
-fission-theme = { path = "../../core/fission-theme" }
+fission-shell = { path = "../fission-shell", version = "0.2.0" }
+fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.2.0" }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
 winit = "0.29.15"
 anyhow = "1.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-ir = { path = "../../core/fission-ir" }
-fission-layout = { path = "../../core/fission-layout" }
-fission-macros = { path = "../../authoring/fission-macros" }
-fission-render = { path = "../../rendering/fission-render" }
-fission-render-vello = { path = "../../rendering/fission-render-vello" }
-fission-widgets = { path = "../../authoring/fission-widgets" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.2.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.2.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.2.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.2.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "fission-shell-mobile"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Shell Mobile"
+description = "Mobile shell wrapper for Android and iOS Fission applications"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [features]
 default = []
 three-d = ["fission-shell-winit/three-d"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.1.1" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.1.1", default-features = false }
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
+fission-shell = { path = "../fission-shell", version = "0.2.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.2.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/shell/fission-shell-mobile/README.md
+++ b/crates/shell/fission-shell-mobile/README.md
@@ -8,9 +8,9 @@ Most application developers should use the public facade instead of depending on
 
 ```toml
 [dependencies]
-fission = { version = "0.1.1", features = ["android"] }
+fission = { version = "0.2.0", features = ["android"] }
 # or
-fission = { version = "0.1.1", features = ["ios"] }
+fission = { version = "0.2.0", features = ["ios"] }
 ```
 
 ## What it provides

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -1,18 +1,21 @@
 [package]
 name = "fission-shell-site"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Static site shell for lowering real Fission UI to static HTML"
+description = "Static site shell for lowering Fission widget trees and content routes to HTML"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.1.1", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.2.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -6,7 +6,7 @@ Static HTML shell for Fission applications and documentation sites.
 
 ```toml
 [dependencies]
-fission = { version = "0.1.1", features = ["site"] }
+fission = { version = "0.2.0", features = ["site"] }
 ```
 
 ```sh

--- a/crates/shell/fission-shell-terminal/Cargo.toml
+++ b/crates/shell/fission-shell-terminal/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-shell-terminal"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Terminal shell backend for Fission applications"
+description = "Terminal shell backend for rendering Fission applications in terminal cells"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 ab_glyph = "0.2"
@@ -13,7 +16,7 @@ crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["png"] }
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }

--- a/crates/shell/fission-shell-terminal/README.md
+++ b/crates/shell/fission-shell-terminal/README.md
@@ -8,7 +8,7 @@ Application developers normally enable it through the facade crate:
 
 ```toml
 [dependencies]
-fission = { version = "0.1.1", features = ["terminal-shell"] }
+fission = { version = "0.2.0", features = ["terminal-shell"] }
 ```
 
 ## What it contains

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "fission-shell-web"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Shell Web"
+description = "Web and WebAssembly shell wrapper for Fission applications"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [features]
 default = []
 three-d = ["fission-shell-winit/three-d"]
 
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
-fission-shell = { path = "../fission-shell", version = "0.1.1" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.1.1", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
+fission-shell = { path = "../fission-shell", version = "0.2.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.2.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -1,27 +1,32 @@
 [package]
 name = "fission-shell-winit"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
-description = "Shared winit shell runtime"
+description = "Shared winit shell runtime for desktop and mobile Fission hosts"
 
+license = "MIT"
+repository = "https://github.com/worka-ai/fission"
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [features]
 default = []
 tray = ["dep:tray-icon"]
 three-d = ["dep:fission-3d"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell" }
-fission-render = { path = "../../rendering/fission-render" }
-fission-render-vello = { path = "../../rendering/fission-render-vello" }
-fission-core = { path = "../../core/fission-core" }
-fission-layout = { path = "../../core/fission-layout" } 
-fission-ir = { path = "../../core/fission-ir" }
-fission-semantics = { path = "../../core/fission-semantics" }
-fission-theme = { path = "../../core/fission-theme" }
-fission-3d = { path = "../../core/fission-3d", optional = true }
+fission-shell = { path = "../fission-shell", version = "0.2.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.2.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.2.0" }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" } 
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
+fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.2.0" }
 winit = "0.29.15"
-fission-diagnostics = { path = "../../tools/fission-diagnostics" }
-fission-test-driver = { path = "../../tools/fission-test-driver" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.2.0" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.2.0" }
 image = "0.25"
 tiny-skia = "0.11.4"
 fontdue = "0.9.3"
@@ -55,6 +60,6 @@ core-graphics = "0.23"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-macros = { path = "../../authoring/fission-macros" }
-fission-widgets = { path = "../../authoring/fission-widgets" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.2.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.2.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "fission-shell"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Shell"
+description = "Shared shell runtime contracts for hosting Fission applications"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.1.1" } # Corrected path
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.2.0" } # Corrected path
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/shell/fission-shell/README.md
+++ b/crates/shell/fission-shell/README.md
@@ -39,4 +39,4 @@ test harness.
 
 ## License
 
-MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation.
+MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation at https://fission.rs.

--- a/crates/tools/cargo-fission/Cargo.toml
+++ b/crates/tools/cargo-fission/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "cargo-fission"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Project scaffolding CLI for Fission"
+description = "The fission command for project setup, running, testing, packaging, sites, and releases"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [[bin]]
 name = "fission"
 path = "src/main.rs"
@@ -21,9 +24,9 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.1.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.1.1" }
-fission-command-release = { path = "../fission-command-release", version = "0.1.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.1.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.1.1" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.1.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.2.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.2.0" }
+fission-command-release = { path = "../fission-command-release", version = "0.2.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.2.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.2.0" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.2.0" }

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-command-core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Shared project and target model for the Fission command"
+description = "Shared project, manifest, target, and diagnostic model for the fission command"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/tools/fission-command-package/Cargo.toml
+++ b/crates/tools/fission-command-package/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "fission-command-package"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Packaging, readiness, and distribution workflows for the Fission command"
+description = "Packaging, readiness, static hosting, and distribution workflows for the fission command"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 aws-config = "1"
 aws-sdk-s3 = "1"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.1.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.1.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.1.1" }
-fission-credentials = { path = "../fission-credentials", version = "0.1.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.2.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.2.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.2.0" }
+fission-credentials = { path = "../fission-credentials", version = "0.2.0" }
 flate2 = "1.0"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-release/Cargo.toml
+++ b/crates/tools/fission-command-release/Cargo.toml
@@ -1,19 +1,22 @@
 [package]
 name = "fission-command-release"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Release metadata, signing, beta, review, and auth workflows for the Fission command"
+description = "Release content, store, auth, beta, and review workflows for the fission command"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.1.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.1.1" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.1.1" }
-fission-credentials = { path = "../fission-credentials", version = "0.1.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.2.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.2.0" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.2.0" }
+fission-credentials = { path = "../fission-credentials", version = "0.2.0" }
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "fission-command-run"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Run, build, test, logs, and doctor workflows for the Fission command"
+description = "Run, build, test, logs, devices, and doctor workflows for the fission command"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-command-core = { path = "../fission-command-core", version = "0.1.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.1.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.2.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "fission-command-site"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Static site command implementation for the Fission command"
+description = "Static site command implementation for the fission command"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.1.1" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.2.0" }
 toml = "0.8"

--- a/crates/tools/fission-command-ui/Cargo.toml
+++ b/crates/tools/fission-command-ui/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "fission-command-ui"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Terminal UI application for the Fission command"
+description = "Terminal UI application for the fission command"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../authoring/fission", version = "0.1.1", default-features = false, features = ["terminal-shell"] }
-fission-command-core = { path = "../fission-command-core", version = "0.1.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.1.1" }
+fission = { path = "../../authoring/fission", version = "0.2.0", default-features = false, features = ["terminal-shell"] }
+fission-command-core = { path = "../fission-command-core", version = "0.2.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/tools/fission-credentials/Cargo.toml
+++ b/crates/tools/fission-credentials/Cargo.toml
@@ -1,16 +1,19 @@
 [package]
 name = "fission-credentials"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Credential vault helpers for the Fission command"
+description = "Credential vault helpers for fission command provider integrations"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
 chacha20poly1305 = "0.10"
-fission-command-core = { path = "../fission-command-core", version = "0.1.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.2.0" }
 getrandom = { version = "0.2", features = ["std"] }
 keyring = { version = "3", default-features = false, features = ["apple-native", "windows-native", "linux-native", "crypto-rust"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/tools/fission-design-system-codegen/Cargo.toml
+++ b/crates/tools/fission-design-system-codegen/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-design-system-codegen"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Build-time Design System Package code generation for Fission"
+description = "Build-time Design System Package code generation for Fission themes"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-diagnostics"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Diagnostics"
+description = "Structured diagnostics and reporting primitives for Fission tools and runtime checks"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [lib]
 path = "src/lib.rs"
 

--- a/crates/tools/fission-test-driver/Cargo.toml
+++ b/crates/tools/fission-test-driver/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "fission-test-driver"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Test Driver"
+description = "Live app testing client and protocol helpers for Fission shells"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/tools/fission-test/Cargo.toml
+++ b/crates/tools/fission-test/Cargo.toml
@@ -1,28 +1,31 @@
 [package]
 name = "fission-test"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/worka-ai/fission"
-description = "Test"
+description = "Headless and runtime testing helpers for Fission applications"
 
+homepage = "https://fission.rs"
+documentation = "https://fission.rs"
+readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.1.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.1.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.1.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.1.1" }
-fission-shell = { path = "../../shell/fission-shell", version = "0.1.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.1.1" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.1.1" }
+fission-core = { path = "../../core/fission-core", version = "0.2.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.2.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.2.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.2.0" }
+fission-shell = { path = "../../shell/fission-shell", version = "0.2.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.2.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.2.0" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
-fission-macros = { path = "../../authoring/fission-macros", version = "0.1.1" }
-fission-diagnostics = { version = "0.1.1", path = "../fission-diagnostics" }
-fission-render-vello = { path = "../../rendering/fission-render-vello" }
-fission-theme = { path = "../../core/fission-theme", version = "0.1.1" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.2.0" }
+fission-diagnostics = { path = "../fission-diagnostics", version = "0.2.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.2.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.2.0" }
 fontique = "0.7"
 serde_json = "1.0"
 
 [dev-dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.2.0" }

--- a/crates/tools/fission-test/README.md
+++ b/crates/tools/fission-test/README.md
@@ -52,4 +52,4 @@ driver.assert_text_visible("Submitted!");
 
 ## License
 
-MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation.
+MIT -- see the [Fission repository](https://github.com/worka-ai/fission) for full documentation at https://fission.rs.


### PR DESCRIPTION
## Summary
- Bumps every publishable Fission crate under `crates/` to `0.2.0`.
- Adds consistent crates.io package metadata: MIT license, repository, homepage, documentation URL, descriptions, and crate READMEs.
- Updates all internal path dependencies to require the matching `0.2.0` package version so crates can be published and resolved from crates.io in dependency order.
- Updates public README links and install snippets to point developers at `https://fission.rs` and the `0.2.0` facade dependency.
- Updates the bundled default design system package/token versions to `0.2.0`.

## Validation
- `cargo test --workspace --all-targets`
- `target/debug/fission site check --project-dir documentation --release`
- `cargo check -p fission`
- `cargo publish --dry-run --allow-dirty --manifest-path crates/core/fission-ir/Cargo.toml`
- `cargo package --allow-dirty --no-verify` passed for independent first-layer crates before dependent crates correctly blocked on unpublished `0.2.0` registry versions.

## Release note
This PR prepares the repository state required before publishing the full Fission 0.2.0 crate graph to crates.io.
