### PR TITLE
Restrict PR platform checks to contributors

### DIFF
--- a/.github/workflows/platform-checks.yml
+++ b/.github/workflows/platform-checks.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   cli:
     name: CLI platform script tests
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -29,6 +32,9 @@ jobs:
 
   web:
     name: Web / wasm
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -59,6 +65,9 @@ jobs:
 
   android:
     name: Android package smoke
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     env:
       ANDROID_MIN_API_LEVEL: '24'
@@ -108,6 +117,9 @@ jobs:
 
   ios:
     name: iOS simulator and device compile
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: macos-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- Adds contributor gating to every `pull_request` job in `platform-checks.yml`.
- Allows normal `push` and `workflow_dispatch` runs to continue unchanged.
- Allows PR checks only for `OWNER`, `MEMBER`, `COLLABORATOR`, or GitHub `CONTRIBUTOR` authors.

## Notes
- GitHub Actions does not support filtering `pull_request` triggers by author before workflow creation. The reliable repository-level implementation is job-level `if` gating, so untrusted PRs produce skipped jobs rather than consuming runners.

## Testing
- YAML change only; inspected workflow expression locally.
