### PR TITLE
Fix mobile target setup and packaging scaffolds

### DIFF
--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -255,13 +255,274 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf};
+    use std::{fs, path::PathBuf, process::Command};
 
     fn unique_dir(name: &str) -> PathBuf {
         let dir =
             std::env::temp_dir().join(format!("cargo-fission-{}-{}", name, std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         dir
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: impl AsRef<std::path::Path>, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn path_with_fake_bin(fake_bin: &std::path::Path) -> String {
+        let existing = std::env::var("PATH").unwrap_or_default();
+        format!("{}:{existing}", fake_bin.display())
+    }
+
+    #[cfg(unix)]
+    fn write_fake_cargo(fake_bin: &std::path::Path) {
+        write_executable(
+            fake_bin.join("cargo"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "metadata" ]]; then
+  printf '%s\n' "$FAKE_TARGET_DIR"
+  exit 0
+fi
+if [[ "${1:-}" == "build" ]]; then
+  target=""
+  package=""
+  profile="debug"
+  args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[$i]}" in
+      --target) target="${args[$((i + 1))]}" ;;
+      --package) package="${args[$((i + 1))]}" ;;
+      --release) profile="release" ;;
+    esac
+  done
+  if [[ -z "$target" || -z "$package" ]]; then
+    printf 'fake cargo expected --target and --package\n' >&2
+    exit 2
+  fi
+  artifact_dir="$FAKE_TARGET_DIR/$target/$profile"
+  mkdir -p "$artifact_dir"
+  lib_name="${package//-/_}"
+  printf 'fake native library\n' > "$artifact_dir/lib${lib_name}.so"
+  printf '#!/usr/bin/env sh\nexit 0\n' > "$artifact_dir/$package"
+  chmod +x "$artifact_dir/$package"
+  exit 0
+fi
+printf 'unsupported fake cargo invocation: %s\n' "$*" >&2
+exit 2
+"#,
+        );
+    }
+
+    #[cfg(unix)]
+    fn write_fake_python3(fake_bin: &std::path::Path) {
+        write_executable(
+            fake_bin.join("python3"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+script=$(cat)
+if [[ "$script" == *"import plistlib"* ]]; then
+  printf 'plistlib must not be used by generated mobile package scripts\n' >&2
+  exit 44
+fi
+if [[ "$script" == *"cargo\", \"metadata\""* || "$script" == *"metadata = json.loads"* ]]; then
+  printf '%s\n' "$FAKE_TARGET_DIR"
+  exit 0
+fi
+if [[ "$script" == *"android:minSdkVersion"* ]]; then
+  if [[ "${1:-}" == "-" ]]; then
+    shift
+  fi
+  source="$1"
+  dest="$2"
+  min_api="$3"
+  target_api="$4"
+  has_code=false
+  if [[ -f "$(dirname "$dest")/apk-root/classes.dex" ]]; then
+    has_code=true
+  fi
+  sed -E \
+    -e "s/android:minSdkVersion=\"[0-9]+\"/android:minSdkVersion=\"$min_api\"/" \
+    -e "s/android:targetSdkVersion=\"[0-9]+\"/android:targetSdkVersion=\"$target_api\"/" \
+    -e "s/android:hasCode=\"(true|false)\"/android:hasCode=\"$has_code\"/" \
+    "$source" > "$dest"
+  exit 0
+fi
+printf 'unsupported fake python3 script\n%s\n' "$script" >&2
+exit 2
+"#,
+        );
+    }
+
+    #[cfg(unix)]
+    fn write_fake_ios_tools(fake_bin: &std::path::Path) {
+        write_executable(
+            fake_bin.join("xcrun"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--find" && "${2:-}" == "plutil" ]]; then
+  printf '%s/plutil\n' "$FISSION_FAKE_BIN"
+  exit 0
+fi
+if [[ "${1:-}" == "--find" && "${2:-}" == "ibtool" ]]; then
+  printf '%s/ibtool\n' "$FISSION_FAKE_BIN"
+  exit 0
+fi
+printf 'unsupported fake xcrun invocation: %s\n' "$*" >&2
+exit 2
+"#,
+        );
+        write_executable(
+            fake_bin.join("plutil"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != "-replace" || "${3:-}" != "-string" ]]; then
+  printf 'unsupported fake plutil invocation: %s\n' "$*" >&2
+  exit 2
+fi
+key="$2"
+value="$4"
+file="$5"
+tmp="$(mktemp)"
+awk -v key="$key" -v value="$value" '
+  replace_next {
+    print "  <string>" value "</string>"
+    replace_next = 0
+    next
+  }
+  {
+    print
+    if ($0 ~ "<key>" key "</key>") {
+      replace_next = 1
+    }
+  }
+' "$file" > "$tmp"
+mv "$tmp" "$file"
+"#,
+        );
+        write_executable(
+            fake_bin.join("ibtool"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--compile" ]]; then
+    mkdir -p "${args[$((i + 1))]}"
+    exit 0
+  fi
+done
+printf 'fake ibtool missing --compile\n' >&2
+exit 2
+"#,
+        );
+    }
+
+    #[cfg(unix)]
+    fn write_fake_android_tools(android_home: &std::path::Path, fake_bin: &std::path::Path) {
+        let build_tools = android_home.join("build-tools/35.0.0");
+        let ndk_bin = android_home.join("ndk/27.0.0/toolchains/llvm/prebuilt/linux-x86_64/bin");
+        fs::create_dir_all(android_home.join("platforms/android-35")).unwrap();
+        fs::write(android_home.join("platforms/android-35/android.jar"), "").unwrap();
+        fs::create_dir_all(&build_tools).unwrap();
+        fs::create_dir_all(&ndk_bin).unwrap();
+        fs::write(ndk_bin.join("aarch64-linux-android24-clang"), "").unwrap();
+        fs::write(ndk_bin.join("llvm-ar"), "").unwrap();
+
+        write_executable(
+            build_tools.join("aapt"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+out=""
+manifest=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -F) out="${args[$((i + 1))]}" ;;
+    -M) manifest="${args[$((i + 1))]}" ;;
+  esac
+done
+if [[ -z "$out" || -z "$manifest" ]]; then
+  printf 'fake aapt missing -F or -M\n' >&2
+  exit 2
+fi
+mkdir -p "$(dirname "$out")"
+{
+  printf 'AAPT_MANIFEST_BEGIN\n'
+  cat "$manifest"
+  printf '\nAAPT_MANIFEST_END\n'
+} > "$out"
+"#,
+        );
+        write_executable(
+            build_tools.join("zipalign"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+args=("$@")
+count=${#args[@]}
+input="${args[$((count - 2))]}"
+output="${args[$((count - 1))]}"
+cp "$input" "$output"
+"#,
+        );
+        write_executable(
+            build_tools.join("apksigner"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+out=""
+input=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--out" ]]; then
+    out="${args[$((i + 1))]}"
+  fi
+done
+input="${args[$((${#args[@]} - 1))]}"
+if [[ -z "$out" ]]; then
+  printf 'fake apksigner missing --out\n' >&2
+  exit 2
+fi
+cp "$input" "$out"
+"#,
+        );
+        write_executable(
+            fake_bin.join("zip"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+archive=""
+entries=()
+for arg in "$@"; do
+  if [[ "$arg" == -* ]]; then
+    continue
+  fi
+  if [[ -z "$archive" ]]; then
+    archive="$arg"
+  else
+    entries+=("$arg")
+  fi
+done
+if [[ -z "$archive" ]]; then
+  printf 'fake zip missing archive\n' >&2
+  exit 2
+fi
+for entry in "${entries[@]}"; do
+  if [[ -d "$entry" ]]; then
+    while IFS= read -r file; do
+      printf 'APK_ENTRY=%s\n' "$file" >> "$archive"
+    done < <(find "$entry" -type f | sort)
+  elif [[ -f "$entry" ]]; then
+    printf 'APK_ENTRY=%s\n' "$entry" >> "$archive"
+  fi
+done
+"#,
+        );
     }
 
     #[test]
@@ -537,6 +798,125 @@ PY
         assert!(hardened.contains("xcrun --find plutil"));
         assert!(hardened.contains("-replace CFBundleExecutable -string"));
         assert!(!hardened.contains("import plistlib"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ios_package_script_executes_without_python_plistlib() {
+        let dir = unique_dir("ios-package-e2e");
+        run([
+            "fission",
+            "init",
+            dir.to_str().unwrap(),
+            "--name",
+            "ios-package-e2e",
+            "--app-id",
+            "com.example.iospackagee2e",
+        ])
+        .unwrap();
+        run([
+            "fission",
+            "add-target",
+            "ios",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let fake_bin = dir.join("fake-bin");
+        let fake_target = dir.join("fake-target");
+        fs::create_dir_all(&fake_bin).unwrap();
+        fs::create_dir_all(&fake_target).unwrap();
+        write_fake_cargo(&fake_bin);
+        write_fake_python3(&fake_bin);
+        write_fake_ios_tools(&fake_bin);
+
+        let output = Command::new("bash")
+            .arg("platforms/ios/package-sim.sh")
+            .current_dir(&dir)
+            .env("PATH", path_with_fake_bin(&fake_bin))
+            .env("FAKE_TARGET_DIR", &fake_target)
+            .env("FISSION_FAKE_BIN", &fake_bin)
+            .env("IOS_BUNDLE_ID", "com.example.overridden")
+            .env("IOS_DISPLAY_NAME", "Overridden iOS")
+            .env("IOS_EXECUTABLE_NAME", "OverriddenExecutable")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "package-sim.sh failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let bundle_dir = String::from_utf8(output.stdout).unwrap();
+        let bundle_dir = PathBuf::from(bundle_dir.trim());
+        assert!(bundle_dir.join("OverriddenExecutable").exists());
+        assert!(bundle_dir.join("LaunchScreen.storyboardc").exists());
+        let plist = fs::read_to_string(bundle_dir.join("Info.plist")).unwrap();
+        assert!(plist.contains("<string>com.example.overridden</string>"));
+        assert!(plist.contains("<string>Overridden iOS</string>"));
+        assert!(plist.contains("<string>OverriddenExecutable</string>"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn android_package_script_builds_native_only_apk_metadata() {
+        let dir = unique_dir("android-package-e2e");
+        run([
+            "fission",
+            "init",
+            dir.to_str().unwrap(),
+            "--name",
+            "android-package-e2e",
+            "--app-id",
+            "com.example.androidpackagee2e",
+        ])
+        .unwrap();
+        run([
+            "fission",
+            "add-target",
+            "android",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let fake_bin = dir.join("fake-bin");
+        let fake_target = dir.join("fake-target");
+        let android_home = dir.join("fake-android-sdk");
+        fs::create_dir_all(&fake_bin).unwrap();
+        fs::create_dir_all(&fake_target).unwrap();
+        write_fake_cargo(&fake_bin);
+        write_fake_python3(&fake_bin);
+        write_fake_android_tools(&android_home, &fake_bin);
+        let keystore = dir.join("debug.keystore");
+        fs::write(&keystore, "fake debug keystore").unwrap();
+
+        let output = Command::new("bash")
+            .arg("platforms/android/package-apk.sh")
+            .current_dir(&dir)
+            .env("PATH", path_with_fake_bin(&fake_bin))
+            .env("FAKE_TARGET_DIR", &fake_target)
+            .env("ANDROID_HOME", &android_home)
+            .env("ANDROID_DEBUG_KEYSTORE", &keystore)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "package-apk.sh failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let apk = String::from_utf8(output.stdout).unwrap();
+        let apk = PathBuf::from(apk.trim());
+        let apk_payload = fs::read_to_string(apk).unwrap();
+        assert!(apk_payload.contains("android:hasCode=\"false\""));
+        assert!(apk_payload.contains("android:minSdkVersion=\"24\""));
+        assert!(apk_payload.contains("android:targetSdkVersion=\"35\""));
+        assert!(apk_payload.contains("APK_ENTRY=lib/arm64-v8a/libandroid_package_e2e.so"));
+        assert!(!apk_payload.contains("APK_ENTRY=classes.dex"));
     }
 
     #[test]

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -343,6 +343,7 @@ mod tests {
         let android_manifest =
             std::fs::read_to_string(dir.join("platforms/android/AndroidManifest.xml")).unwrap();
         assert!(android_manifest.contains("android:icon=\"@drawable/app_icon\""));
+        assert!(android_manifest.contains("android:hasCode=\"false\""));
         assert!(android_manifest.contains("android:targetSdkVersion=\"35\""));
         assert!(android_manifest.contains("android:theme=\"@style/FissionLaunchTheme\""));
         let android_styles =
@@ -363,6 +364,9 @@ mod tests {
         );
         assert!(android_package_script.contains("BUILD_MANIFEST"));
         assert!(android_package_script.contains("android:targetSdkVersion=\"{target_api}\""));
+        assert!(android_package_script.contains("import pathlib"));
+        assert!(android_package_script.contains("with_name(\"apk-root\")"));
+        assert!(android_package_script.contains("android:hasCode="));
         assert!(android_package_script.contains("cp -R \"$SCRIPT_DIR/res/.\""));
         assert!(android_package_script.contains("fission_splash_image.png"));
         assert!(android_package_script.contains("APP_ICONS"));
@@ -391,7 +395,9 @@ mod tests {
         assert!(ios_package_script.contains("BUNDLE_ID=\"${IOS_BUNDLE_ID:-com.example."));
         assert!(ios_package_script.contains("DISPLAY_NAME=\"${IOS_DISPLAY_NAME:-"));
         assert!(ios_package_script.contains("EXECUTABLE_NAME=\"${IOS_EXECUTABLE_NAME:-"));
-        assert!(ios_package_script.contains("plistlib.load"));
+        assert!(ios_package_script.contains("xcrun --find plutil"));
+        assert!(ios_package_script.contains("-replace CFBundleIdentifier -string"));
+        assert!(!ios_package_script.contains("import plistlib"));
         assert!(ios_package_script.contains("PkgInfo"));
         assert!(ios_package_script.contains("PLATFORM_APP_ICONS"));
         assert!(ios_package_script.contains("AppIcon.png"));
@@ -433,6 +439,169 @@ mod tests {
         assert!(std::fs::read_to_string(dir.join("platforms/web/README.md"))
             .unwrap()
             .contains("fission run --target web"));
+    }
+
+    #[test]
+    fn init_hardens_existing_android_native_only_scaffold() {
+        let dir = unique_dir("android-hardening");
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+        run([
+            "fission",
+            "add-target",
+            "android",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let manifest_path = dir.join("platforms/android/AndroidManifest.xml");
+        let package_path = dir.join("platforms/android/package-apk.sh");
+        fs::write(
+            &manifest_path,
+            fs::read_to_string(&manifest_path)
+                .unwrap()
+                .replace("android:hasCode=\"false\"", "android:hasCode=\"true\""),
+        )
+        .unwrap();
+        fs::write(
+            &package_path,
+            fs::read_to_string(&package_path)
+                .unwrap()
+                .replace("import pathlib\n", "")
+                .replace(
+                    r#"has_code = "true" if pathlib.Path(dest).with_name("apk-root").joinpath("classes.dex").exists() else "false"
+manifest = re.sub(r'android:hasCode="(?:true|false)"', f'android:hasCode="{has_code}"', manifest)
+"#,
+                    "",
+                ),
+        )
+        .unwrap();
+
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+
+        let manifest = fs::read_to_string(manifest_path).unwrap();
+        assert!(manifest.contains("android:hasCode=\"false\""));
+        let package_script = fs::read_to_string(package_path).unwrap();
+        assert!(package_script.contains("import pathlib"));
+        assert!(package_script.contains("with_name(\"apk-root\")"));
+        assert!(package_script.contains("android:hasCode="));
+    }
+
+    #[test]
+    fn init_hardens_existing_ios_package_script_without_replacing_user_files() {
+        let dir = unique_dir("ios-package-hardening");
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+        run([
+            "fission",
+            "add-target",
+            "ios",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+        let script_path = dir.join("platforms/ios/package-sim.sh");
+        let mut script = fs::read_to_string(&script_path).unwrap();
+        script = script.replace(
+            r#"cp "$SCRIPT_DIR/Info.plist" "$BUNDLE_DIR/Info.plist"
+PLUTIL=$(xcrun --find plutil 2>/dev/null || command -v plutil || true)
+if [[ -z "$PLUTIL" ]]; then
+  printf 'plutil not found. Install Xcode command line tools to package the iOS simulator app.\n' >&2
+  exit 1
+fi
+"$PLUTIL" -replace CFBundleIdentifier -string "$BUNDLE_ID" "$BUNDLE_DIR/Info.plist"
+"$PLUTIL" -replace CFBundleDisplayName -string "$DISPLAY_NAME" "$BUNDLE_DIR/Info.plist"
+"$PLUTIL" -replace CFBundleName -string "$DISPLAY_NAME" "$BUNDLE_DIR/Info.plist"
+"$PLUTIL" -replace CFBundleExecutable -string "$EXECUTABLE_NAME" "$BUNDLE_DIR/Info.plist"
+"#,
+            r#"python3 - <<'PY' "$SCRIPT_DIR/Info.plist" "$BUNDLE_DIR/Info.plist" "$BUNDLE_ID" "$DISPLAY_NAME" "$EXECUTABLE_NAME"
+import plistlib
+import sys
+
+source, dest, bundle_id, display_name, executable_name = sys.argv[1:]
+with open(source, "rb") as handle:
+    plist = plistlib.load(handle)
+plist["CFBundleIdentifier"] = bundle_id
+plist["CFBundleDisplayName"] = display_name
+plist["CFBundleName"] = display_name
+plist["CFBundleExecutable"] = executable_name
+with open(dest, "wb") as handle:
+    plistlib.dump(plist, handle, sort_keys=False)
+PY
+"#,
+        );
+        fs::write(&script_path, script).unwrap();
+
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+
+        let hardened = fs::read_to_string(script_path).unwrap();
+        assert!(hardened.contains("xcrun --find plutil"));
+        assert!(hardened.contains("-replace CFBundleExecutable -string"));
+        assert!(!hardened.contains("import plistlib"));
+    }
+
+    #[test]
+    fn init_existing_project_enables_features_for_detected_mobile_targets() {
+        let dir = unique_dir("init-mobile-features");
+        fs::create_dir_all(dir.join("src")).unwrap();
+        fs::create_dir_all(dir.join("platforms/android")).unwrap();
+        fs::create_dir_all(dir.join("platforms/ios")).unwrap();
+        fs::write(dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(
+            dir.join("Cargo.toml"),
+            r#"[package]
+name = "existing-mobile"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fission = { version = "0.4.0", default-features = false, features = ["desktop"] }
+"#,
+        )
+        .unwrap();
+
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+
+        let manifest = fs::read_to_string(dir.join("Cargo.toml")).unwrap();
+        assert!(manifest.contains("default-features = false"));
+        assert!(manifest.contains(r#"features = ["desktop", "android", "ios"]"#));
+    }
+
+    #[test]
+    fn add_target_updates_multiline_fission_dependency_features() {
+        let dir = unique_dir("multiline-features");
+        run(["fission", "init", dir.to_str().unwrap()]).unwrap();
+        fs::write(
+            dir.join("Cargo.toml"),
+            r#"[package]
+name = "multiline-features"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+
+[dependencies.fission]
+version = "0.4.0"
+default-features = true
+features = ["desktop"]
+"#,
+        )
+        .unwrap();
+
+        run([
+            "fission",
+            "add-target",
+            "android",
+            "ios",
+            "--project-dir",
+            dir.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let manifest = fs::read_to_string(dir.join("Cargo.toml")).unwrap();
+        assert!(manifest.contains("[dependencies.fission]"));
+        assert!(manifest.contains("default-features = false"));
+        assert!(manifest.contains(r#"features = ["desktop", "android", "ios"]"#));
     }
 
     #[test]

--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use toml_edit::{value, Array, DocumentMut, Item, Table, Value};
+use toml_edit::{value, Array, DocumentMut, InlineTable, Item, Table, Value};
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_APP_ICON_PNG: &[u8] = include_bytes!("../assets/fission_logo.png");
@@ -218,6 +218,7 @@ pub fn init_project(
         scaffold_target_with_policy(root, &project, target, write_policy)?;
     }
     sync_platform_config(root, &project)?;
+    sync_cargo_fission_dependency(root, &project, local_path.as_deref())?;
 
     Ok(())
 }
@@ -359,9 +360,12 @@ pub fn sync_platform_config(root: &Path, project: &FissionProject) -> Result<()>
 fn apply_mobile_run_script_hardening(root: &Path, project: &FissionProject) -> Result<()> {
     if project.targets.contains(&Target::Ios) {
         apply_ios_run_script_hardening(root)?;
+        apply_ios_package_script_hardening(root)?;
     }
     if project.targets.contains(&Target::Android) {
         apply_android_run_script_hardening(root)?;
+        apply_android_package_script_hardening(root)?;
+        apply_android_manifest_hardening(root)?;
     }
     Ok(())
 }
@@ -379,6 +383,28 @@ fn apply_ios_run_script_hardening(root: &Path) -> Result<()> {
     let marker = "xcrun simctl bootstatus \"$DEVICE_ID\" -b\n";
     let insertion = "xcrun simctl bootstatus \"$DEVICE_ID\" -b\nif [[ \"${IOS_SIM_UNINSTALL_BEFORE_INSTALL:-1}\" == \"1\" ]]; then\n  xcrun simctl uninstall \"$DEVICE_ID\" \"$BUNDLE_ID\" >/dev/null 2>&1 || true\nfi\n";
     let updated = existing.replacen(marker, insertion, 1);
+    fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn apply_ios_package_script_hardening(root: &Path) -> Result<()> {
+    let path = root.join("platforms/ios/package-sim.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    if !existing.contains("import plistlib") {
+        return Ok(());
+    }
+    let Some(start) = existing.find("python3 - <<'PY' \"$SCRIPT_DIR/Info.plist\"") else {
+        return Ok(());
+    };
+    let Some(relative_end) = existing[start..].find("\nPY") else {
+        return Ok(());
+    };
+    let end = start + relative_end + "\nPY\n".len();
+    let mut updated = existing;
+    updated.replace_range(start..end, IOS_INFO_PLIST_PLUTIL_PATCH);
     fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))
 }
 
@@ -436,6 +462,51 @@ fn apply_android_run_script_hardening(root: &Path) -> Result<()> {
     Ok(())
 }
 
+fn apply_android_package_script_hardening(root: &Path) -> Result<()> {
+    let path = root.join("platforms/android/package-apk.sh");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut updated = existing.clone();
+    if updated.contains("import re\nimport sys\n") && !updated.contains("import pathlib\n") {
+        updated = updated.replace(
+            "import re\nimport sys\n",
+            "import pathlib\nimport re\nimport sys\n",
+        );
+    }
+    let has_code_line = r#"has_code = "true" if pathlib.Path(dest).with_name("apk-root").joinpath("classes.dex").exists() else "false"
+manifest = re.sub(r'android:hasCode="(?:true|false)"', f'android:hasCode="{has_code}"', manifest)
+"#;
+    if !updated.contains("android:hasCode=") || !updated.contains("with_name(\"apk-root\")") {
+        updated = updated.replace(
+            "manifest = re.sub(r'android:targetSdkVersion=\"\\d+\"', f'android:targetSdkVersion=\"{target_api}\"', manifest)\n",
+            &format!(
+                "manifest = re.sub(r'android:targetSdkVersion=\"\\d+\"', f'android:targetSdkVersion=\"{{target_api}}\"', manifest)\n{has_code_line}"
+            ),
+        );
+    }
+    if updated != existing {
+        fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn apply_android_manifest_hardening(root: &Path) -> Result<()> {
+    let path = root.join("platforms/android/AndroidManifest.xml");
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let updated = existing.replace(r#"android:hasCode="true""#, r#"android:hasCode="false""#);
+    if updated != existing {
+        fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    Ok(())
+}
+
 fn android_wait_for_boot_function() -> &'static str {
     r#"wait_for_android_boot() {
   "$ADB" wait-for-device
@@ -464,6 +535,18 @@ fn replace_android_boot_wait_after(mut text: String, marker: &str, replacement: 
     }
     text
 }
+
+const IOS_INFO_PLIST_PLUTIL_PATCH: &str = r#"cp "$SCRIPT_DIR/Info.plist" "$BUNDLE_DIR/Info.plist"
+PLUTIL=$(xcrun --find plutil 2>/dev/null || command -v plutil || true)
+if [[ -z "$PLUTIL" ]]; then
+  printf 'plutil not found. Install Xcode command line tools to package the iOS simulator app.\n' >&2
+  exit 1
+fi
+"$PLUTIL" -replace CFBundleIdentifier -string "$BUNDLE_ID" "$BUNDLE_DIR/Info.plist"
+"$PLUTIL" -replace CFBundleDisplayName -string "$DISPLAY_NAME" "$BUNDLE_DIR/Info.plist"
+"$PLUTIL" -replace CFBundleName -string "$DISPLAY_NAME" "$BUNDLE_DIR/Info.plist"
+"$PLUTIL" -replace CFBundleExecutable -string "$EXECUTABLE_NAME" "$BUNDLE_DIR/Info.plist"
+"#;
 
 fn apply_platform_capability_config(root: &Path, project: &FissionProject) -> Result<()> {
     if project.capabilities.is_empty() {
@@ -828,98 +911,195 @@ pub fn read_project_config(root: &Path) -> Result<FissionProject> {
 }
 
 fn update_cargo_fission_features(root: &Path, project: &FissionProject) -> Result<()> {
+    sync_cargo_fission_dependency(root, project, None)
+}
+
+fn sync_cargo_fission_dependency(
+    root: &Path,
+    project: &FissionProject,
+    local_path: Option<&Path>,
+) -> Result<()> {
     let path = root.join("Cargo.toml");
     let Ok(text) = fs::read_to_string(&path) else {
         return Ok(());
     };
-    let feature_list = render_fission_feature_list(&project.targets);
+
+    let mut doc = text
+        .parse::<DocumentMut>()
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    let features = fission_features_for_targets(&project.targets);
     let mut changed = false;
-    let mut out = Vec::new();
-    for line in text.lines() {
-        if let Some(updated) = update_inline_fission_dependency(line, &feature_list) {
-            changed |= updated != line;
-            out.push(updated);
-        } else {
-            out.push(line.to_string());
-        }
+
+    if !doc.get("dependencies").is_some_and(Item::is_table_like) {
+        doc["dependencies"] = Item::Table(Table::new());
+        changed = true;
     }
+
+    let use_workspace_fission = local_path.is_none()
+        && workspace_has_fission_dependency(&doc)
+        && doc
+            .get("dependencies")
+            .and_then(Item::as_table_like)
+            .is_none_or(|dependencies| !dependencies.contains_key("fission"));
+    let deps = doc["dependencies"]
+        .as_table_like_mut()
+        .expect("dependencies table was just created");
+    let dep = deps.entry("fission").or_insert(Item::None);
+    changed |= sync_fission_dependency_item(dep, &features, local_path, use_workspace_fission)?;
+
     if changed {
-        fs::write(&path, out.join("\n") + "\n")
+        fs::write(&path, doc.to_string())
             .with_context(|| format!("failed to update {}", path.display()))?;
     }
     Ok(())
 }
 
-fn update_inline_fission_dependency(line: &str, feature_list: &str) -> Option<String> {
-    let trimmed = line.trim_start();
-    if !trimmed.starts_with("fission =") {
-        return None;
-    }
-    let indent = &line[..line.len() - trimmed.len()];
-    let value = trimmed.strip_prefix("fission =")?.trim();
-    if value.starts_with('"') {
-        return Some(format!(
-            "{indent}fission = {{ version = {value}, default-features = false, features = [{feature_list}] }}"
-        ));
-    }
-    if !(value.starts_with('{') && value.ends_with('}')) {
-        return None;
-    }
-    let inner = value
-        .strip_prefix('{')
-        .and_then(|value| value.strip_suffix('}'))?
-        .trim();
-    let mut fields = split_top_level_fields(inner)
-        .into_iter()
-        .filter(|field| {
-            let key = field
-                .split_once('=')
-                .map(|(key, _)| key.trim())
-                .unwrap_or_default();
-            key != "default-features" && key != "features"
-        })
-        .collect::<Vec<_>>();
-    fields.push("default-features = false".to_string());
-    fields.push(format!("features = [{feature_list}]"));
-    Some(format!("{indent}fission = {{ {} }}", fields.join(", ")))
+fn workspace_has_fission_dependency(doc: &DocumentMut) -> bool {
+    doc.get("workspace")
+        .and_then(Item::as_table_like)
+        .and_then(|workspace| workspace.get("dependencies"))
+        .and_then(Item::as_table_like)
+        .is_some_and(|dependencies| dependencies.contains_key("fission"))
 }
 
-fn split_top_level_fields(input: &str) -> Vec<String> {
-    let mut fields = Vec::new();
-    let mut start = 0;
-    let mut bracket_depth = 0usize;
-    let mut in_string = false;
-    let mut escaped = false;
-    for (index, ch) in input.char_indices() {
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == '"' {
-                in_string = false;
-            }
-            continue;
+fn sync_fission_dependency_item(
+    item: &mut Item,
+    features: &[&'static str],
+    local_path: Option<&Path>,
+    use_workspace_fission: bool,
+) -> Result<bool> {
+    match item {
+        Item::None => {
+            *item = Item::Value(Value::InlineTable(new_fission_dependency_table(
+                features,
+                local_path,
+                use_workspace_fission,
+            )));
+            Ok(true)
         }
-        match ch {
-            '"' => in_string = true,
-            '[' => bracket_depth += 1,
-            ']' => bracket_depth = bracket_depth.saturating_sub(1),
-            ',' if bracket_depth == 0 => {
-                let field = input[start..index].trim();
-                if !field.is_empty() {
-                    fields.push(field.to_string());
-                }
-                start = index + ch.len_utf8();
-            }
-            _ => {}
+        Item::Value(Value::String(version)) => {
+            let mut table = InlineTable::new();
+            table.insert("version", Value::String(version.clone()));
+            sync_fission_inline_table(&mut table, features, local_path, use_workspace_fission);
+            *item = Item::Value(Value::InlineTable(table));
+            Ok(true)
         }
+        Item::Value(Value::InlineTable(table)) => Ok(sync_fission_inline_table(
+            table,
+            features,
+            local_path,
+            use_workspace_fission,
+        )),
+        Item::Table(table) => Ok(sync_fission_table(
+            table,
+            features,
+            local_path,
+            use_workspace_fission,
+        )),
+        _ => bail!("unsupported fission dependency format in Cargo.toml"),
     }
-    let field = input[start..].trim();
-    if !field.is_empty() {
-        fields.push(field.to_string());
+}
+
+fn new_fission_dependency_table(
+    features: &[&'static str],
+    local_path: Option<&Path>,
+    use_workspace_fission: bool,
+) -> InlineTable {
+    let mut table = InlineTable::new();
+    if let Some(root) = local_path {
+        table.insert(
+            "path",
+            Value::from(
+                root.join("crates/authoring/fission")
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+        );
+    } else if use_workspace_fission {
+        table.insert("workspace", Value::from(true));
+    } else {
+        table.insert("version", Value::from(CURRENT_VERSION));
     }
-    fields
+    table.insert("default-features", Value::from(false));
+    table.insert("features", cargo_feature_array_value(features));
+    table
+}
+
+fn sync_fission_inline_table(
+    table: &mut InlineTable,
+    features: &[&'static str],
+    local_path: Option<&Path>,
+    use_workspace_fission: bool,
+) -> bool {
+    let before = table.to_string();
+    if let Some(root) = local_path {
+        table.insert(
+            "path",
+            Value::from(
+                root.join("crates/authoring/fission")
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+        );
+        table.remove("version");
+        table.remove("workspace");
+    } else if use_workspace_fission
+        && !table.contains_key("path")
+        && !table.contains_key("version")
+        && !table.contains_key("git")
+    {
+        table.insert("workspace", Value::from(true));
+    } else if !table.contains_key("path")
+        && !table.contains_key("version")
+        && !table.contains_key("workspace")
+        && !table.contains_key("git")
+    {
+        table.insert("version", Value::from(CURRENT_VERSION));
+    }
+    table.insert("default-features", Value::from(false));
+    table.insert("features", cargo_feature_array_value(features));
+    table.to_string() != before
+}
+
+fn sync_fission_table(
+    table: &mut Table,
+    features: &[&'static str],
+    local_path: Option<&Path>,
+    use_workspace_fission: bool,
+) -> bool {
+    let before = table.to_string();
+    if let Some(root) = local_path {
+        table["path"] = value(
+            root.join("crates/authoring/fission")
+                .to_string_lossy()
+                .to_string(),
+        );
+        table.remove("version");
+        table.remove("workspace");
+    } else if use_workspace_fission
+        && !table.contains_key("path")
+        && !table.contains_key("version")
+        && !table.contains_key("git")
+    {
+        table["workspace"] = value(true);
+    } else if !table.contains_key("path")
+        && !table.contains_key("version")
+        && !table.contains_key("workspace")
+        && !table.contains_key("git")
+    {
+        table["version"] = value(CURRENT_VERSION);
+    }
+    table["default-features"] = value(false);
+    table["features"] = Item::Value(cargo_feature_array_value(features));
+    table.to_string() != before
+}
+
+fn cargo_feature_array_value(features: &[&'static str]) -> Value {
+    let mut array = Array::new();
+    for feature in features {
+        array.push(*feature);
+    }
+    Value::Array(array)
 }
 
 fn scaffold_target_with_policy(
@@ -1518,20 +1698,7 @@ rm -rf "$BUNDLE_DIR"
 mkdir -p "$BUNDLE_DIR"
 cp "$TARGET_DIR/$TARGET/$ARTIFACT_DIR/$PACKAGE_NAME" "$BUNDLE_DIR/$EXECUTABLE_NAME"
 chmod +x "$BUNDLE_DIR/$EXECUTABLE_NAME"
-python3 - <<'PY' "$SCRIPT_DIR/Info.plist" "$BUNDLE_DIR/Info.plist" "$BUNDLE_ID" "$DISPLAY_NAME" "$EXECUTABLE_NAME"
-import plistlib
-import sys
-
-source, dest, bundle_id, display_name, executable_name = sys.argv[1:]
-with open(source, "rb") as handle:
-    plist = plistlib.load(handle)
-plist["CFBundleIdentifier"] = bundle_id
-plist["CFBundleDisplayName"] = display_name
-plist["CFBundleName"] = display_name
-plist["CFBundleExecutable"] = executable_name
-with open(dest, "wb") as handle:
-    plistlib.dump(plist, handle, sort_keys=False)
-PY
+{plist_patch}
 shopt -s nullglob
 PLATFORM_APP_ICONS=("$SCRIPT_DIR"/AppIcon.*)
 if (( ${{#PLATFORM_APP_ICONS[@]}} == 0 )); then
@@ -1575,6 +1742,7 @@ printf '%s\n' "$BUNDLE_DIR"
         bundle_id = project.app.app_id,
         bundle_name = bundle_name,
         executable = executable,
+        plist_patch = IOS_INFO_PLIST_PLUTIL_PATCH,
     )
 }
 
@@ -1680,7 +1848,7 @@ fn render_android_manifest(project: &FissionProject) -> String {
     <application
         android:debuggable="true"
         android:extractNativeLibs="true"
-        android:hasCode="true"
+        android:hasCode="false"
         android:icon="@drawable/app_icon"
         android:label="{label}">
         <activity
@@ -2207,6 +2375,7 @@ fi
 
 BUILD_MANIFEST="$BUILD_DIR/AndroidManifest.xml"
 python3 - <<'PY' "$SCRIPT_DIR/AndroidManifest.xml" "$BUILD_MANIFEST" "$ANDROID_MIN_API_LEVEL" "$ANDROID_TARGET_API_LEVEL"
+import pathlib
 import re
 import sys
 
@@ -2214,6 +2383,8 @@ source, dest, min_api, target_api = sys.argv[1:]
 manifest = open(source, encoding="utf-8").read()
 manifest = re.sub(r'android:minSdkVersion="\d+"', f'android:minSdkVersion="{{min_api}}"', manifest)
 manifest = re.sub(r'android:targetSdkVersion="\d+"', f'android:targetSdkVersion="{{target_api}}"', manifest)
+has_code = "true" if pathlib.Path(dest).with_name("apk-root").joinpath("classes.dex").exists() else "false"
+manifest = re.sub(r'android:hasCode="(?:true|false)"', f'android:hasCode="{{has_code}}"', manifest)
 open(dest, "w", encoding="utf-8").write(manifest)
 PY
 


### PR DESCRIPTION
## Summary
- Sync the facade crate features in Cargo.toml during both  and , including existing projects and multiline  tables.
- Harden generated and existing iOS simulator packaging scripts so plist updates use platform  instead of Python .
- Fix Android native-only APK metadata by defaulting  to false and switching it on only when Java helper classes are packaged.
- Add executable package-script tests with mocked iOS and Android toolchains so generated mobile packaging scripts are actually run during CLI tests.

## Verification so far
- 
running 16 tests
test tests::init_creates_project_files ... ok
test tests::cargo_fission_alias_accepts_prefixed_subcommand ... ok
test tests::add_target_preserves_existing_target_files ... ok
test tests::add_target_updates_multiline_fission_dependency_features ... ok
test tests::init_existing_project_is_idempotent ... ok
test tests::custom_splash_config_updates_mobile_platform_files ... ok
test tests::custom_icon_config_is_preserved_and_applied_to_mobile_scaffolds ... ok
test tests::add_target_updates_manifest_and_scaffold ... ok
test tests::init_existing_project_preserves_user_files_and_detects_targets ... ok
test tests::init_existing_project_enables_features_for_detected_mobile_targets ... ok
test tests::add_capability_updates_project_and_platform_config ... ok
test tests::init_hardens_existing_ios_package_script_without_replacing_user_files ... ok
test tests::init_hardens_existing_android_native_only_scaffold ... ok
test tests::doctor_command_runs_in_non_strict_mode ... ok
test tests::ios_package_script_executes_without_python_plistlib ... ok
test tests::android_package_script_builds_native_only_apk_metadata ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.26s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 

## Follow-up verification in progress
- Running all ignored E2E tests before any 0.4.1 release decision.