### PR TITLE
Fix iOS safe area and mobile text layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ dependencies = [
  "clap",
  "serde",
  "toml",
+ "toml_edit 0.23.9",
 ]
 
 [[package]]

--- a/crates/core/fission-core/src/lowering.rs
+++ b/crates/core/fission-core/src/lowering.rs
@@ -147,7 +147,7 @@ pub fn wrap_zstack_child(cx: &mut LoweringContext, child_id: NodeId) -> NodeId {
     item.build(cx)
 }
 
-pub fn build_layout_tree(ir: &CoreIR, env: &Env) -> Vec<LayoutInputNode> {
+pub fn build_layout_tree(ir: &CoreIR, _env: &Env) -> Vec<LayoutInputNode> {
     let mut input_nodes = Vec::new();
 
     let mut parent_map = HashMap::new();
@@ -395,12 +395,6 @@ pub fn build_layout_tree(ir: &CoreIR, env: &Env) -> Vec<LayoutInputNode> {
                     inherit_max_height,
                 ) = inherited_box.unwrap_or((None, None, None, None, None, None));
 
-                let (measured_w, measured_h): (f32, f32) = if let Some(m) = &env.measurer {
-                    m.measure(text, *size, None)
-                } else {
-                    (0.0, 0.0)
-                };
-
                 rich_text_content = Some(vec![fission_ir::op::TextRun {
                     text: text.clone(),
                     style: fission_ir::op::TextStyle {
@@ -419,8 +413,8 @@ pub fn build_layout_tree(ir: &CoreIR, env: &Env) -> Vec<LayoutInputNode> {
                 children_to_visit.clear(); // Leaf node for layout
                 (
                     LayoutOp::Box {
-                        width: inherit_width.or(Some(measured_w)),
-                        height: inherit_height.or(Some(measured_h)),
+                        width: inherit_width,
+                        height: inherit_height,
                         min_width: inherit_min_width,
                         max_width: inherit_max_width,
                         min_height: inherit_min_height,
@@ -430,8 +424,8 @@ pub fn build_layout_tree(ir: &CoreIR, env: &Env) -> Vec<LayoutInputNode> {
                         flex_shrink: 1.0,
                         aspect_ratio: None,
                     },
-                    inherit_width.or(Some(measured_w)),
-                    inherit_height.or(Some(measured_h)),
+                    inherit_width,
+                    inherit_height,
                     0.0,
                     1.0,
                 )
@@ -453,12 +447,6 @@ pub fn build_layout_tree(ir: &CoreIR, env: &Env) -> Vec<LayoutInputNode> {
                     inherit_max_height,
                 ) = inherited_box.unwrap_or((None, None, None, None, None, None));
 
-                let (measured_w, measured_h): (f32, f32) = if let Some(m) = &env.measurer {
-                    m.measure_rich_text(runs, None)
-                } else {
-                    (0.0, 0.0)
-                };
-
                 rich_text_content = Some(runs.clone());
                 if !runs.iter().any(|run| {
                     decode_inline_widget_marker(run.style.font_family.as_deref()).is_some()
@@ -467,8 +455,8 @@ pub fn build_layout_tree(ir: &CoreIR, env: &Env) -> Vec<LayoutInputNode> {
                 }
                 (
                     LayoutOp::Box {
-                        width: inherit_width.or(Some(measured_w)),
-                        height: inherit_height.or(Some(measured_h)),
+                        width: inherit_width,
+                        height: inherit_height,
                         min_width: inherit_min_width,
                         max_width: inherit_max_width,
                         min_height: inherit_min_height,
@@ -478,8 +466,8 @@ pub fn build_layout_tree(ir: &CoreIR, env: &Env) -> Vec<LayoutInputNode> {
                         flex_shrink: 1.0,
                         aspect_ratio: None,
                     },
-                    inherit_width.or(Some(measured_w)),
-                    inherit_height.or(Some(measured_h)),
+                    inherit_width,
+                    inherit_height,
                     0.0,
                     1.0,
                 )

--- a/crates/rendering/fission-render-vello/src/text.rs
+++ b/crates/rendering/fission-render-vello/src/text.rs
@@ -149,6 +149,18 @@ impl VelloTextMeasurer {
         }
     }
 
+    fn layout_measured_size(layout: &Layout<ParleyBrush>) -> (f32, f32) {
+        let height = layout.lines().fold(0.0_f32, |height, line| {
+            let metrics = line.metrics();
+            let line_height = metrics
+                .line_height
+                .max(metrics.ascent + metrics.descent)
+                .max(1.0);
+            height.max(metrics.baseline - metrics.ascent + line_height)
+        });
+        (layout.width(), height)
+    }
+
     pub(crate) fn rich_layout_input_from_render_runs(
         runs: &[fission_render::TextRun],
     ) -> RichLayoutInput {
@@ -657,7 +669,7 @@ pub(crate) fn resolve_rich_text_annotation_at_index(
 impl TextMeasurer for VelloTextMeasurer {
     fn measure(&self, text: &str, font_size: f32, available_width: Option<f32>) -> (f32, f32) {
         let layout = self.get_layout(text, font_size, available_width);
-        (layout.width(), layout.height())
+        Self::layout_measured_size(&layout)
     }
 
     fn measure_rich_text(&self, runs: &[TextRun], available_width: Option<f32>) -> (f32, f32) {
@@ -687,7 +699,7 @@ impl TextMeasurer for VelloTextMeasurer {
             },
         );
 
-        (layout.width(), layout.height())
+        Self::layout_measured_size(&layout)
     }
 
     fn layout_rich_text(
@@ -727,9 +739,10 @@ impl TextMeasurer for VelloTextMeasurer {
             }
         }
 
+        let (width, height) = Self::layout_measured_size(&layout);
         RichTextLayoutInfo {
-            width: layout.width(),
-            height: layout.height(),
+            width,
+            height,
             inline_boxes,
         }
     }
@@ -929,5 +942,49 @@ impl TextMeasurer for VelloTextMeasurer {
         }
 
         (0.0, 0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fission_ir::op::{Color, FontStyle, TextStyle};
+    use fission_layout::TextMeasurer;
+
+    fn measurer() -> VelloTextMeasurer {
+        VelloTextMeasurer::new(Arc::new(Mutex::new(FontContext::new())))
+    }
+
+    fn text_run(text: &str, font_size: f32, line_height: f32) -> TextRun {
+        TextRun {
+            text: text.to_string(),
+            style: TextStyle {
+                font_size,
+                color: Color::BLACK,
+                underline: false,
+                font_family: None,
+                locale: None,
+                font_weight: 800,
+                font_style: FontStyle::Normal,
+                line_height: Some(line_height),
+                letter_spacing: 0.0,
+                background_color: None,
+            },
+        }
+    }
+
+    #[test]
+    fn rich_text_measurement_height_tracks_wrapped_lines() {
+        let measurer = measurer();
+        let runs = vec![text_run("Capability-driven field service", 22.0, 28.0)];
+
+        let (_, one_line_height) = measurer.measure_rich_text(&runs, None);
+        let (wrapped_width, wrapped_height) = measurer.measure_rich_text(&runs, Some(170.0));
+
+        assert!(wrapped_width <= 170.5);
+        assert!(
+            wrapped_height > one_line_height * 1.5,
+            "wrapped text should report multi-line height; one_line={one_line_height}, wrapped={wrapped_height}"
+        );
     }
 }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -559,6 +559,59 @@ fn create_render_state<'w>(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn present_startup_clear_frame(
+    render_state: &mut RenderState<'_>,
+    render_cx: &RenderContext,
+    clear_color: wgpu::Color,
+) -> anyhow::Result<()> {
+    let surface_texture = render_state
+        .surface
+        .surface
+        .get_current_texture()
+        .map_err(|error| anyhow::anyhow!("failed to get startup surface texture: {error}"))?;
+    let target_view = surface_texture
+        .texture
+        .create_view(&wgpu::TextureViewDescriptor::default());
+    let device_handle = &render_cx.devices[render_state.surface.dev_id];
+    let mut encoder =
+        device_handle
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Fission startup clear encoder"),
+            });
+    {
+        let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Fission startup clear pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &target_view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(clear_color),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+    }
+    device_handle.queue.submit(Some(encoder.finish()));
+    surface_texture.present();
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn theme_background_wgpu_color(env: &Env) -> wgpu::Color {
+    wgpu::Color {
+        r: f64::from(env.theme.tokens.colors.background.r) / 255.0,
+        g: f64::from(env.theme.tokens.colors.background.g) / 255.0,
+        b: f64::from(env.theme.tokens.colors.background.b) / 255.0,
+        a: f64::from(env.theme.tokens.colors.background.a) / 255.0,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn native_renderer_request() -> RendererRequest {
     let request = RendererRequest::from_env();
     let force_cpu_vello = std::env::var("FISSION_VELLO_USE_CPU")
@@ -4107,6 +4160,33 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                         #[cfg(target_os = "android")]
                         {
                             window_viewport = Some(current_viewport);
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        if render_state.is_none()
+                            && current_viewport.physical_size.width > 0
+                            && current_viewport.physical_size.height > 0
+                        {
+                            if let Some(render_window) = platform_window.active_window_arc() {
+                                match create_render_state(
+                                    &mut render_cx,
+                                    render_window,
+                                    current_viewport,
+                                ) {
+                                    Ok(mut state) => {
+                                        if let Err(err) = present_startup_clear_frame(
+                                            &mut state,
+                                            &render_cx,
+                                            theme_background_wgpu_color(&env),
+                                        ) {
+                                            eprintln!("startup clear frame failed: {err}");
+                                        }
+                                        render_state = Some(state);
+                                    }
+                                    Err(err) => {
+                                        eprintln!("render surface not ready on resume: {err}");
+                                    }
+                                }
+                            }
                         }
                         pending_resize = Some(current_viewport);
                         resize_needs_settled_frame = true;

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -29,7 +29,7 @@ use winit::{
     window::{CursorIcon, Window, WindowBuilder, WindowId},
 };
 
-use fission_core::env::VideoStatus;
+use fission_core::env::{VideoStatus, WindowInsets};
 use fission_core::lowering::LoweringContext;
 use fission_core::ui::custom_render::downcast_render_object;
 use fission_core::{
@@ -429,7 +429,10 @@ impl WindowViewportState {
         let reported_scale_factor = normalize_scale_factor(window.scale_factor());
         #[cfg(target_os = "ios")]
         {
-            let mut physical_size = window.inner_size();
+            // Winit's iOS `inner_size` is the safe-area rectangle. The renderer
+            // presents into the full view, so the viewport must use the outer
+            // bounds and expose the safe-area separately through `Env`.
+            let mut physical_size = window.outer_size();
             let effective_scale_factor = ios_effective_scale_factor(reported_scale_factor);
             if effective_scale_factor > reported_scale_factor && reported_scale_factor <= 1.0 {
                 physical_size = logical_viewport_to_physical_size(
@@ -470,6 +473,7 @@ impl WindowViewportState {
         ))
     }
 
+    #[cfg(any(test, not(target_os = "ios")))]
     fn with_scale_factor(self, scale_factor: f64) -> Self {
         let scale_factor = normalize_scale_factor(scale_factor);
         let logical_size = self.logical_size();
@@ -478,6 +482,48 @@ impl WindowViewportState {
             scale_factor,
         }
     }
+}
+
+#[cfg(any(test, target_os = "ios"))]
+fn window_insets_from_safe_area_frames(
+    inner_position: PhysicalPosition<i32>,
+    outer_position: PhysicalPosition<i32>,
+    inner_size: PhysicalSize<u32>,
+    outer_size: PhysicalSize<u32>,
+    scale_factor: f64,
+) -> WindowInsets {
+    let scale_factor = normalize_scale_factor(scale_factor) as f32;
+    let left_px = (inner_position.x - outer_position.x).max(0) as i64;
+    let top_px = (inner_position.y - outer_position.y).max(0) as i64;
+    let right_px = (outer_size.width as i64 - inner_size.width as i64 - left_px).max(0);
+    let bottom_px = (outer_size.height as i64 - inner_size.height as i64 - top_px).max(0);
+
+    WindowInsets {
+        top: top_px as f32 / scale_factor,
+        bottom: bottom_px as f32 / scale_factor,
+        left: left_px as f32 / scale_factor,
+        right: right_px as f32 / scale_factor,
+    }
+}
+
+fn window_safe_area_insets(window: &Window, scale_factor: f64) -> WindowInsets {
+    #[cfg(target_os = "ios")]
+    {
+        if let (Ok(inner_position), Ok(outer_position)) =
+            (window.inner_position(), window.outer_position())
+        {
+            return window_insets_from_safe_area_frames(
+                inner_position,
+                outer_position,
+                window.inner_size(),
+                window.outer_size(),
+                scale_factor,
+            );
+        }
+    }
+
+    let _ = (window, scale_factor);
+    WindowInsets::default()
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -2207,16 +2253,16 @@ fn physical_position_to_layout_point(
 fn window_content_origin_physical(window: &Window) -> PhysicalPosition<i32> {
     #[cfg(target_os = "ios")]
     {
-        // Winit's iOS backend reports touches in the full UIView/window
-        // coordinate space, while `inner_size` is the safe-area viewport.
-        // Convert input into the same safe-area-relative space used by layout.
-        if let (Ok(inner), Ok(outer)) = (window.inner_position(), window.outer_position()) {
-            return PhysicalPosition::new(inner.x - outer.x, inner.y - outer.y);
-        }
+        // Layout uses the full iOS view. Safe-area avoidance is exposed through
+        // `Env.window_insets`, so pointer coordinates stay in full-view space.
+        let _ = window;
+        PhysicalPosition::new(0, 0)
     }
-
-    let _ = window;
-    PhysicalPosition::new(0, 0)
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = window;
+        PhysicalPosition::new(0, 0)
+    }
 }
 
 fn window_physical_position_to_layout_point(
@@ -4809,6 +4855,9 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                         match event {
                             WindowEvent::Resized(size) => {
                                 if size.width > 0 && size.height > 0 {
+                                    #[cfg(target_os = "ios")]
+                                    let next_viewport = WindowViewportState::from_window(window);
+                                    #[cfg(not(target_os = "ios"))]
                                     let next_viewport = pending_resize
                                         .unwrap_or_else(|| WindowViewportState::from_window(window))
                                         .with_physical_size(size);
@@ -4839,6 +4888,11 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                 }
                             }
                             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                                #[cfg(target_os = "ios")]
+                                let _ = scale_factor;
+                                #[cfg(target_os = "ios")]
+                                let next_viewport = WindowViewportState::from_window(window);
+                                #[cfg(not(target_os = "ios"))]
                                 let next_viewport = pending_resize
                                     .unwrap_or_else(|| WindowViewportState::from_window(window))
                                     .with_scale_factor(scale_factor);
@@ -5189,6 +5243,8 @@ impl<S: AppState + Default, W: Widget<S> + 'static> WinitApp<S, W> {
                                     &mut invalidations,
                                 );
                                 env.viewport_size = build_viewport;
+                                env.window_insets =
+                                    window_safe_area_insets(window, viewport_state.scale_factor);
 
                                 if let Some(sync) = &self.sync_env {
                                     let state = runtime.get_app_state::<S>().unwrap();
@@ -6860,7 +6916,8 @@ mod tests {
         physical_size_to_layout_size, rect_visible_in_scroll_ancestors,
         repeating_animation_redraw_interval, resize_is_unsettled, resolve_build_viewport,
         sync_tracked_target_texture_size_to_surface, texture_plans_fit_device_limits,
-        visual_rect_for_node, LiveResizeController, WindowViewportState,
+        visual_rect_for_node, window_insets_from_safe_area_frames, LiveResizeController,
+        WindowViewportState,
     };
     use crate::pipeline::CompositorTexturePlan;
     use crate::InvalidationSet;
@@ -6923,6 +6980,22 @@ mod tests {
             PhysicalPosition::new(0, 100),
         );
         assert_eq!(point, fission_render::LayoutPoint::new(120.0, 180.0));
+    }
+
+    #[test]
+    fn safe_area_frames_convert_to_logical_window_insets() {
+        let insets = window_insets_from_safe_area_frames(
+            PhysicalPosition::new(0, 177),
+            PhysicalPosition::new(0, 0),
+            PhysicalSize::new(1206, 2343),
+            PhysicalSize::new(1206, 2622),
+            3.0,
+        );
+
+        assert_eq!(insets.left, 0.0);
+        assert_eq!(insets.right, 0.0);
+        assert_eq!(insets.top, 59.0);
+        assert_eq!(insets.bottom, 34.0);
     }
 
     #[test]

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -282,11 +282,17 @@ mod tests {
         assert!(dir.join("platforms/web/test-browser.sh").exists());
         assert!(dir.join("platforms/ios/README.md").exists());
         assert!(dir.join("platforms/ios/Info.plist").exists());
+        assert!(dir.join("platforms/ios/LaunchScreen.storyboard").exists());
         assert!(dir.join("platforms/ios/package-sim.sh").exists());
         assert!(dir.join("platforms/ios/run-sim.sh").exists());
         assert!(dir.join("platforms/ios/test-sim.sh").exists());
         assert!(dir.join("platforms/android/README.md").exists());
         assert!(dir.join("platforms/android/AndroidManifest.xml").exists());
+        assert!(dir.join("platforms/android/res/values/colors.xml").exists());
+        assert!(dir.join("platforms/android/res/values/styles.xml").exists());
+        assert!(dir
+            .join("platforms/android/res/drawable/fission_splash_background.xml")
+            .exists());
         assert!(dir.join("platforms/android/package-apk.sh").exists());
         assert!(dir.join("platforms/android/run-emulator.sh").exists());
         assert!(dir.join("platforms/android/test-emulator.sh").exists());
@@ -294,6 +300,11 @@ mod tests {
             std::fs::read_to_string(dir.join("platforms/android/AndroidManifest.xml")).unwrap();
         assert!(android_manifest.contains("android:icon=\"@drawable/app_icon\""));
         assert!(android_manifest.contains("android:targetSdkVersion=\"35\""));
+        assert!(android_manifest.contains("android:theme=\"@style/FissionLaunchTheme\""));
+        let android_styles =
+            std::fs::read_to_string(dir.join("platforms/android/res/values/styles.xml")).unwrap();
+        assert!(android_styles.contains("android:windowBackground"));
+        assert!(android_styles.contains("android:windowSplashScreenAnimatedIcon"));
         let android_package_script =
             std::fs::read_to_string(dir.join("platforms/android/package-apk.sh")).unwrap();
         assert!(android_package_script.contains("detect_android_toolchain"));
@@ -308,10 +319,19 @@ mod tests {
         );
         assert!(android_package_script.contains("BUILD_MANIFEST"));
         assert!(android_package_script.contains("android:targetSdkVersion=\"{target_api}\""));
+        assert!(android_package_script.contains("cp -R \"$SCRIPT_DIR/res/.\""));
+        assert!(android_package_script.contains("fission_splash_image.png"));
+        assert!(android_package_script.contains("APP_ICONS"));
+        assert!(android_package_script.contains("res/drawable-nodpi/app_icon.*"));
         let android_run_script =
             std::fs::read_to_string(dir.join("platforms/android/run-emulator.sh")).unwrap();
         assert!(android_run_script.contains("ANDROID_EMULATOR_API_LEVEL"));
         assert!(android_run_script.contains("fission doctor android"));
+        assert!(android_run_script.contains("wait_for_android_boot()"));
+        assert!(android_run_script.contains("cmd package list packages"));
+        assert!(android_run_script.contains("ADB_INSTALL_FLAGS:---no-streaming -r"));
+        assert!(!android_run_script.contains("wait_for_android_boot() {\n  wait_for_android_boot"));
+        assert!(!android_run_script.contains("  wait_for_android_boot\n  wait_for_android_boot"));
         assert!(
             std::fs::read_to_string(dir.join("platforms/android/README.md"))
                 .unwrap()
@@ -329,9 +349,17 @@ mod tests {
         assert!(ios_package_script.contains("EXECUTABLE_NAME=\"${IOS_EXECUTABLE_NAME:-"));
         assert!(ios_package_script.contains("plistlib.load"));
         assert!(ios_package_script.contains("PkgInfo"));
+        assert!(ios_package_script.contains("PLATFORM_APP_ICONS"));
         assert!(ios_package_script.contains("AppIcon.png"));
+        assert!(ios_package_script.contains("LaunchScreen.storyboard"));
+        assert!(ios_package_script.contains("ibtool"));
+        assert!(ios_package_script.contains("LaunchScreen.storyboardc"));
+        assert!(ios_package_script.contains("SplashImage.png"));
+        let ios_plist = std::fs::read_to_string(dir.join("platforms/ios/Info.plist")).unwrap();
+        assert!(ios_plist.contains("UILaunchStoryboardName"));
         let ios_run_script = std::fs::read_to_string(dir.join("platforms/ios/run-sim.sh")).unwrap();
         assert!(ios_run_script.contains("BUNDLE_ID=\"${IOS_BUNDLE_ID:-com.example."));
+        assert!(ios_run_script.contains("IOS_SIM_UNINSTALL_BEFORE_INSTALL"));
         assert!(ios_run_script.contains(
             "xcrun simctl launch --terminate-running-process \"$DEVICE_ID\" \"$BUNDLE_ID\""
         ));
@@ -361,6 +389,121 @@ mod tests {
         assert!(std::fs::read_to_string(dir.join("platforms/web/README.md"))
             .unwrap()
             .contains("fission run --target web"));
+    }
+
+    #[test]
+    fn custom_icon_config_is_preserved_and_applied_to_mobile_scaffolds() {
+        let dir = unique_dir("custom-icons");
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+        fs::copy(
+            dir.join("assets/app-icon.png"),
+            dir.join("assets/shared-icon.png"),
+        )
+        .unwrap();
+        fs::copy(
+            dir.join("assets/app-icon.png"),
+            dir.join("assets/android-icon.png"),
+        )
+        .unwrap();
+        fs::copy(
+            dir.join("assets/app-icon.png"),
+            dir.join("assets/ios-icon.png"),
+        )
+        .unwrap();
+        let mut manifest = fs::read_to_string(dir.join("fission.toml")).unwrap();
+        manifest.push_str(
+            r##"
+
+[package.icons]
+mode = "mixed"
+source = "assets/shared-icon.png"
+safe_zone = 0.72
+allow_upscale = false
+
+[package.icons.android]
+source = "assets/android-icon.png"
+
+[package.icons.ios]
+source = "assets/ios-icon.png"
+"##,
+        );
+        fs::write(dir.join("fission.toml"), manifest).unwrap();
+
+        run([
+            "fission",
+            "add-target",
+            "ios",
+            "android",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let manifest = fs::read_to_string(dir.join("fission.toml")).unwrap();
+        assert!(manifest.contains("[package.icons]"));
+        assert!(manifest.contains("source = \"assets/shared-icon.png\""));
+        assert!(manifest.contains("[package.icons.android]"));
+        assert!(manifest.contains("[package.icons.ios]"));
+        assert!(dir
+            .join("platforms/android/res/drawable-nodpi/app_icon.png")
+            .exists());
+        assert!(dir.join("platforms/ios/AppIcon.png").exists());
+        let android_manifest =
+            fs::read_to_string(dir.join("platforms/android/AndroidManifest.xml")).unwrap();
+        assert!(android_manifest.contains("android:icon=\"@drawable/app_icon\""));
+        let android_package =
+            fs::read_to_string(dir.join("platforms/android/package-apk.sh")).unwrap();
+        assert!(android_package.contains("APP_ICONS"));
+        let ios_package = fs::read_to_string(dir.join("platforms/ios/package-sim.sh")).unwrap();
+        assert!(ios_package.contains("PLATFORM_APP_ICONS"));
+    }
+
+    #[test]
+    fn custom_splash_config_updates_mobile_platform_files() {
+        let dir = unique_dir("custom-splash");
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+        fs::copy(
+            dir.join("assets/app-icon.png"),
+            dir.join("assets/custom-splash.png"),
+        )
+        .unwrap();
+        let mut manifest = fs::read_to_string(dir.join("fission.toml")).unwrap();
+        manifest.push_str(
+            r##"
+
+[app.splash]
+background_color = "#123456"
+image = "assets/custom-splash.png"
+resize_mode = "cover"
+android_animation_duration_ms = 650
+"##,
+        );
+        fs::write(dir.join("fission.toml"), manifest).unwrap();
+
+        run([
+            "fission",
+            "add-target",
+            "ios",
+            "android",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let android_colors =
+            fs::read_to_string(dir.join("platforms/android/res/values/colors.xml")).unwrap();
+        assert!(android_colors.contains("#123456"));
+        let android_styles =
+            fs::read_to_string(dir.join("platforms/android/res/values/styles.xml")).unwrap();
+        assert!(android_styles.contains("650"));
+        assert!(dir
+            .join("platforms/android/res/drawable-nodpi/fission_splash_image.png")
+            .exists());
+        let storyboard =
+            fs::read_to_string(dir.join("platforms/ios/LaunchScreen.storyboard")).unwrap();
+        assert!(storyboard.contains("scaleAspectFill"));
+        assert!(storyboard.contains("red=\"0.070588\""));
+        assert!(dir.join("platforms/ios/SplashImage.png").exists());
     }
 
     #[test]
@@ -442,6 +585,9 @@ mod tests {
         assert!(android_manifest.contains("android.permission.MODIFY_AUDIO_SETTINGS"));
         assert!(android_manifest.contains("android.permission.NEARBY_WIFI_DEVICES"));
         assert!(android_manifest.contains("android.permission.ACCESS_WIFI_STATE"));
+        assert!(dir
+            .join("platforms/android/java/rs/fission/runtime/FissionAndroidCapabilities.java")
+            .exists());
 
         let ios_info = std::fs::read_to_string(dir.join("platforms/ios/Info.plist")).unwrap();
         assert!(ios_info.contains("NFCReaderUsageDescription"));

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -14,3 +14,4 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
+toml_edit = "0.23"

--- a/crates/tools/fission-command-core/src/icons.rs
+++ b/crates/tools/fission-command-core/src/icons.rs
@@ -1,0 +1,429 @@
+use crate::{FissionProject, Target};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_APP_ICON: &str = "assets/app-icon.png";
+
+#[derive(Clone, Debug)]
+pub struct ResolvedIcon {
+    pub path: PathBuf,
+    pub configured: bool,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct IconManifest {
+    package: Option<PackageManifest>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PackageManifest {
+    icon: Option<String>,
+    icons: Option<PackageIcons>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PackageIcons {
+    mode: Option<IconMode>,
+    source: Option<String>,
+    monochrome: Option<String>,
+    background_color: Option<String>,
+    safe_zone: Option<IconSafeZone>,
+    allow_upscale: Option<bool>,
+    android: Option<AndroidIcons>,
+    ios: Option<AppleIcons>,
+    macos: Option<AppleIcons>,
+    windows: Option<WindowsIcons>,
+    linux: Option<LinuxIcons>,
+    web: Option<WebIcons>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum IconMode {
+    Generate,
+    Provided,
+    Mixed,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum IconSafeZone {
+    Named(String),
+    Fraction(f32),
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct AndroidIcons {
+    source: Option<String>,
+    foreground: Option<String>,
+    background: Option<String>,
+    monochrome: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct AppleIcons {
+    source: Option<String>,
+    dark: Option<String>,
+    tinted: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct WindowsIcons {
+    source: Option<String>,
+    light: Option<String>,
+    dark: Option<String>,
+    unplated: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct LinuxIcons {
+    source: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct WebIcons {
+    source: Option<String>,
+    favicon: Option<String>,
+    maskable: Option<String>,
+}
+
+pub fn resolve_app_icon(root: &Path, target: Target) -> Result<Option<ResolvedIcon>> {
+    let manifest = read_icon_manifest(root)?;
+    if let Some(configured) = configured_icon_path(&manifest, target) {
+        let path = root.join(configured);
+        validate_icon_file(&path, target)?;
+        return Ok(Some(ResolvedIcon {
+            path,
+            configured: true,
+        }));
+    }
+
+    for relative in fallback_icon_paths(target) {
+        let path = root.join(relative);
+        if path.is_file() {
+            return Ok(Some(ResolvedIcon {
+                path,
+                configured: false,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+pub(crate) fn apply_platform_icon_config(root: &Path, project: &FissionProject) -> Result<()> {
+    if project.targets.contains(&Target::Android) {
+        apply_android_icon_config(root)?;
+    }
+    if project.targets.contains(&Target::Ios) {
+        apply_ios_icon_config(root)?;
+    }
+    Ok(())
+}
+
+fn read_icon_manifest(root: &Path) -> Result<IconManifest> {
+    let path = root.join("fission.toml");
+    let data =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let manifest: IconManifest = toml::from_str(&data)
+        .with_context(|| format!("failed to parse icon config in {}", path.display()))?;
+    validate_icon_metadata(&manifest)?;
+    Ok(manifest)
+}
+
+fn configured_icon_path(manifest: &IconManifest, target: Target) -> Option<&str> {
+    let package = manifest.package.as_ref()?;
+    let icons = package.icons.as_ref();
+    let platform = match target {
+        Target::Android => icons
+            .and_then(|icons| icons.android.as_ref())
+            .and_then(|icons| icons.source.as_deref().or(icons.foreground.as_deref())),
+        Target::Ios => icons
+            .and_then(|icons| icons.ios.as_ref())
+            .and_then(|icons| icons.source.as_deref()),
+        Target::Macos => icons
+            .and_then(|icons| icons.macos.as_ref())
+            .and_then(|icons| icons.source.as_deref()),
+        Target::Windows => icons
+            .and_then(|icons| icons.windows.as_ref())
+            .and_then(|icons| icons.source.as_deref()),
+        Target::Linux => icons
+            .and_then(|icons| icons.linux.as_ref())
+            .and_then(|icons| icons.source.as_deref()),
+        Target::Web | Target::Site => icons
+            .and_then(|icons| icons.web.as_ref())
+            .and_then(|icons| icons.source.as_deref().or(icons.favicon.as_deref())),
+    };
+    platform
+        .or_else(|| icons.and_then(|icons| icons.source.as_deref()))
+        .or(package.icon.as_deref())
+}
+
+fn fallback_icon_paths(target: Target) -> &'static [&'static str] {
+    match target {
+        Target::Macos => &[
+            "assets/app-icon.icns",
+            "assets/AppIcon.icns",
+            "assets/app-icon.png",
+            "assets/icon.png",
+        ],
+        Target::Windows => &[
+            "assets/app-icon.ico",
+            "assets/AppIcon.ico",
+            "assets/app-icon.png",
+            "assets/icon.png",
+        ],
+        Target::Linux => &[
+            "assets/app-icon.svg",
+            "assets/app-icon.png",
+            "assets/icon.svg",
+            "assets/icon.png",
+        ],
+        _ => &[DEFAULT_APP_ICON, "assets/icon.png"],
+    }
+}
+
+fn validate_icon_file(path: &Path, target: Target) -> Result<()> {
+    if !path.is_file() {
+        bail!("configured icon does not exist: {}", path.display());
+    }
+    let extension = normalized_extension(path).with_context(|| {
+        format!(
+            "configured icon must have a file extension: {}",
+            path.display()
+        )
+    })?;
+    let allowed = match target {
+        Target::Android => &["png", "jpg", "jpeg", "webp", "xml"][..],
+        Target::Ios => &["png", "jpg", "jpeg"][..],
+        Target::Macos => &["icns", "png", "jpg", "jpeg"][..],
+        Target::Windows => &["ico", "png", "jpg", "jpeg"][..],
+        Target::Linux => &["png", "svg"][..],
+        Target::Web | Target::Site => &["ico", "png", "jpg", "jpeg", "svg", "webp"][..],
+    };
+    if !allowed.contains(&extension.as_str()) {
+        bail!(
+            "configured {} icon must use one of: {}",
+            target.as_str(),
+            allowed.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn apply_android_icon_config(root: &Path) -> Result<()> {
+    let Some(icon) = resolve_app_icon(root, Target::Android)? else {
+        return Ok(());
+    };
+    if !icon.configured {
+        return Ok(());
+    }
+    let extension = normalized_extension(&icon.path)?;
+    let (destination, resource_ref) = if extension == "xml" {
+        (
+            root.join("platforms/android/res/drawable/app_icon.xml"),
+            "@drawable/app_icon",
+        )
+    } else {
+        (
+            root.join("platforms/android/res/drawable-nodpi/app_icon.")
+                .with_extension(&extension),
+            "@drawable/app_icon",
+        )
+    };
+    copy_required_asset(&icon.path, &destination)?;
+    ensure_android_manifest_icon_ref(root, resource_ref)?;
+    ensure_android_package_script_copies_icon_resources(root)
+}
+
+fn apply_ios_icon_config(root: &Path) -> Result<()> {
+    let Some(icon) = resolve_app_icon(root, Target::Ios)? else {
+        return Ok(());
+    };
+    if !icon.configured {
+        return Ok(());
+    }
+    let extension = normalized_extension(&icon.path)?;
+    let destination = root
+        .join("platforms/ios")
+        .join(format!("AppIcon.{extension}"));
+    copy_required_asset(&icon.path, &destination)?;
+    ensure_ios_package_script_copies_icon(root)
+}
+
+fn ensure_android_manifest_icon_ref(root: &Path, resource_ref: &str) -> Result<()> {
+    let path = root.join("platforms/android/AndroidManifest.xml");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains(&format!("android:icon=\"{resource_ref}\"")) {
+        return Ok(());
+    }
+    let updated = replace_android_icon_attr(&existing, resource_ref);
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn replace_android_icon_attr(existing: &str, resource_ref: &str) -> String {
+    let Some(start) = existing.find("android:icon=\"") else {
+        return existing.replacen(
+            "android:label=",
+            &format!("android:icon=\"{resource_ref}\"\n        android:label="),
+            1,
+        );
+    };
+    let value_start = start + "android:icon=\"".len();
+    let Some(relative_end) = existing[value_start..].find('"') else {
+        return existing.to_string();
+    };
+    let end = value_start + relative_end;
+    let mut updated = existing.to_string();
+    updated.replace_range(value_start..end, resource_ref);
+    updated
+}
+
+fn ensure_android_package_script_copies_icon_resources(root: &Path) -> Result<()> {
+    let path = root.join("platforms/android/package-apk.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains("app_icon.png") && existing.contains("res/drawable-nodpi/app_icon.*") {
+        return Ok(());
+    }
+    let marker =
+        "cp \"$PROJECT_DIR/assets/app-icon.png\" \"$APK_ROOT/res/drawable-nodpi/app_icon.png\"\n";
+    let replacement = r#"shopt -s nullglob
+APP_ICONS=("$SCRIPT_DIR"/res/drawable-nodpi/app_icon.* "$SCRIPT_DIR"/res/drawable/app_icon.*)
+if (( ${#APP_ICONS[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/app_icon.png"
+fi
+shopt -u nullglob
+"#;
+    let updated = if existing.contains(marker) {
+        existing.replacen(marker, replacement, 1)
+    } else {
+        existing
+    };
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn ensure_ios_package_script_copies_icon(root: &Path) -> Result<()> {
+    let path = root.join("platforms/ios/package-sim.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains("PLATFORM_APP_ICONS") {
+        return Ok(());
+    }
+    let marker = "cp \"$PROJECT_DIR/assets/app-icon.png\" \"$BUNDLE_DIR/AppIcon.png\"\n";
+    let replacement = r#"shopt -s nullglob
+PLATFORM_APP_ICONS=("$SCRIPT_DIR"/AppIcon.*)
+if (( ${#PLATFORM_APP_ICONS[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/AppIcon.png"
+else
+  app_icon="${PLATFORM_APP_ICONS[0]}"
+  cp "$app_icon" "$BUNDLE_DIR/$(basename "$app_icon")"
+fi
+shopt -u nullglob
+"#;
+    let updated = if existing.contains(marker) {
+        existing.replacen(marker, replacement, 1)
+    } else {
+        existing
+    };
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn copy_required_asset(source: &Path, destination: &Path) -> Result<()> {
+    if !source.exists() {
+        bail!("configured icon asset does not exist: {}", source.display());
+    }
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(source, destination).with_context(|| {
+        format!(
+            "failed to copy {} to {}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub fn copy_icon_for_bundle(
+    root: &Path,
+    target: Target,
+    destination: &Path,
+) -> Result<Option<PathBuf>> {
+    let Some(icon) = resolve_app_icon(root, target)? else {
+        return Ok(None);
+    };
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(&icon.path, destination).with_context(|| {
+        format!(
+            "failed to copy {} to {}",
+            icon.path.display(),
+            destination.display()
+        )
+    })?;
+    Ok(Some(icon.path))
+}
+
+pub fn normalized_extension(path: &Path) -> Result<String> {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .with_context(|| format!("path has no extension: {}", path.display()))
+}
+
+fn validate_icon_metadata(manifest: &IconManifest) -> Result<()> {
+    if let Some(icons) = manifest
+        .package
+        .as_ref()
+        .and_then(|package| package.icons.as_ref())
+    {
+        let _ = (
+            &icons.mode,
+            &icons.monochrome,
+            &icons.background_color,
+            icons.allow_upscale,
+        );
+        if let Some(safe_zone) = &icons.safe_zone {
+            match safe_zone {
+                IconSafeZone::Named(value) if matches!(value.as_str(), "platform" | "none") => {}
+                IconSafeZone::Named(value) => bail!(
+                    "package.icons.safe_zone must be `platform`, `none`, or a numeric fraction; got `{value}`"
+                ),
+                IconSafeZone::Fraction(value) if (0.0..=1.0).contains(value) => {}
+                IconSafeZone::Fraction(value) => bail!(
+                    "package.icons.safe_zone numeric fraction must be between 0.0 and 1.0; got {value}"
+                ),
+            }
+        }
+        if let Some(android) = &icons.android {
+            let _ = (&android.background, &android.monochrome);
+        }
+        if let Some(ios) = &icons.ios {
+            let _ = (&ios.dark, &ios.tinted);
+        }
+        if let Some(macos) = &icons.macos {
+            let _ = (&macos.dark, &macos.tinted);
+        }
+        if let Some(windows) = &icons.windows {
+            let _ = (&windows.light, &windows.dark, &windows.unplated);
+        }
+        if let Some(web) = &icons.web {
+            let _ = &web.maskable;
+        }
+    }
+    Ok(())
+}

--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -4,9 +4,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use toml_edit::{value, Array, DocumentMut, Item, Table, Value};
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_APP_ICON_PNG: &[u8] = include_bytes!("../assets/fission_logo.png");
+
+mod icons;
+mod splash;
+pub use icons::{copy_icon_for_bundle, normalized_extension, resolve_app_icon, ResolvedIcon};
+pub use splash::{SplashConfig, SplashResizeMode};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, ValueEnum, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -135,6 +141,8 @@ pub struct FissionProject {
 pub struct AppConfig {
     pub name: String,
     pub app_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub splash: Option<SplashConfig>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -202,7 +210,7 @@ pub fn init_project(
     for target in targets {
         scaffold_target_with_policy(root, &project, target, write_policy)?;
     }
-    apply_platform_capability_config(root, &project)?;
+    sync_platform_config(root, &project)?;
 
     Ok(())
 }
@@ -253,6 +261,9 @@ fn initial_project_config(
             app_id: app_id
                 .or_else(|| existing.as_ref().map(|project| project.app.app_id.clone()))
                 .unwrap_or_else(|| format!("com.example.{}", normalized_name.replace('-', "_"))),
+            splash: existing
+                .as_ref()
+                .and_then(|project| project.app.splash.clone()),
         },
         targets,
         capabilities: existing
@@ -305,7 +316,7 @@ pub fn add_targets(project_dir: &Path, targets: &[Target]) -> Result<()> {
         };
         scaffold_target_with_policy(project_dir, &project, *target, write_policy)?;
     }
-    apply_platform_capability_config(project_dir, &project)?;
+    sync_platform_config(project_dir, &project)?;
     write_project_config(project_dir, &project)?;
     update_cargo_fission_features(project_dir, &project)?;
     write_file_with_policy(
@@ -325,8 +336,125 @@ pub fn add_capabilities(project_dir: &Path, capabilities: &[PlatformCapability])
         project.capabilities.insert(*capability);
     }
     write_project_config(project_dir, &project)?;
-    apply_platform_capability_config(project_dir, &project)?;
+    sync_platform_config(project_dir, &project)?;
     Ok(())
+}
+
+pub fn sync_platform_config(root: &Path, project: &FissionProject) -> Result<()> {
+    apply_platform_capability_config(root, project)?;
+    splash::apply_platform_splash_config(root, project)?;
+    icons::apply_platform_icon_config(root, project)?;
+    apply_mobile_run_script_hardening(root, project)?;
+    Ok(())
+}
+
+fn apply_mobile_run_script_hardening(root: &Path, project: &FissionProject) -> Result<()> {
+    if project.targets.contains(&Target::Ios) {
+        apply_ios_run_script_hardening(root)?;
+    }
+    if project.targets.contains(&Target::Android) {
+        apply_android_run_script_hardening(root)?;
+    }
+    Ok(())
+}
+
+fn apply_ios_run_script_hardening(root: &Path) -> Result<()> {
+    let path = root.join("platforms/ios/run-sim.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains("IOS_SIM_UNINSTALL_BEFORE_INSTALL") {
+        return Ok(());
+    }
+    let marker = "xcrun simctl bootstatus \"$DEVICE_ID\" -b\n";
+    let insertion = "xcrun simctl bootstatus \"$DEVICE_ID\" -b\nif [[ \"${IOS_SIM_UNINSTALL_BEFORE_INSTALL:-1}\" == \"1\" ]]; then\n  xcrun simctl uninstall \"$DEVICE_ID\" \"$BUNDLE_ID\" >/dev/null 2>&1 || true\nfi\n";
+    let updated = existing.replacen(marker, insertion, 1);
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn apply_android_run_script_hardening(root: &Path) -> Result<()> {
+    let path = root.join("platforms/android/run-emulator.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut updated = existing.clone();
+    let wait_function = android_wait_for_boot_function();
+    if let Some(start) = updated.find("wait_for_android_boot() {") {
+        let marker = "\n}\n\nANDROID_EMULATOR_API_LEVEL=";
+        if let Some(relative_end) = updated[start..].find(marker) {
+            let end = start + relative_end + "\n}\n\n".len();
+            updated.replace_range(start..end, &format!("{wait_function}\n\n"));
+        }
+    } else {
+        updated = updated.replacen(
+            "\nANDROID_EMULATOR_API_LEVEL=",
+            &format!("\n{wait_function}\n\nANDROID_EMULATOR_API_LEVEL="),
+            1,
+        );
+    }
+    updated =
+        replace_android_boot_wait_after(updated, "  disown || true\n", "  wait_for_android_boot\n");
+    updated = replace_android_boot_wait_after(
+        updated,
+        "  \"$EMULATOR_BIN\" \"${EMULATOR_ARGS[@]}\" >/tmp/fission-android-emulator.log 2>&1 &\n",
+        "  wait_for_android_boot\n",
+    );
+    if !updated.contains(
+        "printf 'Using existing emulator %s\\n' \"$RUNNING_EMULATOR\"\n  wait_for_android_boot\n",
+    ) {
+        updated = updated.replacen(
+            "printf 'Using existing emulator %s\\n' \"$RUNNING_EMULATOR\"\n",
+            "printf 'Using existing emulator %s\\n' \"$RUNNING_EMULATOR\"\n  wait_for_android_boot\n",
+            1,
+        );
+    }
+    while updated.contains("  wait_for_android_boot\n  wait_for_android_boot\n") {
+        updated = updated.replace(
+            "  wait_for_android_boot\n  wait_for_android_boot\n",
+            "  wait_for_android_boot\n",
+        );
+    }
+    updated = updated.replace(
+        "\"$ADB\" install -r \"$APK\"",
+        "read -r -a ADB_INSTALL_FLAGS <<< \"${ADB_INSTALL_FLAGS:---no-streaming -r}\"\n\"$ADB\" install \"${ADB_INSTALL_FLAGS[@]}\" \"$APK\"",
+    );
+    if updated != existing {
+        fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn android_wait_for_boot_function() -> &'static str {
+    r#"wait_for_android_boot() {
+  "$ADB" wait-for-device
+  until "$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; do
+    sleep 1
+  done
+  local deadline=$((SECONDS + 180))
+  until "$ADB" shell cmd package list packages >/dev/null 2>&1; do
+    if (( SECONDS > deadline )); then
+      printf 'Android package manager did not become available. Restart the emulator with ANDROID_EMULATOR_RESTART=1 and try again.\n' >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}"#
+}
+
+fn replace_android_boot_wait_after(mut text: String, marker: &str, replacement: &str) -> String {
+    let Some(start) = text.find(marker) else {
+        return text;
+    };
+    let wait_start = start + marker.len();
+    let old_wait = "  \"$ADB\" wait-for-device\n  until \"$ADB\" shell getprop sys.boot_completed 2>/dev/null | tr -d '\\r' | grep -q '^1$'; do\n    sleep 1\n  done\n";
+    if text[wait_start..].starts_with(old_wait) {
+        text.replace_range(wait_start..wait_start + old_wait.len(), replacement);
+    }
+    text
 }
 
 fn apply_platform_capability_config(root: &Path, project: &FissionProject) -> Result<()> {
@@ -334,12 +462,21 @@ fn apply_platform_capability_config(root: &Path, project: &FissionProject) -> Re
         return Ok(());
     }
     if project.targets.contains(&Target::Android) {
+        ensure_android_capability_helper(root)?;
         apply_android_capability_config(root, project)?;
     }
     if project.targets.contains(&Target::Ios) {
         apply_ios_capability_config(root, project)?;
     }
     Ok(())
+}
+
+fn ensure_android_capability_helper(root: &Path) -> Result<()> {
+    write_file_with_policy(
+        &root.join("platforms/android/java/rs/fission/runtime/FissionAndroidCapabilities.java"),
+        render_android_capabilities_java(),
+        WritePolicy::PreserveExisting,
+    )
 }
 
 fn apply_android_capability_config(root: &Path, project: &FissionProject) -> Result<()> {
@@ -594,8 +731,80 @@ fn target_scaffold_dir_exists(project_dir: &Path, target: Target) -> bool {
 }
 
 fn write_project_config(root: &Path, project: &FissionProject) -> Result<()> {
+    let path = root.join("fission.toml");
+    if path.exists() {
+        let existing = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let mut doc = existing
+            .parse::<DocumentMut>()
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+        update_project_config_document(&mut doc, project);
+        write_file(&path, &doc.to_string())?;
+        return Ok(());
+    }
     let data = toml::to_string_pretty(project)?;
-    write_file(&root.join("fission.toml"), &(data + "\n"))
+    write_file(&path, &(data + "\n"))
+}
+
+fn update_project_config_document(doc: &mut DocumentMut, project: &FissionProject) {
+    doc["targets"] = value(string_array(
+        project.targets.iter().map(|target| target.as_str()),
+    ));
+    if project.capabilities.is_empty() {
+        doc.as_table_mut().remove("capabilities");
+    } else {
+        doc["capabilities"] = value(string_array(
+            project
+                .capabilities
+                .iter()
+                .map(|capability| capability.as_str()),
+        ));
+    }
+
+    if !doc["app"].is_table() {
+        doc["app"] = Item::Table(Table::new());
+    }
+    doc["app"]["name"] = value(project.app.name.clone());
+    doc["app"]["app_id"] = value(project.app.app_id.clone());
+    if let Some(splash) = &project.app.splash {
+        if !doc["app"]["splash"].is_table() {
+            doc["app"]["splash"] = Item::Table(Table::new());
+        }
+        let splash_item = &mut doc["app"]["splash"];
+        if let Some(background_color) = &splash.background_color {
+            splash_item["background_color"] = value(background_color.clone());
+        }
+        if let Some(image) = &splash.image {
+            splash_item["image"] = value(image.clone());
+        }
+        if let Some(resize_mode) = splash.resize_mode {
+            splash_item["resize_mode"] = value(match resize_mode {
+                SplashResizeMode::Center => "center",
+                SplashResizeMode::Contain => "contain",
+                SplashResizeMode::Cover => "cover",
+            });
+        }
+        if let Some(animated_icon) = &splash.android_animated_icon {
+            splash_item["android_animated_icon"] = value(animated_icon.clone());
+        }
+        if let Some(duration) = splash.android_animation_duration_ms {
+            splash_item["android_animation_duration_ms"] = value(i64::from(duration));
+        }
+    } else if let Some(app) = doc["app"].as_table_like_mut() {
+        app.remove("splash");
+    }
+}
+
+fn string_array<'a>(values: impl Iterator<Item = &'a str>) -> Array {
+    let mut array = Array::new();
+    for value in values {
+        let mut value = Value::from(value);
+        value.decor_mut().set_prefix("\n    ");
+        array.push_formatted(value);
+    }
+    array.set_trailing("\n");
+    array.set_trailing_comma(true);
+    array
 }
 
 pub fn read_project_config(root: &Path) -> Result<FissionProject> {
@@ -729,6 +938,7 @@ fn scaffold_target_with_policy(
                     "Override `ANDROID_HOME`, `ANDROID_NDK`, `ANDROID_MIN_API_LEVEL`, `ANDROID_TARGET_API_LEVEL`, `ANDROID_AVD_NAME`, or `ANDROID_SYSTEM_IMAGE` if your local SDK setup differs.",
                     "Set `ANDROID_EMULATOR_HEADLESS=1` for background/CI runs, or `ANDROID_EMULATOR_RESTART=1` to relaunch a hidden emulator visibly.",
                     "The generated package uses `assets/app-icon.png` as its default launcher icon.",
+                    "Configure `[app.splash]` in `fission.toml` to generate the native Android launch theme, splash background, static image, and optional Android animated drawable.",
                     "Run `fission add-capability nfc --project-dir .` to add NFC manifest permission and feature declarations.",
                     "Run `fission add-capability notifications --project-dir .` to add Android notification permission for API 33 and newer.",
                     "Run `fission add-capability biometric --project-dir .` to add biometric manifest permissions.",
@@ -760,6 +970,7 @@ fn scaffold_target_with_policy(
                     "Run `fission test --target ios --project-dir .` for a simulator launch plus test-control health check.",
                     "Run `./platforms/ios/run-sim.sh` from the project root to build, install, and launch the app on the first available iPhone simulator.",
                     "The generated bundle uses `assets/app-icon.png` as its default app icon.",
+                    "Configure `[app.splash]` in `fission.toml` to generate the native iOS launch storyboard and splash image copied into the simulator bundle.",
                     "Run `fission add-capability nfc --project-dir .` to add the NFC usage description and entitlements file.",
                     "Run `fission add-capability notifications --project-dir .` to record local-notification use. iOS prompts at runtime and does not require an Info.plist usage key for local notifications.",
                     "Run `fission add-capability biometric --project-dir .` to add the Face ID usage description.",
@@ -899,7 +1110,6 @@ fn scaffold_android_bundle(
     let package_script = render_android_package_script(project);
     let run_script = render_android_run_script(project);
     let test_script = render_android_test_script();
-    let android_capabilities = render_android_capabilities_java();
 
     write_file_with_policy(
         &root.join("platforms/android/AndroidManifest.xml"),
@@ -919,11 +1129,6 @@ fn scaffold_android_bundle(
     write_file_with_policy(
         &root.join("platforms/android/test-emulator.sh"),
         &test_script,
-        write_policy,
-    )?;
-    write_file_with_policy(
-        &root.join("platforms/android/java/rs/fission/runtime/FissionAndroidCapabilities.java"),
-        android_capabilities,
         write_policy,
     )?;
     #[cfg(unix)]
@@ -1000,7 +1205,7 @@ fn scaffold_web_bundle(
     Ok(())
 }
 
-fn write_file(path: &Path, contents: &str) -> Result<()> {
+pub(crate) fn write_file(path: &Path, contents: &str) -> Result<()> {
     write_file_with_policy(path, contents, WritePolicy::Overwrite)
 }
 
@@ -1169,6 +1374,8 @@ fn render_ios_plist(project: &FissionProject, executable: &str) -> String {
   <string>1</string>
   <key>CFBundleIconFile</key>
   <string>AppIcon</string>
+  <key>UILaunchStoryboardName</key>
+  <string>LaunchScreen</string>
   <key>LSRequiresIPhoneOS</key>
   <true/>
   <key>MinimumOSVersion</key>
@@ -1303,7 +1510,42 @@ plist["CFBundleExecutable"] = executable_name
 with open(dest, "wb") as handle:
     plistlib.dump(plist, handle, sort_keys=False)
 PY
-cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/AppIcon.png"
+shopt -s nullglob
+PLATFORM_APP_ICONS=("$SCRIPT_DIR"/AppIcon.*)
+if (( ${{#PLATFORM_APP_ICONS[@]}} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/AppIcon.png"
+else
+  app_icon="${{PLATFORM_APP_ICONS[0]}}"
+  cp "$app_icon" "$BUNDLE_DIR/$(basename "$app_icon")"
+fi
+shopt -u nullglob
+shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/SplashImage.*)
+if (( ${{#SPLASH_IMAGES[@]}} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/SplashImage.png"
+else
+  for splash_image in "${{SPLASH_IMAGES[@]}}"; do
+    cp "$splash_image" "$BUNDLE_DIR/"
+  done
+fi
+shopt -u nullglob
+if [[ -f "$SCRIPT_DIR/LaunchScreen.storyboard" ]]; then
+  IBTOOL=$(xcrun --find ibtool 2>/dev/null || true)
+  if [[ -z "$IBTOOL" ]]; then
+    printf 'ibtool not found. Install Xcode command line tools to compile the iOS launch screen storyboard.\n' >&2
+    exit 1
+  fi
+  "$IBTOOL" \
+    --errors \
+    --warnings \
+    --notices \
+    --target-device iphone \
+    --target-device ipad \
+    --minimum-deployment-target 18.0 \
+    --output-format human-readable-text \
+    --compile "$BUNDLE_DIR/LaunchScreen.storyboardc" \
+    "$SCRIPT_DIR/LaunchScreen.storyboard"
+fi
 printf 'APPL????' > "$BUNDLE_DIR/PkgInfo"
 printf '%s\n' "$BUNDLE_DIR"
 "#,
@@ -1349,6 +1591,9 @@ fi
 
 xcrun simctl boot "$DEVICE_ID" >/dev/null 2>&1 || true
 xcrun simctl bootstatus "$DEVICE_ID" -b
+if [[ "${{IOS_SIM_UNINSTALL_BEFORE_INSTALL:-1}}" == "1" ]]; then
+  xcrun simctl uninstall "$DEVICE_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+fi
 xcrun simctl install "$DEVICE_ID" "$BUNDLE_DIR"
 
 if [[ -n "${{FISSION_TEST_CONTROL_PORT:-}}" ]]; then
@@ -1420,7 +1665,8 @@ fn render_android_manifest(project: &FissionProject) -> String {
             android:name="android.app.NativeActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize|uiMode|density"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:theme="@style/FissionLaunchTheme">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="{lib_name}" />
@@ -1899,7 +2145,22 @@ KEYSTORE="${{ANDROID_DEBUG_KEYSTORE:-$HOME/.android/debug.keystore}}"
 rm -rf "$APK_ROOT"
 mkdir -p "$APK_ROOT/lib/arm64-v8a" "$APK_ROOT/res/drawable-nodpi" "$BUILD_DIR"
 cp "$SO_PATH" "$APK_ROOT/lib/arm64-v8a/lib$LIB_NAME.so"
-cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/app_icon.png"
+shopt -s nullglob
+APP_ICONS=("$SCRIPT_DIR"/res/drawable-nodpi/app_icon.* "$SCRIPT_DIR"/res/drawable/app_icon.*)
+if (( ${{#APP_ICONS[@]}} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/app_icon.png"
+fi
+shopt -u nullglob
+shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/res/drawable-nodpi/fission_splash_image.*)
+if (( ${{#SPLASH_IMAGES[@]}} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/fission_splash_image.png"
+fi
+shopt -u nullglob
+if [[ -d "$SCRIPT_DIR/res" ]]; then
+  mkdir -p "$APK_ROOT/res"
+  cp -R "$SCRIPT_DIR/res/." "$APK_ROOT/res/"
+fi
 
 JAVA_SRC_DIR="$SCRIPT_DIR/java"
 if [[ -d "$JAVA_SRC_DIR" ]] && find "$JAVA_SRC_DIR" -name '*.java' -print -quit | grep -q .; then
@@ -1992,6 +2253,21 @@ android_system_image_path() {{
   printf '%s/system-images/%s\n' "$ANDROID_HOME" "${{image//;/\/}}"
 }}
 
+wait_for_android_boot() {{
+  "$ADB" wait-for-device
+  until "$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; do
+    sleep 1
+  done
+  local deadline=$((SECONDS + 180))
+  until "$ADB" shell cmd package list packages >/dev/null 2>&1; do
+    if (( SECONDS > deadline )); then
+      printf 'Android package manager did not become available. Restart the emulator with ANDROID_EMULATOR_RESTART=1 and try again.\n' >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}}
+
 ANDROID_EMULATOR_API_LEVEL="${{ANDROID_EMULATOR_API_LEVEL:-$(detect_latest_emulator_api)}}"
 if [[ -z "$ANDROID_EMULATOR_API_LEVEL" ]]; then
   printf 'No Android arm64 google_apis emulator image found under %s/system-images.\nInstall one with sdkmanager "system-images;android-35;google_apis;arm64-v8a" or set ANDROID_SYSTEM_IMAGE.\n' "$ANDROID_HOME" >&2
@@ -2036,19 +2312,18 @@ if [[ -z "$RUNNING_EMULATOR" ]]; then
   printf 'Launching emulator %s (%s)\n' "$AVD_NAME" "$([[ "$HEADLESS" == "1" ]] && echo headless || echo visible)"
   nohup "$EMULATOR_BIN" "${{EMULATOR_ARGS[@]}}" >/tmp/fission-android-emulator.log 2>&1 &
   disown || true
-  "$ADB" wait-for-device
-  until "$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; do
-    sleep 1
-  done
+  wait_for_android_boot
 else
   printf 'Using existing emulator %s\n' "$RUNNING_EMULATOR"
+  wait_for_android_boot
   if [[ "$HEADLESS" != "1" ]]; then
     printf 'If the window is not visible, restart with ANDROID_EMULATOR_RESTART=1 to relaunch a visible emulator.\n'
   fi
 fi
 
 APK=$("$SCRIPT_DIR/package-apk.sh")
-"$ADB" install -r "$APK"
+read -r -a ADB_INSTALL_FLAGS <<< "${{ADB_INSTALL_FLAGS:---no-streaming -r}}"
+"$ADB" install "${{ADB_INSTALL_FLAGS[@]}}" "$APK"
 "$ADB" forward "tcp:$HOST_PORT" "tcp:$DEVICE_PORT"
 "$ADB" shell am start -n {app_id}/android.app.NativeActivity >/dev/null
 printf 'APK=%s\n' "$APK"

--- a/crates/tools/fission-command-core/src/splash.rs
+++ b/crates/tools/fission-command-core/src/splash.rs
@@ -1,0 +1,561 @@
+use crate::{write_file, FissionProject, Target};
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+const DEFAULT_SPLASH_BACKGROUND: &str = "#F8FAFC";
+const DEFAULT_SPLASH_IMAGE: &str = "assets/app-icon.png";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SplashConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resize_mode: Option<SplashResizeMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub android_animated_icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub android_animation_duration_ms: Option<u16>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SplashResizeMode {
+    Center,
+    Contain,
+    Cover,
+}
+
+pub(crate) fn apply_platform_splash_config(root: &Path, project: &FissionProject) -> Result<()> {
+    validate_splash_config(project)?;
+    if project.targets.contains(&Target::Android) {
+        apply_android_splash_config(root, project)?;
+    }
+    if project.targets.contains(&Target::Ios) {
+        apply_ios_splash_config(root, project)?;
+    }
+    Ok(())
+}
+
+fn validate_splash_config(project: &FissionProject) -> Result<()> {
+    let color = splash_background_color(project);
+    parse_hex_color(color)
+        .with_context(|| format!("invalid app.splash.background_color `{color}`"))?;
+    if let Some(config) = &project.app.splash {
+        if let Some(duration) = config.android_animation_duration_ms {
+            if duration == 0 {
+                bail!("app.splash.android_animation_duration_ms must be greater than zero");
+            }
+        }
+        if let Some(animated_icon) = &config.android_animated_icon {
+            if Path::new(animated_icon)
+                .extension()
+                .and_then(|value| value.to_str())
+                != Some("xml")
+            {
+                bail!(
+                    "app.splash.android_animated_icon must point to an Android XML drawable resource"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_android_splash_config(root: &Path, project: &FissionProject) -> Result<()> {
+    let color = android_color_literal(splash_background_color(project))?;
+    let static_icon = copy_android_splash_image(root, project)?;
+    let animated_icon = copy_android_animated_splash_icon(root, project)?;
+    let window_icon = animated_icon.as_deref().unwrap_or(&static_icon);
+
+    write_file(
+        &root.join("platforms/android/res/values/colors.xml"),
+        &render_android_splash_colors(&color),
+    )?;
+    write_file(
+        &root.join("platforms/android/res/values/styles.xml"),
+        &render_android_splash_styles(window_icon, project),
+    )?;
+    write_file(
+        &root.join("platforms/android/res/drawable/fission_splash_background.xml"),
+        &render_android_splash_background(&static_icon),
+    )?;
+    ensure_android_manifest_uses_splash_theme(root)?;
+    ensure_android_package_script_copies_resources(root)
+}
+
+fn apply_ios_splash_config(root: &Path, project: &FissionProject) -> Result<()> {
+    let color = parse_hex_color(splash_background_color(project))?;
+    let image_name = copy_ios_splash_image(root, project)?;
+    write_file(
+        &root.join("platforms/ios/LaunchScreen.storyboard"),
+        &render_ios_launch_storyboard(&color, image_name.as_deref(), splash_resize_mode(project)),
+    )?;
+    ensure_ios_plist_launch_storyboard(root)?;
+    ensure_ios_package_script_copies_launch_screen(root)
+}
+
+fn splash_background_color(project: &FissionProject) -> &str {
+    project
+        .app
+        .splash
+        .as_ref()
+        .and_then(|config| config.background_color.as_deref())
+        .unwrap_or(DEFAULT_SPLASH_BACKGROUND)
+}
+
+fn splash_resize_mode(project: &FissionProject) -> SplashResizeMode {
+    project
+        .app
+        .splash
+        .as_ref()
+        .and_then(|config| config.resize_mode)
+        .unwrap_or(SplashResizeMode::Contain)
+}
+
+#[derive(Clone, Copy)]
+struct RgbaColor {
+    red: u8,
+    green: u8,
+    blue: u8,
+    alpha: u8,
+}
+
+fn parse_hex_color(value: &str) -> Result<RgbaColor> {
+    let hex = value
+        .strip_prefix('#')
+        .with_context(|| "expected #RRGGBB or #RRGGBBAA")?;
+    if hex.len() != 6 && hex.len() != 8 {
+        bail!("expected #RRGGBB or #RRGGBBAA");
+    }
+    let parse_byte = |range: std::ops::Range<usize>| -> Result<u8> {
+        u8::from_str_radix(&hex[range], 16).with_context(|| "expected hexadecimal color digits")
+    };
+    Ok(RgbaColor {
+        red: parse_byte(0..2)?,
+        green: parse_byte(2..4)?,
+        blue: parse_byte(4..6)?,
+        alpha: if hex.len() == 8 {
+            parse_byte(6..8)?
+        } else {
+            255
+        },
+    })
+}
+
+fn android_color_literal(value: &str) -> Result<String> {
+    let color = parse_hex_color(value)?;
+    if color.alpha == 255 {
+        Ok(format!(
+            "#{:02X}{:02X}{:02X}",
+            color.red, color.green, color.blue
+        ))
+    } else {
+        Ok(format!(
+            "#{:02X}{:02X}{:02X}{:02X}",
+            color.alpha, color.red, color.green, color.blue
+        ))
+    }
+}
+
+fn copy_android_splash_image(root: &Path, project: &FissionProject) -> Result<String> {
+    let resource_name = "fission_splash_image";
+    if let Some(source) = configured_splash_image(project) {
+        let source = root.join(source);
+        let extension = android_bitmap_extension(&source)?;
+        let destination = root
+            .join("platforms/android/res/drawable-nodpi")
+            .join(format!("{resource_name}.{extension}"));
+        copy_required_asset(&source, &destination)?;
+    } else {
+        let source = root.join(DEFAULT_SPLASH_IMAGE);
+        android_bitmap_extension(&source)?;
+        if !source.exists() {
+            bail!("default splash asset does not exist: {}", source.display());
+        }
+    }
+    Ok(format!("@drawable/{resource_name}"))
+}
+
+fn copy_android_animated_splash_icon(
+    root: &Path,
+    project: &FissionProject,
+) -> Result<Option<String>> {
+    let Some(source) = project
+        .app
+        .splash
+        .as_ref()
+        .and_then(|config| config.android_animated_icon.as_deref())
+    else {
+        return Ok(None);
+    };
+    let destination = root.join("platforms/android/res/drawable/fission_splash_animated_icon.xml");
+    copy_required_asset(&root.join(source), &destination)?;
+    Ok(Some("@drawable/fission_splash_animated_icon".to_string()))
+}
+
+fn copy_ios_splash_image(root: &Path, project: &FissionProject) -> Result<Option<String>> {
+    if let Some(source) = configured_splash_image(project) {
+        let source = root.join(source);
+        let extension = ios_image_extension(&source)?;
+        let destination = root
+            .join("platforms/ios")
+            .join(format!("SplashImage.{extension}"));
+        copy_required_asset(&source, &destination)?;
+    } else {
+        let source = root.join(DEFAULT_SPLASH_IMAGE);
+        ios_image_extension(&source)?;
+        if !source.exists() {
+            bail!("default splash asset does not exist: {}", source.display());
+        }
+    }
+    Ok(Some("SplashImage".to_string()))
+}
+
+fn configured_splash_image(project: &FissionProject) -> Option<&str> {
+    project
+        .app
+        .splash
+        .as_ref()
+        .and_then(|config| config.image.as_deref())
+}
+
+fn copy_required_asset(source: &Path, destination: &Path) -> Result<()> {
+    if !source.exists() {
+        bail!(
+            "configured splash asset does not exist: {}",
+            source.display()
+        );
+    }
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(source, destination).with_context(|| {
+        format!(
+            "failed to copy {} to {}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn android_bitmap_extension(path: &Path) -> Result<String> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .with_context(|| {
+            format!(
+                "splash image must have a file extension: {}",
+                path.display()
+            )
+        })?;
+    match extension.as_str() {
+        "png" | "jpg" | "jpeg" | "webp" => Ok(extension),
+        _ => bail!("Android splash image must be png, jpg, jpeg, or webp"),
+    }
+}
+
+fn ios_image_extension(path: &Path) -> Result<String> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .with_context(|| {
+            format!(
+                "splash image must have a file extension: {}",
+                path.display()
+            )
+        })?;
+    match extension.as_str() {
+        "png" | "jpg" | "jpeg" => Ok(extension),
+        _ => bail!("iOS splash image must be png, jpg, or jpeg"),
+    }
+}
+
+fn render_android_splash_colors(color: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="fission_splash_background">{color}</color>
+</resources>
+"#
+    )
+}
+
+fn render_android_splash_styles(window_icon: &str, project: &FissionProject) -> String {
+    let duration = project
+        .app
+        .splash
+        .as_ref()
+        .and_then(|config| config.android_animation_duration_ms)
+        .unwrap_or(800);
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="FissionLaunchTheme" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowDisablePreview">false</item>
+        <item name="android:windowBackground">@drawable/fission_splash_background</item>
+        <item name="android:windowSplashScreenBackground">@color/fission_splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">{window_icon}</item>
+        <item name="android:windowSplashScreenAnimationDuration">{duration}</item>
+    </style>
+</resources>
+"#
+    )
+}
+
+fn render_android_splash_background(static_icon: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/fission_splash_background" />
+    <item android:gravity="center">
+        <bitmap
+            android:gravity="center"
+            android:src="{static_icon}" />
+    </item>
+</layer-list>
+"#
+    )
+}
+
+fn render_ios_launch_storyboard(
+    color: &RgbaColor,
+    image_name: Option<&str>,
+    resize_mode: SplashResizeMode,
+) -> String {
+    let content_mode = match resize_mode {
+        SplashResizeMode::Center => "center",
+        SplashResizeMode::Contain => "scaleAspectFit",
+        SplashResizeMode::Cover => "scaleAspectFill",
+    };
+    let image_view = image_name.map(|name| {
+        format!(
+            r#"
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="{content_mode}" image="{image}" translatesAutoresizingMaskIntoConstraints="NO" id="splash-image">
+                            <rect key="frame" x="79" y="320" width="256" height="256"/>
+                        </imageView>"#,
+            image = xml_escape_attr(name)
+        )
+    }).unwrap_or_default();
+    let image_constraints = if image_name.is_some() {
+        r#"
+                        <constraint firstItem="splash-image" firstAttribute="centerX" secondItem="splash-root" secondAttribute="centerX" id="splash-center-x"/>
+                        <constraint firstItem="splash-image" firstAttribute="centerY" secondItem="splash-root" secondAttribute="centerY" id="splash-center-y"/>
+                        <constraint firstItem="splash-image" firstAttribute="width" constant="256" id="splash-width"/>
+                        <constraint firstItem="splash-image" firstAttribute="height" constant="256" id="splash-height"/>"#
+    } else {
+        ""
+    };
+    let resources = image_name
+        .map(|name| {
+            format!(
+                r#"
+    <resources>
+        <image name="{image}" width="256" height="256"/>
+    </resources>"#,
+                image = xml_escape_attr(name)
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="splash-controller">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="splash-scene">
+            <objects>
+                <viewController id="splash-controller" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="splash-root">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>{image_view}
+                        </subviews>
+                        <color key="backgroundColor" red="{red:.6}" green="{green:.6}" blue="{blue:.6}" alpha="{alpha:.6}" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>{image_constraints}
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="splash-first-responder" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>{resources}
+</document>
+"#,
+        red = f32::from(color.red) / 255.0,
+        green = f32::from(color.green) / 255.0,
+        blue = f32::from(color.blue) / 255.0,
+        alpha = f32::from(color.alpha) / 255.0,
+    )
+}
+
+fn xml_escape_attr(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn ensure_android_manifest_uses_splash_theme(root: &Path) -> Result<()> {
+    let path = root.join("platforms/android/AndroidManifest.xml");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains("android:theme=\"@style/FissionLaunchTheme\"") {
+        return Ok(());
+    }
+    let updated = if existing.contains("android:launchMode=\"singleTask\">") {
+        existing.replacen(
+            "android:launchMode=\"singleTask\">",
+            "android:launchMode=\"singleTask\"\n            android:theme=\"@style/FissionLaunchTheme\">",
+            1,
+        )
+    } else {
+        existing.replacen(
+            "android:exported=\"true\"",
+            "android:exported=\"true\"\n            android:theme=\"@style/FissionLaunchTheme\"",
+            1,
+        )
+    };
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn ensure_android_package_script_copies_resources(root: &Path) -> Result<()> {
+    let path = root.join("platforms/android/package-apk.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains("fission_splash_image.png")
+        && existing.contains("cp -R \"$SCRIPT_DIR/res/.\" \"$APK_ROOT/res/\"")
+    {
+        return Ok(());
+    }
+    let marker =
+        "cp \"$PROJECT_DIR/assets/app-icon.png\" \"$APK_ROOT/res/drawable-nodpi/app_icon.png\"\n";
+    let insertion = r#"shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/res/drawable-nodpi/fission_splash_image.*)
+if (( ${#SPLASH_IMAGES[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/fission_splash_image.png"
+fi
+shopt -u nullglob
+if [[ -d "$SCRIPT_DIR/res" ]]; then
+  mkdir -p "$APK_ROOT/res"
+  cp -R "$SCRIPT_DIR/res/." "$APK_ROOT/res/"
+fi
+"#;
+    let old_start = "if [[ -d \"$SCRIPT_DIR/res\" ]]; then\n";
+    let updated = if let Some(start) = existing.find(old_start) {
+        if let Some(relative_end) = existing[start..].find("fi\n") {
+            let end = start + relative_end + "fi\n".len();
+            let mut updated = existing.clone();
+            updated.replace_range(start..end, insertion);
+            updated
+        } else {
+            existing.replacen(marker, &(marker.to_string() + insertion), 1)
+        }
+    } else {
+        existing.replacen(marker, &(marker.to_string() + insertion), 1)
+    };
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn ensure_ios_plist_launch_storyboard(root: &Path) -> Result<()> {
+    let path = root.join("platforms/ios/Info.plist");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains("UILaunchStoryboardName") {
+        return Ok(());
+    }
+    let entry = "  <key>UILaunchStoryboardName</key>\n  <string>LaunchScreen</string>\n";
+    let updated = existing.replacen(
+        "  <key>MinimumOSVersion</key>",
+        &format!("{entry}  <key>MinimumOSVersion</key>"),
+        1,
+    );
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn ensure_ios_package_script_copies_launch_screen(root: &Path) -> Result<()> {
+    let path = root.join("platforms/ios/package-sim.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if existing.contains("ibtool")
+        && existing.contains("LaunchScreen.storyboardc")
+        && existing.contains("$BUNDLE_DIR/SplashImage.png")
+    {
+        return Ok(());
+    }
+    let marker = "cp \"$PROJECT_DIR/assets/app-icon.png\" \"$BUNDLE_DIR/AppIcon.png\"\n";
+    let insertion = r#"shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/SplashImage.*)
+if (( ${#SPLASH_IMAGES[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/SplashImage.png"
+else
+  for splash_image in "${SPLASH_IMAGES[@]}"; do
+    cp "$splash_image" "$BUNDLE_DIR/"
+  done
+fi
+shopt -u nullglob
+if [[ -f "$SCRIPT_DIR/LaunchScreen.storyboard" ]]; then
+  IBTOOL=$(xcrun --find ibtool 2>/dev/null || true)
+  if [[ -z "$IBTOOL" ]]; then
+    printf 'ibtool not found. Install Xcode command line tools to compile the iOS launch screen storyboard.\n' >&2
+    exit 1
+  fi
+  "$IBTOOL" \
+    --errors \
+    --warnings \
+    --notices \
+    --target-device iphone \
+    --target-device ipad \
+    --minimum-deployment-target 18.0 \
+    --output-format human-readable-text \
+    --compile "$BUNDLE_DIR/LaunchScreen.storyboardc" \
+    "$SCRIPT_DIR/LaunchScreen.storyboard"
+fi
+"#;
+    let old_start = "shopt -s nullglob\n";
+    let old_end = "    \"$SCRIPT_DIR/LaunchScreen.storyboard\"\nfi\n";
+    let updated = if let Some(start) = existing.find(old_start) {
+        if existing[start..].contains("LaunchScreen.storyboard") {
+            if let Some(relative_end) = existing[start..].find(old_end) {
+                let end = start + relative_end + old_end.len();
+                let mut updated = existing.clone();
+                updated.replace_range(start..end, insertion);
+                updated
+            } else {
+                existing.replacen(marker, &(marker.to_string() + insertion), 1)
+            }
+        } else {
+            let mut updated = existing.clone();
+            updated.insert_str(start, insertion);
+            updated
+        }
+    } else {
+        existing.replacen(marker, &(marker.to_string() + insertion), 1)
+    };
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -1,7 +1,8 @@
 use super::*;
 use anyhow::{bail, Context, Result};
 use fission_command_core::{
-    cargo_package_name, read_project_config, FissionProject, PlatformCapability, Target,
+    cargo_package_name, normalized_extension, read_project_config, resolve_app_icon,
+    sync_platform_config, FissionProject, PlatformCapability, Target,
 };
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -229,6 +230,7 @@ fn package_windows_exe(options: &PackageOptions) -> Result<ArtifactManifest> {
 fn package_android_apk(options: &PackageOptions) -> Result<ArtifactManifest> {
     ensure_package_target(options, Target::Android, PackageFormat::Apk)?;
     let project = read_project_config(&options.project_dir)?;
+    sync_platform_config(&options.project_dir, &project)?;
     let profile = profile_name(options.release);
     let staging_dir = clean_package_dir(options)?;
     let script = options.project_dir.join("platforms/android/package-apk.sh");
@@ -264,6 +266,9 @@ fn package_with_project_script(
 ) -> Result<ArtifactManifest> {
     ensure_package_target(options, target, options.format)?;
     let project = read_project_config(&options.project_dir)?;
+    if matches!(target, Target::Android | Target::Ios) {
+        sync_platform_config(&options.project_dir, &project)?;
+    }
     let profile = profile_name(options.release);
     let staging_dir = clean_package_dir(options)?;
     let script = options.project_dir.join(relative_script);
@@ -1033,8 +1038,16 @@ fn create_macos_app_bundle(
             app_bundle.display()
         )
     })?;
-    if let Some(icon) = app_icon_path(&options.project_dir) {
-        let _ = fs::copy(icon, resources.join("AppIcon.png"));
+    if let Some(icon) = resolve_app_icon(&options.project_dir, Target::Macos)? {
+        let extension = normalized_extension(&icon.path)?;
+        let destination = resources.join(format!("AppIcon.{extension}"));
+        fs::copy(&icon.path, &destination).with_context(|| {
+            format!(
+                "failed to copy macOS app icon {} to {}",
+                icon.path.display(),
+                destination.display()
+            )
+        })?;
     }
     let version =
         cargo_package_version(&options.project_dir).unwrap_or_else(|| "0.1.0".to_string());
@@ -1071,6 +1084,8 @@ fn render_info_plist(
   <string>{}</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
   <key>CFBundleShortVersionString</key>
   <string>{}</string>
   <key>CFBundleVersion</key>
@@ -1401,18 +1416,6 @@ fn display_app_name(value: &str) -> String {
     } else {
         out.trim().to_string()
     }
-}
-
-fn app_icon_path(project_dir: &Path) -> Option<PathBuf> {
-    [
-        "assets/app-icon.icns",
-        "assets/AppIcon.icns",
-        "assets/app-icon.png",
-        "assets/icon.png",
-    ]
-    .into_iter()
-    .map(|relative| project_dir.join(relative))
-    .find(|path| path.exists())
 }
 
 fn escape_xml(value: &str) -> String {

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -2,7 +2,8 @@ pub mod doctor;
 
 use anyhow::{bail, Context, Result};
 use fission_command_core::{
-    ios_executable_name, read_project_config, FissionProject, PlatformCapability, Target,
+    ios_executable_name, normalized_extension, read_project_config, resolve_app_icon,
+    sync_platform_config, FissionProject, PlatformCapability, Target,
 };
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -133,6 +134,7 @@ pub fn run_app(options: RunOptions) -> Result<()> {
         options.device.as_deref(),
     )?;
     ensure_target_configured(&project, &options.project_dir, device.target)?;
+    sync_target_platform_config(&options.project_dir, &project, device.target)?;
 
     match device.target {
         Target::Linux | Target::Macos | Target::Windows => run_desktop(&project, &options, &device),
@@ -153,6 +155,7 @@ pub fn build_app(options: BuildOptions) -> Result<()> {
     let project = read_project_config(&options.project_dir)?;
     let target = options.target.unwrap_or_else(host_desktop_target);
     ensure_target_configured(&project, &options.project_dir, target)?;
+    sync_target_platform_config(&options.project_dir, &project, target)?;
 
     match target {
         Target::Linux | Target::Macos | Target::Windows => {
@@ -183,6 +186,7 @@ pub fn test_app(options: TestOptions) -> Result<()> {
     let project = read_project_config(&options.project_dir)?;
     let target = options.target.unwrap_or_else(host_desktop_target);
     ensure_target_configured(&project, &options.project_dir, target)?;
+    sync_target_platform_config(&options.project_dir, &project, target)?;
 
     match target {
         Target::Linux | Target::Macos | Target::Windows => {
@@ -219,6 +223,17 @@ pub fn test_app(options: TestOptions) -> Result<()> {
             },
         ),
     }
+}
+
+fn sync_target_platform_config(
+    project_dir: &Path,
+    project: &FissionProject,
+    target: Target,
+) -> Result<()> {
+    if matches!(target, Target::Android | Target::Ios) {
+        sync_platform_config(project_dir, project)?;
+    }
+    Ok(())
 }
 
 pub fn attach_logs(options: LogOptions) -> Result<()> {
@@ -654,6 +669,7 @@ fn run_android(project: &FissionProject, options: &RunOptions, device: &Device) 
             .arg("-s")
             .arg(&device.id)
             .arg("install")
+            .arg("--no-streaming")
             .arg("-r")
             .arg(&apk),
         "Android install",
@@ -975,8 +991,16 @@ fn package_macos_run_app(
             binary.path.display()
         )
     })?;
-    if let Some(icon) = app_icon_path(&project_dir) {
-        let _ = fs::copy(icon, resources_dir.join("AppIcon.png"));
+    if let Some(icon) = resolve_app_icon(&project_dir, Target::Macos)? {
+        let extension = normalized_extension(&icon.path)?;
+        let destination = resources_dir.join(format!("AppIcon.{extension}"));
+        fs::copy(&icon.path, &destination).with_context(|| {
+            format!(
+                "failed to copy macOS app icon {} to {}",
+                icon.path.display(),
+                destination.display()
+            )
+        })?;
     }
 
     fs::write(
@@ -1015,10 +1039,8 @@ fn package_linux_run_app(
     }
     let bin_dir = app_root.join("bin");
     let applications_dir = app_root.join("share/applications");
-    let icons_dir = app_root.join("share/icons/hicolor/512x512/apps");
     fs::create_dir_all(&bin_dir)?;
     fs::create_dir_all(&applications_dir)?;
-    fs::create_dir_all(&icons_dir)?;
 
     let executable = bin_dir.join(&binary.executable_name);
     fs::copy(&binary.path, &executable).with_context(|| {
@@ -1028,8 +1050,22 @@ fn package_linux_run_app(
         )
     })?;
     copy_unix_mode(&binary.path, &executable).ok();
-    if let Some(icon) = app_icon_path(&project_dir) {
-        let _ = fs::copy(icon, icons_dir.join(format!("{}.png", project.app.app_id)));
+    if let Some(icon) = resolve_app_icon(&project_dir, Target::Linux)? {
+        let extension = normalized_extension(&icon.path)?;
+        let icons_dir = if extension == "svg" {
+            app_root.join("share/icons/hicolor/scalable/apps")
+        } else {
+            app_root.join("share/icons/hicolor/512x512/apps")
+        };
+        fs::create_dir_all(&icons_dir)?;
+        let destination = icons_dir.join(format!("{}.{}", project.app.app_id, extension));
+        fs::copy(&icon.path, &destination).with_context(|| {
+            format!(
+                "failed to copy Linux app icon {} to {}",
+                icon.path.display(),
+                destination.display()
+            )
+        })?;
     }
     fs::write(
         applications_dir.join(format!("{}.desktop", project.app.app_id)),
@@ -1071,8 +1107,16 @@ fn package_windows_run_app(
             binary.path.display()
         )
     })?;
-    if let Some(icon) = app_icon_path(&project_dir) {
-        let _ = fs::copy(icon, app_root.join("app-icon.png"));
+    if let Some(icon) = resolve_app_icon(&project_dir, Target::Windows)? {
+        let extension = normalized_extension(&icon.path)?;
+        let destination = app_root.join(format!("app-icon.{extension}"));
+        fs::copy(&icon.path, &destination).with_context(|| {
+            format!(
+                "failed to copy Windows app icon {} to {}",
+                icon.path.display(),
+                destination.display()
+            )
+        })?;
     }
     fs::write(
         app_root.join(format!(
@@ -1164,6 +1208,8 @@ fn render_macos_run_info_plist(
   <string>{}</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
   <key>NSHighResolutionCapable</key>
   <true/>
 {}
@@ -1217,11 +1263,6 @@ fn render_macos_run_capability_plist_entries(project: &FissionProject) -> String
         );
     }
     out
-}
-
-fn app_icon_path(project_dir: &Path) -> Option<PathBuf> {
-    let path = project_dir.join("assets/app-icon.png");
-    path.is_file().then_some(path)
 }
 
 fn macos_display_name(name: &str) -> String {

--- a/docs/rfc-fission-agent-kit.md
+++ b/docs/rfc-fission-agent-kit.md
@@ -1,0 +1,803 @@
+# RFC: Fission Agent Kit and AI Tool Integrations
+
+Status: proposal
+Audience: Fission CLI, developer tooling, testing, documentation, editor integration, and MCP implementers
+Scope: local-first AI tooling that makes Fission projects easier for coding agents to inspect, validate, and modify
+
+## 1. Summary
+
+Fission should provide an agent-facing toolkit that makes real Fission applications legible to AI coding tools without requiring developers to adopt a new editor, a new app model, or a hosted service. The toolkit should expose project context, documentation, route and widget structure, layout snapshots, screenshots, tests, action/reducer traces, and safe code-generation workflows through the Fission CLI and the Model Context Protocol.
+
+The goal is adoption and correctness. Developers are already using AI assistants inside terminals, editors, chat interfaces, and CI systems. Fission should meet those tools where they are by making the framework easy to inspect and verify. The value is not a proprietary AI IDE. The value is that Fission projects can be understood, tested, debugged, and changed through stable, framework-aware tools instead of generic text search and guesswork.
+
+This RFC defines the product and implementation shape for the Fission Agent Kit:
+
+- a local MCP server;
+- generated rules files for agentic coding tools;
+- a deterministic project indexer;
+- a version-aware documentation retriever;
+- component and screen generators that produce normal Rust code;
+- layout, screenshot, and visual comparison tools;
+- action/reducer tracing and replay;
+- test runners with machine-readable output;
+- a safe permission model for read, write, execution, and network access.
+
+These tools must remain aligned with Fission's architecture. They inspect and operate on real Fission projects. They must not create a parallel UI model, bypass `Widget::build`, bypass reducers, bypass the router, bypass the design-system pipeline, or generate code that depends on private framework internals.
+
+## 2. Goals
+
+- Make Fission applications easy for AI coding tools to understand without relying on broad repository scans.
+- Provide a local MCP server that exposes Fission-aware resources, prompts, and tools.
+- Generate concise agent rules for common coding environments while keeping the user's own instructions intact.
+- Build a deterministic project index that records crates, modules, widgets, routes, actions, reducers, selectors, capabilities, design systems, tests, examples, and documentation.
+- Provide a documentation retriever that is version-aware and grounded in the local Fission docs shipped with the project or installed toolchain.
+- Provide code generators that create normal Fission Rust code using the public facade crate, prelude, widget structs, actions, reducers, selectors, and tests.
+- Expose layout inspection and screenshot capture through the same runtime/devtools pipeline used by humans.
+- Expose action/reducer traces that can be explained and replayed in tests where host effects are mocked or recorded.
+- Make every agent-facing operation available through the CLI first, then expose the same functionality through MCP.
+- Keep side effects explicit: reading is safe by default; writes, command execution, network access, and credential access require opt-in configuration.
+- Produce stable machine-readable outputs so CI, editor plugins, MCP clients, and future tools can consume the same data.
+
+## 3. Non-goals
+
+- Do not build a new IDE.
+- Do not replace `rust-analyzer`, Rust compiler diagnostics, or native debuggers.
+- Do not require a hosted service for local development.
+- Do not make AI tooling the primary commercial product surface for Fission.
+- Do not make generated code a hidden source of truth.
+- Do not infer application behavior from naming conventions when compiler/runtime data is available.
+- Do not expose a generic shell execution tool through MCP by default.
+- Do not let MCP clients read files outside the configured project roots.
+- Do not send source code, screenshots, traces, credentials, or project indexes to a remote service unless the developer explicitly configures that service.
+- Do not put agent/debug serialization on the production runtime hot path.
+
+## 4. Positioning
+
+Fission should be a strong framework for AI-assisted development because its architecture is explicit:
+
+- UI is expressed as typed Rust widgets.
+- Application changes flow through actions and reducers.
+- Long-running work is represented through jobs and services.
+- Host features are represented through capabilities.
+- The shell pipeline can expose widget trees, layout, display output, semantics, hit testing, and screenshots.
+- The CLI owns project setup, target management, test, build, package, and release workflows.
+
+The Agent Kit should turn those properties into practical tooling. A coding agent should be able to answer questions such as:
+
+- Which routes exist and what widgets build them?
+- Which reducer handles this action?
+- Why does this button not receive input at this viewport size?
+- What changed visually after this patch?
+- Which capability configuration is missing for Android or iOS?
+- Which docs page explains this API?
+- What tests should run before this change is accepted?
+
+The answer should come from Fission's project index, runtime snapshots, traces, docs, and tests. If the tool cannot prove something from those sources, it should say so. It should not fill gaps with confident guesses.
+
+## 5. Relationship to the Developer Tooling RFC
+
+The Agent Kit depends on the developer tooling architecture described in `docs/rfc-developer-tooling.md`.
+
+That RFC defines the Fission Developer Tooling Protocol, or FDTP, as the protocol exposed by development builds and consumed by devtools, IDE plugins, the terminal UI, CI trace viewers, and test recorders. The Agent Kit should consume FDTP instead of inventing a second inspection protocol.
+
+The division of responsibility should be:
+
+- FDTP exposes live runtime truth: widget tree, Core IR, layout, display list, semantics, hit testing, traces, logs, profiles, screenshots, and shell capability data.
+- The project index exposes repository truth: crates, modules, source locations, route declarations, widget implementations, action/reducer definitions, design-system files, tests, examples, and docs.
+- The MCP server exposes both through a standard AI-tool interface.
+- The CLI owns local execution, artifact generation, security policy, and configuration.
+
+When a live app is available, runtime data wins over static index data. When no app is running, the index can still help agents navigate the repository and propose changes, but it must mark static-only conclusions as advisory.
+
+## 6. Command model
+
+The CLI should expose the Agent Kit under `fission agent`.
+
+```text
+fission agent init --project-dir . --clients codex,claude,cursor --mcp
+fission agent context --project-dir . --format markdown
+fission agent context --project-dir . --format json
+fission agent index --project-dir .
+fission agent mcp --project-dir .
+fission agent docs --query "reducers" --format markdown
+fission agent inspect-layout --project-dir . --route / --viewport 1440x900
+fission agent screenshot --project-dir . --route / --target desktop --theme light
+fission agent compare-screenshot --project-dir . --route / --baseline main
+fission agent replay-action --project-dir . --trace target/fission/traces/login.json
+fission agent run-tests --project-dir . --profile smoke --format json
+fission agent generate component --name EmptyState --route /inbox --with-test
+fission agent propose-fix --project-dir . --diagnostic target/fission/diagnostics/layout.json
+```
+
+`fission agent init` must be idempotent. It may create managed files, but it must not overwrite user-managed instructions unless the file contains a Fission-managed marker. If a target file already exists without a marker, the command should print a patch or write a sibling file that the user can merge manually.
+
+Generated files may include:
+
+```text
+AGENTS.md
+.cursor/rules/fission.mdc
+CLAUDE.md
+.fission/agent/config.toml
+.fission/agent/README.md
+```
+
+The exact client-specific filenames can evolve, but Fission-owned sections must be clearly marked and safely updateable.
+
+## 7. Configuration
+
+Agent configuration should live under `fission.toml` for project-level settings, with generated caches under `.fission/agent/`.
+
+```toml
+[agent]
+enabled = true
+index_dir = ".fission/agent/index"
+docs = "bundled"
+allow_write_tools = false
+allow_command_tools = false
+allow_network_tools = false
+allow_screenshot_tools = true
+include = ["src/**", "examples/**", "content/**", "documentation/**"]
+exclude = ["target/**", ".git/**", "dist/**", ".fission/agent/index/**"]
+
+[agent.mcp]
+enabled = true
+transport = "stdio"
+host = "127.0.0.1"
+port = 0
+
+[agent.rules]
+clients = ["codex", "claude", "cursor"]
+managed = true
+
+[agent.tests]
+default_profile = "smoke"
+```
+
+`fission agent init` may populate this configuration, but developers must be able to edit it by hand. CI should be able to run every command non-interactively.
+
+## 8. MCP server
+
+The MCP server should be a local process started by an AI client, editor integration, or the Fission CLI.
+
+```text
+fission agent mcp --project-dir .
+```
+
+The server should support MCP resources, prompts, and tools:
+
+- resources expose read-only context such as project summaries, docs, route manifests, design-system data, screenshots, traces, and diagnostics;
+- prompts expose reusable workflows such as "build a component", "debug a layout problem", and "write a reducer test";
+- tools perform bounded operations such as rendering a route, running tests, comparing screenshots, generating a patch, or explaining an action trace.
+
+The server must respect the client's declared project roots and Fission's configured include/exclude rules. If the client does not provide roots, the CLI-supplied `--project-dir` becomes the only root.
+
+### 8.1 MCP resources
+
+Required resources:
+
+```text
+fission://project/context
+fission://project/manifest
+fission://project/index
+fission://docs/index
+fission://docs/page/<path>
+fission://routes
+fission://widgets
+fission://actions
+fission://reducers
+fission://selectors
+fission://capabilities
+fission://design-system
+fission://tests
+fission://trace/<id>
+fission://screenshot/<id>
+fission://diagnostic/<id>
+```
+
+Resources should be stable and small enough for agents to use directly. Large resources should return summaries plus links to more specific resources.
+
+### 8.2 MCP prompts
+
+Required prompts:
+
+```text
+fission_build_component
+fission_debug_layout
+fission_write_reducer_test
+fission_explain_reducer_path
+fission_add_capability
+fission_fix_visual_regression
+fission_migrate_api
+fission_prepare_release
+```
+
+Prompts should be workflow guides, not hidden policy. They should tell the agent which Fission tools to call, what evidence to collect, and what files are usually involved.
+
+### 8.3 MCP tools
+
+Required tools:
+
+```text
+read_fission_project
+read_fission_tree
+inspect_widget
+inspect_layout
+inspect_design_system
+render_route
+capture_screenshot
+compare_screenshot
+run_fission_tests
+explain_reducer_path
+trace_action
+replay_action
+generate_component
+validate_project
+propose_fix
+```
+
+Tool outputs should be JSON objects with stable schemas. Human-readable summaries may be included, but the machine-readable data is the contract.
+
+Example `inspect_layout` output:
+
+```json
+{
+  "route": "/",
+  "target": "desktop",
+  "viewport": { "width": 1440, "height": 900, "scale": 2.0 },
+  "theme": "light",
+  "nodes": [
+    {
+      "node_id": "node:42",
+      "widget": "crate::components::HomePageHero",
+      "source": "src/components/home_page_hero.rs:18:1",
+      "bounds": { "x": 64, "y": 96, "width": 720, "height": 320 },
+      "semantics": ["heading", "button"],
+      "hit_testable": true
+    }
+  ],
+  "diagnostics": []
+}
+```
+
+### 8.4 Side-effect classes
+
+Every MCP tool should declare one side-effect class:
+
+```text
+read_only
+generates_artifact
+writes_project_files
+runs_project_code
+uses_network
+uses_credentials
+```
+
+The server should allow `read_only` tools by default. All other classes require project configuration or a CLI flag. Tools with multiple classes require every relevant permission.
+
+`propose_fix` should return a patch by default. Applying that patch is a separate operation and should be disabled unless write tools are enabled.
+
+## 9. Project indexer
+
+The project indexer should build a deterministic, local index under `.fission/agent/index/`.
+
+The indexer should use the strongest source of truth available:
+
+1. `cargo metadata` for workspace, package, feature, target, dependency, and manifest information;
+2. Rust compiler or rustdoc-derived data where available for resolved symbols and public API shape;
+3. Fission-specific build metadata for routes, widgets, capabilities, design systems, and static site content;
+4. source parsing as an advisory fallback for navigation hints only.
+
+Source parsing must not become an authoritative substitute for compiler/runtime truth. If a result comes from parsing alone, the index should label it as `confidence = "advisory"`.
+
+The index should capture:
+
+- package and crate graph;
+- enabled Fission targets;
+- public app entry points;
+- route declarations and source locations;
+- structs that implement `Widget`;
+- components organized by module path;
+- actions from `#[fission_action]`, `#[fission_reducer]`, and manual `Action` implementations;
+- reducers and their action/state types;
+- selectors and source locations;
+- capability usage and platform configuration;
+- jobs, services, resources, and commands;
+- design-system package files and generated Rust modules;
+- static site content collections and generated routes;
+- test targets, smoke tests, and visual baselines;
+- README and documentation pages relevant to the project.
+
+### 9.1 Cache invalidation
+
+The index should be invalidated by:
+
+- `Cargo.toml`, `Cargo.lock`, and `fission.toml` changes;
+- changed feature sets;
+- changed Rust source file hashes;
+- changed design-system JSON files;
+- changed content files;
+- changed generated code version;
+- changed Fission CLI version.
+
+The index should be safe to delete. Rebuilding it must not change project behavior.
+
+## 10. Documentation retriever
+
+The docs retriever should give agents grounded documentation without forcing them to scrape the website or guess APIs.
+
+Sources, in priority order:
+
+1. docs bundled with the installed Fission CLI or facade crate;
+2. docs checked into the current repository;
+3. docs from `https://fission.rs` matching the configured Fission version;
+4. user-provided documentation sources configured in `fission.toml`.
+
+Every returned chunk should include:
+
+- title;
+- source path or URL;
+- Fission version if known;
+- target platform applicability;
+- API names mentioned;
+- short excerpt;
+- next links.
+
+The retriever should prefer guide material for "how do I" questions and reference material for "what does this type or method do" questions.
+
+## 11. Rules files
+
+`fission agent init` should generate concise rules for agentic coding tools. These rules should be practical and project-specific.
+
+Rules should include:
+
+- use the `fission` facade crate and prelude unless a lower-level crate is explicitly needed;
+- organize reusable UI as structs implementing `Widget`, not ad hoc functions returning nodes;
+- keep widget structs as configuration, not long-lived mutable state stores;
+- model application changes as actions and reducers;
+- use selectors for derived state and expensive reads;
+- use capabilities for host-provided features;
+- use the design-system APIs rather than hard-coded colors and spacing;
+- run the relevant `fission` tests and screenshot checks before reporting UI changes complete;
+- do not add platform-specific dependencies unless gated behind the correct feature;
+- do not edit generated files unless the generator explicitly supports it.
+
+Rules should also include project-specific commands:
+
+```text
+fission check --project-dir .
+fission test --project-dir .
+fission site check --project-dir . --release
+fission agent inspect-layout --project-dir . --route /
+```
+
+The exact commands should come from `fission.toml` and the project index.
+
+## 12. Editor and AI client integrations
+
+The Agent Kit should integrate with the tools developers already use. The integration should be layered so each client consumes the same Fission functionality instead of receiving a separate implementation.
+
+Required integration layers:
+
+- CLI commands for every operation;
+- MCP server for AI clients that support MCP;
+- generated rules files for clients that read repository instructions;
+- optional editor plugins for richer UI;
+- CI output formats for non-interactive verification.
+
+The first editor integrations should prioritize:
+
+- VS Code-compatible editors, because they provide a common extension model and are widely used with AI coding tools;
+- JetBrains IDEs, because they are common in Rust and professional application development workflows;
+- terminal-first editors through CLI, MCP, LSP, DAP, and generated rules rather than bespoke UI.
+
+Editor plugins should not reimplement Fission logic. They should call the CLI, connect to FDTP, or connect to the MCP server. Their job is presentation:
+
+- show route and widget trees;
+- open source locations from layout nodes;
+- display screenshots and visual diffs;
+- show action/reducer traces;
+- run Fission test profiles;
+- surface project readiness and capability diagnostics;
+- launch the developer tooling UI.
+
+The generated rules files are the minimum viable integration. A developer should still get useful AI behavior in clients that have no Fission-specific plugin.
+
+## 13. Component and screen generation
+
+The generator should create normal project files. It should never generate hidden runtime state or framework-private code.
+
+Supported generation targets:
+
+- component;
+- screen;
+- route;
+- action;
+- reducer;
+- selector;
+- capability setup;
+- design-system usage example;
+- widget reference example;
+- static site page;
+- reducer test;
+- visual smoke test.
+
+Example:
+
+```text
+fission agent generate component \
+  --name EmptyInboxState \
+  --module src/components/empty_inbox_state.rs \
+  --with-test \
+  --with-screenshot
+```
+
+Generated Rust should follow the same conventions documented for users:
+
+```rust
+use fission::prelude::*;
+
+pub struct EmptyInboxState {
+    pub title: String,
+    pub message: String,
+}
+
+impl Widget for EmptyInboxState {
+    fn build(&self, ctx: &mut BuildCtx) -> Node {
+        // real implementation generated from the selected template
+        todo!()
+    }
+}
+```
+
+The generator may use templates, design-system tokens, route context, and existing project conventions. It should print a summary of created files and the tests it expects the developer or agent to run.
+
+## 14. Layout inspector
+
+The layout inspector should work in two modes:
+
+1. attach to a running development app through FDTP;
+2. launch a headless render session for a route, viewport, target, theme, and locale.
+
+Required inputs:
+
+```text
+route
+target
+viewport width/height/scale
+theme
+locale
+platform text scale
+platform safe areas
+```
+
+Required output:
+
+- widget tree;
+- source locations;
+- layout bounds;
+- constraints;
+- display list summary;
+- semantics;
+- hit-test regions;
+- focus order;
+- overflow diagnostics;
+- accessibility diagnostics where available;
+- screenshot artifact ID.
+
+This is the primary tool agents should use before making layout changes. It gives the agent a framework-aware view instead of forcing it to infer layout from screenshots alone.
+
+## 15. Screenshot oracle
+
+The screenshot oracle should capture and compare route output.
+
+Capabilities:
+
+- capture a route at a target, viewport, theme, and locale;
+- compare against a named baseline;
+- produce pixel diff images;
+- produce structural diff summaries from layout/display-list data;
+- ignore configured unstable regions such as timestamps;
+- output artifacts that CI can upload;
+- return machine-readable pass/fail details.
+
+Screenshot comparison should not be the only source of truth. It should be paired with layout and semantics data so agents can distinguish "looks different" from "tree structure changed", "hit testing changed", or "accessibility changed".
+
+## 16. Test runner
+
+The Agent Kit should wrap existing Fission and Cargo test flows and return structured results.
+
+Required profiles:
+
+```text
+unit
+integration
+smoke
+visual
+site
+platform
+release-preflight
+```
+
+Example output:
+
+```json
+{
+  "profile": "smoke",
+  "status": "failed",
+  "duration_ms": 18422,
+  "failures": [
+    {
+      "kind": "layout",
+      "route": "/settings",
+      "message": "Primary button is outside the safe area",
+      "artifact": "fission://diagnostic/layout/settings-safe-area"
+    }
+  ]
+}
+```
+
+Agents should be able to run the smallest relevant profile first, then escalate to broader checks when a patch touches shared infrastructure.
+
+## 17. Action and reducer tracing
+
+The action/reducer tracer should explain how user input changes app state.
+
+Trace entries should include:
+
+- input event or synthetic action source;
+- action type and payload summary;
+- route and focused widget;
+- reducer function and source location;
+- previous state hash;
+- next state hash;
+- changed fields where safe to expose;
+- selector invalidations;
+- effects requested;
+- jobs, services, commands, resources, and capabilities invoked;
+- host responses where recorded or mocked;
+- diagnostics and errors.
+
+Replay should be deterministic when every host interaction is mocked or recorded. If a trace contains non-replayable host effects, the tool should mark them explicitly and stop before pretending the replay is complete.
+
+## 18. `propose_fix`
+
+`propose_fix` should be a patch generator, not an autonomous editor by default.
+
+Inputs:
+
+- diagnostic artifact;
+- optional route;
+- optional source span;
+- optional expected outcome;
+- optional test profile.
+
+Outputs:
+
+- unified diff patch;
+- explanation of why the patch is proposed;
+- files affected;
+- commands to verify;
+- risks and assumptions.
+
+`propose_fix` may apply patches only when `allow_write_tools = true` and the caller uses an explicit apply mode.
+
+## 19. Security model
+
+Security must be designed into the Agent Kit from the start.
+
+Required rules:
+
+- read-only tools are enabled by default;
+- write tools are disabled by default;
+- command execution tools are disabled by default;
+- network tools are disabled by default;
+- credential access is disabled by default;
+- project roots are enforced;
+- include/exclude globs are enforced;
+- `.gitignore` and Fission agent excludes are respected unless explicitly overridden;
+- secrets are redacted in context summaries, traces, and screenshots where possible;
+- generated rules must not include credentials or machine-specific secrets;
+- MCP server sessions should be local by default through stdio or localhost;
+- remote MCP access is out of scope for the first implementation.
+
+The MCP server should produce an audit log for side-effecting operations:
+
+```text
+.fission/agent/audit.log
+```
+
+The audit log should include timestamp, tool name, side-effect class, files touched, commands run, artifacts produced, and caller identity when available.
+
+## 20. Output schemas and artifacts
+
+All machine-facing commands should support JSON output.
+
+Artifacts should be addressable through stable IDs:
+
+```text
+fission://artifact/screenshot/<id>
+fission://artifact/diff/<id>
+fission://artifact/trace/<id>
+fission://artifact/diagnostic/<id>
+```
+
+On disk, artifacts should live under:
+
+```text
+target/fission/agent/
+```
+
+The `.fission/agent/` directory is for local configuration and indexes. `target/fission/agent/` is for rebuildable artifacts.
+
+## 21. Implementation plan
+
+### 21.1 Pass 1: local context and rules
+
+- Add `fission agent init`.
+- Add idempotent generation for agent rules files.
+- Add `fission agent context --format markdown|json`.
+- Add bundled docs lookup for installed Fission docs.
+- Add config parsing for `[agent]`.
+
+Acceptance criteria:
+
+- a new project can generate rules without losing user-authored content;
+- an agent can read a concise project summary;
+- no command runs arbitrary project code.
+
+### 21.2 Pass 2: MCP read-only server
+
+- Add `fission agent mcp`.
+- Expose resources for project context, docs, routes, widgets, actions, reducers, selectors, capabilities, design system, tests, and diagnostics.
+- Expose prompts for common Fission workflows.
+- Expose read-only tools only.
+
+Acceptance criteria:
+
+- a compatible MCP client can discover Fission resources, prompts, and tools;
+- the server cannot read outside the configured project root;
+- tool/resource output is deterministic across repeated calls when the project is unchanged.
+
+### 21.3 Pass 3: project indexer
+
+- Add deterministic index generation.
+- Use `cargo metadata` for workspace/package information.
+- Add Fission-specific index extraction.
+- Add cache invalidation.
+- Add confidence labels for compiler-backed, runtime-backed, generated, and advisory findings.
+
+Acceptance criteria:
+
+- the index identifies route, widget, action, reducer, selector, capability, design-system, test, and documentation locations in real Fission apps;
+- deleting the index and rebuilding produces equivalent output.
+
+### 21.4 Pass 4: runtime inspection bridge
+
+- Connect agent tools to FDTP.
+- Add `inspect-layout`, `render-route`, and `screenshot`.
+- Add headless route rendering where the target supports it.
+- Return layout, semantics, hit-test, screenshot, and diagnostic artifacts.
+
+Acceptance criteria:
+
+- an agent can render a route and inspect layout without parsing screenshots;
+- visual artifacts and structured layout data refer to the same frame.
+
+### 21.5 Pass 5: tests and visual checks
+
+- Add `run-tests`.
+- Add `compare-screenshot`.
+- Add artifact manifests.
+- Add CI-friendly JSON output.
+
+Acceptance criteria:
+
+- CI can run the same checks exposed to MCP;
+- an agent can identify which test failed and which artifact explains it.
+
+### 21.6 Pass 6: action/reducer tracing
+
+- Add action/reducer trace capture through FDTP.
+- Add `explain-reducer-path`.
+- Add `trace-action`.
+- Add `replay-action` for recorded or mocked host interactions.
+
+Acceptance criteria:
+
+- an agent can explain how a user action changed state;
+- replay refuses to claim success when a trace contains unmocked host effects.
+
+### 21.7 Pass 7: safe generation and patch proposals
+
+- Add component, screen, action, reducer, selector, capability, and test generators.
+- Add `propose-fix` patch output.
+- Add optional apply mode gated by write permissions.
+
+Acceptance criteria:
+
+- generated code uses public Fission APIs and project conventions;
+- patch proposals include verification commands;
+- no write occurs unless explicitly enabled.
+
+## 22. Testing requirements
+
+Unit tests:
+
+- config parsing;
+- include/exclude matching;
+- managed rules-file section replacement;
+- resource URI parsing;
+- side-effect class enforcement;
+- cache invalidation;
+- JSON schema serialization;
+- docs chunk ranking.
+
+Integration tests:
+
+- `fission agent init` is idempotent;
+- MCP resources are discoverable;
+- MCP read-only tools cannot escape the project root;
+- project index survives deletion and rebuild;
+- generated component compiles in a sample app;
+- `inspect-layout` returns source-linked bounds for a sample route;
+- screenshot capture produces an artifact manifest;
+- `run-tests` maps failures into structured JSON;
+- write tools are rejected by default.
+
+Smoke tests:
+
+- run the MCP server with a real Fission example;
+- ask for project context;
+- render one route;
+- capture one screenshot;
+- run the smoke test profile;
+- generate one component patch without applying it.
+
+## 23. Documentation requirements
+
+Documentation should cover:
+
+- why the Agent Kit exists;
+- how to initialize agent support in a project;
+- how to connect MCP clients;
+- how to use the CLI commands directly;
+- what data the tools can read;
+- which operations can change files or run code;
+- how to disable tools;
+- how to write project-specific agent rules;
+- how to add generated components safely;
+- how to use screenshots and traces in code review;
+- how to run the same checks in CI.
+
+The docs should be written as practical guides. A developer should be able to follow a guide from an existing Fission app to a working MCP configuration, then verify it by asking the client to inspect a route and run a test.
+
+## 24. Open questions
+
+- Should the first MCP transport be stdio only, or should localhost HTTP/WebSocket be supported immediately for clients that prefer long-running servers?
+- Should generated rules use one shared `AGENTS.md` plus client-specific pointers, or should each client receive fully expanded rules?
+- Which compiler-backed data source should be the first implementation target for resolved Rust symbol information?
+- How much of the screenshot oracle should live in the Agent Kit versus the lower-level developer tooling crates?
+- Should CI visual regression storage be implemented as local artifacts only in the first version, or should provider uploads be included later through the post-build lifecycle tooling?
+
+## 25. Consistency checks
+
+The implementation is consistent with this RFC only if the following statements remain true:
+
+- Fission keeps one app model: widgets, reducers, router, design systems, shells, and capabilities remain the source of truth.
+- FDTP remains the live runtime inspection protocol.
+- The MCP server is an adapter over Fission tooling, not a second runtime.
+- Local development does not require a hosted service.
+- Read-only agent operations work by default.
+- Side-effecting operations require explicit configuration.
+- Code generation produces normal Rust files that developers can review and edit.
+- Runtime-backed evidence beats static index guesses.
+- Static index findings are marked advisory when they are not compiler-backed, generated, or runtime-backed.
+- The toolchain is useful from multiple AI clients and editors.
+
+## 26. References
+
+- Model Context Protocol specification: `https://modelcontextprotocol.io/specification/2025-06-18`
+- MCP server concepts: `https://modelcontextprotocol.io/docs/learn/server-concepts`
+- MCP tools: `https://modelcontextprotocol.io/specification/2025-06-18/server/tools`
+- MCP prompts: `https://modelcontextprotocol.io/docs/concepts/prompts`
+- Fission developer tooling RFC: `docs/rfc-developer-tooling.md`

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -58,8 +58,36 @@ The terminal user interface shell is currently a shell/tooling surface rather th
 | --- | --- | --- | --- |
 | `name` | string | Yes | Rust package/app name used by generated scripts and site fallback title. Prefer a Cargo-compatible kebab-case name such as `field-inspector`. |
 | `app_id` | string | Yes | Stable application identifier used by generated mobile/desktop package metadata. Use a reverse-domain identifier such as `com.example.field_inspector`. |
+| `splash` | table | No | Native launch-screen configuration for iOS and Android. When omitted, generated mobile targets use `assets/app-icon.png` on a neutral background instead of showing an empty black startup window. |
 
 `app.name` should match the Cargo package name for normal generated projects. `fission init` refuses to set a conflicting name for an existing Cargo package because the generated scripts call Cargo by package name.
+
+### `[app.splash]`
+
+`[app.splash]` controls the platform-owned launch surface shown before the first Fission frame is ready. This is not an in-app loading page; it is native startup configuration generated into the Android activity theme and the iOS launch storyboard so the operating system has something branded to draw while the process, renderer, and app code start.
+
+Use it when mobile startup currently shows a blank or black screen, or when the app needs a product-specific launch mark. Keep the content simple. The launch surface should introduce the app, not perform onboarding, advertising, account selection, or any work that belongs in the real Fission widget tree.
+
+| Field | Type | Required | Default | Meaning |
+| --- | --- | --- | --- | --- |
+| `background_color` | string | No | `#F8FAFC` | Hex color in `#RRGGBB` or `#RRGGBBAA` form. Android receives the matching Android color literal; iOS receives an sRGB storyboard color. |
+| `image` | string | No | `assets/app-icon.png` | Project-relative image used as the static splash mark. Android accepts PNG, JPEG, and WebP. iOS accepts PNG and JPEG. |
+| `resize_mode` | string | No | `contain` | How the image is placed where the platform supports it: `center`, `contain`, or `cover`. Use `contain` for logos and `cover` only for artwork designed to crop safely. |
+| `android_animated_icon` | string | No | none | Project-relative Android XML drawable used for Android's native animated splash icon. This is Android-only and should be an animated vector drawable or other Android XML drawable accepted by the platform packager. |
+| `android_animation_duration_ms` | integer | No | `800` | Android native splash icon animation duration. Must be greater than zero when set. |
+
+Example:
+
+```toml
+[app.splash]
+background_color = "#06131F"
+image = "assets/splash-mark.png"
+resize_mode = "contain"
+android_animated_icon = "assets/android/splash-animated.xml"
+android_animation_duration_ms = 900
+```
+
+iOS launch screens are static by platform design. If an app needs a longer animated handoff after launch, implement that as the first route or app state in the Fission widget tree, then transition into the main screen when the required data is ready.
 
 ## `[site]`
 
@@ -162,6 +190,85 @@ Client-side search is optional. When enabled, the build writes a local search in
 ## `[package]`
 
 `[package]` contains packaging and signing references. It is read by `fission package`, `fission signing ...`, and readiness checks.
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `icon` | string | No | Legacy shorthand for `[package.icons].source`. Prefer `[package.icons]` for new projects because it supports target-specific icon sources. |
+
+### `[package.icons]`
+
+`[package.icons]` declares the application icon sources used by generated run bundles, platform packages, and release readiness checks. `assets/app-icon.png` is only the default seed written by `fission init`; it is not the only supported icon path.
+
+Use the shared `source` when one high-resolution icon can represent the app everywhere. Add platform-specific overrides when a platform needs a different source, file format, silhouette, background plate, or store treatment. All paths are project-relative.
+
+`fission add-target`, `fission run`, and `fission package` preserve this table when they update `targets`, `capabilities`, or generated platform files. For Android and iOS, adding or syncing a mobile target copies configured platform icons into `platforms/android/res/...` or `platforms/ios/AppIcon.*` so the checked-in platform scaffold remains reproducible. Desktop development bundles resolve the same table at run/package time and copy the selected icon into the generated `.app`, Linux desktop bundle, or Windows development bundle.
+
+| Field | Type | Required | Default | Meaning |
+| --- | --- | --- | --- | --- |
+| `mode` | string | No | `generate` | Icon handling intent. `generate` means Fission may generate platform outputs from sources, `provided` means the project supplies target-ready files, and `mixed` means platform-provided outputs win while missing outputs can be generated. Current run/package flows consume the declared sources directly and validate paths early. |
+| `source` | string | No | `assets/app-icon.png` fallback | Shared full-colour launcher icon source. The file must be usable by every target that falls back to it; set platform-specific overrides when one format does not work everywhere. |
+| `monochrome` | string | No | none | Shared monochrome/silhouette source for platforms that support themed icons. |
+| `background_color` | string | No | none | Hex colour used when a target icon requires a background plate and no platform-specific background is supplied. |
+| `safe_zone` | string or number | No | `platform` | Padding/cropping intent for generated icon outputs. Accepted design values are `platform`, `none`, or a numeric fraction such as `0.72`. |
+| `allow_upscale` | boolean | No | `true` | Whether generated icon output may enlarge raster sources when a target output needs more pixels than the source provides. Current development run bundles validate and copy the selected source directly; release icon generation uses this as a quality rule. |
+
+Example:
+
+```toml
+[package.icons]
+mode = "mixed"
+source = "assets/brand/app-icon.png"
+monochrome = "assets/brand/app-icon-monochrome.svg"
+background_color = "#07111F"
+safe_zone = "platform"
+allow_upscale = false
+```
+
+### `[package.icons.android]`
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `source` | string | No | Android launcher icon source. Current generated Android packages copy PNG, JPEG, WebP, or XML drawable sources into the APK resource set as `app_icon`. |
+| `foreground` | string | No | Adaptive-icon foreground source. If `source` is omitted, current generated packages use this as the launcher icon source. |
+| `background` | string | No | Adaptive-icon background source or plate. |
+| `monochrome` | string | No | Android themed-icon monochrome source. |
+
+### `[package.icons.ios]`
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `source` | string | No | iOS app icon source copied into generated simulator bundles as `AppIcon.*`. Use PNG for best compatibility with the current simulator bundle flow. |
+| `dark` | string | No | Dark appearance app icon source for release icon generation. |
+| `tinted` | string | No | Tinted appearance app icon source for release icon generation. |
+
+### `[package.icons.macos]`
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `source` | string | No | macOS bundle icon source. `.icns` is preferred for release packages; PNG is accepted by current development bundles. |
+
+### `[package.icons.windows]`
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `source` | string | No | Windows app icon source. `.ico` is preferred for packaged release output; PNG is accepted by current development bundles. |
+| `light` | string | No | Light-theme tile/icon source for package generation. |
+| `dark` | string | No | Dark-theme tile/icon source for package generation. |
+| `unplated` | string | No | Unplated Store icon source. |
+
+### `[package.icons.linux]`
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `source` | string | No | Linux desktop icon source. SVG is copied to the scalable icon directory; PNG is copied to the generated hicolor bitmap icon directory. |
+
+### `[package.icons.web]`
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `source` | string | No | Web app icon source used by web packaging flows. |
+| `favicon` | string | No | Browser favicon source for web/package metadata. Static sites separately use `[site].favicon`. |
+| `maskable` | string | No | Maskable web app icon source. |
 
 ### `[package.macos]`
 

--- a/examples/field-inspector/platforms/android/AndroidManifest.xml
+++ b/examples/field-inspector/platforms/android/AndroidManifest.xml
@@ -50,7 +50,8 @@
             android:name="android.app.NativeActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize|uiMode|density"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:theme="@style/FissionLaunchTheme">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="field_inspector" />

--- a/examples/field-inspector/platforms/android/package-apk.sh
+++ b/examples/field-inspector/platforms/android/package-apk.sh
@@ -140,6 +140,16 @@ rm -rf "$APK_ROOT"
 mkdir -p "$APK_ROOT/lib/arm64-v8a" "$APK_ROOT/res/drawable-nodpi" "$BUILD_DIR"
 cp "$SO_PATH" "$APK_ROOT/lib/arm64-v8a/lib$LIB_NAME.so"
 cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/app_icon.png"
+shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/res/drawable-nodpi/fission_splash_image.*)
+if (( ${#SPLASH_IMAGES[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/fission_splash_image.png"
+fi
+shopt -u nullglob
+if [[ -d "$SCRIPT_DIR/res" ]]; then
+  mkdir -p "$APK_ROOT/res"
+  cp -R "$SCRIPT_DIR/res/." "$APK_ROOT/res/"
+fi
 
 JAVA_SRC_DIR="$SCRIPT_DIR/java"
 if [[ -d "$JAVA_SRC_DIR" ]] && find "$JAVA_SRC_DIR" -name '*.java' -print -quit | grep -q .; then

--- a/examples/field-inspector/platforms/android/res/drawable/fission_splash_background.xml
+++ b/examples/field-inspector/platforms/android/res/drawable/fission_splash_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/fission_splash_background" />
+    <item android:gravity="center">
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/fission_splash_image" />
+    </item>
+</layer-list>

--- a/examples/field-inspector/platforms/android/res/values/colors.xml
+++ b/examples/field-inspector/platforms/android/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="fission_splash_background">#F8FAFC</color>
+</resources>

--- a/examples/field-inspector/platforms/android/res/values/styles.xml
+++ b/examples/field-inspector/platforms/android/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="FissionLaunchTheme" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowDisablePreview">false</item>
+        <item name="android:windowBackground">@drawable/fission_splash_background</item>
+        <item name="android:windowSplashScreenBackground">@color/fission_splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/fission_splash_image</item>
+        <item name="android:windowSplashScreenAnimationDuration">800</item>
+    </style>
+</resources>

--- a/examples/field-inspector/platforms/android/run-emulator.sh
+++ b/examples/field-inspector/platforms/android/run-emulator.sh
@@ -20,6 +20,20 @@ android_system_image_path() {
   printf '%s/system-images/%s\n' "$ANDROID_HOME" "${image//;/\/}"
 }
 
+wait_for_android_boot() {
+  "$ADB" wait-for-device
+  until "$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; do
+    sleep 1
+  done
+  local deadline=$((SECONDS + 180))
+  until "$ADB" shell cmd package list packages >/dev/null 2>&1; do
+    if (( SECONDS > deadline )); then
+      printf 'Android package manager did not become available. Restart the emulator with ANDROID_EMULATOR_RESTART=1 and try again.\n' >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
 ANDROID_EMULATOR_API_LEVEL="${ANDROID_EMULATOR_API_LEVEL:-$(detect_latest_emulator_api)}"
 if [[ -z "$ANDROID_EMULATOR_API_LEVEL" ]]; then
   printf 'No Android arm64 google_apis emulator image found under %s/system-images.\nInstall one with sdkmanager "system-images;android-35;google_apis;arm64-v8a" or set ANDROID_SYSTEM_IMAGE.\n' "$ANDROID_HOME" >&2
@@ -64,19 +78,18 @@ if [[ -z "$RUNNING_EMULATOR" ]]; then
   printf 'Launching emulator %s (%s)\n' "$AVD_NAME" "$([[ "$HEADLESS" == "1" ]] && echo headless || echo visible)"
   nohup "$EMULATOR_BIN" "${EMULATOR_ARGS[@]}" >/tmp/fission-android-emulator.log 2>&1 &
   disown || true
-  "$ADB" wait-for-device
-  until "$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; do
-    sleep 1
-  done
+  wait_for_android_boot
 else
   printf 'Using existing emulator %s\n' "$RUNNING_EMULATOR"
+  wait_for_android_boot
   if [[ "$HEADLESS" != "1" ]]; then
     printf 'If the window is not visible, restart with ANDROID_EMULATOR_RESTART=1 to relaunch a visible emulator.\n'
   fi
 fi
 
 APK=$("$SCRIPT_DIR/package-apk.sh")
-"$ADB" install -r "$APK"
+read -r -a ADB_INSTALL_FLAGS <<< "${ADB_INSTALL_FLAGS:---no-streaming -r}"
+"$ADB" install "${ADB_INSTALL_FLAGS[@]}" "$APK"
 "$ADB" forward "tcp:$HOST_PORT" "tcp:$DEVICE_PORT"
 "$ADB" shell am start -n com.fission.examples.fieldinspector/android.app.NativeActivity >/dev/null
 printf 'APK=%s\n' "$APK"

--- a/examples/field-inspector/platforms/ios/Info.plist
+++ b/examples/field-inspector/platforms/ios/Info.plist
@@ -24,6 +24,8 @@
   <string>AppIcon</string>
   <key>LSRequiresIPhoneOS</key>
   <true/>
+  <key>UILaunchStoryboardName</key>
+  <string>LaunchScreen</string>
   <key>MinimumOSVersion</key>
   <string>18.0</string>
 

--- a/examples/field-inspector/platforms/ios/LaunchScreen.storyboard
+++ b/examples/field-inspector/platforms/ios/LaunchScreen.storyboard
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="splash-controller">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="splash-scene">
+            <objects>
+                <viewController id="splash-controller" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="splash-root">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="SplashImage" translatesAutoresizingMaskIntoConstraints="NO" id="splash-image">
+                            <rect key="frame" x="79" y="320" width="256" height="256"/>
+                        </imageView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.972549" green="0.980392" blue="0.988235" alpha="1.000000" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                        <constraint firstItem="splash-image" firstAttribute="centerX" secondItem="splash-root" secondAttribute="centerX" id="splash-center-x"/>
+                        <constraint firstItem="splash-image" firstAttribute="centerY" secondItem="splash-root" secondAttribute="centerY" id="splash-center-y"/>
+                        <constraint firstItem="splash-image" firstAttribute="width" constant="256" id="splash-width"/>
+                        <constraint firstItem="splash-image" firstAttribute="height" constant="256" id="splash-height"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="splash-first-responder" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="SplashImage" width="256" height="256"/>
+    </resources>
+</document>

--- a/examples/field-inspector/platforms/ios/package-sim.sh
+++ b/examples/field-inspector/platforms/ios/package-sim.sh
@@ -55,5 +55,32 @@ with open(dest, "wb") as handle:
     plistlib.dump(plist, handle, sort_keys=False)
 PY
 cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/AppIcon.png"
+shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/SplashImage.*)
+if (( ${#SPLASH_IMAGES[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/SplashImage.png"
+else
+  for splash_image in "${SPLASH_IMAGES[@]}"; do
+    cp "$splash_image" "$BUNDLE_DIR/"
+  done
+fi
+shopt -u nullglob
+if [[ -f "$SCRIPT_DIR/LaunchScreen.storyboard" ]]; then
+  IBTOOL=$(xcrun --find ibtool 2>/dev/null || true)
+  if [[ -z "$IBTOOL" ]]; then
+    printf 'ibtool not found. Install Xcode command line tools to compile the iOS launch screen storyboard.\n' >&2
+    exit 1
+  fi
+  "$IBTOOL" \
+    --errors \
+    --warnings \
+    --notices \
+    --target-device iphone \
+    --target-device ipad \
+    --minimum-deployment-target 18.0 \
+    --output-format human-readable-text \
+    --compile "$BUNDLE_DIR/LaunchScreen.storyboardc" \
+    "$SCRIPT_DIR/LaunchScreen.storyboard"
+fi
 printf 'APPL????' > "$BUNDLE_DIR/PkgInfo"
 printf '%s\n' "$BUNDLE_DIR"

--- a/examples/field-inspector/platforms/ios/run-sim.sh
+++ b/examples/field-inspector/platforms/ios/run-sim.sh
@@ -31,6 +31,9 @@ fi
 
 xcrun simctl boot "$DEVICE_ID" >/dev/null 2>&1 || true
 xcrun simctl bootstatus "$DEVICE_ID" -b
+if [[ "${IOS_SIM_UNINSTALL_BEFORE_INSTALL:-1}" == "1" ]]; then
+  xcrun simctl uninstall "$DEVICE_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+fi
 xcrun simctl install "$DEVICE_ID" "$BUNDLE_DIR"
 
 if [[ -n "${FISSION_TEST_CONTROL_PORT:-}" ]]; then

--- a/examples/field-inspector/src/components/app.rs
+++ b/examples/field-inspector/src/components/app.rs
@@ -49,12 +49,18 @@ impl Widget<FieldInspectorState> for FieldInspectorApp {
             .into_node()
         };
 
+        let scroll = Scroll {
+            child: Some(Box::new(content)),
+            direction: FlexDirection::Column,
+            show_scrollbar: true,
+            flex_grow: 1.0,
+            ..Default::default()
+        }
+        .into_node();
+
         Container::new(
-            Scroll {
-                child: Some(Box::new(content)),
-                direction: FlexDirection::Column,
-                show_scrollbar: true,
-                flex_grow: 1.0,
+            SafeArea {
+                child: Box::new(scroll),
                 ..Default::default()
             }
             .into_node(),
@@ -113,7 +119,7 @@ fn hero(ctx: &mut BuildCtx<FieldInspectorState>, view: &View<FieldInspectorState
             title_text(
                 view,
                 "Capability-driven field service",
-                if is_compact(view) { 25.0 } else { 34.0 },
+                if is_compact(view) { 19.0 } else { 34.0 },
             ),
             muted_text(
                 view,

--- a/examples/field-inspector/src/components/ui.rs
+++ b/examples/field-inspector/src/components/ui.rs
@@ -52,28 +52,35 @@ pub fn responsive_grid<S: AppState>(
 }
 
 pub fn muted_text<S: AppState>(view: &View<S>, text: impl Into<String>) -> Node {
+    let compact = is_compact(view);
     Text::new(text.into())
-        .size(13.0)
-        .line_height(19.0)
+        .size(if compact { 12.0 } else { 13.0 })
+        .line_height(if compact { 18.0 } else { 19.0 })
         .color(view.env.theme.tokens.colors.text_secondary)
         .into_node()
 }
 
 pub fn body_text<S: AppState>(view: &View<S>, text: impl Into<String>) -> Node {
+    let compact = is_compact(view);
     Text::new(text.into())
-        .size(14.0)
-        .line_height(21.0)
+        .size(if compact { 13.0 } else { 14.0 })
+        .line_height(if compact { 19.0 } else { 21.0 })
         .color(view.env.theme.tokens.colors.text_primary)
         .into_node()
 }
 
 pub fn title_text<S: AppState>(view: &View<S>, text: impl Into<String>, size: f32) -> Node {
-    Text::new(text.into())
+    let compact = is_compact(view);
+    let size = if compact { size.min(22.0) } else { size };
+    let mut title = Text::new(text.into())
         .size(size)
-        .line_height(size + 8.0)
+        .line_height(size + if compact { 6.0 } else { 8.0 })
         .weight(800)
-        .color(view.env.theme.tokens.colors.text_primary)
-        .into_node()
+        .color(view.env.theme.tokens.colors.text_primary);
+    if compact {
+        title = title.max_width(usable_width(view, 64.0));
+    }
+    title.into_node()
 }
 
 pub fn panel_card<S: AppState>(view: &View<S>, child: Node) -> Node {
@@ -159,15 +166,20 @@ pub fn status_pill<S: AppState>(
     };
     Container::new(
         Text::new(label.into())
-            .size(12.0)
-            .line_height(16.0)
+            .size(if is_compact(view) { 11.0 } else { 12.0 })
+            .line_height(if is_compact(view) { 15.0 } else { 16.0 })
             .weight(800)
+            .wrap(false)
             .color(fg)
             .into_node(),
     )
     .bg(bg)
     .border_radius(999.0)
-    .padding([10.0, 10.0, 4.0, 4.0])
+    .padding(if is_compact(view) {
+        [8.0, 8.0, 4.0, 4.0]
+    } else {
+        [10.0, 10.0, 4.0, 4.0]
+    })
     .into_node()
 }
 
@@ -183,8 +195,8 @@ pub fn metric<S: AppState>(
             children: vec![
                 muted_text(view, label.into()),
                 Text::new(value.into())
-                    .size(19.0)
-                    .line_height(25.0)
+                    .size(if is_compact(view) { 17.0 } else { 19.0 })
+                    .line_height(if is_compact(view) { 23.0 } else { 25.0 })
                     .weight(800)
                     .color(view.env.theme.tokens.colors.text_primary)
                     .into_node(),

--- a/examples/inbox/src/main.rs
+++ b/examples/inbox/src/main.rs
@@ -1,7 +1,10 @@
 use fission::core::ui::{Container, Node, Row};
 use fission::core::{reduce_with, BuildCtx, Env, View, Widget, WidgetNodeId};
 use fission::i18n::{Locale, TranslationBundle};
-use fission::prelude::DesktopApp;
+use fission::prelude::{
+    DesignMode, DesignSystem, DesktopApp, FissionCupertinoDesignSystem, FissionFluent2DesignSystem,
+    FissionLiquidGlassDesignSystem, FissionMaterialDesign3DesignSystem,
+};
 use fission::theme::Theme;
 use fission::widgets::{
     Center, Drawer, DrawerSide, Overlay, Route, Router, SafeArea, SplitDirection, SplitView, Toast,
@@ -606,13 +609,37 @@ fn main() -> anyhow::Result<()> {
     let mut app = DesktopApp::new(InboxApp)
         .with_title("Fission Inbox")
         .with_env(create_env())
+        // .with_sync_env(|state: &InboxState, env: &mut Env| {
+        //     env.locale = state.locale.clone();
+        //     env.theme = if state.theme_mode == "Dark" {
+        //         Theme::dark()
+        //     } else {
+        //         Theme::default()
+        //     };
+        // })
+        // .with_design_system::<FissionCupertinoDesignSystem>(DesignMode::Light)
+        // .with_sync_env(|state: &InboxState, env: &mut Env| {
+        //     env.locale = state.locale.clone();
+        //     env.theme = FissionCupertinoDesignSystem::theme(if state.theme_mode == "dark"{ DesignMode::Dark} else {DesignMode::Light});
+        // })
+        // .with_design_system::<FissionLiquidGlassDesignSystem>(DesignMode::Light)
+        // .with_sync_env(|state: &InboxState, env: &mut Env| {
+        //     env.locale = state.locale.clone();
+        //     env.theme = FissionLiquidGlassDesignSystem::theme(if state.theme_mode == "dark"{ DesignMode::Dark} else {DesignMode::Light});
+        // })
+        // .with_design_system::<FissionMaterialDesign3DesignSystem>(DesignMode::Light)
+        // .with_sync_env(|state: &InboxState, env: &mut Env| {
+        //     env.locale = state.locale.clone();
+        //     env.theme = FissionMaterialDesign3DesignSystem::theme(if state.theme_mode == "dark"{ DesignMode::Dark} else {DesignMode::Light});
+        // })
+        .with_design_system::<FissionFluent2DesignSystem>(DesignMode::Light)
         .with_sync_env(|state: &InboxState, env: &mut Env| {
             env.locale = state.locale.clone();
-            env.theme = if state.theme_mode == "Dark" {
-                Theme::dark()
+            env.theme = FissionFluent2DesignSystem::theme(if state.theme_mode == "dark" {
+                DesignMode::Dark
             } else {
-                Theme::default()
-            };
+                DesignMode::Light
+            });
         });
 
     // Register global handlers

--- a/examples/web-smoke/platforms/android/AndroidManifest.xml
+++ b/examples/web-smoke/platforms/android/AndroidManifest.xml
@@ -18,7 +18,8 @@
             android:name="android.app.NativeActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize|uiMode|density"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:theme="@style/FissionLaunchTheme">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="web_smoke" />

--- a/examples/web-smoke/platforms/android/package-apk.sh
+++ b/examples/web-smoke/platforms/android/package-apk.sh
@@ -139,6 +139,16 @@ rm -rf "$APK_ROOT"
 mkdir -p "$APK_ROOT/lib/arm64-v8a" "$APK_ROOT/res/drawable-nodpi" "$BUILD_DIR"
 cp "$SO_PATH" "$APK_ROOT/lib/arm64-v8a/lib$LIB_NAME.so"
 cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/app_icon.png"
+shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/res/drawable-nodpi/fission_splash_image.*)
+if (( ${#SPLASH_IMAGES[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$APK_ROOT/res/drawable-nodpi/fission_splash_image.png"
+fi
+shopt -u nullglob
+if [[ -d "$SCRIPT_DIR/res" ]]; then
+  mkdir -p "$APK_ROOT/res"
+  cp -R "$SCRIPT_DIR/res/." "$APK_ROOT/res/"
+fi
 
 BUILD_MANIFEST="$BUILD_DIR/AndroidManifest.xml"
 python3 - <<'PY' "$SCRIPT_DIR/AndroidManifest.xml" "$BUILD_MANIFEST" "$ANDROID_MIN_API_LEVEL" "$ANDROID_TARGET_API_LEVEL"

--- a/examples/web-smoke/platforms/android/res/drawable/fission_splash_background.xml
+++ b/examples/web-smoke/platforms/android/res/drawable/fission_splash_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/fission_splash_background" />
+    <item android:gravity="center">
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/fission_splash_image" />
+    </item>
+</layer-list>

--- a/examples/web-smoke/platforms/android/res/values/colors.xml
+++ b/examples/web-smoke/platforms/android/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="fission_splash_background">#F8FAFC</color>
+</resources>

--- a/examples/web-smoke/platforms/android/res/values/styles.xml
+++ b/examples/web-smoke/platforms/android/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="FissionLaunchTheme" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowDisablePreview">false</item>
+        <item name="android:windowBackground">@drawable/fission_splash_background</item>
+        <item name="android:windowSplashScreenBackground">@color/fission_splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/fission_splash_image</item>
+        <item name="android:windowSplashScreenAnimationDuration">800</item>
+    </style>
+</resources>

--- a/examples/web-smoke/platforms/android/run-emulator.sh
+++ b/examples/web-smoke/platforms/android/run-emulator.sh
@@ -20,6 +20,20 @@ android_system_image_path() {
   printf '%s/system-images/%s\n' "$ANDROID_HOME" "${image//;/\/}"
 }
 
+wait_for_android_boot() {
+  "$ADB" wait-for-device
+  until "$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; do
+    sleep 1
+  done
+  local deadline=$((SECONDS + 180))
+  until "$ADB" shell cmd package list packages >/dev/null 2>&1; do
+    if (( SECONDS > deadline )); then
+      printf 'Android package manager did not become available. Restart the emulator with ANDROID_EMULATOR_RESTART=1 and try again.\n' >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
 ANDROID_EMULATOR_API_LEVEL="${ANDROID_EMULATOR_API_LEVEL:-$(detect_latest_emulator_api)}"
 if [[ -z "$ANDROID_EMULATOR_API_LEVEL" ]]; then
   printf 'No Android arm64 google_apis emulator image found under %s/system-images.\nInstall one with sdkmanager "system-images;android-35;google_apis;arm64-v8a" or set ANDROID_SYSTEM_IMAGE.\n' "$ANDROID_HOME" >&2
@@ -63,19 +77,18 @@ if [[ -z "$RUNNING_EMULATOR" ]]; then
   fi
   printf 'Launching emulator %s (%s)\n' "$AVD_NAME" "$([[ "$HEADLESS" == "1" ]] && echo headless || echo visible)"
   "$EMULATOR_BIN" "${EMULATOR_ARGS[@]}" >/tmp/fission-android-emulator.log 2>&1 &
-  "$ADB" wait-for-device
-  until "$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; do
-    sleep 1
-  done
+  wait_for_android_boot
 else
   printf 'Using existing emulator %s\n' "$RUNNING_EMULATOR"
+  wait_for_android_boot
   if [[ "$HEADLESS" != "1" ]]; then
     printf 'If the window is not visible, restart with ANDROID_EMULATOR_RESTART=1 to relaunch a visible emulator.\n'
   fi
 fi
 
 APK=$("$SCRIPT_DIR/package-apk.sh")
-"$ADB" install -r "$APK"
+read -r -a ADB_INSTALL_FLAGS <<< "${ADB_INSTALL_FLAGS:---no-streaming -r}"
+"$ADB" install "${ADB_INSTALL_FLAGS[@]}" "$APK"
 "$ADB" forward "tcp:$HOST_PORT" "tcp:$DEVICE_PORT"
 "$ADB" shell am start -n com.example.web_smoke/android.app.NativeActivity >/dev/null
 printf 'APK=%s\n' "$APK"

--- a/examples/web-smoke/platforms/ios/Info.plist
+++ b/examples/web-smoke/platforms/ios/Info.plist
@@ -24,6 +24,8 @@
   <string>AppIcon</string>
   <key>LSRequiresIPhoneOS</key>
   <true/>
+  <key>UILaunchStoryboardName</key>
+  <string>LaunchScreen</string>
   <key>MinimumOSVersion</key>
   <string>18.0</string>
   <key>UIDeviceFamily</key>

--- a/examples/web-smoke/platforms/ios/LaunchScreen.storyboard
+++ b/examples/web-smoke/platforms/ios/LaunchScreen.storyboard
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="splash-controller">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="splash-scene">
+            <objects>
+                <viewController id="splash-controller" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="splash-root">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="SplashImage" translatesAutoresizingMaskIntoConstraints="NO" id="splash-image">
+                            <rect key="frame" x="79" y="320" width="256" height="256"/>
+                        </imageView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.972549" green="0.980392" blue="0.988235" alpha="1.000000" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                        <constraint firstItem="splash-image" firstAttribute="centerX" secondItem="splash-root" secondAttribute="centerX" id="splash-center-x"/>
+                        <constraint firstItem="splash-image" firstAttribute="centerY" secondItem="splash-root" secondAttribute="centerY" id="splash-center-y"/>
+                        <constraint firstItem="splash-image" firstAttribute="width" constant="256" id="splash-width"/>
+                        <constraint firstItem="splash-image" firstAttribute="height" constant="256" id="splash-height"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="splash-first-responder" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="SplashImage" width="256" height="256"/>
+    </resources>
+</document>

--- a/examples/web-smoke/platforms/ios/package-sim.sh
+++ b/examples/web-smoke/platforms/ios/package-sim.sh
@@ -55,5 +55,32 @@ with open(dest, "wb") as handle:
     plistlib.dump(plist, handle, sort_keys=False)
 PY
 cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/AppIcon.png"
+shopt -s nullglob
+SPLASH_IMAGES=("$SCRIPT_DIR"/SplashImage.*)
+if (( ${#SPLASH_IMAGES[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$BUNDLE_DIR/SplashImage.png"
+else
+  for splash_image in "${SPLASH_IMAGES[@]}"; do
+    cp "$splash_image" "$BUNDLE_DIR/"
+  done
+fi
+shopt -u nullglob
+if [[ -f "$SCRIPT_DIR/LaunchScreen.storyboard" ]]; then
+  IBTOOL=$(xcrun --find ibtool 2>/dev/null || true)
+  if [[ -z "$IBTOOL" ]]; then
+    printf 'ibtool not found. Install Xcode command line tools to compile the iOS launch screen storyboard.\n' >&2
+    exit 1
+  fi
+  "$IBTOOL" \
+    --errors \
+    --warnings \
+    --notices \
+    --target-device iphone \
+    --target-device ipad \
+    --minimum-deployment-target 18.0 \
+    --output-format human-readable-text \
+    --compile "$BUNDLE_DIR/LaunchScreen.storyboardc" \
+    "$SCRIPT_DIR/LaunchScreen.storyboard"
+fi
 printf 'APPL????' > "$BUNDLE_DIR/PkgInfo"
 printf '%s\n' "$BUNDLE_DIR"

--- a/examples/web-smoke/platforms/ios/run-sim.sh
+++ b/examples/web-smoke/platforms/ios/run-sim.sh
@@ -31,6 +31,9 @@ fi
 
 xcrun simctl boot "$DEVICE_ID" >/dev/null 2>&1 || true
 xcrun simctl bootstatus "$DEVICE_ID" -b
+if [[ "${IOS_SIM_UNINSTALL_BEFORE_INSTALL:-1}" == "1" ]]; then
+  xcrun simctl uninstall "$DEVICE_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+fi
 xcrun simctl install "$DEVICE_ID" "$BUNDLE_DIR"
 
 if [[ -n "${FISSION_TEST_CONTROL_PORT:-}" ]]; then


### PR DESCRIPTION
## Summary
- add native app icon and launch-surface generation still missing from main
- use the full iOS outer viewport for rendering and expose safe-area insets through `Env.window_insets`
- wrap the field-inspector root in `SafeArea` and tighten compact mobile typography
- fix text layout lowering/measurement so wrapped text reserves the correct height

## Verification
- `cargo test -p fission-core text_layout`
- `cargo test -p fission-render-vello rich_text_measurement_height_tracks_wrapped_lines`
- `cargo test -p fission-shell-winit safe_area_frames_convert_to_logical_window_insets`
- `cargo check -p field-inspector`
- `cargo run -p cargo-fission --bin fission -- run --target ios --device FCB9A1FD-65A7-4706-A77A-AFC2BB156188 --project-dir examples/field-inspector --detach`
- simulator screenshot: `manual_audit/ios-safe-area/field-inspector-after-hero-title-size.png`