### PR TITLE
Add typed image loading and product browser example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,10 +2459,15 @@ dependencies = [
  "fission-layout",
  "fission-render",
  "image 0.24.9",
+ "js-sys",
  "lazy_static",
  "parley",
  "peniko",
+ "ureq",
  "vello",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "web-time 0.2.4",
 ]
 
@@ -2590,6 +2595,7 @@ dependencies = [
  "fontdue",
  "fontique",
  "image 0.25.9",
+ "js-sys",
  "lazy_static",
  "objc",
  "pollster",
@@ -2598,8 +2604,10 @@ dependencies = [
  "serde_json",
  "tiny-skia",
  "tray-icon",
+ "ureq",
  "vello",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "web-time 0.2.4",
  "winit",
@@ -5312,6 +5320,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "product-browser"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fission",
+ "fission-test-driver",
+ "image 0.25.9",
+ "reqwest",
+ "serde",
 ]
 
 [[package]]

--- a/crates/authoring/fission-widgets/src/avatar.rs
+++ b/crates/authoring/fission-widgets/src/avatar.rs
@@ -27,14 +27,15 @@ impl<S: fission_core::AppState> Widget<S> for Avatar {
         let radius = size / 2.0;
 
         let content = if let Some(src) = &self.src {
-            Image {
-                source: src.clone(),
-                width: Some(size),
-                height: Some(size),
-                fit: Some(fission_core::op::ImageFit::Cover),
-                ..Default::default()
-            }
-            .into()
+            let image = if src.starts_with("https://") || src.starts_with("http://") {
+                Image::network(src.clone())
+            } else {
+                Image::asset(src.clone())
+            };
+            image
+                .size(size, size)
+                .fit(fission_core::op::ImageFit::Cover)
+                .into()
         } else {
             let initials = self
                 .name

--- a/crates/authoring/fission-widgets/src/circular_progress.rs
+++ b/crates/authoring/fission-widgets/src/circular_progress.rs
@@ -1,37 +1,47 @@
-use fission_core::ui::Node;
-use fission_core::{BuildCtx, LowerDyn, LoweringContext, NodeBuilder, View, Widget};
+use fission_core::ui::{Composite, Node};
+use fission_core::{
+    AnimationPropertyId, AnimationRequest, AnimationStartValue, BuildCtx, EasingFunction, LowerDyn,
+    LoweringContext, NodeBuilder, View, Widget, WidgetNodeId,
+};
 use fission_ir::{op::Color, LayoutOp, NodeId, Op, PaintOp};
 use serde::{Deserialize, Serialize};
 use std::f32::consts::PI;
 
+const SPIN_DURATION_MS: u64 = 900;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CircularProgress {
+    pub id: WidgetNodeId,
     pub value: Option<f32>, // 0.0 to 1.0. If None, indeterminate (spinner).
     pub size: f32,
     pub color: Option<Color>,
     pub track_color: Option<Color>,
     pub thickness: f32,
+    #[serde(default = "circular_progress_default_animated")]
+    pub animated: bool,
 }
 
 impl Default for CircularProgress {
     fn default() -> Self {
         Self {
+            id: WidgetNodeId::explicit("fission.widgets.circular_progress"),
             value: None,
             size: 40.0,
             color: None,
             track_color: None,
             thickness: 4.0,
+            animated: true,
         }
     }
 }
 
 impl<S: fission_core::AppState> Widget<S> for CircularProgress {
-    fn build(&self, _ctx: &mut BuildCtx<S>, view: &View<S>) -> Node {
+    fn build(&self, ctx: &mut BuildCtx<S>, view: &View<S>) -> Node {
         let tokens = &view.env.theme.tokens;
         let color = self.color.unwrap_or(tokens.colors.primary);
         let track_color = self.track_color.unwrap_or(tokens.colors.border);
 
-        Node::Custom(fission_core::ui::CustomNode {
+        let node = Node::Custom(fission_core::ui::CustomNode {
             debug_tag: "CircularProgress".into(),
             lowerer: Some(std::sync::Arc::new(CircularProgressLowerer {
                 value: self.value,
@@ -41,8 +51,31 @@ impl<S: fission_core::AppState> Widget<S> for CircularProgress {
                 thickness: self.thickness,
             })),
             render_object: None,
-        })
+        });
+
+        if self.value.is_none() && self.animated {
+            ctx.anim_for(self.id).request(AnimationRequest {
+                property: AnimationPropertyId::Rotation,
+                from: AnimationStartValue::Explicit(0.0),
+                to: PI * 2.0,
+                duration_ms: SPIN_DURATION_MS,
+                repeat: true,
+                delay_ms: 0,
+                frame_interval_ms: None,
+                easing: EasingFunction::Linear,
+            });
+            Composite::new(node)
+                .repaint_boundary(true)
+                .animated_rotation(self.id, 0.0)
+                .into_node()
+        } else {
+            node
+        }
     }
+}
+
+const fn circular_progress_default_animated() -> bool {
+    true
 }
 
 #[derive(Debug)]
@@ -91,8 +124,7 @@ impl LowerDyn for CircularProgressLowerer {
         .build(cx);
 
         // Value Arc
-        let val = self.value.unwrap_or(0.25); // Default 25% for indeterminate (should animate rotation)
-                                              // TODO: Indeterminate animation rotation.
+        let val = self.value.unwrap_or(0.25);
 
         let angle = val * 2.0 * PI;
         // Arc from -PI/2 (top) to -PI/2 + angle.

--- a/crates/authoring/fission-widgets/src/future_builder.rs
+++ b/crates/authoring/fission-widgets/src/future_builder.rs
@@ -1,0 +1,203 @@
+use fission_core::{
+    ActionEnvelope, AppState, BuildCtx, JobRef, JobResource, JobSpec, Node, ResourceKey,
+    ResourcePolicy, View, Widget,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AsyncConnectionState {
+    /// No async work is currently connected to the builder.
+    None,
+    /// Work has been declared and is waiting for a result.
+    Waiting,
+    /// Work is still producing values or progress.
+    Active,
+    /// Work completed with either data or an error.
+    Done,
+}
+
+impl Default for AsyncConnectionState {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AsyncSnapshot<T, E> {
+    /// Current async connection state.
+    pub connection_state: AsyncConnectionState,
+    /// Last successful value, when one is available.
+    pub data: Option<T>,
+    /// Last error value, when one is available.
+    pub error: Option<E>,
+}
+
+impl<T, E> AsyncSnapshot<T, E> {
+    pub fn none() -> Self {
+        Self::nothing()
+    }
+
+    pub fn nothing() -> Self {
+        Self {
+            connection_state: AsyncConnectionState::None,
+            data: None,
+            error: None,
+        }
+    }
+
+    pub fn waiting() -> Self {
+        Self {
+            connection_state: AsyncConnectionState::Waiting,
+            data: None,
+            error: None,
+        }
+    }
+
+    pub fn with_data(connection_state: AsyncConnectionState, data: T) -> Self {
+        Self {
+            connection_state,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    pub fn with_error(connection_state: AsyncConnectionState, error: E) -> Self {
+        Self {
+            connection_state,
+            data: None,
+            error: Some(error),
+        }
+    }
+
+    pub fn in_state(mut self, connection_state: AsyncConnectionState) -> Self {
+        self.connection_state = connection_state;
+        self
+    }
+
+    pub fn has_data(&self) -> bool {
+        self.data.is_some()
+    }
+
+    pub fn has_error(&self) -> bool {
+        self.error.is_some()
+    }
+
+    pub fn data(&self) -> Option<&T> {
+        self.data.as_ref()
+    }
+
+    pub fn error(&self) -> Option<&E> {
+        self.error.as_ref()
+    }
+
+    pub fn require_data(&self) -> &T {
+        self.data
+            .as_ref()
+            .expect("AsyncSnapshot::require_data called without data")
+    }
+}
+
+pub type AsyncWidgetBuilder<S, T, E> =
+    Arc<dyn Fn(&mut BuildCtx<S>, &View<S>, &AsyncSnapshot<T, E>) -> Node + Send + Sync + 'static>;
+
+/// Declares one async job resource and builds UI from the current snapshot.
+///
+/// The snapshot belongs in application state. Successful and failed job
+/// callbacks should update that state; this widget then renders the latest
+/// snapshot during the next build.
+pub struct FutureBuilder<S, J>
+where
+    S: AppState,
+    J: JobSpec,
+{
+    pub key: ResourceKey,
+    pub job: JobRef<J>,
+    pub request: J::Request,
+    pub snapshot: AsyncSnapshot<J::Ok, J::Err>,
+    pub on_ok: Option<ActionEnvelope>,
+    pub on_err: Option<ActionEnvelope>,
+    pub deps: Option<Vec<u8>>,
+    pub policy: ResourcePolicy,
+    pub builder: AsyncWidgetBuilder<S, J::Ok, J::Err>,
+}
+
+impl<S, J> FutureBuilder<S, J>
+where
+    S: AppState,
+    J: JobSpec,
+{
+    pub fn new<F>(
+        key: ResourceKey,
+        job: JobRef<J>,
+        request: J::Request,
+        snapshot: AsyncSnapshot<J::Ok, J::Err>,
+        builder: F,
+    ) -> Self
+    where
+        F: Fn(&mut BuildCtx<S>, &View<S>, &AsyncSnapshot<J::Ok, J::Err>) -> Node
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self {
+            key,
+            job,
+            request,
+            snapshot,
+            on_ok: None,
+            on_err: None,
+            deps: None,
+            policy: ResourcePolicy::RestartOnChange,
+            builder: Arc::new(builder),
+        }
+    }
+
+    pub fn on_ok(mut self, action: ActionEnvelope) -> Self {
+        self.on_ok = Some(action);
+        self
+    }
+
+    pub fn on_err(mut self, action: ActionEnvelope) -> Self {
+        self.on_err = Some(action);
+        self
+    }
+
+    pub fn deps<T: Serialize>(mut self, deps: T) -> Self {
+        self.deps =
+            Some(serde_json::to_vec(&deps).expect("FutureBuilder deps serialization must succeed"));
+        self
+    }
+
+    pub fn preserve_on_change(mut self) -> Self {
+        self.policy = ResourcePolicy::PreserveOnChange;
+        self
+    }
+
+    pub fn restart_on_change(mut self) -> Self {
+        self.policy = ResourcePolicy::RestartOnChange;
+        self
+    }
+}
+
+impl<S, J> Widget<S> for FutureBuilder<S, J>
+where
+    S: AppState,
+    J: JobSpec,
+    J::Request: Clone,
+{
+    fn build(&self, ctx: &mut BuildCtx<S>, view: &View<S>) -> Node {
+        let mut resource = JobResource::new(self.key.clone(), self.job, self.request.clone());
+        resource.policy = self.policy;
+        resource.deps = self.deps.clone();
+        if let Some(action) = &self.on_ok {
+            resource = resource.on_ok(action.clone());
+        }
+        if let Some(action) = &self.on_err {
+            resource = resource.on_err(action.clone());
+        }
+        ctx.resources.job(resource);
+
+        (self.builder)(ctx, view, &self.snapshot)
+    }
+}

--- a/crates/authoring/fission-widgets/src/lib.rs
+++ b/crates/authoring/fission-widgets/src/lib.rs
@@ -16,7 +16,7 @@
 //! - **Menus**: [`Menu`], [`MenuButton`], [`MenuItem`], [`Select`], [`Combobox`], [`SegmentedControl`]
 //! - **Navigation**: [`Tabs`], [`Accordion`]
 //! - **Display**: [`Badge`], [`Tag`], [`Card`], [`Avatar`], [`EmptyState`], [`Icon`]
-//! - **Loading**: [`ProgressBar`], [`Spinner`], [`Skeleton`]
+//! - **Loading**: [`ProgressBar`], [`Spinner`], [`Skeleton`], [`FutureBuilder`], [`RefreshIndicator`]
 //! - **Transitions**: [`Hero`]
 //!
 //! # Example
@@ -195,6 +195,12 @@ pub use stat::Stat;
 
 pub mod circular_progress;
 pub use circular_progress::CircularProgress;
+
+pub mod future_builder;
+pub use future_builder::{AsyncConnectionState, AsyncSnapshot, AsyncWidgetBuilder, FutureBuilder};
+
+pub mod refresh_indicator;
+pub use refresh_indicator::{RefreshIndicator, RefreshIndicatorStatus};
 
 pub mod stepper;
 pub use stepper::Stepper;

--- a/crates/authoring/fission-widgets/src/markdown.rs
+++ b/crates/authoring/fission-widgets/src/markdown.rs
@@ -223,14 +223,15 @@ impl<'a> MarkdownRenderer<'a> {
 
     fn image_block(&self, _node_ref: NodeRef, image: &MarkdownImage) -> Node {
         let source = image.destination_str(self.source).to_string();
-        Image {
-            source,
-            width: Some(self.image_width),
-            height: Some(self.image_height),
-            fit: Some(ImageFit::Contain),
-            ..Default::default()
-        }
-        .into_node()
+        let image = if source.starts_with("https://") || source.starts_with("http://") {
+            Image::network(source)
+        } else {
+            Image::asset(source)
+        };
+        image
+            .size(self.image_width, self.image_height)
+            .fit(ImageFit::Contain)
+            .into_node()
     }
 
     fn code_block(&self, code: &CodeBlock) -> Node {

--- a/crates/authoring/fission-widgets/src/refresh_indicator.rs
+++ b/crates/authoring/fission-widgets/src/refresh_indicator.rs
@@ -1,0 +1,242 @@
+use crate::CircularProgress;
+use fission_core::op::Color;
+use fission_core::ui::{
+    Align, Composite, Container, GestureDetector, Node, Positioned, Spacer, ZStack,
+};
+use fission_core::{ActionEnvelope, AppState, BuildCtx, View, Widget, WidgetNodeId};
+use serde::{Deserialize, Serialize};
+
+/// Visual state for a pull-to-refresh interaction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RefreshIndicatorStatus {
+    #[default]
+    Inactive,
+    Drag,
+    Armed,
+    Refreshing,
+    Done,
+}
+
+/// Adds a pull-to-refresh affordance above scrollable content.
+///
+/// The widget is intentionally stateless. Store the current status and pulled
+/// distance in application state, update them from drag reducer input, and
+/// provide an `on_refresh` action that starts the refresh work.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RefreshIndicator {
+    pub id: WidgetNodeId,
+    pub child: Box<Node>,
+    pub status: RefreshIndicatorStatus,
+    pub pulled_extent: f32,
+    pub trigger_distance: f32,
+    pub displacement: f32,
+    pub edge_offset: f32,
+    pub color: Option<Color>,
+    pub background_color: Option<Color>,
+    pub track_color: Option<Color>,
+    pub stroke_width: f32,
+    pub indicator_size: f32,
+    pub on_pull_start: Option<ActionEnvelope>,
+    pub on_pull_update: Option<ActionEnvelope>,
+    pub on_pull_cancel: Option<ActionEnvelope>,
+    pub on_refresh: Option<ActionEnvelope>,
+}
+
+impl Default for RefreshIndicator {
+    fn default() -> Self {
+        Self {
+            id: WidgetNodeId::explicit("fission.widgets.refresh_indicator"),
+            child: Box::new(Spacer::default().into_node()),
+            status: RefreshIndicatorStatus::Inactive,
+            pulled_extent: 0.0,
+            trigger_distance: 80.0,
+            displacement: 40.0,
+            edge_offset: 0.0,
+            color: None,
+            background_color: None,
+            track_color: None,
+            stroke_width: 4.0,
+            indicator_size: 36.0,
+            on_pull_start: None,
+            on_pull_update: None,
+            on_pull_cancel: None,
+            on_refresh: None,
+        }
+    }
+}
+
+impl RefreshIndicator {
+    pub fn new(child: Node) -> Self {
+        Self {
+            child: Box::new(child),
+            ..Default::default()
+        }
+    }
+
+    pub fn id(mut self, id: WidgetNodeId) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn status(mut self, status: RefreshIndicatorStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    pub fn pulled_extent(mut self, pulled_extent: f32) -> Self {
+        self.pulled_extent = pulled_extent.max(0.0);
+        self
+    }
+
+    pub fn trigger_distance(mut self, trigger_distance: f32) -> Self {
+        self.trigger_distance = trigger_distance.max(1.0);
+        self
+    }
+
+    pub fn displacement(mut self, displacement: f32) -> Self {
+        self.displacement = displacement.max(0.0);
+        self
+    }
+
+    pub fn edge_offset(mut self, edge_offset: f32) -> Self {
+        self.edge_offset = edge_offset.max(0.0);
+        self
+    }
+
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    pub fn background_color(mut self, color: Color) -> Self {
+        self.background_color = Some(color);
+        self
+    }
+
+    pub fn track_color(mut self, color: Color) -> Self {
+        self.track_color = Some(color);
+        self
+    }
+
+    pub fn stroke_width(mut self, stroke_width: f32) -> Self {
+        self.stroke_width = stroke_width.max(1.0);
+        self
+    }
+
+    pub fn indicator_size(mut self, indicator_size: f32) -> Self {
+        self.indicator_size = indicator_size.max(1.0);
+        self
+    }
+
+    pub fn on_pull_start(mut self, action: ActionEnvelope) -> Self {
+        self.on_pull_start = Some(action);
+        self
+    }
+
+    pub fn on_pull_update(mut self, action: ActionEnvelope) -> Self {
+        self.on_pull_update = Some(action);
+        self
+    }
+
+    pub fn on_pull_cancel(mut self, action: ActionEnvelope) -> Self {
+        self.on_pull_cancel = Some(action);
+        self
+    }
+
+    pub fn on_refresh(mut self, action: ActionEnvelope) -> Self {
+        self.on_refresh = Some(action);
+        self
+    }
+
+    fn indicator_progress(&self) -> Option<f32> {
+        match self.status {
+            RefreshIndicatorStatus::Inactive => Some(0.0),
+            RefreshIndicatorStatus::Drag | RefreshIndicatorStatus::Armed => {
+                Some((self.pulled_extent / self.trigger_distance.max(1.0)).clamp(0.0, 1.0))
+            }
+            RefreshIndicatorStatus::Refreshing => None,
+            RefreshIndicatorStatus::Done => Some(1.0),
+        }
+    }
+
+    fn is_indicator_visible(&self) -> bool {
+        self.status != RefreshIndicatorStatus::Inactive || self.pulled_extent > 0.0
+    }
+
+    fn progress_id(&self) -> WidgetNodeId {
+        WidgetNodeId::from_u128(self.id.as_u128() ^ 1)
+    }
+
+    fn child_offset(&self) -> f32 {
+        match self.status {
+            RefreshIndicatorStatus::Inactive => self.pulled_extent.min(self.displacement),
+            RefreshIndicatorStatus::Drag | RefreshIndicatorStatus::Armed => {
+                self.pulled_extent.min(self.displacement)
+            }
+            RefreshIndicatorStatus::Refreshing => self.displacement,
+            RefreshIndicatorStatus::Done => 0.0,
+        }
+    }
+}
+
+impl<S: AppState> Widget<S> for RefreshIndicator {
+    fn build(&self, ctx: &mut BuildCtx<S>, view: &View<S>) -> Node {
+        let tokens = &view.env.theme.tokens;
+        let pull_offset = self.child_offset();
+        let indicator_top = self.edge_offset + pull_offset * 0.5;
+
+        let child = if pull_offset > 0.0 {
+            Composite::new(*self.child.clone())
+                .translate_y(pull_offset)
+                .into_node()
+        } else {
+            *self.child.clone()
+        };
+        let mut children = vec![child];
+        if self.is_indicator_visible() {
+            let progress = CircularProgress {
+                id: self.progress_id(),
+                value: self.indicator_progress(),
+                size: self.indicator_size,
+                color: Some(self.color.unwrap_or(tokens.colors.primary)),
+                track_color: Some(self.track_color.unwrap_or(tokens.colors.border)),
+                thickness: self.stroke_width,
+                animated: true,
+            }
+            .build(ctx, view);
+
+            let indicator = Container::new(progress)
+                .size(self.indicator_size + 16.0, self.indicator_size + 16.0)
+                .bg(self.background_color.unwrap_or(tokens.colors.surface))
+                .border(tokens.colors.border, 1.0)
+                .border_radius((self.indicator_size + 16.0) * 0.5)
+                .padding_all(8.0)
+                .into_node();
+
+            children.push(
+                Positioned {
+                    top: Some(indicator_top),
+                    left: Some(0.0),
+                    right: Some(0.0),
+                    height: Some(self.indicator_size + 16.0),
+                    child: Some(Box::new(Align::new(indicator).into_node())),
+                    ..Default::default()
+                }
+                .into_node(),
+            );
+        }
+
+        GestureDetector {
+            child: Box::new(ZStack { id: None, children }.into_node()),
+            on_drag_start: self.on_pull_start.clone(),
+            on_drag_update: self.on_pull_update.clone(),
+            on_drag_end: if self.status == RefreshIndicatorStatus::Armed {
+                self.on_refresh.clone()
+            } else {
+                self.on_pull_cancel.clone()
+            },
+            ..Default::default()
+        }
+        .into_node()
+    }
+}

--- a/crates/authoring/fission-widgets/tests/circular_progress_test.rs
+++ b/crates/authoring/fission-widgets/tests/circular_progress_test.rs
@@ -1,0 +1,50 @@
+use fission_core::{AnimationPropertyId, AppState, BuildCtx, Node, View, Widget, WidgetNodeId};
+use fission_widgets::CircularProgress;
+
+#[derive(Default, Debug, Clone)]
+struct State;
+impl AppState for State {}
+
+#[test]
+fn indeterminate_circular_progress_registers_rotation_animation() {
+    let env = fission_core::Env::default();
+    let runtime = fission_core::RuntimeState::default();
+    let state = State;
+    let view = View::new(&state, &runtime, &env, None);
+    let mut ctx = BuildCtx::<State>::new();
+    let id = WidgetNodeId::explicit("test-progress");
+
+    let node = CircularProgress {
+        id,
+        value: None,
+        ..Default::default()
+    }
+    .build(&mut ctx, &view);
+
+    assert!(matches!(node, Node::Composite(_)));
+    assert_eq!(ctx.animation_requests.len(), 1);
+    assert_eq!(ctx.animation_requests[0].0, id);
+    assert_eq!(
+        ctx.animation_requests[0].1.property,
+        AnimationPropertyId::Rotation
+    );
+    assert!(ctx.animation_requests[0].1.repeat);
+}
+
+#[test]
+fn determinate_circular_progress_does_not_register_animation() {
+    let env = fission_core::Env::default();
+    let runtime = fission_core::RuntimeState::default();
+    let state = State;
+    let view = View::new(&state, &runtime, &env, None);
+    let mut ctx = BuildCtx::<State>::new();
+
+    let node = CircularProgress {
+        value: Some(0.5),
+        ..Default::default()
+    }
+    .build(&mut ctx, &view);
+
+    assert!(matches!(node, Node::Custom(_)));
+    assert!(ctx.animation_requests.is_empty());
+}

--- a/crates/authoring/fission-widgets/tests/future_builder_test.rs
+++ b/crates/authoring/fission-widgets/tests/future_builder_test.rs
@@ -1,0 +1,95 @@
+use fission_core::{
+    Action, AppState, BuildCtx, Effect, JobRef, JobSpec, Node, ResourceKey, RuntimeResourceKind,
+    View, Widget,
+};
+use fission_widgets::{AsyncConnectionState, AsyncSnapshot, FutureBuilder, Text, TextContent};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone)]
+struct State;
+impl AppState for State {}
+
+#[derive(Debug)]
+struct LoadMessage;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct LoadMessageRequest {
+    id: u32,
+}
+
+impl JobSpec for LoadMessage {
+    type Request = LoadMessageRequest;
+    type Ok = String;
+    type Err = String;
+
+    const NAME: &'static str = "load-message";
+}
+
+const LOAD_MESSAGE: JobRef<LoadMessage> = JobRef::new("load-message");
+
+#[fission_macros::fission_action]
+struct MessageLoaded;
+
+#[test]
+fn async_snapshot_helpers_report_state() {
+    let empty = AsyncSnapshot::<String, String>::none();
+    assert_eq!(empty.connection_state, AsyncConnectionState::None);
+    assert!(!empty.has_data());
+    assert!(!empty.has_error());
+
+    let loaded =
+        AsyncSnapshot::<String, String>::with_data(AsyncConnectionState::Done, "ready".to_string());
+    assert_eq!(loaded.data(), Some(&"ready".to_string()));
+    assert_eq!(loaded.require_data(), "ready");
+}
+
+#[test]
+fn future_builder_declares_job_and_builds_from_snapshot() {
+    let env = fission_core::Env::default();
+    let runtime = fission_core::RuntimeState::default();
+    let state = State;
+    let view = View::new(&state, &runtime, &env, None);
+    let mut ctx = BuildCtx::<State>::new();
+
+    let loaded = MessageLoaded;
+    let loaded_action = fission_core::ActionEnvelope {
+        id: MessageLoaded::static_id(),
+        payload: loaded.encode(),
+    };
+
+    let node = FutureBuilder::new(
+        ResourceKey::new("message"),
+        LOAD_MESSAGE,
+        LoadMessageRequest { id: 42 },
+        AsyncSnapshot::<String, String>::waiting(),
+        |_ctx, _view, snapshot| Text::new(format!("{:?}", snapshot.connection_state)).into_node(),
+    )
+    .deps(("message", 42_u32))
+    .preserve_on_change()
+    .on_ok(loaded_action.clone())
+    .build(&mut ctx, &view);
+
+    let Node::Text(text) = node else {
+        panic!("FutureBuilder should render the node returned by its builder");
+    };
+    assert_eq!(text.content, TextContent::Literal("Waiting".to_string()));
+
+    let resources = ctx.take_resources();
+    assert_eq!(resources.len(), 1);
+    assert_eq!(resources[0].key, "message");
+    assert_eq!(
+        resources[0].policy,
+        fission_core::ResourcePolicy::PreserveOnChange
+    );
+    assert!(resources[0].deps.is_some());
+
+    let RuntimeResourceKind::Job(job) = &resources[0].kind else {
+        panic!("FutureBuilder should declare a job resource");
+    };
+
+    let Effect::Job(request) = &job.effect.effect else {
+        panic!("FutureBuilder should emit a job effect");
+    };
+    assert_eq!(request.job_name, "load-message");
+    assert_eq!(job.effect.on_ok.as_ref(), Some(&loaded_action));
+}

--- a/crates/authoring/fission-widgets/tests/hero_test.rs
+++ b/crates/authoring/fission-widgets/tests/hero_test.rs
@@ -14,13 +14,7 @@ impl AppState for TestState {}
 fn test_hero_compilation() {
     let _hero = Hero {
         tag: "avatar".into(),
-        child: Box::new(
-            Image {
-                source: "test.png".into(),
-                ..Default::default()
-            }
-            .into_node(),
-        ),
+        child: Box::new(Image::asset("test.png").into_node()),
     };
     assert!(true);
 }

--- a/crates/authoring/fission-widgets/tests/refresh_indicator_test.rs
+++ b/crates/authoring/fission-widgets/tests/refresh_indicator_test.rs
@@ -1,0 +1,91 @@
+use fission_core::{Action, AppState, BuildCtx, Node, View, Widget};
+use fission_widgets::{RefreshIndicator, RefreshIndicatorStatus, Text};
+
+#[derive(Default, Debug, Clone)]
+struct State;
+impl AppState for State {}
+
+#[fission_macros::fission_action]
+struct RefreshRequested;
+
+#[fission_macros::fission_action]
+struct PullCanceled;
+
+fn action<A: Action>(action: A) -> fission_core::ActionEnvelope {
+    fission_core::ActionEnvelope {
+        id: A::static_id(),
+        payload: action.encode(),
+    }
+}
+
+fn build_view() -> (fission_core::Env, fission_core::RuntimeState, State) {
+    (
+        fission_core::Env::default(),
+        fission_core::RuntimeState::default(),
+        State,
+    )
+}
+
+#[test]
+fn refresh_indicator_dispatches_refresh_when_armed() {
+    let (env, runtime, state) = build_view();
+    let view = View::new(&state, &runtime, &env, None);
+    let mut ctx = BuildCtx::<State>::new();
+    let refresh = action(RefreshRequested);
+    let cancel = action(PullCanceled);
+
+    let node = RefreshIndicator::new(Text::new("content").into_node())
+        .status(RefreshIndicatorStatus::Armed)
+        .pulled_extent(90.0)
+        .on_refresh(refresh.clone())
+        .on_pull_cancel(cancel)
+        .build(&mut ctx, &view);
+
+    let Node::GestureDetector(detector) = node else {
+        panic!("RefreshIndicator should wrap content in a gesture detector");
+    };
+
+    assert_eq!(detector.on_drag_end.as_ref(), Some(&refresh));
+    let Node::ZStack(stack) = *detector.child else {
+        panic!("RefreshIndicator should use a stack for the overlay");
+    };
+    assert_eq!(stack.children.len(), 2);
+}
+
+#[test]
+fn refresh_indicator_dispatches_cancel_when_not_armed() {
+    let (env, runtime, state) = build_view();
+    let view = View::new(&state, &runtime, &env, None);
+    let mut ctx = BuildCtx::<State>::new();
+    let refresh = action(RefreshRequested);
+    let cancel = action(PullCanceled);
+
+    let node = RefreshIndicator::new(Text::new("content").into_node())
+        .status(RefreshIndicatorStatus::Drag)
+        .pulled_extent(20.0)
+        .on_refresh(refresh)
+        .on_pull_cancel(cancel.clone())
+        .build(&mut ctx, &view);
+
+    let Node::GestureDetector(detector) = node else {
+        panic!("RefreshIndicator should wrap content in a gesture detector");
+    };
+    assert_eq!(detector.on_drag_end.as_ref(), Some(&cancel));
+}
+
+#[test]
+fn refresh_indicator_hides_overlay_when_inactive() {
+    let (env, runtime, state) = build_view();
+    let view = View::new(&state, &runtime, &env, None);
+    let mut ctx = BuildCtx::<State>::new();
+
+    let node = RefreshIndicator::new(Text::new("content").into_node()).build(&mut ctx, &view);
+
+    let Node::GestureDetector(detector) = node else {
+        panic!("RefreshIndicator should wrap content in a gesture detector");
+    };
+    let Node::ZStack(stack) = *detector.child else {
+        panic!("RefreshIndicator should use a stack for the overlay");
+    };
+    assert_eq!(stack.children.len(), 1);
+}

--- a/crates/core/fission-core/src/ui/mod.rs
+++ b/crates/core/fission-core/src/ui/mod.rs
@@ -9,7 +9,9 @@ pub use traits::{Lower, LowerDyn};
 pub use widgets::{
     ActionScope, Align, BadgeTone, Builder, Button, ButtonContentAlign, ButtonHierarchy,
     ButtonVariant, CardPattern, Checkbox, Column, ComponentSize, ComponentState, Composite,
-    Container, FocusScope, GestureDetector, Grid, GridItem, Icon, Image, LayoutBuilder, LazyColumn,
-    Overlay, Positioned, Radio, RichText, RichTextRun, Row, SafeArea, Scroll, Slider, Spacer,
-    Switch, Text, TextContent, TextFontStyle, TextInput, TextRunStyle, Video, ZStack,
+    Container, FocusScope, GestureDetector, Grid, GridItem, HttpHeader, Icon, Image,
+    ImageAlignment, ImageCachePolicy, ImageErrorBehavior, ImageLoadingBehavior, ImageRequest,
+    ImageSource, LayoutBuilder, LazyColumn, Overlay, Positioned, Radio, RichText, RichTextRun, Row,
+    SafeArea, Scroll, Slider, Spacer, Switch, Text, TextContent, TextFontStyle, TextInput,
+    TextRunStyle, Video, ZStack,
 };

--- a/crates/core/fission-core/src/ui/widgets/image.rs
+++ b/crates/core/fission-core/src/ui/widgets/image.rs
@@ -6,50 +6,158 @@ use fission_ir::{
 };
 use serde::{Deserialize, Serialize};
 
-fn resolve_svg_content(source: &str) -> Option<String> {
-    let trimmed = source.trim_start();
-    if trimmed.starts_with("<svg") {
-        return Some(source.to_string());
-    }
+pub use fission_ir::op::{
+    HttpHeader, ImageAlignment, ImageCachePolicy, ImageErrorBehavior, ImageLoadingBehavior,
+    ImageRequest, ImageSource,
+};
 
-    if source.to_ascii_lowercase().ends_with(".svg") {
-        return std::fs::read_to_string(source).ok();
-    }
-
-    None
-}
-
-/// A raster image widget.
+/// Displays an image from an asset, file, network URL, memory buffer, or inline SVG.
 ///
-/// Displays an image from a URL or asset path. The `fit` property controls
-/// how the image is scaled within its layout box.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// Image {
-///     source: "https://example.com/photo.jpg".into(),
-///     width: Some(200.0),
-///     height: Some(150.0),
-///     fit: Some(ImageFit::Cover),
-///     ..Default::default()
-/// }
-/// ```
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+/// `Image` is declarative: it describes the image source and presentation. The
+/// active shell is responsible for loading, decoding, caching, and repainting
+/// when the image becomes available.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Image {
     /// Explicit node identity.
     pub id: Option<NodeId>,
-    /// URL or asset path to the image.
-    pub source: String,
+    /// Typed image request consumed by the shell image pipeline.
+    pub request: ImageRequest,
     /// Fixed width in layout points.
     pub width: Option<f32>,
     /// Fixed height in layout points.
     pub height: Option<f32>,
-    /// How the image is scaled to fit its layout box (default: `Contain`).
-    pub fit: Option<ImageFit>,
+    /// How the image is scaled to fit its layout box.
+    pub fit: ImageFit,
+    /// How fitted image content is positioned inside its layout box.
+    pub alignment: ImageAlignment,
+}
+
+impl Default for Image {
+    fn default() -> Self {
+        Self {
+            id: None,
+            request: ImageRequest::default(),
+            width: None,
+            height: None,
+            fit: ImageFit::Contain,
+            alignment: ImageAlignment::Center,
+        }
+    }
 }
 
 impl Image {
+    pub fn asset(path: impl Into<String>) -> Self {
+        Self::from_source(ImageSource::Asset { path: path.into() })
+    }
+
+    pub fn file(path: impl Into<String>) -> Self {
+        Self::from_source(ImageSource::File { path: path.into() })
+    }
+
+    pub fn network(url: impl Into<String>) -> Self {
+        Self::from_source(ImageSource::Network {
+            url: url.into(),
+            headers: Vec::new(),
+            cache_policy: ImageCachePolicy::Default,
+        })
+    }
+
+    pub fn memory(bytes: impl Into<Vec<u8>>) -> Self {
+        Self::from_source(ImageSource::Memory {
+            bytes: bytes.into(),
+            mime_type: None,
+        })
+    }
+
+    pub fn svg_text(content: impl Into<String>) -> Self {
+        Self::from_source(ImageSource::SvgText {
+            content: content.into(),
+        })
+    }
+
+    pub fn from_source(source: ImageSource) -> Self {
+        Self {
+            request: ImageRequest {
+                source,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    pub fn id(mut self, id: NodeId) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    pub fn height(mut self, height: f32) -> Self {
+        self.height = Some(height);
+        self
+    }
+
+    pub fn size(mut self, width: f32, height: f32) -> Self {
+        self.width = Some(width);
+        self.height = Some(height);
+        self
+    }
+
+    pub fn fit(mut self, fit: ImageFit) -> Self {
+        self.fit = fit;
+        self
+    }
+
+    pub fn alignment(mut self, alignment: ImageAlignment) -> Self {
+        self.alignment = alignment;
+        self
+    }
+
+    pub fn semantic_label(mut self, label: impl Into<String>) -> Self {
+        self.request.semantic_label = Some(label.into());
+        self
+    }
+
+    pub fn cache_size(mut self, width: u32, height: u32) -> Self {
+        self.request.cache_width = Some(width);
+        self.request.cache_height = Some(height);
+        self
+    }
+
+    pub fn loading(mut self, loading: ImageLoadingBehavior) -> Self {
+        self.request.loading = loading;
+        self
+    }
+
+    pub fn error(mut self, error: ImageErrorBehavior) -> Self {
+        self.request.error = error;
+        self
+    }
+
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        if let ImageSource::Network { headers, .. } = &mut self.request.source {
+            headers.push(HttpHeader {
+                name: name.into(),
+                value: value.into(),
+            });
+        }
+        self
+    }
+
+    pub fn cache_policy(mut self, cache_policy: ImageCachePolicy) -> Self {
+        if let ImageSource::Network {
+            cache_policy: policy,
+            ..
+        } = &mut self.request.source
+        {
+            *policy = cache_policy;
+        }
+        self
+    }
+
     pub fn into_node(self) -> crate::ui::Node {
         crate::ui::Node::Image(self)
     }
@@ -58,17 +166,17 @@ impl Image {
 impl Lower for Image {
     fn lower(&self, cx: &mut LoweringContext) -> NodeId {
         let layout_id = self.id.unwrap_or_else(|| cx.next_node_id());
-        let paint_op = if let Some(content) = resolve_svg_content(&self.source) {
-            PaintOp::DrawSvg {
-                content,
+        let paint_op = match &self.request.source {
+            ImageSource::SvgText { content } => PaintOp::DrawSvg {
+                content: content.clone(),
                 fill: None,
                 stroke: None,
-            }
-        } else {
-            PaintOp::DrawImage {
-                source: self.source.clone(),
-                fit: self.fit.unwrap_or(ImageFit::Contain),
-            }
+            },
+            _ => PaintOp::DrawImage {
+                request: self.request.clone(),
+                fit: self.fit,
+                alignment: self.alignment,
+            },
         };
         let paint_id = NodeBuilder::new(cx.next_node_id(), Op::Paint(paint_op)).build(cx);
 

--- a/crates/core/fission-core/src/ui/widgets/mod.rs
+++ b/crates/core/fission-core/src/ui/widgets/mod.rs
@@ -36,7 +36,10 @@ pub use container::Container;
 pub use fission_theme::{BadgeTone, ButtonHierarchy, CardPattern, ComponentSize, ComponentState};
 pub use grid::{Grid, GridItem};
 pub use icon::Icon;
-pub use image::Image;
+pub use image::{
+    HttpHeader, Image, ImageAlignment, ImageCachePolicy, ImageErrorBehavior, ImageLoadingBehavior,
+    ImageRequest, ImageSource,
+};
 pub use lazy_column::LazyColumn;
 pub use overlay::Overlay;
 pub use positioned::Positioned;

--- a/crates/core/fission-core/src/ui/widgets/stack.rs
+++ b/crates/core/fission-core/src/ui/widgets/stack.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// ```rust,ignore
 /// ZStack {
 ///     children: vec![
-///         Image { source: "bg.png".into(), ..Default::default() }.into_node().into(),
+///         Image::asset("bg.png").into_node().into(),
 ///         Positioned {
 ///             bottom: Some(16.0),
 ///             right: Some(16.0),

--- a/crates/core/fission-core/src/ui/widgets/text.rs
+++ b/crates/core/fission-core/src/ui/widgets/text.rs
@@ -116,7 +116,7 @@ impl TextRunStyle {
             .font_size
             .or(fallback_size)
             .unwrap_or(theme.tokens.typography.body_medium_size);
-        let base_line_height = self.line_height;
+        let base_line_height = self.line_height.or(Some(base_font_size * 1.2));
         let base_letter_spacing = self.letter_spacing.unwrap_or(0.0);
         fission_ir::op::TextStyle {
             font_size: base_font_size * scale,
@@ -915,7 +915,7 @@ impl Text {
             locale: self.locale.clone(),
             font_weight: self.font_weight.unwrap_or(400),
             font_style: self.font_style.into(),
-            line_height: self.line_height.map(|value| value * scale),
+            line_height: Some(self.line_height.unwrap_or(base_font_size * 1.2) * scale),
             letter_spacing: self.letter_spacing.unwrap_or(0.0) * scale,
             background_color: None,
         }

--- a/crates/core/fission-core/tests/image_widget.rs
+++ b/crates/core/fission-core/tests/image_widget.rs
@@ -1,0 +1,116 @@
+use fission_core::env::{Env, RuntimeState};
+use fission_core::lowering::LoweringContext;
+use fission_core::ui::{Image, Node};
+use fission_ir::op::{ImageAlignment, ImageCachePolicy, ImageFit, ImageSource, Op, PaintOp};
+use fission_ir::CoreIR;
+
+fn lower_image(image: Image) -> CoreIR {
+    let env = Env::default();
+    let runtime = RuntimeState::default();
+    let mut cx = LoweringContext::new(&env, &runtime, None, None);
+    let root = Node::Image(image).lower(&mut cx);
+    cx.ir.root = Some(root);
+    cx.ir
+}
+
+fn draw_image_op(ir: &CoreIR) -> Option<&PaintOp> {
+    ir.nodes.values().find_map(|node| match &node.op {
+        Op::Paint(op @ PaintOp::DrawImage { .. }) => Some(op),
+        _ => None,
+    })
+}
+
+#[test]
+fn network_image_lowers_to_typed_draw_image_request() {
+    let ir = lower_image(
+        Image::network("https://cdn.example.com/product.webp")
+            .header("Accept", "image/webp")
+            .cache_policy(ImageCachePolicy::Disk)
+            .cache_size(320, 180)
+            .semantic_label("Product photo")
+            .size(160.0, 90.0)
+            .fit(ImageFit::Cover)
+            .alignment(ImageAlignment::TopStart),
+    );
+
+    let Some(PaintOp::DrawImage {
+        request,
+        fit,
+        alignment,
+    }) = draw_image_op(&ir)
+    else {
+        panic!("expected DrawImage paint op");
+    };
+
+    assert_eq!(*fit, ImageFit::Cover);
+    assert_eq!(*alignment, ImageAlignment::TopStart);
+    assert_eq!(request.cache_width, Some(320));
+    assert_eq!(request.cache_height, Some(180));
+    assert_eq!(request.semantic_label.as_deref(), Some("Product photo"));
+
+    let ImageSource::Network {
+        url,
+        headers,
+        cache_policy,
+    } = &request.source
+    else {
+        panic!("expected network image source");
+    };
+    assert_eq!(url, "https://cdn.example.com/product.webp");
+    assert_eq!(*cache_policy, ImageCachePolicy::Disk);
+    assert_eq!(headers.len(), 1);
+    assert_eq!(headers[0].name, "Accept");
+    assert_eq!(headers[0].value, "image/webp");
+}
+
+#[test]
+fn image_lowering_keeps_sized_layout_parent_and_draw_image_child() {
+    let ir = lower_image(
+        Image::network("https://cdn.example.com/product.webp")
+            .size(88.0, 44.0)
+            .fit(ImageFit::Contain),
+    );
+
+    let root_id = ir.root.expect("image root");
+    let root = ir.nodes.get(&root_id).expect("root node");
+    match &root.op {
+        Op::Layout(fission_ir::op::LayoutOp::Box { width, height, .. }) => {
+            assert_eq!(*width, Some(88.0));
+            assert_eq!(*height, Some(44.0));
+        }
+        other => panic!("expected image root to be a sized layout box, got {other:?}"),
+    }
+    assert_eq!(root.children.len(), 1);
+
+    let paint = ir.nodes.get(&root.children[0]).expect("image paint child");
+    assert!(matches!(
+        &paint.op,
+        Op::Paint(PaintOp::DrawImage {
+            request,
+            fit: ImageFit::Contain,
+            ..
+        }) if request.source.network_url() == Some("https://cdn.example.com/product.webp")
+    ));
+}
+
+#[test]
+fn svg_text_lowers_to_draw_svg() {
+    let ir = lower_image(Image::svg_text("<svg viewBox=\"0 0 10 10\"></svg>").size(10.0, 10.0));
+
+    assert!(ir.nodes.values().any(|node| matches!(
+        &node.op,
+        Op::Paint(PaintOp::DrawSvg { content, .. }) if content.contains("<svg")
+    )));
+}
+
+#[test]
+fn asset_and_network_constructors_create_typed_sources() {
+    assert!(matches!(
+        Image::network("https://example.com/a.png").request.source,
+        ImageSource::Network { .. }
+    ));
+    assert!(matches!(
+        Image::asset("assets/a.png").request.source,
+        ImageSource::Asset { .. }
+    ));
+}

--- a/crates/core/fission-ir/src/op.rs
+++ b/crates/core/fission-ir/src/op.rs
@@ -799,6 +799,155 @@ pub enum ImageFit {
     None,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
+pub enum ImageAlignment {
+    TopStart,
+    TopCenter,
+    TopEnd,
+    CenterStart,
+    #[default]
+    Center,
+    CenterEnd,
+    BottomStart,
+    BottomCenter,
+    BottomEnd,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct HttpHeader {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
+pub enum ImageCachePolicy {
+    #[default]
+    Default,
+    Reload,
+    MemoryOnly,
+    Disk,
+    NoStore,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub enum ImageSource {
+    Asset {
+        path: String,
+    },
+    File {
+        path: String,
+    },
+    Network {
+        url: String,
+        #[serde(default)]
+        headers: Vec<HttpHeader>,
+        #[serde(default)]
+        cache_policy: ImageCachePolicy,
+    },
+    Memory {
+        bytes: Vec<u8>,
+        #[serde(default)]
+        mime_type: Option<String>,
+    },
+    SvgText {
+        content: String,
+    },
+}
+
+impl Default for ImageSource {
+    fn default() -> Self {
+        Self::Asset {
+            path: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
+pub enum ImageLoadingBehavior {
+    #[default]
+    Empty,
+    ThemePlaceholder,
+    BlurHash(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
+pub enum ImageErrorBehavior {
+    #[default]
+    Empty,
+    ThemeError,
+    AltText,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
+pub struct ImageRequest {
+    pub source: ImageSource,
+    #[serde(default)]
+    pub cache_width: Option<u32>,
+    #[serde(default)]
+    pub cache_height: Option<u32>,
+    #[serde(default)]
+    pub semantic_label: Option<String>,
+    #[serde(default)]
+    pub loading: ImageLoadingBehavior,
+    #[serde(default)]
+    pub error: ImageErrorBehavior,
+}
+
+impl ImageSource {
+    pub fn stable_identity(&self) -> String {
+        match self {
+            Self::Asset { path } => format!("asset:{path}"),
+            Self::File { path } => format!("file:{path}"),
+            Self::Network {
+                url,
+                headers,
+                cache_policy,
+            } => {
+                let mut identity = format!("network:{cache_policy:?}:{url}");
+                for header in headers {
+                    identity.push('|');
+                    identity.push_str(&header.name.to_ascii_lowercase());
+                    identity.push('=');
+                    identity.push_str(&header.value);
+                }
+                identity
+            }
+            Self::Memory { bytes, mime_type } => {
+                let digest = blake3::hash(bytes);
+                format!("memory:{}:{digest}", mime_type.as_deref().unwrap_or(""))
+            }
+            Self::SvgText { content } => {
+                let digest = blake3::hash(content.as_bytes());
+                format!("svg:{digest}")
+            }
+        }
+    }
+
+    pub fn local_path(&self) -> Option<&str> {
+        match self {
+            Self::Asset { path } | Self::File { path } => Some(path),
+            _ => None,
+        }
+    }
+
+    pub fn network_url(&self) -> Option<&str> {
+        match self {
+            Self::Network { url, .. } => Some(url),
+            _ => None,
+        }
+    }
+}
+
+impl ImageRequest {
+    pub fn stable_cache_key(&self) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.source.stable_identity().as_bytes());
+        hasher.update(&self.cache_width.unwrap_or_default().to_le_bytes());
+        hasher.update(&self.cache_height.unwrap_or_default().to_le_bytes());
+        hasher.finalize().to_hex().to_string()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TextStyle {
     pub font_size: LayoutUnit,
@@ -941,8 +1090,9 @@ pub enum PaintOp {
         paragraph_style: Option<TextParagraphStyle>,
     },
     DrawImage {
-        source: String,
+        request: ImageRequest,
         fit: ImageFit,
+        alignment: ImageAlignment,
     },
     DrawPath {
         path: String,
@@ -1017,10 +1167,15 @@ impl std::hash::Hash for PaintOp {
                 caret_radius.map(|r| r.to_bits()).hash(state);
                 paragraph_style.hash(state);
             }
-            Self::DrawImage { source, fit } => {
+            Self::DrawImage {
+                request,
+                fit,
+                alignment,
+            } => {
                 3.hash(state);
-                source.hash(state);
+                request.hash(state);
                 fit.hash(state);
+                alignment.hash(state);
             }
             Self::DrawPath { path, fill, stroke } => {
                 4.hash(state);
@@ -1046,9 +1201,9 @@ impl std::hash::Hash for PaintOp {
 mod tests {
     use super::{
         decode_inline_widget_marker, decode_text_paragraph_style, encode_inline_widget_marker,
-        encode_text_paragraph_style, InlineWidgetMarker, TextAlign, TextDirection,
-        TextHeightBehavior, TextOverflow, TextParagraphStyle, TextWidthBasis,
-        TEXT_PARAGRAPH_MAX_ENCODED_LINES,
+        encode_text_paragraph_style, HttpHeader, ImageCachePolicy, ImageRequest, ImageSource,
+        InlineWidgetMarker, TextAlign, TextDirection, TextHeightBehavior, TextOverflow,
+        TextParagraphStyle, TextWidthBasis, TEXT_PARAGRAPH_MAX_ENCODED_LINES,
     };
 
     #[test]
@@ -1090,6 +1245,50 @@ mod tests {
                 strut_line_height: None,
                 text_height_behavior: TextHeightBehavior::default(),
             })
+        );
+    }
+
+    #[test]
+    fn image_request_cache_key_is_stable_and_dimension_sensitive() {
+        let request = ImageRequest {
+            source: ImageSource::Network {
+                url: "https://cdn.example.com/image.webp".into(),
+                headers: vec![HttpHeader {
+                    name: "Accept".into(),
+                    value: "image/webp".into(),
+                }],
+                cache_policy: ImageCachePolicy::Default,
+            },
+            cache_width: Some(320),
+            cache_height: Some(180),
+            ..Default::default()
+        };
+
+        let same = request.clone();
+        let mut resized = request.clone();
+        resized.cache_width = Some(640);
+
+        assert_eq!(request.stable_cache_key(), same.stable_cache_key());
+        assert_ne!(request.stable_cache_key(), resized.stable_cache_key());
+    }
+
+    #[test]
+    fn image_source_helpers_report_path_and_network_sources() {
+        assert_eq!(
+            ImageSource::Asset {
+                path: "assets/logo.png".into()
+            }
+            .local_path(),
+            Some("assets/logo.png")
+        );
+        assert_eq!(
+            ImageSource::Network {
+                url: "https://example.com/logo.png".into(),
+                headers: Vec::new(),
+                cache_policy: ImageCachePolicy::Default,
+            }
+            .network_url(),
+            Some("https://example.com/logo.png")
         );
     }
 

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -21,5 +21,12 @@ image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ureq = "2"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 web-time = "0.2"
+web-sys = { version = "0.3", features = ["Headers", "Request", "RequestInit", "RequestMode", "Response", "Window"] }

--- a/crates/rendering/fission-render-vello/src/lib.rs
+++ b/crates/rendering/fission-render-vello/src/lib.rs
@@ -4,8 +4,8 @@ pub use text::VelloTextMeasurer;
 
 use anyhow::Result;
 use fission_ir::op::{
-    decode_text_paragraph_style, TextAlign, TextDirection, TextHeightBehavior, TextOverflow,
-    TextParagraphStyle, TextWidthBasis,
+    decode_text_paragraph_style, HttpHeader, ImageAlignment, ImageRequest, ImageSource, TextAlign,
+    TextDirection, TextHeightBehavior, TextOverflow, TextParagraphStyle, TextWidthBasis,
 };
 use fission_render::{
     surface_placeholder_color, Color as RenderColor, DisplayList, DisplayOp, LayerClip,
@@ -96,7 +96,12 @@ use parley::layout::{Alignment as ParleyAlignment, AlignmentOptions, PositionedL
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex};
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::Read;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
 use vello::{Glyph, Scene};
 
 const PARAGRAPH_FADE_SLICE_COUNT: usize = 8;
@@ -326,8 +331,278 @@ fn paragraph_fade(
 }
 
 lazy_static! {
-    static ref IMAGE_CACHE: Mutex<HashMap<String, Arc<ImageData>>> = Mutex::new(HashMap::new());
+    static ref IMAGE_CACHE: Mutex<HashMap<String, ImageCacheEntry>> = Mutex::new(HashMap::new());
     static ref SVG_CACHE: Mutex<HashMap<u64, Arc<SvgCacheEntry>>> = Mutex::new(HashMap::new());
+}
+
+static IMAGE_CACHE_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone)]
+enum ImageCacheEntry {
+    Ready(Arc<ImageData>),
+    Loading,
+    Failed,
+}
+
+pub fn image_cache_generation() -> u64 {
+    IMAGE_CACHE_GENERATION.load(Ordering::Acquire)
+}
+
+pub fn image_cache_has_pending() -> bool {
+    IMAGE_CACHE
+        .lock()
+        .unwrap()
+        .values()
+        .any(|entry| matches!(entry, ImageCacheEntry::Loading))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn decode_image_from_path(
+    path: &str,
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<ImageData>> {
+    let img = image::open(path).ok()?;
+    decode_dynamic_image(img, cache_width, cache_height)
+}
+
+fn decode_image_from_bytes(
+    bytes: &[u8],
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<ImageData>> {
+    let img = image::load_from_memory(bytes).ok()?;
+    decode_dynamic_image(img, cache_width, cache_height)
+}
+
+fn decode_dynamic_image(
+    mut img: image::DynamicImage,
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<ImageData>> {
+    if let (Some(width), Some(height)) = (cache_width, cache_height) {
+        if width > 0 && height > 0 {
+            img = img.resize(width, height, image::imageops::FilterType::Triangle);
+        }
+    }
+    let img = img.to_rgba8();
+    let (width, height) = img.dimensions();
+    let data = img.into_raw();
+    Some(Arc::new(ImageData {
+        data: Blob::new(Arc::new(data)),
+        format: ImageFormat::Rgba8,
+        alpha_type: ImageAlphaType::Alpha,
+        width,
+        height,
+    }))
+}
+
+fn complete_image_load(key: String, image: Option<Arc<ImageData>>) {
+    let mut cache = IMAGE_CACHE.lock().unwrap();
+    cache.insert(
+        key,
+        image
+            .map(ImageCacheEntry::Ready)
+            .unwrap_or(ImageCacheEntry::Failed),
+    );
+    IMAGE_CACHE_GENERATION.fetch_add(1, Ordering::AcqRel);
+}
+
+fn aligned_offset(extra_width: f64, extra_height: f64, alignment: ImageAlignment) -> (f64, f64) {
+    let x = match alignment {
+        ImageAlignment::TopStart | ImageAlignment::CenterStart | ImageAlignment::BottomStart => 0.0,
+        ImageAlignment::TopCenter | ImageAlignment::Center | ImageAlignment::BottomCenter => {
+            extra_width / 2.0
+        }
+        ImageAlignment::TopEnd | ImageAlignment::CenterEnd | ImageAlignment::BottomEnd => {
+            extra_width
+        }
+    };
+    let y = match alignment {
+        ImageAlignment::TopStart | ImageAlignment::TopCenter | ImageAlignment::TopEnd => 0.0,
+        ImageAlignment::CenterStart | ImageAlignment::Center | ImageAlignment::CenterEnd => {
+            extra_height / 2.0
+        }
+        ImageAlignment::BottomStart | ImageAlignment::BottomCenter | ImageAlignment::BottomEnd => {
+            extra_height
+        }
+    };
+    (x, y)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_image_load(key: String, request: ImageRequest) {
+    std::thread::spawn(move || {
+        let image = match request.source {
+            ImageSource::Asset { path } | ImageSource::File { path } => {
+                decode_image_from_path(&path, request.cache_width, request.cache_height)
+            }
+            ImageSource::Memory { bytes, .. } => {
+                decode_image_from_bytes(&bytes, request.cache_width, request.cache_height)
+            }
+            ImageSource::Network { url, headers, .. } => {
+                fetch_network_image(&url, headers, request.cache_width, request.cache_height)
+            }
+            ImageSource::SvgText { .. } => None,
+        };
+        complete_image_load(key, image);
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn spawn_image_load(key: String, request: ImageRequest) {
+    match request.source {
+        ImageSource::Memory { bytes, .. } => {
+            let image = decode_image_from_bytes(&bytes, request.cache_width, request.cache_height);
+            complete_image_load(key, image);
+        }
+        ImageSource::Asset { path } => {
+            wasm_bindgen_futures::spawn_local(async move {
+                let image = fetch_wasm_image_bytes(&path, Vec::new())
+                    .await
+                    .and_then(|bytes| {
+                        decode_image_from_bytes(&bytes, request.cache_width, request.cache_height)
+                    });
+                complete_image_load(key, image);
+            });
+        }
+        ImageSource::Network { url, headers, .. } => {
+            wasm_bindgen_futures::spawn_local(async move {
+                let image = fetch_wasm_image_bytes(&url, headers)
+                    .await
+                    .and_then(|bytes| {
+                        decode_image_from_bytes(&bytes, request.cache_width, request.cache_height)
+                    });
+                complete_image_load(key, image);
+            });
+        }
+        ImageSource::File { .. } | ImageSource::SvgText { .. } => {
+            complete_image_load(key, None);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn fetch_wasm_image_bytes(url: &str, headers: Vec<HttpHeader>) -> Option<Vec<u8>> {
+    use wasm_bindgen::JsCast;
+
+    let window = web_sys::window()?;
+    let init = web_sys::RequestInit::new();
+    init.set_method("GET");
+    init.set_mode(web_sys::RequestMode::Cors);
+    let request = web_sys::Request::new_with_str_and_init(url, &init).ok()?;
+    for header in headers {
+        request.headers().set(&header.name, &header.value).ok()?;
+    }
+    let response = wasm_bindgen_futures::JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .ok()?;
+    let response = response.dyn_into::<web_sys::Response>().ok()?;
+    if !response.ok() {
+        return None;
+    }
+    let buffer = wasm_bindgen_futures::JsFuture::from(response.array_buffer().ok()?)
+        .await
+        .ok()?;
+    let bytes = js_sys::Uint8Array::new(&buffer);
+    let mut out = vec![0; bytes.length() as usize];
+    bytes.copy_to(&mut out);
+    Some(out)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn fetch_network_image(
+    url: &str,
+    headers: Vec<HttpHeader>,
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<ImageData>> {
+    let mut request = ureq::get(url).set("User-Agent", "FissionImageLoader/0.2");
+    for header in headers {
+        request = request.set(&header.name, &header.value);
+    }
+    let response = request.call().ok()?;
+    let mut bytes = Vec::new();
+    response.into_reader().read_to_end(&mut bytes).ok()?;
+    let image = image::load_from_memory(&bytes).ok()?;
+    decode_dynamic_image(image, cache_width, cache_height)
+}
+
+#[cfg(test)]
+mod image_tests {
+    use super::*;
+    use std::io::Cursor;
+    use std::net::TcpListener;
+    use std::time::{Duration, Instant};
+
+    fn tiny_png() -> Vec<u8> {
+        let image = image::RgbaImage::from_pixel(1, 1, image::Rgba([255, 0, 0, 255]));
+        let mut bytes = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(image)
+            .write_to(&mut bytes, image::ImageOutputFormat::Png)
+            .expect("encode png");
+        bytes.into_inner()
+    }
+
+    fn serve_once(body: Vec<u8>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test image server");
+        let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut request = [0_u8; 1024];
+            let _ = std::io::Read::read(&mut stream, &mut request);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = std::io::Write::write_all(&mut stream, response.as_bytes());
+            let _ = std::io::Write::write_all(&mut stream, &body);
+            let _ = std::io::Write::flush(&mut stream);
+        });
+        url
+    }
+
+    #[test]
+    fn memory_image_load_populates_cache_off_thread() {
+        let request = ImageRequest {
+            source: ImageSource::Memory {
+                bytes: tiny_png(),
+                mime_type: Some("image/png".into()),
+            },
+            cache_width: Some(1),
+            cache_height: Some(1),
+            ..Default::default()
+        };
+        let key = request.stable_cache_key();
+        IMAGE_CACHE.lock().unwrap().remove(&key);
+        let before = image_cache_generation();
+
+        spawn_image_load(key.clone(), request);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while image_cache_generation() == before && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let cache = IMAGE_CACHE.lock().unwrap();
+        let Some(ImageCacheEntry::Ready(image)) = cache.get(&key) else {
+            panic!("expected decoded image in cache");
+        };
+        assert_eq!(image.width, 1);
+        assert_eq!(image.height, 1);
+    }
+
+    #[test]
+    fn network_image_fetch_decodes_png_response() {
+        let url = serve_once(tiny_png());
+        let image = fetch_network_image(&url, Vec::new(), Some(1), Some(1))
+            .expect("fetch and decode test image");
+
+        assert_eq!(image.width, 1);
+        assert_eq!(image.height, 1);
+    }
 }
 
 #[derive(Debug)]
@@ -979,28 +1254,21 @@ impl<'a> VelloRenderer<'a> {
         }
     }
 
-    fn get_image(&self, path: &str) -> Option<Arc<ImageData>> {
-        let mut cache = IMAGE_CACHE.lock().unwrap();
-        if let Some(img) = cache.get(path) {
-            return Some(Arc::clone(img));
+    fn get_image(&self, request: &ImageRequest) -> Option<Arc<ImageData>> {
+        let key = request.stable_cache_key();
+        {
+            let mut cache = IMAGE_CACHE.lock().unwrap();
+            if let Some(entry) = cache.get(&key) {
+                return match entry {
+                    ImageCacheEntry::Ready(img) => Some(Arc::clone(img)),
+                    ImageCacheEntry::Loading | ImageCacheEntry::Failed => None,
+                };
+            }
+            cache.insert(key.clone(), ImageCacheEntry::Loading);
         }
 
-        if let Ok(img) = image::open(path) {
-            let img = img.to_rgba8();
-            let (width, height) = img.dimensions();
-            let data = img.into_raw();
-            let image_data = Arc::new(ImageData {
-                data: Blob::new(Arc::new(data)),
-                format: ImageFormat::Rgba8,
-                alpha_type: ImageAlphaType::Alpha,
-                width,
-                height,
-            });
-            cache.insert(path.to_string(), Arc::clone(&image_data));
-            Some(image_data)
-        } else {
-            None
-        }
+        spawn_image_load(key, request.clone());
+        None
     }
 
     fn affine_from_mat4(matrix: &[f32; 16]) -> Affine {
@@ -1008,9 +1276,9 @@ impl<'a> VelloRenderer<'a> {
         let m10 = matrix[1] as f64;
         let m01 = matrix[4] as f64;
         let m11 = matrix[5] as f64;
-        let m03 = matrix[12] as f64;
-        let m13 = matrix[13] as f64;
-        Affine::new([m00, m10, m01, m11, m03, m13])
+        let dx = matrix[12] as f64;
+        let dy = matrix[13] as f64;
+        Affine::new([m00, m10, m01, m11, dx, dy])
     }
 
     fn with_clip_rect<F>(&mut self, rect: Rect, draw: F)
@@ -2245,9 +2513,13 @@ impl<'a> VelloRenderer<'a> {
                     );
                 }
                 DisplayOp::DrawImage {
-                    source, rect, fit, ..
+                    request,
+                    rect,
+                    fit,
+                    alignment,
+                    ..
                 } => {
-                    if let Some(image_data) = self.get_image(source) {
+                    if let Some(image_data) = self.get_image(request) {
                         let rect_w = rect.size.width as f64;
                         let rect_h = rect.size.height as f64;
                         let img_w = image_data.width as f64;
@@ -2268,22 +2540,26 @@ impl<'a> VelloRenderer<'a> {
                                 let scale = (rect_w / img_w).min(rect_h / img_h);
                                 let w = img_w * scale;
                                 let h = img_h * scale;
+                                let (offset_x, offset_y) =
+                                    aligned_offset(rect_w - w, rect_h - h, *alignment);
                                 (
                                     scale,
                                     scale,
-                                    rect.origin.x as f64 + (rect_w - w) / 2.0,
-                                    rect.origin.y as f64 + (rect_h - h) / 2.0,
+                                    rect.origin.x as f64 + offset_x,
+                                    rect.origin.y as f64 + offset_y,
                                 )
                             }
                             fission_render::ImageFit::Cover => {
                                 let scale = (rect_w / img_w).max(rect_h / img_h);
                                 let w = img_w * scale;
                                 let h = img_h * scale;
+                                let (offset_x, offset_y) =
+                                    aligned_offset(rect_w - w, rect_h - h, *alignment);
                                 (
                                     scale,
                                     scale,
-                                    rect.origin.x as f64 + (rect_w - w) / 2.0,
-                                    rect.origin.y as f64 + (rect_h - h) / 2.0,
+                                    rect.origin.x as f64 + offset_x,
+                                    rect.origin.y as f64 + offset_y,
                                 )
                             }
                             fission_render::ImageFit::None => {
@@ -2298,7 +2574,15 @@ impl<'a> VelloRenderer<'a> {
                             image: &*image_data,
                             sampler: ImageSampler::default(),
                         };
-                        self.scene.draw_image(brush, transform);
+                        let clip_rect = Rect::new(
+                            rect.origin.x as f64,
+                            rect.origin.y as f64,
+                            (rect.origin.x + rect.size.width) as f64,
+                            (rect.origin.y + rect.size.height) as f64,
+                        );
+                        self.with_clip_rect(clip_rect, |this| {
+                            this.scene.draw_image(brush, transform);
+                        });
                     }
                 }
                 DisplayOp::DrawPath {

--- a/crates/rendering/fission-render/src/lib.rs
+++ b/crates/rendering/fission-render/src/lib.rs
@@ -1,4 +1,6 @@
-use fission_ir::op::{EmbedKind, RichTextAnnotation, TextParagraphStyle};
+use fission_ir::op::{
+    EmbedKind, ImageAlignment, ImageRequest, RichTextAnnotation, TextParagraphStyle,
+};
 use fission_ir::{NodeId, WidgetNodeId};
 pub use fission_layout::{LayoutPoint, LayoutRect, LayoutSize, LayoutUnit};
 use serde::{Deserialize, Serialize};
@@ -147,8 +149,9 @@ pub enum DisplayOp {
     },
     DrawImage {
         rect: LayoutRect,
-        source: String,
+        request: ImageRequest,
         fit: ImageFit,
+        alignment: ImageAlignment,
         bounds: LayoutRect,
         node_id: Option<NodeId>,
     },

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -121,13 +121,9 @@ impl DocumentationPage<'_> {
         let mut children = Vec::new();
         if let Some(logo) = self.site_logo {
             children.push(
-                Image {
-                    source: logo.to_string(),
-                    width: Some(tokens.spacing.xl),
-                    height: Some(tokens.spacing.xl),
-                    ..Default::default()
-                }
-                .into_node(),
+                Image::asset(logo.to_string())
+                    .size(tokens.spacing.xl, tokens.spacing.xl)
+                    .into_node(),
             );
         }
         children.push(

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, bail, Result};
 use fission_ir::op::{
     decode_inline_widget_marker, AlignItems, BoxShadow, Color, Fill, FlexDirection, FlexWrap,
-    FontStyle, GridPlacement, GridTrack, ImageFit, JustifyContent, LayoutOp, LineCap, LineJoin, Op,
-    PaintOp, Stroke, TextAlign, TextOverflow, TextRun,
+    FontStyle, GridPlacement, GridTrack, ImageFit, ImageSource, JustifyContent, LayoutOp, LineCap,
+    LineJoin, Op, PaintOp, Stroke, TextAlign, TextOverflow, TextRun,
 };
 use fission_ir::{CoreIR, CoreNode, NodeId, Role};
 use fission_theme::{DesignMode, Theme};
@@ -821,7 +821,7 @@ impl HtmlRenderer<'_> {
                     node.id
                 ))
             }
-            PaintOp::DrawImage { source, fit } => {
+            PaintOp::DrawImage { request, fit, .. } => {
                 let class_name = self.class_name(
                     "fission-site-img",
                     vec![
@@ -831,9 +831,10 @@ impl HtmlRenderer<'_> {
                     ],
                 );
                 Ok(format!(
-                    "<img class=\"{}\" src=\"{}\" alt=\"\" data-fission-node=\"{}\">",
+                    "<img class=\"{}\" src=\"{}\" alt=\"{}\" data-fission-node=\"{}\">",
                     escape_attr(&class_name),
-                    escape_attr(&self.resolve_asset_src(source)),
+                    escape_attr(&self.resolve_image_src(&request.source)),
+                    escape_attr(request.semantic_label.as_deref().unwrap_or("")),
                     node.id
                 ))
             }
@@ -1112,6 +1113,16 @@ impl HtmlRenderer<'_> {
             relative_href_for_route(&self.options.current_route_path, source)
         } else {
             source.to_string()
+        }
+    }
+
+    fn resolve_image_src(&self, source: &ImageSource) -> String {
+        match source {
+            ImageSource::Asset { path } | ImageSource::File { path } => {
+                self.resolve_asset_src(path)
+            }
+            ImageSource::Network { url, .. } => url.clone(),
+            ImageSource::Memory { .. } | ImageSource::SvgText { .. } => String::new(),
         }
     }
 
@@ -1699,6 +1710,44 @@ mod tests {
         assert!(rendered.html.contains("Hello &lt;site&gt;"));
         assert!(!rendered.html.contains("style=\""));
         assert!(rendered.css.contains(".fs_"));
+    }
+
+    #[test]
+    fn renders_typed_image_sources_to_img_elements() {
+        let root = NodeId::explicit("root");
+        let image = NodeId::explicit("image");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            image,
+            Op::Paint(PaintOp::DrawImage {
+                request: fission_ir::op::ImageRequest {
+                    source: ImageSource::Network {
+                        url: "https://cdn.example.com/product.webp".into(),
+                        headers: Vec::new(),
+                        cache_policy: fission_ir::op::ImageCachePolicy::Default,
+                    },
+                    semantic_label: Some("Product photo".into()),
+                    ..Default::default()
+                },
+                fit: ImageFit::Cover,
+                alignment: fission_ir::op::ImageAlignment::Center,
+            }),
+            Vec::new(),
+        );
+        ir.add_node(
+            root,
+            Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 1 }),
+            vec![image],
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered
+            .html
+            .contains("src=\"https://cdn.example.com/product.webp\""));
+        assert!(rendered.html.contains("alt=\"Product photo\""));
+        assert!(rendered.css.contains("object-fit:cover"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-terminal/tests/terminal_shell_tests.rs
+++ b/crates/shell/fission-shell-terminal/tests/terminal_shell_tests.rs
@@ -87,8 +87,14 @@ fn terminal_verifier_rejects_graphical_only_paint() {
     ir.add_node(
         id,
         fission_ir::Op::Paint(fission_ir::PaintOp::DrawImage {
-            source: "image.png".to_string(),
+            request: fission_ir::op::ImageRequest {
+                source: fission_ir::op::ImageSource::Asset {
+                    path: "image.png".to_string(),
+                },
+                ..Default::default()
+            },
             fit: fission_ir::op::ImageFit::Contain,
+            alignment: fission_ir::op::ImageAlignment::Center,
         }),
         Vec::new(),
     );

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -42,6 +42,9 @@ bincode = "1.3"
 base64 = "0.22"
 tray-icon = { version = "0.24", optional = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ureq = "2"
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 arboard = "3.4"
 
@@ -50,8 +53,10 @@ winit = { version = "0.29.15", features = ["android-native-activity"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
 web-time = "0.2"
-web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElement", "ImageData", "Location", "Window"] }
+web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "Document", "Element", "Headers", "HtmlCanvasElement", "ImageData", "Location", "Request", "RequestInit", "RequestMode", "Response", "Window"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -2908,8 +2908,9 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
         let mut current_mods: u8 = 0;
 
         // Test control (enabled via FISSION_TEST_CONTROL_PORT env var).
-        // The TCP server injects TestEvents via the EventLoopProxy and receives
-        // query responses through a dedicated mpsc channel.
+        // The TCP server injects TestEvents via the EventLoopProxy. Query
+        // events carry per-command response channels, so a timed-out command
+        // cannot poison the next command with a stale response.
         #[cfg(not(target_arch = "wasm32"))]
         let test_control_port = self.test_control_port.or_else(|| {
             std::env::var("FISSION_TEST_CONTROL_PORT")
@@ -2919,9 +2920,8 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
         #[cfg(all(target_os = "android", not(target_arch = "wasm32")))]
         let pending_test_events = test_control::create_pending_event_queue();
         #[cfg(not(target_arch = "wasm32"))]
-        let test_response_tx: Option<test_control::ResponseSender> =
-            test_control_port.map(|port| {
-                let (resp_tx, resp_rx) = test_control::create_response_channel();
+        let test_control_enabled = test_control_port
+            .map(|port| {
                 #[cfg(target_os = "android")]
                 let injector = test_control::EventInjector::Queue {
                     queue: pending_test_events.clone(),
@@ -2929,13 +2929,17 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                 };
                 #[cfg(not(target_os = "android"))]
                 let injector = test_control::EventInjector::Proxy(event_proxy.clone());
-                test_control::spawn_server(port, injector, resp_rx);
-                resp_tx
-            });
+                test_control::spawn_server(port, injector);
+                true
+            })
+            .unwrap_or(false);
         #[cfg(target_arch = "wasm32")]
-        let test_response_tx: Option<test_control::ResponseSender> = None;
+        let test_control_enabled = false;
+        #[cfg(not(target_os = "android"))]
+        let _ = test_control_enabled;
         // Pending screenshot/pump: path + whether it needs a screenshot (vs pump).
         let mut pending_screenshot_path: Option<String> = None;
+        let mut pending_screenshot_response_tx: Option<test_control::ResponseSender> = None;
         #[cfg(not(target_os = "android"))]
         let mut window_viewport = WindowViewportState::from_window(&platform_window);
         #[cfg(target_os = "android")]
@@ -2956,6 +2960,8 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
             paint: true,
             composite: true,
         };
+        let mut vello_image_cache_generation = fission_render_vello::image_cache_generation();
+        let mut software_image_cache_generation = software_renderer::image_cache_generation();
 
         let event_handler =
             move |event: Event<TestEvent>, elwt: &EventLoopWindowTarget<TestEvent>| {
@@ -3281,13 +3287,12 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                 );
                             }
                         }
-                        TestEvent::TapText { text } => {
+                        TestEvent::TapText { text, response_tx } => {
                             let Some(window) = platform_window.active_window() else {
-                                if let Some(ref tx) = test_response_tx {
-                                    let _ = tx.send(fission_test_driver::TestResponse::Error {
+                                let _ =
+                                    response_tx.send(fission_test_driver::TestResponse::Error {
                                         message: "window not ready".into(),
                                     });
-                                }
                                 return;
                             };
                             let resp = handle_tap_text(&text, &mut runtime, &pipeline);
@@ -3305,9 +3310,7 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                     invalidations.mark_build();
                                 }
                             }
-                            if let Some(ref tx) = test_response_tx {
-                                let _ = tx.send(resp);
-                            }
+                            let _ = response_tx.send(resp);
                             request_redraw_logged(
                                 window,
                                 elwt,
@@ -3318,16 +3321,16 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                 "test_tap_text",
                             );
                         }
-                        TestEvent::Screenshot { path } => {
+                        TestEvent::Screenshot { path, response_tx } => {
                             let Some(window) = platform_window.active_window() else {
-                                if let Some(ref tx) = test_response_tx {
-                                    let _ = tx.send(fission_test_driver::TestResponse::Error {
+                                let _ =
+                                    response_tx.send(fission_test_driver::TestResponse::Error {
                                         message: "window not ready".into(),
                                     });
-                                }
                                 return;
                             };
                             pending_screenshot_path = Some(path);
+                            pending_screenshot_response_tx = Some(response_tx);
                             pending_capture_settle = resize_is_unsettled(
                                 pending_resize.is_some(),
                                 resize_needs_settled_frame,
@@ -3335,16 +3338,16 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                             );
                             window.request_redraw();
                         }
-                        TestEvent::CaptureScreenshot => {
+                        TestEvent::CaptureScreenshot { response_tx } => {
                             let Some(window) = platform_window.active_window() else {
-                                if let Some(ref tx) = test_response_tx {
-                                    let _ = tx.send(fission_test_driver::TestResponse::Error {
+                                let _ =
+                                    response_tx.send(fission_test_driver::TestResponse::Error {
                                         message: "window not ready".into(),
                                     });
-                                }
                                 return;
                             };
                             pending_screenshot_path = Some("__capture__".into());
+                            pending_screenshot_response_tx = Some(response_tx);
                             pending_capture_settle = resize_is_unsettled(
                                 pending_resize.is_some(),
                                 resize_needs_settled_frame,
@@ -3352,28 +3355,24 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                             );
                             window.request_redraw();
                         }
-                        TestEvent::GetText => {
+                        TestEvent::GetText { response_tx } => {
                             let resp = build_get_text_response(&pipeline);
-                            if let Some(ref tx) = test_response_tx {
-                                let _ = tx.send(resp);
-                            }
+                            let _ = response_tx.send(resp);
                         }
-                        TestEvent::GetTree => {
+                        TestEvent::GetTree { response_tx } => {
                             let resp = build_get_tree_response(&pipeline);
-                            if let Some(ref tx) = test_response_tx {
-                                let _ = tx.send(resp);
-                            }
+                            let _ = response_tx.send(resp);
                         }
-                        TestEvent::Pump => {
+                        TestEvent::Pump { response_tx } => {
                             let Some(window) = platform_window.active_window() else {
-                                if let Some(ref tx) = test_response_tx {
-                                    let _ = tx.send(fission_test_driver::TestResponse::Error {
+                                let _ =
+                                    response_tx.send(fission_test_driver::TestResponse::Error {
                                         message: "window not ready".into(),
                                     });
-                                }
                                 return;
                             };
                             pending_screenshot_path = Some("__pump__".into());
+                            pending_screenshot_response_tx = Some(response_tx);
                             pending_capture_settle = resize_is_unsettled(
                                 pending_resize.is_some(),
                                 resize_needs_settled_frame,
@@ -3382,10 +3381,8 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                             window.request_redraw();
                         }
                         TestEvent::Wake => {}
-                        TestEvent::Wait { ms: _ } => {
-                            if let Some(ref tx) = test_response_tx {
-                                let _ = tx.send(fission_test_driver::TestResponse::Ok {});
-                            }
+                        TestEvent::Wait { ms: _, response_tx } => {
+                            let _ = response_tx.send(fission_test_driver::TestResponse::Ok {});
                         }
                         TestEvent::Quit => {
                             elwt.exit();
@@ -3861,6 +3858,32 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                             );
                         }
 
+                        let next_vello_image_generation =
+                            fission_render_vello::image_cache_generation();
+                        let next_software_image_generation =
+                            software_renderer::image_cache_generation();
+                        let image_cache_changed = next_vello_image_generation
+                            != vello_image_cache_generation
+                            || next_software_image_generation != software_image_cache_generation;
+                        if image_cache_changed {
+                            vello_image_cache_generation = next_vello_image_generation;
+                            software_image_cache_generation = next_software_image_generation;
+                            #[cfg(not(target_arch = "wasm32"))]
+                            retained_scene_cache.clear();
+                            invalidations.mark_paint();
+                            request_redraw_logged(
+                                &window,
+                                elwt,
+                                &mut last_redraw_at,
+                                min_frame,
+                                &mut redraw_pending,
+                                &mut frame_trace,
+                                "image_cache",
+                            );
+                        }
+                        let image_cache_pending = fission_render_vello::image_cache_has_pending()
+                            || software_renderer::image_cache_has_pending();
+
                         // When a frame_hook is registered, ensure the event loop
                         // wakes at least every 2 seconds so the hook fires even
                         // when no user input or animation is happening (e.g. for
@@ -3873,6 +3896,7 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
 
                         let has_pending_work = effect_results_dispatched
                             || frame_hook_wants_redraw
+                            || image_cache_changed
                             || invalidations.any()
                             || resize_unsettled
                             || pending_capture_settle;
@@ -3983,6 +4007,9 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                 }
                             }
                             elwt.set_control_flow(ControlFlow::WaitUntil(wake_at));
+                        } else if image_cache_pending {
+                            let wake_at = now + Duration::from_millis(50);
+                            elwt.set_control_flow(ControlFlow::WaitUntil(wake_at));
                         } else if let Some(blink_at) = blink_wake_at {
                             let reasons = frame_trace.take_redraw_reasons();
                             frame_trace.emit(
@@ -4022,7 +4049,7 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                 "schedule=idle pending_resize=false redraw_pending=false highest=none",
                             );
                             #[cfg(target_os = "android")]
-                            if test_response_tx.is_some() {
+                            if test_control_enabled {
                                 elwt.set_control_flow(ControlFlow::Poll);
                             } else {
                                 elwt.set_control_flow(ControlFlow::WaitUntil(
@@ -4531,6 +4558,7 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                             if capture_ready {
                                                 pending_capture_settle = false;
                                                 let _ = pending_screenshot_path.take();
+                                                let _ = pending_screenshot_response_tx.take();
                                             }
 
                                             pending_resize = None;
@@ -4800,7 +4828,9 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                                         layout_size_to_image_dimensions(
                                                             target_viewport,
                                                         );
-                                                    if let Some(ref tx) = test_response_tx {
+                                                    if let Some(tx) =
+                                                        pending_screenshot_response_tx.take()
+                                                    {
                                                         if path == "__pump__" {
                                                             let _ = tx.send(
                                                             fission_test_driver::TestResponse::Ok {},

--- a/crates/shell/fission-shell-winit/src/pipeline.rs
+++ b/crates/shell/fission-shell-winit/src/pipeline.rs
@@ -2087,6 +2087,25 @@ fn build_local_paint_list(
                 annotations,
             });
         }
+        Op::Paint(fission_ir::PaintOp::DrawImage {
+            request,
+            fit,
+            alignment,
+        }) => {
+            list.push(DisplayOp::DrawImage {
+                rect,
+                request: request.clone(),
+                fit: match fit {
+                    fission_ir::op::ImageFit::Contain => fission_render::ImageFit::Contain,
+                    fission_ir::op::ImageFit::Cover => fission_render::ImageFit::Cover,
+                    fission_ir::op::ImageFit::Fill => fission_render::ImageFit::Fill,
+                    fission_ir::op::ImageFit::None => fission_render::ImageFit::None,
+                },
+                alignment: *alignment,
+                bounds: rect,
+                node_id: Some(node_id),
+            });
+        }
         Op::Paint(fission_ir::PaintOp::DrawPath { path, fill, stroke }) => {
             list.push(DisplayOp::DrawPath {
                 path: path.clone(),
@@ -2368,7 +2387,10 @@ mod tests {
     use fission_core::env::Env;
     use fission_core::registry::AnimationPropertyId;
     use fission_core::ScrollStateMap;
-    use fission_ir::op::{Color, Fill, RichTextAnnotation, TextRun, TextStyle};
+    use fission_ir::op::{
+        Color, Fill, ImageAlignment, ImageFit, ImageRequest, ImageSource, RichTextAnnotation,
+        TextRun, TextStyle,
+    };
     use fission_ir::semantics::ActionTrigger;
     use fission_ir::{
         ActionEntry, CompositeScalar, CompositeStyle, CoreIR, EmbedKind, LayoutOp, NodeId, Op,
@@ -2556,6 +2578,147 @@ mod tests {
             }
             other => panic!("expected rich text op, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn draw_image_paint_ops_flow_into_display_ops() {
+        let node_id = NodeId::derived(12, &[0]);
+        let request = ImageRequest {
+            source: ImageSource::Network {
+                url: "https://example.com/product.webp".into(),
+                headers: Vec::new(),
+                cache_policy: Default::default(),
+            },
+            cache_width: Some(220),
+            cache_height: Some(160),
+            semantic_label: Some("Product thumbnail".into()),
+            ..Default::default()
+        };
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            node_id,
+            Op::Paint(PaintOp::DrawImage {
+                request: request.clone(),
+                fit: ImageFit::Cover,
+                alignment: ImageAlignment::Center,
+            }),
+            vec![],
+        );
+
+        let node = ir.nodes.get(&node_id).expect("image node");
+        let rect = LayoutRect::new(24.0, 32.0, 220.0, 160.0);
+        let list = build_local_paint_list(&ir, node_id, node, rect).expect("display list");
+
+        match list.ops.first() {
+            Some(DisplayOp::DrawImage {
+                rect: image_rect,
+                request: image_request,
+                fit,
+                alignment,
+                bounds,
+                node_id: Some(image_node_id),
+            }) => {
+                assert_eq!(*image_rect, rect);
+                assert_eq!(image_request, &request);
+                assert_eq!(*fit, fission_render::ImageFit::Cover);
+                assert_eq!(*alignment, ImageAlignment::Center);
+                assert_eq!(*bounds, rect);
+                assert_eq!(*image_node_id, node_id);
+            }
+            other => panic!("expected image display op, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retained_pipeline_scene_keeps_draw_image_ops() {
+        let image_id = NodeId::derived(13, &[0]);
+        let root_id = NodeId::derived(13, &[1]);
+        let request = ImageRequest {
+            source: ImageSource::Network {
+                url: "https://example.com/catalog/thumbnail.webp".into(),
+                headers: Vec::new(),
+                cache_policy: Default::default(),
+            },
+            semantic_label: Some("Catalog thumbnail".into()),
+            ..Default::default()
+        };
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            image_id,
+            Op::Paint(PaintOp::DrawImage {
+                request: request.clone(),
+                fit: ImageFit::Cover,
+                alignment: ImageAlignment::Center,
+            }),
+            vec![],
+        );
+        ir.add_node(
+            root_id,
+            Op::Layout(LayoutOp::Box {
+                width: Some(220.0),
+                height: Some(160.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0, 0.0, 0.0, 0.0],
+                flex_grow: 0.0,
+                flex_shrink: 0.0,
+                aspect_ratio: None,
+            }),
+            vec![image_id],
+        );
+        ir.set_root(root_id);
+
+        let mut pipeline = Pipeline::new();
+        let mut layout_engine = LayoutEngine::new();
+        let scroll = ScrollStateMap::default();
+        pipeline.replace_ir(ir, &Env::default());
+        pipeline
+            .ensure_layout(
+                LayoutRect::new(0.0, 0.0, 320.0, 240.0),
+                &mut layout_engine,
+                &scroll,
+            )
+            .unwrap();
+        pipeline
+            .prepare_current(
+                LayoutSize {
+                    width: 320.0,
+                    height: 240.0,
+                },
+                LayoutSize {
+                    width: 320.0,
+                    height: 240.0,
+                },
+                false,
+                &scroll,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+
+        let display_list = pipeline.retained_scene().expect("retained scene").flatten();
+        let image_op = display_list.ops.iter().find_map(|op| match op {
+            DisplayOp::DrawImage {
+                rect,
+                request: image_request,
+                fit,
+                alignment,
+                ..
+            } => Some((rect, image_request, fit, alignment)),
+            _ => None,
+        });
+
+        let Some((rect, image_request, fit, alignment)) = image_op else {
+            panic!("retained scene dropped DrawImage op");
+        };
+        assert_eq!(image_request, &request);
+        assert_eq!(*fit, fission_render::ImageFit::Cover);
+        assert_eq!(*alignment, ImageAlignment::Center);
+        assert_eq!(rect.size.width, 220.0);
+        assert_eq!(rect.size.height, 160.0);
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/software_renderer.rs
+++ b/crates/shell/fission-shell-winit/src/software_renderer.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use fission_ir::op::{HttpHeader, ImageAlignment, ImageRequest, ImageSource};
 use fission_render::{
     surface_placeholder_color, Color as RenderColor, DisplayList, DisplayOp, Fill, ImageFit,
     LineCap, LineJoin, RenderScene, Stroke, TextRun,
@@ -9,9 +10,13 @@ use fontdue::{
 };
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::fs;
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::Read;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex, OnceLock,
+};
 use tiny_skia::{
     Color, FillRule as TinyFillRule, FilterQuality, GradientStop, LineCap as TinyLineCap,
     LineJoin as TinyLineJoin, Mask, Paint, Path, PathBuilder, Pixmap, PixmapPaint, Point,
@@ -45,8 +50,16 @@ enum SvgShape {
 }
 
 static DEFAULT_FONT: OnceLock<Font> = OnceLock::new();
-static IMAGE_CACHE: OnceLock<Mutex<HashMap<String, Arc<Pixmap>>>> = OnceLock::new();
+static IMAGE_CACHE: OnceLock<Mutex<HashMap<String, ImageCacheEntry>>> = OnceLock::new();
 static SVG_CACHE: OnceLock<Mutex<HashMap<u64, Arc<SvgCacheEntry>>>> = OnceLock::new();
+static IMAGE_CACHE_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone)]
+enum ImageCacheEntry {
+    Ready(Arc<Pixmap>),
+    Loading,
+    Failed,
+}
 
 fn default_font() -> &'static Font {
     DEFAULT_FONT.get_or_init(|| {
@@ -58,8 +71,20 @@ fn default_font() -> &'static Font {
     })
 }
 
-fn image_cache() -> &'static Mutex<HashMap<String, Arc<Pixmap>>> {
+fn image_cache() -> &'static Mutex<HashMap<String, ImageCacheEntry>> {
     IMAGE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn image_cache_generation() -> u64 {
+    IMAGE_CACHE_GENERATION.load(Ordering::Acquire)
+}
+
+pub(crate) fn image_cache_has_pending() -> bool {
+    image_cache()
+        .lock()
+        .unwrap()
+        .values()
+        .any(|entry| matches!(entry, ImageCacheEntry::Loading))
 }
 
 fn svg_cache() -> &'static Mutex<HashMap<u64, Arc<SvgCacheEntry>>> {
@@ -309,22 +334,381 @@ fn wrap_max_width(bounds_width: f32, font_size: f32, wrap: bool) -> Option<f32> 
     Some(bounds_width.ceil() + font_size * 0.5)
 }
 
-fn cached_image(path: &str) -> Option<Arc<Pixmap>> {
-    if let Some(image) = image_cache().lock().unwrap().get(path) {
-        return Some(Arc::clone(image));
+fn cached_image(request: &ImageRequest) -> Option<Arc<Pixmap>> {
+    let key = request.stable_cache_key();
+    {
+        let mut cache = image_cache().lock().unwrap();
+        if let Some(entry) = cache.get(&key) {
+            return match entry {
+                ImageCacheEntry::Ready(image) => Some(Arc::clone(image)),
+                ImageCacheEntry::Loading | ImageCacheEntry::Failed => None,
+            };
+        }
+        cache.insert(key.clone(), ImageCacheEntry::Loading);
     }
 
-    let data = fs::read(path).ok()?;
-    let dyn_img = image::load_from_memory(&data).ok()?;
-    let rgba = dyn_img.to_rgba8();
+    spawn_image_load(key, request.clone());
+    None
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn decode_image_from_path(
+    path: &str,
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<Pixmap>> {
+    image::open(path)
+        .ok()
+        .and_then(|image| decode_dynamic_image(image, cache_width, cache_height))
+}
+
+fn decode_image_from_bytes(
+    bytes: &[u8],
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<Pixmap>> {
+    image::load_from_memory(bytes)
+        .ok()
+        .and_then(|image| decode_dynamic_image(image, cache_width, cache_height))
+}
+
+fn decode_dynamic_image(
+    mut image: image::DynamicImage,
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<Pixmap>> {
+    if let (Some(width), Some(height)) = (cache_width, cache_height) {
+        if width > 0 && height > 0 {
+            image = image.resize(width, height, image::imageops::FilterType::Triangle);
+        }
+    }
+    let rgba = image.to_rgba8();
     let (width, height) = rgba.dimensions();
     let size = tiny_skia::IntSize::from_wh(width, height)?;
-    let pixmap = Pixmap::from_vec(rgba.into_raw(), size)?;
-    let pixmap = Arc::new(pixmap);
+    Pixmap::from_vec(rgba.into_raw(), size).map(Arc::new)
+}
 
+fn complete_image_load(key: String, image: Option<Arc<Pixmap>>) {
     let mut cache = image_cache().lock().unwrap();
-    cache.insert(path.to_string(), Arc::clone(&pixmap));
-    Some(pixmap)
+    cache.insert(
+        key,
+        image
+            .map(ImageCacheEntry::Ready)
+            .unwrap_or(ImageCacheEntry::Failed),
+    );
+    IMAGE_CACHE_GENERATION.fetch_add(1, Ordering::AcqRel);
+}
+
+fn aligned_offset(extra_width: f32, extra_height: f32, alignment: ImageAlignment) -> (f32, f32) {
+    let x = match alignment {
+        ImageAlignment::TopStart | ImageAlignment::CenterStart | ImageAlignment::BottomStart => 0.0,
+        ImageAlignment::TopCenter | ImageAlignment::Center | ImageAlignment::BottomCenter => {
+            extra_width / 2.0
+        }
+        ImageAlignment::TopEnd | ImageAlignment::CenterEnd | ImageAlignment::BottomEnd => {
+            extra_width
+        }
+    };
+    let y = match alignment {
+        ImageAlignment::TopStart | ImageAlignment::TopCenter | ImageAlignment::TopEnd => 0.0,
+        ImageAlignment::CenterStart | ImageAlignment::Center | ImageAlignment::CenterEnd => {
+            extra_height / 2.0
+        }
+        ImageAlignment::BottomStart | ImageAlignment::BottomCenter | ImageAlignment::BottomEnd => {
+            extra_height
+        }
+    };
+    (x, y)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_image_load(key: String, request: ImageRequest) {
+    std::thread::spawn(move || {
+        let image = match request.source {
+            ImageSource::Asset { path } | ImageSource::File { path } => {
+                decode_image_from_path(&path, request.cache_width, request.cache_height)
+            }
+            ImageSource::Memory { bytes, .. } => {
+                decode_image_from_bytes(&bytes, request.cache_width, request.cache_height)
+            }
+            ImageSource::Network { url, headers, .. } => {
+                fetch_network_image(&url, headers, request.cache_width, request.cache_height)
+            }
+            ImageSource::SvgText { .. } => None,
+        };
+        complete_image_load(key, image);
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn spawn_image_load(key: String, request: ImageRequest) {
+    match request.source {
+        ImageSource::Memory { bytes, .. } => {
+            let image = decode_image_from_bytes(&bytes, request.cache_width, request.cache_height);
+            complete_image_load(key, image);
+        }
+        ImageSource::Asset { path } => {
+            wasm_bindgen_futures::spawn_local(async move {
+                let image = fetch_wasm_image_bytes(&path, Vec::new())
+                    .await
+                    .and_then(|bytes| {
+                        decode_image_from_bytes(&bytes, request.cache_width, request.cache_height)
+                    });
+                complete_image_load(key, image);
+            });
+        }
+        ImageSource::Network { url, headers, .. } => {
+            wasm_bindgen_futures::spawn_local(async move {
+                let image = fetch_wasm_image_bytes(&url, headers)
+                    .await
+                    .and_then(|bytes| {
+                        decode_image_from_bytes(&bytes, request.cache_width, request.cache_height)
+                    });
+                complete_image_load(key, image);
+            });
+        }
+        ImageSource::File { .. } | ImageSource::SvgText { .. } => {
+            complete_image_load(key, None);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn fetch_wasm_image_bytes(url: &str, headers: Vec<HttpHeader>) -> Option<Vec<u8>> {
+    use wasm_bindgen::JsCast;
+
+    let window = web_sys::window()?;
+    let init = web_sys::RequestInit::new();
+    init.set_method("GET");
+    init.set_mode(web_sys::RequestMode::Cors);
+    let request = web_sys::Request::new_with_str_and_init(url, &init).ok()?;
+    for header in headers {
+        request.headers().set(&header.name, &header.value).ok()?;
+    }
+    let response = wasm_bindgen_futures::JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .ok()?;
+    let response = response.dyn_into::<web_sys::Response>().ok()?;
+    if !response.ok() {
+        return None;
+    }
+    let buffer = wasm_bindgen_futures::JsFuture::from(response.array_buffer().ok()?)
+        .await
+        .ok()?;
+    let bytes = js_sys::Uint8Array::new(&buffer);
+    let mut out = vec![0; bytes.length() as usize];
+    bytes.copy_to(&mut out);
+    Some(out)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn fetch_network_image(
+    url: &str,
+    headers: Vec<HttpHeader>,
+    cache_width: Option<u32>,
+    cache_height: Option<u32>,
+) -> Option<Arc<Pixmap>> {
+    let mut request = ureq::get(url).set("User-Agent", "FissionImageLoader/0.2");
+    for header in headers {
+        request = request.set(&header.name, &header.value);
+    }
+    request
+        .call()
+        .ok()
+        .and_then(|response| {
+            let mut bytes = Vec::new();
+            response.into_reader().read_to_end(&mut bytes).ok()?;
+            image::load_from_memory(&bytes).ok()
+        })
+        .and_then(|image| decode_dynamic_image(image, cache_width, cache_height))
+}
+
+#[cfg(test)]
+mod image_tests {
+    use super::*;
+    use std::io::Cursor;
+    use std::net::TcpListener;
+    use std::time::{Duration, Instant};
+
+    fn tiny_png() -> Vec<u8> {
+        let image = image::RgbaImage::from_pixel(1, 1, image::Rgba([0, 128, 255, 255]));
+        let mut bytes = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(image)
+            .write_to(&mut bytes, image::ImageFormat::Png)
+            .expect("encode png");
+        bytes.into_inner()
+    }
+
+    fn solid_png(width: u32, height: u32, rgba: [u8; 4]) -> Vec<u8> {
+        let image = image::RgbaImage::from_pixel(width, height, image::Rgba(rgba));
+        let mut bytes = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(image)
+            .write_to(&mut bytes, image::ImageFormat::Png)
+            .expect("encode png");
+        bytes.into_inner()
+    }
+
+    fn serve_once(body: Vec<u8>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test image server");
+        let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut request = [0_u8; 1024];
+            let _ = std::io::Read::read(&mut stream, &mut request);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = std::io::Write::write_all(&mut stream, response.as_bytes());
+            let _ = std::io::Write::write_all(&mut stream, &body);
+            let _ = std::io::Write::flush(&mut stream);
+        });
+        url
+    }
+
+    #[test]
+    fn memory_image_load_populates_cache_off_thread() {
+        let request = ImageRequest {
+            source: ImageSource::Memory {
+                bytes: tiny_png(),
+                mime_type: Some("image/png".into()),
+            },
+            cache_width: Some(1),
+            cache_height: Some(1),
+            ..Default::default()
+        };
+        let key = request.stable_cache_key();
+        image_cache().lock().unwrap().remove(&key);
+        let before = image_cache_generation();
+
+        spawn_image_load(key.clone(), request);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while image_cache_generation() == before && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let cache = image_cache().lock().unwrap();
+        let Some(ImageCacheEntry::Ready(image)) = cache.get(&key) else {
+            panic!("expected decoded image in cache");
+        };
+        assert_eq!(image.width(), 1);
+        assert_eq!(image.height(), 1);
+    }
+
+    #[test]
+    fn network_image_fetch_decodes_png_response() {
+        let url = serve_once(tiny_png());
+        let image = fetch_network_image(&url, Vec::new(), Some(1), Some(1))
+            .expect("fetch and decode test image");
+
+        assert_eq!(image.width(), 1);
+        assert_eq!(image.height(), 1);
+    }
+
+    #[test]
+    fn cached_image_request_paints_visible_pixels() {
+        let request = ImageRequest {
+            source: ImageSource::Memory {
+                bytes: tiny_png(),
+                mime_type: Some("image/png".into()),
+            },
+            cache_width: Some(1),
+            cache_height: Some(1),
+            ..Default::default()
+        };
+        let key = request.stable_cache_key();
+        image_cache().lock().unwrap().remove(&key);
+        let before = image_cache_generation();
+        spawn_image_load(key.clone(), request.clone());
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while image_cache_generation() == before && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let rect = fission_render::LayoutRect::new(0.0, 0.0, 4.0, 4.0);
+        let mut display_list = DisplayList::new(rect);
+        display_list.push(DisplayOp::DrawImage {
+            rect,
+            request,
+            fit: ImageFit::Fill,
+            alignment: ImageAlignment::Center,
+            bounds: rect,
+            node_id: None,
+        });
+        let scene = RenderScene::from_display_list(display_list);
+        let transparent = RenderColor {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        };
+        let pixels = SoftwareRenderer::render(&scene, 4, 4, transparent, 1.0)
+            .expect("render software image scene");
+
+        assert!(
+            pixels
+                .chunks_exact(4)
+                .any(|pixel| pixel[3] > 0 && (pixel[0] > 0 || pixel[1] > 0 || pixel[2] > 0)),
+            "expected image draw to produce visible non-transparent pixels"
+        );
+    }
+
+    #[test]
+    fn cover_image_draw_is_clipped_to_destination_rect() {
+        let request = ImageRequest {
+            source: ImageSource::Memory {
+                bytes: solid_png(4, 2, [255, 0, 0, 255]),
+                mime_type: Some("image/png".into()),
+            },
+            ..Default::default()
+        };
+        let key = request.stable_cache_key();
+        image_cache().lock().unwrap().remove(&key);
+        let before = image_cache_generation();
+        spawn_image_load(key.clone(), request.clone());
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while image_cache_generation() == before && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let bounds = fission_render::LayoutRect::new(0.0, 0.0, 10.0, 10.0);
+        let rect = fission_render::LayoutRect::new(4.0, 4.0, 2.0, 2.0);
+        let mut display_list = DisplayList::new(bounds);
+        display_list.push(DisplayOp::DrawImage {
+            rect,
+            request,
+            fit: ImageFit::Cover,
+            alignment: ImageAlignment::Center,
+            bounds: rect,
+            node_id: None,
+        });
+        let scene = RenderScene::from_display_list(display_list);
+        let transparent = RenderColor {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        };
+        let pixels = SoftwareRenderer::render(&scene, 10, 10, transparent, 1.0)
+            .expect("render clipped cover image");
+
+        let pixel_at = |x: usize, y: usize| {
+            let start = (y * 10 + x) * 4;
+            &pixels[start..start + 4]
+        };
+
+        assert_eq!(pixel_at(3, 4), &[0, 0, 0, 0]);
+        assert_eq!(pixel_at(6, 4), &[0, 0, 0, 0]);
+        assert!(
+            pixel_at(4, 4)[3] > 0 && pixel_at(4, 4)[0] > 0,
+            "expected destination rect to contain image pixels"
+        );
+    }
 }
 
 pub struct SoftwareRenderer {
@@ -466,6 +850,24 @@ impl SoftwareRenderer {
         }
     }
 
+    fn with_temporary_clip_rect<F>(
+        &mut self,
+        rect: fission_render::LayoutRect,
+        draw: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(&mut Self) -> Result<()>,
+    {
+        let Some(path) = rect_path(rect) else {
+            return Ok(());
+        };
+        self.push_state();
+        self.ensure_clip_path(&path);
+        let result = draw(self);
+        self.pop_state();
+        result
+    }
+
     fn start_opacity_layer(&mut self, alpha: f32) -> Result<()> {
         let mut layer = Pixmap::new(self.width, self.height)
             .ok_or_else(|| anyhow!("failed to allocate software layer"))?;
@@ -546,9 +948,13 @@ impl SoftwareRenderer {
                     self.draw_rich_text(runs, *position, *bounds, *wrap)?;
                 }
                 DisplayOp::DrawImage {
-                    rect, source, fit, ..
+                    rect,
+                    request,
+                    fit,
+                    alignment,
+                    ..
                 } => {
-                    self.draw_image(*rect, source, *fit)?;
+                    self.draw_image(*rect, request, *fit, *alignment)?;
                 }
                 DisplayOp::DrawPath {
                     path,
@@ -808,10 +1214,11 @@ impl SoftwareRenderer {
     fn draw_image(
         &mut self,
         rect: fission_render::LayoutRect,
-        source: &str,
+        request: &ImageRequest,
         fit: ImageFit,
+        alignment: ImageAlignment,
     ) -> Result<()> {
-        let image = match cached_image(source) {
+        let image = match cached_image(request) {
             Some(image) => image,
             None => return Ok(()),
         };
@@ -829,22 +1236,24 @@ impl SoftwareRenderer {
                 let scale = (rect_w / img_w).min(rect_h / img_h);
                 let w = img_w * scale;
                 let h = img_h * scale;
+                let (offset_x, offset_y) = aligned_offset(rect_w - w, rect_h - h, alignment);
                 (
                     scale,
                     scale,
-                    rect.origin.x + (rect_w - w) / 2.0,
-                    rect.origin.y + (rect_h - h) / 2.0,
+                    rect.origin.x + offset_x,
+                    rect.origin.y + offset_y,
                 )
             }
             ImageFit::Cover => {
                 let scale = (rect_w / img_w).max(rect_h / img_h);
                 let w = img_w * scale;
                 let h = img_h * scale;
+                let (offset_x, offset_y) = aligned_offset(rect_w - w, rect_h - h, alignment);
                 (
                     scale,
                     scale,
-                    rect.origin.x + (rect_w - w) / 2.0,
-                    rect.origin.y + (rect_h - h) / 2.0,
+                    rect.origin.x + offset_x,
+                    rect.origin.y + offset_y,
                 )
             }
             ImageFit::None => (1.0, 1.0, rect.origin.x, rect.origin.y),
@@ -855,19 +1264,21 @@ impl SoftwareRenderer {
             .transform
             .post_translate(dx, dy)
             .post_scale(scale_x, scale_y);
-        let clip = self.current_clip().cloned();
-        let surface = self.current_surface_mut();
-        let mut paint = PixmapPaint::default();
-        paint.quality = FilterQuality::Bilinear;
-        surface.draw_pixmap(
-            0,
-            0,
-            image.as_ref().as_ref(),
-            &paint,
-            transform,
-            clip.as_ref(),
-        );
-        Ok(())
+        self.with_temporary_clip_rect(rect, |this| {
+            let clip = this.current_clip().cloned();
+            let surface = this.current_surface_mut();
+            let mut paint = PixmapPaint::default();
+            paint.quality = FilterQuality::Bilinear;
+            surface.draw_pixmap(
+                0,
+                0,
+                image.as_ref().as_ref(),
+                &paint,
+                transform,
+                clip.as_ref(),
+            );
+            Ok(())
+        })
     }
 
     fn draw_path(

--- a/crates/shell/fission-shell-winit/src/test_control.rs
+++ b/crates/shell/fission-shell-winit/src/test_control.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Mutex};
 use winit::event_loop::EventLoopProxy;
 
 /// Sender for query responses from the main event loop back to the TCP server.
-pub type ResponseSender = mpsc::Sender<TestResponse>;
+pub type ResponseSender = fission_test_driver::TestResponseSender;
 /// Receiver for query responses.
 pub type ResponseReceiver = mpsc::Receiver<TestResponse>;
 /// Shared queue used on platforms where winit user events are unreliable.
@@ -33,15 +33,6 @@ pub enum EventInjector {
     },
 }
 
-/// Create a (sender, receiver) pair for query responses.
-///
-/// The sender is stored by the main event loop; when a query `TestEvent`
-/// (GetText, GetTree, Screenshot, etc.) is handled it sends the result
-/// through this channel. The TCP server thread waits on the receiver.
-pub fn create_response_channel() -> (ResponseSender, ResponseReceiver) {
-    mpsc::channel()
-}
-
 #[cfg(not(target_arch = "wasm32"))]
 pub fn create_pending_event_queue() -> PendingEventQueue {
     Arc::new(Mutex::new(VecDeque::new()))
@@ -49,11 +40,7 @@ pub fn create_pending_event_queue() -> PendingEventQueue {
 
 /// Spawn the TCP test-control server.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn spawn_server(
-    port: u16,
-    injector: EventInjector,
-    response_rx: ResponseReceiver,
-) -> std::thread::JoinHandle<()> {
+pub fn spawn_server(port: u16, injector: EventInjector) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
             .unwrap_or_else(|e| panic!("failed to bind test control port {}: {}", port, e));
@@ -61,7 +48,7 @@ pub fn spawn_server(
 
         for stream in listener.incoming() {
             match stream {
-                Ok(stream) => handle_connection(stream, &injector, &response_rx),
+                Ok(stream) => handle_connection(stream, &injector),
                 Err(e) => eprintln!("[fission-test-control] accept error: {}", e),
             }
         }
@@ -69,11 +56,7 @@ pub fn spawn_server(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn handle_connection(
-    mut stream: TcpStream,
-    injector: &EventInjector,
-    response_rx: &ResponseReceiver,
-) {
+fn handle_connection(mut stream: TcpStream, injector: &EventInjector) {
     let mut buf = Vec::new();
     let mut tmp = [0u8; 4096];
 
@@ -144,16 +127,12 @@ fn handle_connection(
         }
     };
 
-    let response = dispatch_command(cmd, injector, response_rx);
+    let response = dispatch_command(cmd, injector);
     send_http_response(&mut stream, 200, &serde_json::to_string(&response).unwrap());
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn dispatch_command(
-    cmd: TestCommand,
-    injector: &EventInjector,
-    response_rx: &ResponseReceiver,
-) -> TestResponse {
+fn dispatch_command(cmd: TestCommand, injector: &EventInjector) -> TestResponse {
     match cmd {
         TestCommand::Tap { x, y } => {
             inject_event(injector, TestEvent::MouseMove { x, y });
@@ -200,10 +179,10 @@ fn dispatch_command(
             );
             TestResponse::Ok {}
         }
-        TestCommand::TapText { text } => {
-            inject_event(injector, TestEvent::TapText { text });
-            wait_for_response(response_rx)
-        }
+        TestCommand::TapText { text } => query_event(injector, |response_tx| TestEvent::TapText {
+            text,
+            response_tx,
+        }),
         TestCommand::Scroll { x, y, dx, dy } => {
             inject_event(injector, TestEvent::Scroll { x, y, dx, dy });
             TestResponse::Ok {}
@@ -229,29 +208,24 @@ fn dispatch_command(
             );
             TestResponse::Ok {}
         }
-        TestCommand::Screenshot { path } => {
-            inject_event(injector, TestEvent::Screenshot { path });
-            wait_for_response(response_rx)
-        }
-        TestCommand::CaptureScreenshot {} => {
-            inject_event(injector, TestEvent::CaptureScreenshot);
-            wait_for_response(response_rx)
-        }
+        TestCommand::Screenshot { path } => query_event(injector, |response_tx| {
+            TestEvent::Screenshot { path, response_tx }
+        }),
+        TestCommand::CaptureScreenshot {} => query_event(injector, |response_tx| {
+            TestEvent::CaptureScreenshot { response_tx }
+        }),
         TestCommand::GetText {} => {
-            inject_event(injector, TestEvent::GetText);
-            wait_for_response(response_rx)
+            query_event(injector, |response_tx| TestEvent::GetText { response_tx })
         }
         TestCommand::GetTree {} => {
-            inject_event(injector, TestEvent::GetTree);
-            wait_for_response(response_rx)
+            query_event(injector, |response_tx| TestEvent::GetTree { response_tx })
         }
         TestCommand::Wait { ms } => {
             std::thread::sleep(std::time::Duration::from_millis(ms));
             TestResponse::Ok {}
         }
         TestCommand::Pump {} => {
-            inject_event(injector, TestEvent::Pump);
-            wait_for_response(response_rx)
+            query_event(injector, |response_tx| TestEvent::Pump { response_tx })
         }
         TestCommand::Quit {} => {
             inject_event(injector, TestEvent::Quit);
@@ -272,6 +246,16 @@ fn dispatch_command(
             TestResponse::Ok {}
         }
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn query_event<F>(injector: &EventInjector, make_event: F) -> TestResponse
+where
+    F: FnOnce(ResponseSender) -> TestEvent,
+{
+    let (response_tx, response_rx) = mpsc::channel();
+    inject_event(injector, make_event(response_tx));
+    wait_for_response(&response_rx)
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/tools/fission-test-driver/src/lib.rs
+++ b/crates/tools/fission-test-driver/src/lib.rs
@@ -129,21 +129,32 @@ pub enum TestEvent {
     // --- Queries / control (need response channel) ---
     Screenshot {
         path: String,
+        response_tx: TestResponseSender,
     },
-    CaptureScreenshot,
-    GetText,
-    GetTree,
-    Pump,
+    CaptureScreenshot {
+        response_tx: TestResponseSender,
+    },
+    GetText {
+        response_tx: TestResponseSender,
+    },
+    GetTree {
+        response_tx: TestResponseSender,
+    },
+    Pump {
+        response_tx: TestResponseSender,
+    },
     Wake,
     Quit,
     /// Internal: TapText resolves a text label to coordinates; the server
     /// injects this so the main loop can do the lookup with access to the IR.
     TapText {
         text: String,
+        response_tx: TestResponseSender,
     },
     /// Internal: Wait is handled server-side (sleep) then responds.
     Wait {
         ms: u64,
+        response_tx: TestResponseSender,
     },
 }
 
@@ -194,6 +205,9 @@ pub enum TestResponse {
         message: String,
     },
 }
+
+/// Per-command response channel used by the shell event loop.
+pub type TestResponseSender = std::sync::mpsc::Sender<TestResponse>;
 
 // --- Client ---
 

--- a/crates/tools/fission-test/src/lib.rs
+++ b/crates/tools/fission-test/src/lib.rs
@@ -802,16 +802,21 @@ fn generate_display_list_with_visited(
                         node_id: Some(node_id),
                     });
                 }
-                fission_ir::Op::Paint(fission_ir::PaintOp::DrawImage { source, fit }) => {
+                fission_ir::Op::Paint(fission_ir::PaintOp::DrawImage {
+                    request,
+                    fit,
+                    alignment,
+                }) => {
                     list.push(DisplayOp::DrawImage {
                         rect: geom.rect,
-                        source: source.clone(),
+                        request: request.clone(),
                         fit: match fit {
                             fission_ir::op::ImageFit::Contain => fission_render::ImageFit::Contain,
                             fission_ir::op::ImageFit::Cover => fission_render::ImageFit::Cover,
                             fission_ir::op::ImageFit::Fill => fission_render::ImageFit::Fill,
                             fission_ir::op::ImageFit::None => fission_render::ImageFit::None,
                         },
+                        alignment: *alignment,
                         bounds: geom.rect,
                         node_id: Some(node_id),
                     });

--- a/crates/tools/fission-test/tests/media.rs
+++ b/crates/tools/fission-test/tests/media.rs
@@ -1,9 +1,9 @@
 use fission_core::ui::Image;
 use fission_core::AppState;
+use fission_ir::op::{ImageAlignment, ImageFit};
 use fission_render::DisplayOp;
 use fission_test::TestHarness;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct DummyState;
@@ -13,12 +13,7 @@ impl AppState for DummyState {}
 fn test_image_render_op() {
     let mut harness = TestHarness::new(DummyState);
 
-    harness = harness.with_root_widget(Image {
-        source: "test.png".into(),
-        width: Some(100.0),
-        height: Some(100.0),
-        ..Default::default()
-    });
+    harness = harness.with_root_widget(Image::asset("test.png").size(100.0, 100.0));
 
     harness.pump().expect("Pump failed");
 
@@ -26,8 +21,11 @@ fn test_image_render_op() {
 
     let mut found_image = false;
     for op in dl.ops {
-        if let DisplayOp::DrawImage { source, rect, .. } = op {
-            if source == "test.png" && rect.width() == 100.0 && rect.height() == 100.0 {
+        if let DisplayOp::DrawImage { request, rect, .. } = op {
+            if request.source.local_path() == Some("test.png")
+                && rect.width() == 100.0
+                && rect.height() == 100.0
+            {
                 found_image = true;
             }
         }
@@ -37,23 +35,58 @@ fn test_image_render_op() {
 }
 
 #[test]
+fn test_network_image_render_op_preserves_request_and_fit() {
+    let mut harness = TestHarness::new(DummyState);
+
+    harness = harness.with_root_widget(
+        Image::network("https://cdn.example.com/product.webp")
+            .size(220.0, 160.0)
+            .cache_size(440, 320)
+            .semantic_label("Product thumbnail")
+            .fit(ImageFit::Cover)
+            .alignment(ImageAlignment::TopCenter),
+    );
+
+    harness.pump().expect("Pump failed");
+
+    let dl = harness.get_last_display_list().expect("No display list");
+    let image = dl.ops.into_iter().find_map(|op| match op {
+        DisplayOp::DrawImage {
+            request,
+            rect,
+            fit,
+            alignment,
+            ..
+        } => Some((request, rect, fit, alignment)),
+        _ => None,
+    });
+
+    let Some((request, rect, fit, alignment)) = image else {
+        panic!("DrawImage op not found for network image");
+    };
+    assert_eq!(
+        request.source.network_url(),
+        Some("https://cdn.example.com/product.webp")
+    );
+    assert_eq!(request.cache_width, Some(440));
+    assert_eq!(request.cache_height, Some(320));
+    assert_eq!(request.semantic_label.as_deref(), Some("Product thumbnail"));
+    assert_eq!(rect.width(), 220.0);
+    assert_eq!(rect.height(), 160.0);
+    assert_eq!(fit, fission_render::ImageFit::Cover);
+    assert_eq!(alignment, ImageAlignment::TopCenter);
+}
+
+#[test]
 fn test_svg_image_render_op() {
     let mut harness = TestHarness::new(DummyState);
 
-    let svg_path =
-        std::env::temp_dir().join(format!("fission-image-test-{}.svg", std::process::id()));
-    let mut file = std::fs::File::create(&svg_path).expect("create temp svg");
-    file.write_all(
-        br#"<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="18" height="8" rx="2"/></svg>"#,
-    )
-    .expect("write temp svg");
-
-    harness = harness.with_root_widget(Image {
-        source: svg_path.to_string_lossy().to_string(),
-        width: Some(120.0),
-        height: Some(60.0),
-        ..Default::default()
-    });
+    harness = harness.with_root_widget(
+        Image::svg_text(
+            r#"<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="18" height="8" rx="2"/></svg>"#,
+        )
+        .size(120.0, 60.0),
+    );
 
     harness.pump().expect("Pump failed");
 
@@ -70,8 +103,6 @@ fn test_svg_image_render_op() {
             }
         }
     }
-
-    std::fs::remove_file(&svg_path).ok();
 
     assert!(found_svg, "DrawSvg op not found or incorrect for svg image");
 }

--- a/documentation/content/reference/widgets/catalog.mdx
+++ b/documentation/content/reference/widgets/catalog.mdx
@@ -109,6 +109,8 @@ These widgets present information once layout and state flow are already clear.
 | `CircularProgress` | [CircularProgress](/reference/widgets/circular-progress) | Circular progress display |
 | `Spinner` | [Spinner](/reference/widgets/spinner) | Indeterminate loading motion |
 | `Skeleton` | [Skeleton](/reference/widgets/skeleton) | Placeholder loading layout |
+| `FutureBuilder` | [FutureBuilder](/reference/widgets/future-builder) | Async job-backed display builder |
+| `RefreshIndicator` | [RefreshIndicator](/reference/widgets/refresh-indicator) | Pull-to-refresh wrapper |
 | `Stat` | [Stat](/reference/widgets/stat) | Labeled metric display |
 | `Stepper` | [Stepper](/reference/widgets/stepper) | Step-by-step process indicator |
 | `Calendar` | [Calendar](/reference/widgets/calendar) | Calendar grid display |

--- a/documentation/content/reference/widgets/display-and-data.mdx
+++ b/documentation/content/reference/widgets/display-and-data.mdx
@@ -40,6 +40,8 @@ Their job is usually to present information, status, metrics, or structured reco
 | `CircularProgress` | [CircularProgress](/reference/widgets/circular-progress) | Show circular progress |
 | `Spinner` | [Spinner](/reference/widgets/spinner) | Show indeterminate activity |
 | `Skeleton` | [Skeleton](/reference/widgets/skeleton) | Reserve visual structure during loading |
+| `FutureBuilder` | [FutureBuilder](/reference/widgets/future-builder) | Declare a one-shot async job and render from an app-owned snapshot |
+| `RefreshIndicator` | [RefreshIndicator](/reference/widgets/refresh-indicator) | Add pull-to-refresh behavior around scrollable content |
 | `Stat` | [Stat](/reference/widgets/stat) | Present one labeled metric clearly |
 | `Stepper` | [Stepper](/reference/widgets/stepper) | Show multi-step progress or flow |
 

--- a/documentation/content/reference/widgets/media.mdx
+++ b/documentation/content/reference/widgets/media.mdx
@@ -13,7 +13,7 @@ Some of these widgets are still ordinary display widgets with a media flavor, su
 
 | Widget | Dedicated page | When to choose it |
 | --- | --- | --- |
-| `Image` | [Image](/reference/widgets/image) | Static image content |
+| `Image` | [Image](/reference/widgets/image) | Asset, file, memory, SVG, or network image content inside normal layout |
 | `Video` | [Video](/reference/widgets/video) | Video playback surface tied to runtime registration |
 | `WebView` | [WebView](/reference/widgets/web-view) | Embedded browser content surface |
 | `TerminalView` | [TerminalView](/reference/widgets/terminal-view) | Interactive terminal surface inside the app |
@@ -32,7 +32,7 @@ Some of these widgets are still ordinary display widgets with a media flavor, su
 
 ## How to choose within this family
 
-Use `Image` when the content is still ordinary image display.
+Use `Image` when the content is still ordinary image display. It supports typed asset, file, network, memory, and SVG sources, and it participates in layout like any other widget.
 
 Move to `Video`, `WebView`, or `TerminalView` when the surface needs runtime registration or host-backed behavior.
 

--- a/documentation/content/reference/widgets/widget-pages/circular-progress.mdx
+++ b/documentation/content/reference/widgets/widget-pages/circular-progress.mdx
@@ -1,13 +1,13 @@
 ---
 title: CircularProgress
-description: Show determinate progress in a compact circular form factor.
+description: Show determinate or indeterminate progress in a compact circular form factor.
 slug: /widgets/circular-progress
 ---
 # CircularProgress
 
 `CircularProgress` is the round progress indicator.
 
-It is useful when progress needs to fit into a small square region such as a sidebar card, dashboard tile, or media status chip. It answers "how far through is this?" without consuming a full row the way a linear bar does.
+It is useful when progress needs to fit into a small square region such as a sidebar card, dashboard tile, media status chip, or refresh affordance. With `value: Some(...)` it answers "how far through is this?". With `value: None` it becomes an indeterminate animated activity indicator.
 
 ## Example
 
@@ -30,17 +30,18 @@ This gives a compact 72 percent progress ring that can sit beside text or a stat
 
 | Field | Type | Meaning | Notes / default behavior |
 | --- | --- | --- | --- |
-| `value` | `Option<f32>` | Progress fraction for the ring. | Use `Some` for determinate progress. `None` means indeterminate intent, but see note below. |
+| `value` | `Option<f32>` | Progress fraction for the ring. | Use `Some(0.0..=1.0)` for determinate progress. Use `None` for indeterminate activity. |
 | `size` | `f32` | Outer width and height of the indicator. | Defaults to `40.0`. |
 | `color` | `Option<Color>` | Indicator arc color override. | Defaults to the theme's primary color. |
 | `track_color` | `Option<Color>` | Background track color override. | Defaults to the theme's border color. |
 | `thickness` | `f32` | Stroke width of the ring. | Defaults to `4.0`. |
+| `animated` | `bool` | Whether indeterminate mode should spin. | Defaults to `true`. Applies when `value` is `None`. |
 
 ## Determinate versus indeterminate behavior
 
-The public contract suggests that `value: None` is the indeterminate mode. In the checked-in implementation, though, that mode currently renders a fixed partial arc rather than a spinning animated indicator. For true indeterminate loading feedback, [`Spinner`](/reference/widgets/spinner) is the better current choice.
+`value: None` is indeterminate mode. The widget draws a partial arc and, when `animated` is true, registers a rotation animation for its `id`. Give each concurrently animated indicator a stable distinct `WidgetNodeId` so their animation state does not collide.
 
-Also note that the widget expects a value in the `0.0` to `1.0` range and does not clamp it internally. Clamp upstream if the data may drift outside that range.
+For determinate progress, pass `Some(fraction)`. The widget expects a value in the `0.0` to `1.0` range and does not clamp it internally. Clamp upstream if the data may drift outside that range.
 
 ## Specific advice
 

--- a/documentation/content/reference/widgets/widget-pages/future-builder.mdx
+++ b/documentation/content/reference/widgets/widget-pages/future-builder.mdx
@@ -1,0 +1,59 @@
+---
+title: FutureBuilder
+description: Declare a one-shot async job resource and build UI from an app-owned snapshot.
+slug: /widgets/future-builder
+---
+# FutureBuilder
+
+`FutureBuilder` connects a screen to one async job and lets the widget tree render from the latest snapshot held in application state.
+
+Use it when a screen needs request-and-response data: load products, fetch a profile, parse an imported file, save a document, or perform another one-shot operation where the app expects one success or one error. The widget declares the resource during `build()`. Reducers still own the state changes when the job completes.
+
+## Basic shape
+
+```rust
+use fission::prelude::*;
+
+let products = FutureBuilder::new(
+    ResourceKey::new("catalog.products"),
+    PRODUCTS_JOB,
+    view.state.product_request(),
+    view.state.products.clone(),
+    |ctx, view, snapshot| {
+        ProductList {
+            snapshot: snapshot.clone(),
+        }
+        .build(ctx, view)
+    },
+)
+.deps(view.state.product_request())
+.on_ok(with_reducer!(ctx, ProductsLoaded, on_products_loaded))
+.on_err(with_reducer!(ctx, ProductsFailed, on_products_failed))
+.build(ctx, view);
+```
+
+The important rule is that the snapshot is not hidden inside the widget. Store it in your app state. The success and error reducers update that state, and the next build renders the new snapshot.
+
+## Field table
+
+| Field | Type | Meaning | Notes / default behavior |
+| --- | --- | --- | --- |
+| `key` | `ResourceKey` | Stable identity for this job resource. | Keep it stable for the logical resource, not for a single frame. |
+| `job` | `JobRef<J>` | The registered job to run. | The shell must register a handler for the job. |
+| `request` | `J::Request` | Request payload passed to the job. | Cloneable request value. |
+| `snapshot` | `AsyncSnapshot<J::Ok, J::Err>` | Current app-owned loading/data/error state. | Reducers update it after job callbacks. |
+| `on_ok` | `Option<ActionEnvelope>` | Action dispatched when the job succeeds. | Use this to bind the success reducer. |
+| `on_err` | `Option<ActionEnvelope>` | Action dispatched when the job fails. | Use this to bind the error reducer. |
+| `deps` | `Option<Vec<u8>>` | Serialized dependency identity. | Changing deps restarts or preserves according to `policy`. |
+| `policy` | `ResourcePolicy` | How resource changes are handled. | Defaults to `RestartOnChange`. |
+| `builder` | `AsyncWidgetBuilder` | Closure that renders the current snapshot. | Keep it pure; do not perform side effects inside it. |
+
+## Snapshot states
+
+`AsyncSnapshot` has three pieces: a connection state, optional data, and optional error.
+
+Use `AsyncSnapshot::waiting()` when a request starts. Use `AsyncSnapshot::with_data(AsyncConnectionState::Done, value)` when it succeeds. Use `AsyncSnapshot::with_error(AsyncConnectionState::Done, error)` when it fails. The helper methods `data()`, `error()`, `has_data()`, and `has_error()` make display widgets straightforward.
+
+## Related
+
+[`Spinner`](/reference/widgets/spinner), [`CircularProgress`](/reference/widgets/circular-progress), [`Skeleton`](/reference/widgets/skeleton), and [Resources and async](/docs/guides/resources-and-async).

--- a/documentation/content/reference/widgets/widget-pages/image.mdx
+++ b/documentation/content/reference/widgets/widget-pages/image.mdx
@@ -1,52 +1,144 @@
 ---
 title: Image
-description: Display raster images or scalable vector graphics (SVG) content inside the layout tree.
+description: Display asset, file, network, memory, or SVG images inside the Fission layout tree.
 slug: /widgets/image
 ---
 # Image
 
-`Image` is the general image widget.
+`Image` displays visual content inside the ordinary Fission widget tree. Use it for product photos, profile images, diagrams, illustrations, thumbnails, and other still media that should be measured, laid out, clipped, and tested like the rest of your interface.
 
-Use it for photos, illustrations, thumbnails, diagrams, and any other visual content that belongs in the app's normal layout flow. The widget focuses on display, not asset management or accessibility semantics.
+An `Image` is declarative. Your widget describes what image should appear and how it should fit inside its layout box. The active shell is responsible for loading, decoding, caching, and repainting after asynchronous sources such as network images become available.
 
-## Example
+## Choose the source explicitly
+
+Use the typed constructors instead of passing raw strings around. They tell Fission what kind of source you mean and avoid ambiguous path-versus-URL behavior.
 
 ```rust
-use fission::core::op::ImageFit;
-use fission::core::ui::Image;
+use fission::prelude::*;
 
-let node = Image {
-    source: view.state.hero_image_url.clone(),
-    width: Some(320.0),
-    height: Some(180.0),
-    fit: Some(ImageFit::Cover),
-    ..Default::default()
-}
-.into_node();
+let avatar = Image::asset("assets/avatar.png")
+    .size(48.0, 48.0)
+    .semantic_label("Sam's profile photo")
+    .into_node();
+
+let product = Image::network(product.thumbnail.clone())
+    .size(220.0, 160.0)
+    .fit(ir_op::ImageFit::Contain)
+    .semantic_label(format!("{} product image", product.title))
+    .into_node();
 ```
 
-`Cover` is a good choice when the image should fill a card or hero frame even if some cropping occurs.
+Use `asset` for files shipped with the app, `file` for an explicit local file path, `network` for `http` or `https` images, `memory` when you already have bytes, and `svg_text` for inline SVG content. Network images are loaded asynchronously; the widget still reserves the size you give it, then the shell repaints when the decoded image is ready.
+
+## Pick the fit based on the content
+
+The `fit` setting controls how the decoded image is scaled inside the widget's layout box.
+
+| Fit | What it does | Good use cases | Tradeoff |
+| --- | --- | --- | --- |
+| `ImageFit::Contain` | Scales the whole image until it fits inside the box. | Product photos, diagrams, document previews, screenshots, anything where losing edges would be misleading. | May leave empty space on one axis. |
+| `ImageFit::Cover` | Scales the image until the whole box is covered. | Hero images, card backgrounds, decorative thumbnails where cropping is acceptable. | Crops whichever axis overflows. The renderer clips the image to the widget bounds. |
+| `ImageFit::Fill` | Stretches width and height independently. | Rare cases where distortion is acceptable, such as generated textures or placeholders. | Changes the image aspect ratio. |
+| `ImageFit::None` | Paints at the decoded image's natural pixel size. | Low-level rendering experiments or already-sized memory images. | Usually wrong in responsive UI because it ignores the layout box size. |
+
+For catalog-style screens, start with `Contain`. Users expect to see the whole product. For a large banner or background image, `Cover` usually looks better because it avoids letterboxing.
+
+## Control cropping with alignment
+
+When `Contain` leaves empty space or `Cover` crops an edge, `alignment` decides where the image sits inside the box.
+
+```rust
+let banner = Image::network(view.state.banner_url.clone())
+    .size(640.0, 240.0)
+    .fit(ir_op::ImageFit::Cover)
+    .alignment(ImageAlignment::TopCenter)
+    .semantic_label("Spring campaign banner")
+    .into_node();
+```
+
+Use centered alignment for most content. Use top, bottom, start, or end alignment when the meaningful part of the image consistently lives on one side.
+
+## Network images
+
+`Image::network` stores a typed network request. You can attach request headers and cache hints when the image endpoint needs them.
+
+```rust
+let protected = Image::network(view.state.signed_url.clone())
+    .header("Accept", "image/webp,image/png")
+    .cache_size(440, 320)
+    .cache_policy(ImageCachePolicy::MemoryOnly)
+    .size(220.0, 160.0)
+    .fit(ir_op::ImageFit::Contain)
+    .semantic_label("Invoice preview")
+    .into_node();
+```
+
+`cache_size` asks the loader to decode or resize toward a target pixel size. It is useful for long lists where a thumbnail should not keep a full-size original in memory. `cache_policy` describes the intended caching behavior; shell implementations may use it differently depending on platform support.
+
+Do not perform network fetches manually inside `build()`. `build()` should only describe the UI. Put the URL in app state and let the image pipeline load the bytes.
 
 ## Field table
 
 | Field | Type | Meaning | Notes / default behavior |
 | --- | --- | --- | --- |
-| `id` | `Option<NodeId>` | Stable node identity. | Defaults to `None`. |
-| `source` | `String` | Image source path, web address, inline scalable vector graphics (SVG), or SVG file path. | Required. The renderer treats inline `<svg...>` content and `.svg` files specially. |
-| `width` | `Option<f32>` | Fixed layout width. | Defaults to `None`. Set explicit dimensions or parent constraints for predictable results. |
-| `height` | `Option<f32>` | Fixed layout height. | Defaults to `None`. |
-| `fit` | `Option<ImageFit>` | How the image should scale inside its box. | Defaults to `Contain` when rendering non-scalable vector graphics (SVG) images. |
+| `id` | `Option<NodeId>` | Stable node identity. | Defaults to `None`. Most images do not need an explicit id. |
+| `request` | `ImageRequest` | Typed image request containing an asset, file, network URL, memory buffer, or inline SVG source. | Prefer `Image::asset`, `Image::file`, `Image::network`, `Image::memory`, or `Image::svg_text`. |
+| `width` | `Option<f32>` | Fixed layout width in logical points. | Defaults to `None`. Give images explicit dimensions or place them inside a parent that constrains them. |
+| `height` | `Option<f32>` | Fixed layout height in logical points. | Defaults to `None`. Lists and grids should usually give thumbnails both width and height. |
+| `fit` | `ImageFit` | How the image scales inside its box. | Defaults to `Contain`. |
+| `alignment` | `ImageAlignment` | Where fitted content sits when there is empty space or cropping. | Defaults to `Center`. |
 
-## Responsive and accessibility notes
+## Builder methods
 
-In responsive layouts, the main question is not only which image to show, but how much cropping is acceptable. `Contain` preserves the whole image but may leave empty space. `Cover` fills the region but may crop edges.
+| Method | Purpose | Notes |
+| --- | --- | --- |
+| `Image::asset(path)` | Load an app asset. | Use for images packaged with the app. |
+| `Image::file(path)` | Load a local file path. | Use only when the app intentionally works with local files. |
+| `Image::network(url)` | Load a remote image. | Loaded asynchronously by the shell. |
+| `Image::memory(bytes)` | Decode bytes already held by the app. | Good for capability results or generated previews. |
+| `Image::svg_text(content)` | Render inline SVG text. | Lowers to SVG drawing instead of raster image loading. |
+| `.size(width, height)` | Set both layout dimensions. | Preferred for thumbnails and cards. |
+| `.width(width)` / `.height(height)` | Set one layout dimension. | Use when the other axis comes from parent layout. |
+| `.fit(fit)` | Set scaling behavior. | `Contain` preserves full content; `Cover` fills and crops. |
+| `.alignment(alignment)` | Set crop or empty-space alignment. | Useful with `Cover` hero images. |
+| `.semantic_label(label)` | Add accessibility meaning. | Omit only for decorative images. |
+| `.cache_size(width, height)` | Request a decode/cache target size. | Helps thumbnail-heavy screens avoid wasting memory. |
+| `.header(name, value)` | Add a network header. | Applies only to network images. |
+| `.cache_policy(policy)` | Set network cache intent. | Applies only to network images. |
 
-The current public contract does not include alt text or a semantic label. If the image carries meaning, provide that meaning with surrounding text or parent-level semantics instead of assuming assistive technology can infer it.
+## Layout advice
 
-## Specific advice
+Give image widgets deliberate bounds. A source alone does not say how much space the image should occupy, and flexible containers need concrete constraints to produce predictable results.
 
-Give images deliberate layout constraints. A source string alone does not express how large the image should be in a flexible screen.
+For grids and cards, the most stable pattern is:
+
+```rust
+let thumbnail = Image::network(product.thumbnail.clone())
+    .size(220.0, 160.0)
+    .fit(ir_op::ImageFit::Contain)
+    .semantic_label(format!("Photo of {}", product.title))
+    .into_node();
+```
+
+For background-like imagery, use `Cover` and choose an alignment that keeps the important region visible:
+
+```rust
+let hero = Image::network(view.state.hero_url.clone())
+    .size(720.0, 320.0)
+    .fit(ir_op::ImageFit::Cover)
+    .alignment(ImageAlignment::Center)
+    .semantic_label("Featured destination")
+    .into_node();
+```
+
+The renderer clips fitted images to their widget bounds. If a `Cover` image appears outside its card, that is a renderer bug, not something app code should work around with manual clipping containers.
+
+## Accessibility and testing
+
+Set `semantic_label` when the image communicates information. A product photo, chart preview, document thumbnail, or profile image should have a useful label. Pure decoration can omit the label.
+
+Image rendering is testable. Cheap tests should verify that an `Image` lowers to `PaintOp::DrawImage` and then to `DisplayOp::DrawImage`. End-to-end tests can capture screenshots and assert that expected image regions contain visible pixels. Use fixed local or memory images for deterministic unit tests; use network images only in smoke tests where exercising the real shell loader is the point.
 
 ## Related
 
-[`Icon`](/reference/widgets/icon), [`Avatar`](/reference/widgets/avatar), [`Card`](/reference/widgets/card), and [`AspectRatio`](/reference/widgets/aspect-ratio).
+[`Icon`](/reference/widgets/icon), [`Avatar`](/reference/widgets/avatar), [`Card`](/reference/widgets/card), [`Grid`](/reference/widgets/grid), and [`AspectRatio`](/reference/widgets/aspect-ratio).

--- a/documentation/content/reference/widgets/widget-pages/refresh-indicator.mdx
+++ b/documentation/content/reference/widgets/widget-pages/refresh-indicator.mdx
@@ -1,0 +1,65 @@
+---
+title: RefreshIndicator
+description: Add a pull-to-refresh affordance above scrollable content.
+slug: /widgets/refresh-indicator
+---
+# RefreshIndicator
+
+`RefreshIndicator` adds a pull-to-refresh interaction around scrollable content.
+
+It is stateless. The app stores the current refresh status and pulled distance, reducers update those values from drag events, and `on_refresh` starts the actual refresh work. This keeps refresh behavior testable and consistent with the rest of Fission's state model.
+
+## Basic shape
+
+```rust
+use fission::prelude::*;
+
+let content = RefreshIndicator::new(product_list)
+    .id(WidgetNodeId::explicit("catalog.refresh"))
+    .status(view.state.refresh_status)
+    .pulled_extent(view.state.pulled_extent)
+    .trigger_distance(80.0)
+    .displacement(64.0)
+    .on_pull_start(with_reducer!(ctx, PullStarted, on_pull_started))
+    .on_pull_update(with_reducer!(ctx, PullUpdated, on_pull_updated))
+    .on_pull_cancel(with_reducer!(ctx, PullCanceled, on_pull_canceled))
+    .on_refresh(with_reducer!(ctx, RefreshProducts, on_refresh_products))
+    .build(ctx, view);
+```
+
+`on_pull_update` receives pointer drag data through the reducer context. Store the accumulated pulled distance in state. When the user releases after crossing `trigger_distance`, `on_refresh` fires.
+
+## Field table
+
+| Field | Type | Meaning | Notes / default behavior |
+| --- | --- | --- | --- |
+| `id` | `WidgetNodeId` | Stable identity for the refresh indicator and its progress animation. | Set this explicitly when a screen has more than one refresh region. |
+| `child` | `Box<Node>` | Content being refreshed. | Usually a scrollable list or grid. |
+| `status` | `RefreshIndicatorStatus` | Current visual and interaction state. | Defaults to `Inactive`. |
+| `pulled_extent` | `f32` | Current pull distance in logical points. | Stored in app state. |
+| `trigger_distance` | `f32` | Pull distance needed to trigger refresh. | Defaults to `80.0`. |
+| `displacement` | `f32` | How far the child content is visually displaced. | Defaults to `40.0`. |
+| `edge_offset` | `f32` | Extra top offset before the indicator appears. | Defaults to `0.0`. |
+| `color` | `Option<Color>` | Progress arc color override. | Defaults to theme primary. |
+| `background_color` | `Option<Color>` | Indicator container background override. | Defaults to theme surface. |
+| `track_color` | `Option<Color>` | Progress track color override. | Defaults to theme border. |
+| `stroke_width` | `f32` | Progress stroke width. | Defaults to `4.0`. |
+| `indicator_size` | `f32` | Inner progress indicator size. | Defaults to `36.0`. |
+| `on_pull_start` | `Option<ActionEnvelope>` | Action dispatched when dragging starts. | Usually sets status to `Drag`. |
+| `on_pull_update` | `Option<ActionEnvelope>` | Action dispatched for drag movement. | Usually updates `pulled_extent` and arms the refresh. |
+| `on_pull_cancel` | `Option<ActionEnvelope>` | Action dispatched when release does not refresh. | Usually resets status and pull distance. |
+| `on_refresh` | `Option<ActionEnvelope>` | Action dispatched when the pull is released while armed. | Usually starts a job/resource refresh. |
+
+## Status values
+
+| Status | Meaning |
+| --- | --- |
+| `Inactive` | No pull is active and the indicator is hidden. |
+| `Drag` | The user is pulling but has not crossed the trigger distance. |
+| `Armed` | The pull distance is enough to refresh if released. |
+| `Refreshing` | Refresh work is running. The indicator uses indeterminate progress. |
+| `Done` | Refresh has completed and the indicator can settle. |
+
+## Related
+
+[`FutureBuilder`](/reference/widgets/future-builder), [`CircularProgress`](/reference/widgets/circular-progress), [`Scroll`](/reference/widgets/scroll), and [Resources and async](/docs/guides/resources-and-async).

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -100,12 +100,8 @@ fn footer_identity(ctx: &mut BuildCtx<DocsState>, view: &View<DocsState>) -> Nod
                 semantic_row(
                     "site-route:/",
                     vec![
-                        Image {
-                            source: "/img/fission-mark.svg".to_string(),
-                            width: Some(tokens.spacing.l),
-                            height: Some(tokens.spacing.l),
-                            ..Default::default()
-                        }
+                        Image::asset("/img/fission-mark.svg")
+                            .size(tokens.spacing.l, tokens.spacing.l)
                         .into_node(),
                         Text::new("Fission")
                             .size(tokens.typography.font_size_lg)

--- a/documentation/src/components/home_nav.rs
+++ b/documentation/src/components/home_nav.rs
@@ -30,13 +30,9 @@ impl Widget<DocsState> for HomePageNav {
                     semantic_row(
                         "site-route:/",
                         vec![
-                            Image {
-                                source: "/img/fission-mark.svg".to_string(),
-                                width: Some(tokens.spacing.l),
-                                height: Some(tokens.spacing.l),
-                                ..Default::default()
-                            }
-                            .into_node(),
+                            Image::asset("/img/fission-mark.svg")
+                                .size(tokens.spacing.l, tokens.spacing.l)
+                                .into_node(),
                             Text::new("Fission")
                                 .size(tokens.typography.font_size_lg)
                                 .weight(tokens.typography.font_weight_bold)

--- a/documentation/src/components/home_widgets.rs
+++ b/documentation/src/components/home_widgets.rs
@@ -645,13 +645,12 @@ impl ChartImageCard {
 impl Widget<DocsState> for ChartImageCard {
     fn build(&self, _ctx: &mut BuildCtx<DocsState>, view: &View<DocsState>) -> Node {
         let tokens = &view.env.theme.tokens;
-        let mut image_children = vec![Image {
-            source: self.image.to_string(),
-            width: Some(chart_tile_width(tokens) - tokens.spacing.l),
-            height: Some(tokens.spacing.xxxxl * 1.15),
-            ..Default::default()
-        }
-        .into_node()];
+        let mut image_children = vec![Image::asset(self.image)
+            .size(
+                chart_tile_width(tokens) - tokens.spacing.l,
+                tokens.spacing.xxxxl * 1.15,
+            )
+            .into_node()];
         if let Some(badge) = self.badge {
             image_children.push(
                 Text::new(badge)

--- a/documentation/src/components/marketing.rs
+++ b/documentation/src/components/marketing.rs
@@ -937,13 +937,9 @@ fn visual_row(view: &View<DocsState>, label: &'static str, body: &'static str) -
 fn chart_thumb(view: &View<DocsState>, src: &'static str) -> Node {
     let tokens = &view.env.theme.tokens;
     Container::new(
-        Image {
-            source: src.to_string(),
-            width: Some(tokens.spacing.xxxxl * 1.85),
-            height: Some(tokens.spacing.xxxxl * 1.05),
-            ..Default::default()
-        }
-        .into_node(),
+        Image::asset(src)
+            .size(tokens.spacing.xxxxl * 1.85, tokens.spacing.xxxxl * 1.05)
+            .into_node(),
     )
     .padding_all(tokens.spacing.xs)
     .bg_fill(Fill::Solid(tokens.colors.on_surface.with_alpha(245)))

--- a/examples/inbox/src/components/email_detail.rs
+++ b/examples/inbox/src/components/email_detail.rs
@@ -339,24 +339,18 @@ impl Widget<InboxState> for EmailDetail {
                             AspectRatio {
                                 ratio: 4.0 / 3.0,
                                 child: Box::new(
-                                    Image {
-                                        source: "https://picsum.photos/200/150".into(),
-                                        fit: Some(ImageFit::Cover),
-                                        ..Default::default()
-                                    }
-                                    .into_node(),
+                                    Image::network("https://picsum.photos/200/150")
+                                        .fit(ImageFit::Cover)
+                                        .into_node(),
                                 ),
                             }
                             .build(ctx, view),
                             AspectRatio {
                                 ratio: 4.0 / 3.0,
                                 child: Box::new(
-                                    Image {
-                                        source: "https://picsum.photos/201/150".into(),
-                                        fit: Some(ImageFit::Cover),
-                                        ..Default::default()
-                                    }
-                                    .into_node(),
+                                    Image::network("https://picsum.photos/201/150")
+                                        .fit(ImageFit::Cover)
+                                        .into_node(),
                                 ),
                             }
                             .build(ctx, view),

--- a/examples/product-browser/Cargo.toml
+++ b/examples/product-browser/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "product-browser"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+fission = { path = "../../crates/authoring/fission", default-features = false, features = ["desktop"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+fission-test-driver = { path = "../../crates/tools/fission-test-driver" }
+image = "0.25"

--- a/examples/product-browser/README.md
+++ b/examples/product-browser/README.md
@@ -1,0 +1,11 @@
+# product-browser
+
+A small product catalog showing `FutureBuilder` and `RefreshIndicator` against real API data.
+
+Run it with:
+
+```sh
+cargo run -p product-browser
+```
+
+The example loads products and categories from DummyJSON, renders a responsive grid/list, supports search and category filtering, and uses pull-to-refresh to restart the product load.

--- a/examples/product-browser/src/api.rs
+++ b/examples/product-browser/src/api.rs
@@ -1,0 +1,191 @@
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+const API_BASE: &str = "https://dummyjson.com";
+const USER_AGENT: &str = "FissionProductBrowser/0.1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiError {
+    pub message: String,
+}
+
+impl ApiError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl From<reqwest::Error> for ApiError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::new(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProductRequest {
+    pub query: String,
+    pub category: Option<String>,
+    pub limit: u32,
+    pub refresh_generation: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProductPage {
+    pub products: Vec<Product>,
+    pub total: u32,
+    pub skip: u32,
+    pub limit: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Product {
+    pub id: u64,
+    pub title: String,
+    pub description: String,
+    pub category: String,
+    pub price: f64,
+    pub discount_percentage: Option<f64>,
+    pub rating: f64,
+    pub stock: u32,
+    pub brand: Option<String>,
+    pub thumbnail: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProductCategory {
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Debug)]
+pub struct ProductsJob;
+
+impl JobSpec for ProductsJob {
+    type Request = ProductRequest;
+    type Ok = ProductPage;
+    type Err = ApiError;
+
+    const NAME: &'static str = "product-browser.products";
+}
+
+pub const PRODUCTS_JOB: JobRef<ProductsJob> = JobRef::new(ProductsJob::NAME);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CategoriesRequest {
+    pub refresh_generation: u64,
+}
+
+#[derive(Debug)]
+pub struct CategoriesJob;
+
+impl JobSpec for CategoriesJob {
+    type Request = CategoriesRequest;
+    type Ok = Vec<ProductCategory>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "product-browser.categories";
+}
+
+pub const CATEGORIES_JOB: JobRef<CategoriesJob> = JobRef::new(CategoriesJob::NAME);
+
+pub async fn fetch_products(request: ProductRequest) -> Result<ProductPage, ApiError> {
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(ApiError::from)?;
+
+    let trimmed_query = request.query.trim();
+    let limit = request.limit.clamp(1, 100).to_string();
+    let response = if !trimmed_query.is_empty() {
+        client
+            .get(format!("{API_BASE}/products/search"))
+            .query(&[("q", trimmed_query), ("limit", limit.as_str())])
+            .send()
+            .await?
+    } else if let Some(category) = request
+        .category
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        client
+            .get(format!("{API_BASE}/products/category/{category}"))
+            .query(&[("limit", limit.as_str())])
+            .send()
+            .await?
+    } else {
+        client
+            .get(format!("{API_BASE}/products"))
+            .query(&[("limit", limit.as_str())])
+            .send()
+            .await?
+    };
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(ApiError::new(format!(
+            "product request failed with {status}"
+        )));
+    }
+
+    response.json::<ProductPage>().await.map_err(ApiError::from)
+}
+
+pub async fn fetch_categories(
+    _request: CategoriesRequest,
+) -> Result<Vec<ProductCategory>, ApiError> {
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(ApiError::from)?;
+    let response = client
+        .get(format!("{API_BASE}/products/categories"))
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(ApiError::new(format!(
+            "category request failed with {status}"
+        )));
+    }
+
+    response
+        .json::<Vec<ProductCategory>>()
+        .await
+        .map_err(ApiError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn product_with_thumbnail(thumbnail: &str) -> Product {
+        Product {
+            id: 42,
+            title: "Demo".into(),
+            description: "Demo product".into(),
+            category: "demo".into(),
+            price: 1.0,
+            discount_percentage: None,
+            rating: 4.0,
+            stock: 10,
+            brand: None,
+            thumbnail: thumbnail.into(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn product_model_preserves_remote_thumbnail_url() {
+        let product = product_with_thumbnail("https://cdn.example.com/products/42/thumbnail.webp");
+        assert_eq!(
+            product.thumbnail,
+            "https://cdn.example.com/products/42/thumbnail.webp"
+        );
+    }
+}

--- a/examples/product-browser/src/components/browser.rs
+++ b/examples/product-browser/src/components/browser.rs
@@ -1,0 +1,238 @@
+use crate::api::{CATEGORIES_JOB, PRODUCTS_JOB};
+use crate::components::categories::CategoryRail;
+use crate::components::product_detail::ProductDetail;
+use crate::components::product_results::ProductResults;
+use crate::model::{
+    on_categories_failed, on_categories_loaded, on_products_failed, on_products_loaded,
+    on_pull_canceled, on_pull_started, on_pull_updated, on_refresh_products, on_search_changed,
+    CategoriesFailed, CategoriesLoaded, ProductBrowserState, ProductsFailed, ProductsLoaded,
+    PullCanceled, PullStarted, PullUpdated, RefreshProducts, SearchChanged,
+};
+use fission::core::ResourceKey;
+use fission::prelude::*;
+
+pub struct ProductBrowserApp;
+
+impl Widget<ProductBrowserState> for ProductBrowserApp {
+    fn build(
+        &self,
+        ctx: &mut BuildCtx<ProductBrowserState>,
+        view: &View<ProductBrowserState>,
+    ) -> Node {
+        let tokens = &view.env.theme.tokens;
+        let viewport = view.viewport_size();
+        let wide = viewport.width >= 980.0;
+        let grid = viewport.width >= 760.0;
+
+        let products_loaded = with_reducer!(ctx, ProductsLoaded, on_products_loaded);
+        let products_failed = with_reducer!(ctx, ProductsFailed, on_products_failed);
+        let categories_loaded = with_reducer!(ctx, CategoriesLoaded, on_categories_loaded);
+        let categories_failed = with_reducer!(ctx, CategoriesFailed, on_categories_failed);
+        let search_changed = with_reducer!(ctx, SearchChanged(String::new()), on_search_changed);
+        let pull_started = with_reducer!(ctx, PullStarted, on_pull_started);
+        let pull_updated = with_reducer!(ctx, PullUpdated, on_pull_updated);
+        let pull_canceled = with_reducer!(ctx, PullCanceled, on_pull_canceled);
+        let refresh_products = with_reducer!(ctx, RefreshProducts, on_refresh_products);
+
+        let products_request = view.state.product_request();
+        let categories_request = view.state.categories_request();
+        let product_snapshot = view.state.products.clone();
+        let category_snapshot = view.state.categories.clone();
+        let selected_product = view.state.selected_product();
+
+        let category_node = FutureBuilder::new(
+            ResourceKey::new("product-browser.categories"),
+            CATEGORIES_JOB,
+            categories_request.clone(),
+            category_snapshot,
+            |ctx, view, snapshot| {
+                CategoryRail {
+                    snapshot: snapshot.clone(),
+                }
+                .build(ctx, view)
+            },
+        )
+        .deps(categories_request)
+        .on_ok(categories_loaded)
+        .on_err(categories_failed)
+        .build(ctx, view);
+
+        let product_node = FutureBuilder::new(
+            ResourceKey::new("product-browser.products"),
+            PRODUCTS_JOB,
+            products_request.clone(),
+            product_snapshot,
+            move |ctx, view, snapshot| {
+                ProductResults {
+                    snapshot: snapshot.clone(),
+                    use_grid: grid,
+                }
+                .build(ctx, view)
+            },
+        )
+        .deps(products_request)
+        .on_ok(products_loaded)
+        .on_err(products_failed)
+        .build(ctx, view);
+
+        let refreshed_products = RefreshIndicator::new(product_node)
+            .id(WidgetNodeId::explicit("product-browser.refresh"))
+            .status(view.state.refresh_status)
+            .pulled_extent(view.state.pulled_extent)
+            .trigger_distance(80.0)
+            .displacement(64.0)
+            .on_pull_start(pull_started)
+            .on_pull_update(pull_updated)
+            .on_pull_cancel(pull_canceled)
+            .on_refresh(refresh_products)
+            .build(ctx, view);
+
+        let product_area = Container::new(refreshed_products)
+            .flex_grow(1.0)
+            .bg(tokens.colors.background)
+            .into_node();
+
+        let content = if wide {
+            let detail_panel = Column {
+                gap: Some(0.0),
+                children: vec![
+                    ProductDetail {
+                        product: selected_product.clone(),
+                    }
+                    .build(ctx, view),
+                    Spacer {
+                        flex_grow: 1.0,
+                        ..Default::default()
+                    }
+                    .into_node(),
+                ],
+                ..Default::default()
+            }
+            .into_node();
+
+            Row {
+                gap: Some(18.0),
+                flex_grow: 1.0,
+                align_items: ir_op::AlignItems::Stretch,
+                children: vec![category_node, product_area, detail_panel],
+                ..Default::default()
+            }
+            .into_node()
+        } else {
+            Column {
+                gap: Some(16.0),
+                flex_grow: 1.0,
+                children: vec![
+                    category_node,
+                    product_area,
+                    ProductDetail {
+                        product: selected_product,
+                    }
+                    .build(ctx, view),
+                ],
+                ..Default::default()
+            }
+            .into_node()
+        };
+
+        Container::new(
+            Column {
+                gap: Some(18.0),
+                children: vec![
+                    Header {
+                        on_search: search_changed,
+                    }
+                    .build(ctx, view),
+                    content,
+                ],
+                ..Default::default()
+            }
+            .into_node(),
+        )
+        .height(viewport.height.max(1.0))
+        .padding_all(24.0)
+        .bg(tokens.colors.background)
+        .into_node()
+    }
+}
+
+struct Header {
+    on_search: ActionEnvelope,
+}
+
+impl Widget<ProductBrowserState> for Header {
+    fn build(
+        &self,
+        _ctx: &mut BuildCtx<ProductBrowserState>,
+        view: &View<ProductBrowserState>,
+    ) -> Node {
+        let tokens = &view.env.theme.tokens;
+        let summary = match view.state.products.data() {
+            Some(page) if page.total > page.products.len() as u32 => {
+                format!(
+                    "{} shown from {} matching products",
+                    page.products.len(),
+                    page.total
+                )
+            }
+            Some(page) => format!("{} products shown", page.products.len()),
+            None if view.state.products.has_error() => "Product service unavailable".to_string(),
+            None => "Loading product catalog".to_string(),
+        };
+        let title = Column {
+            gap: Some(6.0),
+            children: vec![
+                Text::new("Product Browser")
+                    .size(34.0)
+                    .line_height(42.0)
+                    .weight(800)
+                    .color(tokens.colors.text_primary)
+                    .into_node(),
+                Text::new(summary)
+                    .size(14.0)
+                    .line_height(20.0)
+                    .color(tokens.colors.text_secondary)
+                    .into_node(),
+            ],
+            ..Default::default()
+        }
+        .into_node();
+
+        let search = TextInput {
+            value: view.state.query.clone(),
+            placeholder: Some("Search products".into()),
+            on_change: Some(self.on_search.clone()),
+            width: Some(if view.viewport_size().width >= 720.0 {
+                320.0
+            } else {
+                (view.viewport_size().width - 48.0).max(240.0)
+            }),
+            ..Default::default()
+        }
+        .into_node();
+
+        if view.viewport_size().width >= 720.0 {
+            Row {
+                gap: Some(18.0),
+                children: vec![
+                    title,
+                    Spacer {
+                        flex_grow: 1.0,
+                        ..Default::default()
+                    }
+                    .into_node(),
+                    search,
+                ],
+                ..Default::default()
+            }
+            .into_node()
+        } else {
+            Column {
+                gap: Some(14.0),
+                children: vec![title, search],
+                ..Default::default()
+            }
+            .into_node()
+        }
+    }
+}

--- a/examples/product-browser/src/components/categories.rs
+++ b/examples/product-browser/src/components/categories.rs
@@ -1,0 +1,98 @@
+use crate::api::{ApiError, ProductCategory};
+use crate::model::{on_category_selected, CategorySelected, ProductBrowserState};
+use fission::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct CategoryRail {
+    pub snapshot: AsyncSnapshot<Vec<ProductCategory>, ApiError>,
+}
+
+impl Widget<ProductBrowserState> for CategoryRail {
+    fn build(
+        &self,
+        ctx: &mut BuildCtx<ProductBrowserState>,
+        view: &View<ProductBrowserState>,
+    ) -> Node {
+        let tokens = &view.env.theme.tokens;
+        let mut children = vec![
+            Text::new("Categories")
+                .size(16.0)
+                .weight(700)
+                .color(tokens.colors.text_primary)
+                .into_node(),
+            category_button(ctx, view, "All products".to_string(), None),
+        ];
+
+        match self.snapshot.connection_state {
+            AsyncConnectionState::Waiting => children.push(
+                Text::new("Loading categories...")
+                    .size(13.0)
+                    .color(tokens.colors.text_secondary)
+                    .into_node(),
+            ),
+            _ if self.snapshot.has_error() => children.push(
+                Text::new("Categories unavailable")
+                    .size(13.0)
+                    .color(tokens.colors.text_secondary)
+                    .into_node(),
+            ),
+            _ => {
+                if let Some(categories) = self.snapshot.data() {
+                    children.extend(categories.iter().map(|category| {
+                        category_button(
+                            ctx,
+                            view,
+                            category.name.clone(),
+                            Some(category.slug.clone()),
+                        )
+                    }));
+                }
+            }
+        }
+
+        Container::new(
+            Scroll {
+                child: Some(Box::new(
+                    Column {
+                        gap: Some(8.0),
+                        children,
+                        ..Default::default()
+                    }
+                    .into_node(),
+                )),
+                flex_grow: 1.0,
+                ..Default::default()
+            }
+            .into_node(),
+        )
+        .width(220.0)
+        .padding_all(16.0)
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(22.0)
+        .into_node()
+    }
+}
+
+fn category_button(
+    ctx: &mut BuildCtx<ProductBrowserState>,
+    view: &View<ProductBrowserState>,
+    label: String,
+    category: Option<String>,
+) -> Node {
+    let selected = view.state.selected_category == category;
+    let action = with_reducer!(ctx, CategorySelected(category), on_category_selected);
+    Button {
+        on_press: Some(action),
+        variant: if selected {
+            ButtonVariant::Filled
+        } else {
+            ButtonVariant::Ghost
+        },
+        content_align: ButtonContentAlign::Start,
+        width: Some(188.0),
+        child: Some(Box::new(Text::new(label).max_lines(1).into_node())),
+        ..Default::default()
+    }
+    .into_node()
+}

--- a/examples/product-browser/src/components/mod.rs
+++ b/examples/product-browser/src/components/mod.rs
@@ -1,0 +1,5 @@
+pub mod browser;
+pub mod categories;
+pub mod product_card;
+pub mod product_detail;
+pub mod product_results;

--- a/examples/product-browser/src/components/product_card.rs
+++ b/examples/product-browser/src/components/product_card.rs
@@ -1,0 +1,94 @@
+use crate::api::Product;
+use crate::model::{on_product_selected, ProductBrowserState, ProductSelected};
+use fission::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct ProductCard {
+    pub product: Product,
+    pub selected: bool,
+    pub compact: bool,
+}
+
+impl Widget<ProductBrowserState> for ProductCard {
+    fn build(
+        &self,
+        ctx: &mut BuildCtx<ProductBrowserState>,
+        view: &View<ProductBrowserState>,
+    ) -> Node {
+        let tokens = &view.env.theme.tokens;
+        let select = with_reducer!(ctx, ProductSelected(self.product.id), on_product_selected);
+        let border = if self.selected {
+            tokens.colors.primary
+        } else {
+            tokens.colors.border
+        };
+        let image = Image::network(self.product.thumbnail.clone())
+            .size(
+                if self.compact { 96.0 } else { 220.0 },
+                if self.compact { 96.0 } else { 160.0 },
+            )
+            .fit(ir_op::ImageFit::Contain)
+            .into_node();
+
+        let details = Column {
+            gap: Some(6.0),
+            children: vec![
+                Text::new(self.product.title.clone())
+                    .size(if self.compact { 16.0 } else { 18.0 })
+                    .weight(700)
+                    .color(tokens.colors.text_primary)
+                    .max_lines(2)
+                    .into_node(),
+                Text::new(format!(
+                    "{} · {:.1} stars",
+                    self.product.category, self.product.rating
+                ))
+                .size(13.0)
+                .color(tokens.colors.text_secondary)
+                .max_lines(1)
+                .into_node(),
+                Text::new(format!("${:.2}", self.product.price))
+                    .size(18.0)
+                    .weight(700)
+                    .color(tokens.colors.primary)
+                    .into_node(),
+                Text::new(format!("{} in stock", self.product.stock))
+                    .size(12.0)
+                    .color(tokens.colors.text_secondary)
+                    .into_node(),
+            ],
+            ..Default::default()
+        }
+        .into_node();
+
+        let content = if self.compact {
+            Row {
+                gap: Some(14.0),
+                children: vec![image, details],
+                ..Default::default()
+            }
+            .into_node()
+        } else {
+            Column {
+                gap: Some(12.0),
+                children: vec![image, details],
+                ..Default::default()
+            }
+            .into_node()
+        };
+
+        GestureDetector {
+            child: Box::new(
+                Container::new(content)
+                    .bg(tokens.colors.surface)
+                    .border(border, if self.selected { 2.0 } else { 1.0 })
+                    .border_radius(18.0)
+                    .padding_all(14.0)
+                    .into_node(),
+            ),
+            on_tap: Some(select),
+            ..Default::default()
+        }
+        .into_node()
+    }
+}

--- a/examples/product-browser/src/components/product_detail.rs
+++ b/examples/product-browser/src/components/product_detail.rs
@@ -1,0 +1,84 @@
+use crate::api::Product;
+use crate::model::ProductBrowserState;
+use fission::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct ProductDetail {
+    pub product: Option<Product>,
+}
+
+impl Widget<ProductBrowserState> for ProductDetail {
+    fn build(
+        &self,
+        _ctx: &mut BuildCtx<ProductBrowserState>,
+        view: &View<ProductBrowserState>,
+    ) -> Node {
+        let tokens = &view.env.theme.tokens;
+        let content = if let Some(product) = &self.product {
+            Column {
+                gap: Some(14.0),
+                align_items: ir_op::AlignItems::Start,
+                children: vec![
+                    Image::network(product.thumbnail.clone())
+                        .size(280.0, 220.0)
+                        .fit(ir_op::ImageFit::Contain)
+                        .into_node(),
+                    Text::new(product.title.clone())
+                        .size(24.0)
+                        .weight(800)
+                        .color(tokens.colors.text_primary)
+                        .max_width(300.0)
+                        .into_node(),
+                    Text::new(format!("${:.2}", product.price))
+                        .size(28.0)
+                        .weight(800)
+                        .color(tokens.colors.primary)
+                        .into_node(),
+                    Text::new(format!(
+                        "{:.1} stars · {} in stock · {}",
+                        product.rating, product.stock, product.category
+                    ))
+                    .size(13.0)
+                    .color(tokens.colors.text_secondary)
+                    .max_width(300.0)
+                    .into_node(),
+                    Text::new(product.description.clone())
+                        .size(15.0)
+                        .color(tokens.colors.text_primary)
+                        .max_width(300.0)
+                        .into_node(),
+                    Text::new(if product.tags.is_empty() {
+                        "No tags".to_string()
+                    } else {
+                        format!("Tags: {}", product.tags.join(", "))
+                    })
+                    .size(13.0)
+                    .color(tokens.colors.text_secondary)
+                    .max_width(300.0)
+                    .into_node(),
+                ],
+                ..Default::default()
+            }
+            .into_node()
+        } else {
+            Center {
+                child: Box::new(
+                    Text::new("Select a product to see the details")
+                        .color(tokens.colors.text_secondary)
+                        .max_width(260.0)
+                        .into_node(),
+                ),
+            }
+            .build(_ctx, view)
+        };
+
+        Container::new(content)
+            .width(340.0)
+            .flex_shrink(0.0)
+            .padding_all(20.0)
+            .bg(tokens.colors.surface)
+            .border(tokens.colors.border, 1.0)
+            .border_radius(24.0)
+            .into_node()
+    }
+}

--- a/examples/product-browser/src/components/product_results.rs
+++ b/examples/product-browser/src/components/product_results.rs
@@ -1,0 +1,152 @@
+use crate::api::{ApiError, ProductPage};
+use crate::components::product_card::ProductCard;
+use crate::model::ProductBrowserState;
+use fission::prelude::*;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct ProductResults {
+    pub snapshot: AsyncSnapshot<ProductPage, ApiError>,
+    pub use_grid: bool,
+}
+
+impl Widget<ProductBrowserState> for ProductResults {
+    fn build(
+        &self,
+        ctx: &mut BuildCtx<ProductBrowserState>,
+        view: &View<ProductBrowserState>,
+    ) -> Node {
+        let tokens = &view.env.theme.tokens;
+        if self.snapshot.connection_state == AsyncConnectionState::Waiting {
+            return Center {
+                child: Box::new(
+                    Column {
+                        gap: Some(12.0),
+                        children: vec![
+                            CircularProgress {
+                                id: WidgetNodeId::explicit("product-browser.loading"),
+                                ..Default::default()
+                            }
+                            .build(ctx, view),
+                            Text::new("Loading products...")
+                                .color(tokens.colors.text_secondary)
+                                .into_node(),
+                        ],
+                        ..Default::default()
+                    }
+                    .into_node(),
+                ),
+            }
+            .build(ctx, view);
+        }
+
+        if let Some(error) = self.snapshot.error() {
+            return Center {
+                child: Box::new(
+                    Column {
+                        gap: Some(12.0),
+                        children: vec![
+                            Text::new("Products could not be loaded")
+                                .size(22.0)
+                                .weight(700)
+                                .color(tokens.colors.text_primary)
+                                .into_node(),
+                            Text::new(error.message.clone())
+                                .color(tokens.colors.text_secondary)
+                                .max_width(520.0)
+                                .into_node(),
+                        ],
+                        ..Default::default()
+                    }
+                    .into_node(),
+                ),
+            }
+            .build(ctx, view);
+        }
+
+        let Some(page) = self.snapshot.data() else {
+            return Spacer {
+                flex_grow: 1.0,
+                ..Default::default()
+            }
+            .into_node();
+        };
+
+        if page.products.is_empty() {
+            return Center {
+                child: Box::new(
+                    Text::new("No products match the current filters")
+                        .color(tokens.colors.text_secondary)
+                        .into_node(),
+                ),
+            }
+            .build(ctx, view);
+        }
+
+        if self.use_grid {
+            let columns: usize = if view.viewport_size().width >= 1280.0 {
+                3
+            } else {
+                2
+            };
+            let rows = (page.products.len() + columns - 1) / columns;
+            let items = page
+                .products
+                .iter()
+                .enumerate()
+                .map(|(index, product)| {
+                    let row = (index / columns) as i16 + 1;
+                    let col = (index % columns) as i16 + 1;
+                    GridItem::new(
+                        ProductCard {
+                            product: product.clone(),
+                            selected: Some(product.id) == view.state.selected_product_id,
+                            compact: false,
+                        }
+                        .build(ctx, view),
+                    )
+                    .cell(row, col)
+                    .into_node()
+                })
+                .collect();
+
+            Scroll {
+                child: Some(Box::new(
+                    Grid {
+                        columns: vec![ir_op::GridTrack::Fr(1.0); columns],
+                        rows: vec![ir_op::GridTrack::Auto; rows],
+                        column_gap: Some(16.0),
+                        row_gap: Some(16.0),
+                        padding: [4.0, 16.0, 4.0, 24.0],
+                        children: items,
+                        ..Default::default()
+                    }
+                    .into_node(),
+                )),
+                flex_grow: 1.0,
+                ..Default::default()
+            }
+            .into_node()
+        } else {
+            let items = page
+                .products
+                .iter()
+                .map(|product| {
+                    ProductCard {
+                        product: product.clone(),
+                        selected: Some(product.id) == view.state.selected_product_id,
+                        compact: true,
+                    }
+                    .build(ctx, view)
+                })
+                .collect();
+
+            LazyColumn {
+                id: None,
+                children: Arc::new(items),
+                item_height: 138.0,
+            }
+            .into_node()
+        }
+    }
+}

--- a/examples/product-browser/src/main.rs
+++ b/examples/product-browser/src/main.rs
@@ -1,0 +1,25 @@
+mod api;
+mod components;
+mod model;
+
+use api::{fetch_categories, fetch_products, CATEGORIES_JOB, PRODUCTS_JOB};
+use components::browser::ProductBrowserApp;
+use fission::prelude::*;
+use model::ProductBrowserState;
+
+fn main() -> anyhow::Result<()> {
+    DesktopApp::new(ProductBrowserApp)
+        .with_title("Fission Product Browser")
+        .with_async(|asyncs| {
+            asyncs.register_job(PRODUCTS_JOB, |request, _| async move {
+                fetch_products(request).await
+            });
+            asyncs.register_job(CATEGORIES_JOB, |request, _| async move {
+                fetch_categories(request).await
+            });
+        })
+        .with_sync_env(|_state: &ProductBrowserState, env: &mut Env| {
+            env.theme = Theme::default();
+        })
+        .run()
+}

--- a/examples/product-browser/src/model.rs
+++ b/examples/product-browser/src/model.rs
@@ -1,0 +1,200 @@
+use crate::api::{
+    ApiError, CategoriesRequest, Product, ProductCategory, ProductPage, ProductRequest,
+    CATEGORIES_JOB, PRODUCTS_JOB,
+};
+use fission::prelude::*;
+
+const PRODUCT_LIMIT: u32 = 30;
+const REFRESH_TRIGGER: f32 = 80.0;
+
+#[derive(Debug, Clone)]
+pub struct ProductBrowserState {
+    pub query: String,
+    pub selected_category: Option<String>,
+    pub selected_product_id: Option<u64>,
+    pub products: AsyncSnapshot<ProductPage, ApiError>,
+    pub categories: AsyncSnapshot<Vec<ProductCategory>, ApiError>,
+    pub product_generation: u64,
+    pub category_generation: u64,
+    pub refresh_status: RefreshIndicatorStatus,
+    pub pulled_extent: f32,
+}
+
+impl Default for ProductBrowserState {
+    fn default() -> Self {
+        Self {
+            query: String::new(),
+            selected_category: None,
+            selected_product_id: None,
+            products: AsyncSnapshot::waiting(),
+            categories: AsyncSnapshot::waiting(),
+            product_generation: 0,
+            category_generation: 0,
+            refresh_status: RefreshIndicatorStatus::Inactive,
+            pulled_extent: 0.0,
+        }
+    }
+}
+
+impl ProductBrowserState {
+    pub fn product_request(&self) -> ProductRequest {
+        ProductRequest {
+            query: self.query.clone(),
+            category: self.selected_category.clone(),
+            limit: PRODUCT_LIMIT,
+            refresh_generation: self.product_generation,
+        }
+    }
+
+    pub fn categories_request(&self) -> CategoriesRequest {
+        CategoriesRequest {
+            refresh_generation: self.category_generation,
+        }
+    }
+
+    pub fn selected_product(&self) -> Option<Product> {
+        let page = self.products.data()?;
+        let id = self.selected_product_id?;
+        page.products
+            .iter()
+            .find(|product| product.id == id)
+            .cloned()
+    }
+
+    fn restart_products(&mut self) {
+        self.product_generation = self.product_generation.saturating_add(1);
+        self.products = AsyncSnapshot::waiting();
+    }
+}
+
+impl AppState for ProductBrowserState {}
+
+#[fission_reducer(SearchChanged)]
+pub fn on_search_changed(state: &mut ProductBrowserState, query: String) {
+    state.query = query;
+    state.selected_category = None;
+    state.selected_product_id = None;
+    state.refresh_status = RefreshIndicatorStatus::Inactive;
+    state.pulled_extent = 0.0;
+    state.restart_products();
+}
+
+#[fission_reducer(CategorySelected)]
+pub fn on_category_selected(state: &mut ProductBrowserState, category: Option<String>) {
+    state.selected_category = category;
+    state.selected_product_id = None;
+    state.refresh_status = RefreshIndicatorStatus::Inactive;
+    state.pulled_extent = 0.0;
+    state.restart_products();
+}
+
+#[fission_reducer(ProductSelected)]
+pub fn on_product_selected(state: &mut ProductBrowserState, product_id: u64) {
+    state.selected_product_id = Some(product_id);
+}
+
+#[fission_reducer(ProductsLoaded)]
+pub fn on_products_loaded(
+    state: &mut ProductBrowserState,
+    ctx: &mut ReducerContext<ProductBrowserState>,
+) {
+    if let Some(page) = ctx.input.job_ok(PRODUCTS_JOB) {
+        if state.selected_product_id.is_none() {
+            state.selected_product_id = page.products.first().map(|product| product.id);
+        }
+        state.products = AsyncSnapshot::with_data(AsyncConnectionState::Done, page);
+        state.refresh_status = RefreshIndicatorStatus::Inactive;
+        state.pulled_extent = 0.0;
+    }
+}
+
+#[fission_reducer(ProductsFailed)]
+pub fn on_products_failed(
+    state: &mut ProductBrowserState,
+    ctx: &mut ReducerContext<ProductBrowserState>,
+) {
+    let error = ctx.input.job_err(PRODUCTS_JOB).unwrap_or_else(|| ApiError {
+        message: ctx
+            .input
+            .job_error_message(PRODUCTS_JOB)
+            .unwrap_or("Unable to load products")
+            .to_string(),
+    });
+    state.products = AsyncSnapshot::with_error(AsyncConnectionState::Done, error);
+    state.refresh_status = RefreshIndicatorStatus::Inactive;
+    state.pulled_extent = 0.0;
+}
+
+#[fission_reducer(CategoriesLoaded)]
+pub fn on_categories_loaded(
+    state: &mut ProductBrowserState,
+    ctx: &mut ReducerContext<ProductBrowserState>,
+) {
+    if let Some(categories) = ctx.input.job_ok(CATEGORIES_JOB) {
+        state.categories = AsyncSnapshot::with_data(AsyncConnectionState::Done, categories);
+    }
+}
+
+#[fission_reducer(CategoriesFailed)]
+pub fn on_categories_failed(
+    state: &mut ProductBrowserState,
+    ctx: &mut ReducerContext<ProductBrowserState>,
+) {
+    let error = ctx
+        .input
+        .job_err(CATEGORIES_JOB)
+        .unwrap_or_else(|| ApiError {
+            message: ctx
+                .input
+                .job_error_message(CATEGORIES_JOB)
+                .unwrap_or("Unable to load categories")
+                .to_string(),
+        });
+    state.categories = AsyncSnapshot::with_error(AsyncConnectionState::Done, error);
+}
+
+#[fission_reducer(PullStarted)]
+pub fn on_pull_started(state: &mut ProductBrowserState) {
+    if state.refresh_status != RefreshIndicatorStatus::Refreshing {
+        state.refresh_status = RefreshIndicatorStatus::Drag;
+        state.pulled_extent = 0.0;
+    }
+}
+
+#[fission_reducer(PullUpdated)]
+pub fn on_pull_updated(
+    state: &mut ProductBrowserState,
+    ctx: &mut ReducerContext<ProductBrowserState>,
+) {
+    if state.refresh_status == RefreshIndicatorStatus::Refreshing {
+        return;
+    }
+
+    let Some((_, _, _, delta_y)) = ctx.input.as_pointer() else {
+        return;
+    };
+
+    state.pulled_extent = (state.pulled_extent + delta_y).max(0.0);
+    state.refresh_status = if state.pulled_extent >= REFRESH_TRIGGER {
+        RefreshIndicatorStatus::Armed
+    } else if state.pulled_extent > 0.0 {
+        RefreshIndicatorStatus::Drag
+    } else {
+        RefreshIndicatorStatus::Inactive
+    };
+}
+
+#[fission_reducer(PullCanceled)]
+pub fn on_pull_canceled(state: &mut ProductBrowserState) {
+    if state.refresh_status != RefreshIndicatorStatus::Refreshing {
+        state.refresh_status = RefreshIndicatorStatus::Inactive;
+        state.pulled_extent = 0.0;
+    }
+}
+
+#[fission_reducer(RefreshProducts)]
+pub fn on_refresh_products(state: &mut ProductBrowserState) {
+    state.refresh_status = RefreshIndicatorStatus::Refreshing;
+    state.pulled_extent = REFRESH_TRIGGER;
+    state.restart_products();
+}

--- a/examples/product-browser/tests/live_e2e.rs
+++ b/examples/product-browser/tests/live_e2e.rs
@@ -1,0 +1,94 @@
+use fission_test_driver::LiveTestClient;
+use std::net::TcpListener;
+use std::process::{Child, Command};
+
+fn reserve_control_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind ephemeral test port")
+        .local_addr()
+        .expect("read ephemeral test port")
+        .port()
+}
+
+fn launch_product_browser(control_port: u16) -> Child {
+    let bin = std::env::var("CARGO_BIN_EXE_product-browser")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_product_browser"))
+        .unwrap_or_else(|_| "target/debug/product-browser".to_string());
+    Command::new(bin)
+        .env("FISSION_TEST_CONTROL_PORT", control_port.to_string())
+        .env("FISSION_BACKGROUND_TEST", "1")
+        .spawn()
+        .expect("failed to launch product-browser")
+}
+
+fn screenshot_dir() -> String {
+    let dir = std::env::var("FISSION_SCREENSHOT_DIR").unwrap_or_else(|_| {
+        format!(
+            "{}/../../.artifacts/screenshots/examples/product-browser/live_e2e",
+            env!("CARGO_MANIFEST_DIR")
+        )
+    });
+    std::fs::create_dir_all(&dir).expect("create screenshot dir");
+    dir
+}
+
+fn assert_region_has_visible_image_pixels(path: &str, region: (u32, u32, u32, u32)) {
+    let img = image::open(path).expect("open screenshot").to_rgba8();
+    let (x, y, width, height) = region;
+    assert!(
+        x + width <= img.width() && y + height <= img.height(),
+        "region {region:?} outside screenshot {}x{}",
+        img.width(),
+        img.height()
+    );
+
+    let mut visible_pixels = 0usize;
+    for py in y..(y + height) {
+        for px in x..(x + width) {
+            let pixel = img.get_pixel(px, py).0;
+            let [r, g, b, a] = pixel;
+            if a > 0 && (r < 245 || g < 245 || b < 245) {
+                visible_pixels += 1;
+            }
+        }
+    }
+
+    assert!(
+        visible_pixels > 500,
+        "expected visible non-white image pixels in {region:?}, found {visible_pixels}; screenshot={path}"
+    );
+}
+
+#[test]
+#[ignore]
+fn product_browser_displays_remote_product_images() {
+    let control_port = reserve_control_port();
+    let mut child = launch_product_browser(control_port);
+    let client = LiveTestClient::connect(control_port);
+    client
+        .wait_for_ready(15_000)
+        .expect("product-browser did not start");
+    client
+        .simulate_resize(1200, 800)
+        .expect("resize product-browser");
+    client.wait(8_000).expect("wait for products and images");
+    client.pump().expect("pump after async image loads");
+    client
+        .assert_text_visible("30 shown")
+        .expect("product data should load before image assertion");
+    client
+        .assert_text_visible("Essence Mascara Lash Princess")
+        .expect("first product should be visible");
+
+    let path = format!("{}/product_browser_remote_images.png", screenshot_dir());
+    client
+        .screenshot(&path)
+        .expect("capture product screenshot");
+
+    assert_region_has_visible_image_pixels(&path, (280, 128, 220, 160));
+    assert_region_has_visible_image_pixels(&path, (556, 128, 220, 160));
+    assert_region_has_visible_image_pixels(&path, (856, 130, 280, 220));
+
+    client.quit().expect("quit");
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary
- Adds typed image sources (`asset`, `file`, `network`, `memory`, `svg_text`) and lowers them through IR, display lists, tests, static-site HTML, terminal verification, and winit/Vello/software renderers.
- Adds async image loading/caching for native and wasm, clips image draws to destination bounds, and invalidates/repaints when cached image data arrives.
- Adds `FutureBuilder`, `RefreshIndicator`, and animated indeterminate `CircularProgress`, with unit coverage.
- Adds the `product-browser` example using real API data, `FutureBuilder`, `RefreshIndicator`, `Grid`, remote images, and a live screenshot E2E test.
- Updates image/media/loading widget documentation and reference pages.
- Includes the contributor-only PR workflow gate so platform checks only run for contributor-associated PR authors.

## Testing
- `cargo test -p fission-core --test image_widget`
- `cargo test -p fission-widgets --test circular_progress_test`
- `cargo test -p fission-widgets --test future_builder_test`
- `cargo test -p fission-widgets --test refresh_indicator_test`
- `cargo test -p fission-test --test media`
- `cargo test -p fission-shell-winit image_tests`
- `cargo test -p fission-shell-winit retained_pipeline_scene_keeps_draw_image_ops`
- `cargo check -p fission-shell-winit -p fission-render-vello -p product-browser`
- `cargo test -p product-browser --test live_e2e product_browser_displays_remote_product_images -- --ignored --nocapture`
