### PR TITLE
Improve SSR support for production sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "bincode",
  "blake3",
  "fission-core",
+ "fission-i18n",
  "fission-ir",
  "fission-layout",
  "fission-shell-site",
@@ -2819,6 +2820,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "fission-core",
+ "fission-i18n",
  "fission-ir",
  "fission-layout",
  "fission-theme",

--- a/crates/authoring/fission-widgets/src/markdown.rs
+++ b/crates/authoring/fission-widgets/src/markdown.rs
@@ -1,10 +1,11 @@
 use crate::stack::VStack;
 use fission_core::op::Color;
 use fission_core::ui::{
-    Column, Container, Image, RichText, RichTextRun, Row, Scroll, Text, TextFontStyle, Widget,
+    Column, Container, Image, RichText, RichTextRun, Row, Scroll, SemanticsRegion, Text,
+    TextFontStyle, Widget,
 };
 use fission_core::{build::ViewHandle, FlexDirection};
-use fission_ir::op::{AlignItems, ImageFit};
+use fission_ir::op::{AlignItems, FlexWrap, ImageFit};
 use fission_ir::{Role, Semantics};
 use rushdown::ast::{
     Arena, CodeBlock, CodeSpan, Heading, HtmlBlock, Image as MarkdownImage, KindData, Link,
@@ -104,6 +105,12 @@ struct MarkdownRenderer<'a> {
     code_family: String,
 }
 
+struct MarkdownImageBlock<'a> {
+    node_ref: NodeRef,
+    image: &'a MarkdownImage,
+    link_destination: Option<String>,
+}
+
 impl<'a> MarkdownRenderer<'a> {
     fn new(source: &'a str, arena: &'a Arena, view: ViewHandle<()>) -> Self {
         let tokens = &view.env().theme.tokens;
@@ -197,8 +204,8 @@ impl<'a> MarkdownRenderer<'a> {
     }
 
     fn paragraph(&self, node_ref: NodeRef, font_size: f32) -> Widget {
-        if let Some((image_ref, image)) = self.single_image(node_ref) {
-            return self.image_block(image_ref, image);
+        if let Some(images) = self.image_blocks(node_ref) {
+            return self.image_group(images);
         }
         let runs = self.inline_runs(node_ref, self.inline_style(font_size));
         if runs.is_empty() {
@@ -212,29 +219,112 @@ impl<'a> MarkdownRenderer<'a> {
         }
     }
 
-    fn single_image(&self, node_ref: NodeRef) -> Option<(NodeRef, &MarkdownImage)> {
-        let mut children = self.arena[node_ref].children(self.arena);
-        let child_ref = children.next()?;
-        if children.next().is_some() {
-            return None;
+    fn image_blocks(&self, node_ref: NodeRef) -> Option<Vec<MarkdownImageBlock<'a>>> {
+        let mut images = Vec::new();
+        for child_ref in self.arena[node_ref].children(self.arena) {
+            if self.is_blank_text(child_ref) {
+                continue;
+            }
+            let image = self.image_block_child(child_ref)?;
+            images.push(image);
         }
+        if images.is_empty() {
+            None
+        } else {
+            Some(images)
+        }
+    }
+
+    fn image_block_child(&self, child_ref: NodeRef) -> Option<MarkdownImageBlock<'a>> {
         match self.arena[child_ref].kind_data() {
-            KindData::Image(image) => Some((child_ref, image)),
+            KindData::Image(image) => Some(MarkdownImageBlock {
+                node_ref: child_ref,
+                image,
+                link_destination: None,
+            }),
+            KindData::Link(link) => {
+                let mut image_block = None;
+                for nested_ref in self.arena[child_ref].children(self.arena) {
+                    if self.is_blank_text(nested_ref) {
+                        continue;
+                    }
+                    let KindData::Image(image) = self.arena[nested_ref].kind_data() else {
+                        return None;
+                    };
+                    if image_block.is_some() {
+                        return None;
+                    }
+                    image_block = Some(MarkdownImageBlock {
+                        node_ref: nested_ref,
+                        image,
+                        link_destination: Some(link.destination_str(self.source).to_string()),
+                    });
+                }
+                image_block
+            }
             _ => None,
         }
     }
 
-    fn image_block(&self, _node_ref: NodeRef, image: &MarkdownImage) -> Widget {
-        let source = image.destination_str(self.source).to_string();
+    fn is_blank_text(&self, node_ref: NodeRef) -> bool {
+        match self.arena[node_ref].kind_data() {
+            KindData::Text(text) => text.str(self.source).trim().is_empty(),
+            KindData::RawHtml(raw_html) => raw_html.str(self.source).trim().is_empty(),
+            _ => false,
+        }
+    }
+
+    fn image_group(&self, images: Vec<MarkdownImageBlock<'a>>) -> Widget {
+        if images.len() == 1 {
+            return self.image_block(&images[0], self.image_width, self.image_height);
+        }
+
+        let children = images
+            .iter()
+            .map(|image| {
+                Container::new(self.image_block(
+                    image,
+                    (self.image_width * 0.36).max(180.0),
+                    (self.image_height * 0.36).max(128.0),
+                ))
+                .into()
+            })
+            .collect();
+
+        Row {
+            children,
+            gap: Some(10.0),
+            wrap: FlexWrap::Wrap,
+            align_items: AlignItems::Start,
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn image_block(&self, block: &MarkdownImageBlock<'a>, width: f32, height: f32) -> Widget {
+        let source = block.image.destination_str(self.source).to_string();
         let image = if source.starts_with("https://") || source.starts_with("http://") {
             Image::network(source)
         } else {
             Image::asset(source)
         };
-        image
-            .size(self.image_width, self.image_height)
+        let alt = self.plain_text(block.node_ref);
+        let mut widget: Widget = image
+            .size(width, height)
             .fit(ImageFit::Contain)
-            .into()
+            .semantic_label(alt.clone())
+            .into();
+        if let Some(destination) = &block.link_destination {
+            widget = SemanticsRegion::new(widget)
+                .identifier(format!("markdown-link:{destination}"))
+                .label(if alt.trim().is_empty() {
+                    "Open image".to_string()
+                } else {
+                    alt
+                })
+                .into();
+        }
+        widget
     }
 
     fn code_block(&self, code: &CodeBlock) -> Widget {

--- a/crates/authoring/fission-widgets/tests/markdown_viewer_test.rs
+++ b/crates/authoring/fission-widgets/tests/markdown_viewer_test.rs
@@ -1,5 +1,7 @@
 use fission_core::internal::BuildCtx;
 use fission_core::{build, Env, GlobalState, RuntimeState, View, Widget};
+use fission_ir::op::{ImageSource, PaintOp};
+use fission_ir::Op;
 use fission_widgets::MarkdownViewer;
 
 #[derive(Default, Debug, Clone)]
@@ -99,4 +101,52 @@ fn renders_gfm_table_as_rows_and_cells() {
         .children
         .iter()
         .all(|row| fission_core::internal::widget_kind_name(row) == "Row"));
+}
+
+#[test]
+fn renders_linked_markdown_images_as_image_links() {
+    let node = build_markdown(
+        "[![Bluetooth screenshot](https://cdn.example.com/thumb.png)](https://cdn.example.com/full.png)\n",
+    );
+    let content = scroll_content(node);
+    let ir = fission_core::internal::lower_widget_to_ir(&content);
+
+    assert!(ir.nodes.values().any(|node| matches!(
+        &node.op,
+        Op::Paint(PaintOp::DrawImage { request, .. })
+            if matches!(
+                &request.source,
+                ImageSource::Network { url, .. } if url == "https://cdn.example.com/thumb.png"
+            )
+            && request.semantic_label.as_deref() == Some("Bluetooth screenshot")
+    )));
+    assert!(ir.nodes.values().any(|node| matches!(
+        &node.op,
+        Op::Semantics(semantics)
+            if semantics.identifier.as_deref()
+                == Some("markdown-link:https://cdn.example.com/full.png")
+    )));
+}
+
+#[test]
+fn renders_image_only_paragraphs_as_wrapping_galleries() {
+    let node = build_markdown(
+        "[![One](https://cdn.example.com/one.png)](https://cdn.example.com/one-full.png) [![Two](https://cdn.example.com/two.png)](https://cdn.example.com/two-full.png)\n",
+    );
+    let content = scroll_content(node);
+
+    let column = fission_core::internal::widget_as_column(&content)
+        .expect("expected MarkdownViewer content to be a Column");
+    assert_eq!(
+        fission_core::internal::widget_kind_name(&column.children[0]),
+        "Row"
+    );
+
+    let ir = fission_core::internal::lower_widget_to_ir(&content);
+    let image_count = ir
+        .nodes
+        .values()
+        .filter(|node| matches!(&node.op, Op::Paint(PaintOp::DrawImage { .. })))
+        .count();
+    assert_eq!(image_count, 2);
 }

--- a/crates/core/fission-core/src/ui/widgets/image.rs
+++ b/crates/core/fission-core/src/ui/widgets/image.rs
@@ -182,7 +182,7 @@ impl InternalLower for Image {
                 max_height: None,
                 padding: [0.0; 4],
                 flex_grow: 0.0,
-                flex_shrink: 0.0,
+                flex_shrink: 1.0,
                 aspect_ratio: None,
             }),
         );

--- a/crates/core/fission-core/src/ui/widgets/semantics_region.rs
+++ b/crates/core/fission-core/src/ui/widgets/semantics_region.rs
@@ -18,6 +18,8 @@ pub struct SemanticsRegion {
     pub identifier: Option<String>,
     /// Optional accessible label for the region.
     pub label: Option<String>,
+    /// Optional semantic value exposed to shells and renderers.
+    pub value: Option<String>,
     /// Semantic role. Defaults to a generic region.
     pub role: Role,
     /// Actions attached to the semantic region.
@@ -62,6 +64,16 @@ impl SemanticsRegion {
         self
     }
 
+    /// Sets the semantic value exposed to shells and HTML renderers.
+    ///
+    /// Most semantic regions do not need a value. It is useful for renderer
+    /// extensions where the stable identifier names the behavior and the value
+    /// carries structured, serializable configuration.
+    pub fn value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
     /// Sets the semantic role of the region.
     ///
     /// Choose the role that matches the user-visible behavior of the wrapped
@@ -93,6 +105,7 @@ impl Default for SemanticsRegion {
             id: None,
             identifier: None,
             label: None,
+            value: None,
             role: Role::Generic,
             actions: ActionSet::default(),
             child: None,
@@ -108,6 +121,7 @@ impl InternalLower for SemanticsRegion {
             role: self.role,
             identifier: self.identifier.clone(),
             label: self.label.clone(),
+            value: self.value.clone(),
             actions: self.actions.clone(),
             ..Default::default()
         };

--- a/crates/core/fission-core/tests/image_widget.rs
+++ b/crates/core/fission-core/tests/image_widget.rs
@@ -74,9 +74,15 @@ fn image_lowering_keeps_sized_layout_parent_and_draw_image_child() {
     let root_id = ir.root.expect("image root");
     let root = ir.nodes.get(&root_id).expect("root node");
     match &root.op {
-        Op::Layout(fission_ir::op::LayoutOp::Box { width, height, .. }) => {
+        Op::Layout(fission_ir::op::LayoutOp::Box {
+            width,
+            height,
+            flex_shrink,
+            ..
+        }) => {
             assert_eq!(*width, Some(88.0));
             assert_eq!(*height, Some(44.0));
+            assert_eq!(*flex_shrink, 1.0);
         }
         other => panic!("expected image root to be a sized layout box, got {other:?}"),
     }

--- a/crates/rendering/fission-render-vello/src/lib.rs
+++ b/crates/rendering/fission-render-vello/src/lib.rs
@@ -1346,7 +1346,10 @@ impl<'a> VelloRenderer<'a> {
     }
 
     fn rects_intersect(a: Rect, b: Rect) -> bool {
-        a.width() > 0.0 && a.height() > 0.0 && b.width() > 0.0 && b.height() > 0.0
+        a.width() > 0.0
+            && a.height() > 0.0
+            && b.width() > 0.0
+            && b.height() > 0.0
             && a.x1 >= b.x0
             && a.x0 <= b.x1
             && a.y1 >= b.y0
@@ -1354,7 +1357,12 @@ impl<'a> VelloRenderer<'a> {
     }
 
     fn intersect_rects(a: Rect, b: Rect) -> Rect {
-        Rect::new(a.x0.max(b.x0), a.y0.max(b.y0), a.x1.min(b.x1), a.y1.min(b.y1))
+        Rect::new(
+            a.x0.max(b.x0),
+            a.y0.max(b.y0),
+            a.x1.min(b.x1),
+            a.y1.min(b.y1),
+        )
     }
 
     fn local_rect_visible(&self, rect: Rect) -> bool {
@@ -1650,9 +1658,7 @@ impl<'a> VelloRenderer<'a> {
                         let overlap_end = range.end.min(run_text_range.end);
                         if overlap_start < overlap_end {
                             let bg_color = Color::from_rgba8(bg.r, bg.g, bg.b, bg.a);
-                            let x0 = clip
-                                .map(|clip| run_left.max(clip.left))
-                                .unwrap_or(run_left);
+                            let x0 = clip.map(|clip| run_left.max(clip.left)).unwrap_or(run_left);
                             let x1 = clip
                                 .map(|clip| run_right.min(clip.right))
                                 .unwrap_or(run_right);
@@ -1724,9 +1730,7 @@ impl<'a> VelloRenderer<'a> {
                         deco_brush.0[3],
                     );
 
-                    let x0 = clip
-                        .map(|clip| run_left.max(clip.left))
-                        .unwrap_or(run_left);
+                    let x0 = clip.map(|clip| run_left.max(clip.left)).unwrap_or(run_left);
                     let x1 = clip
                         .map(|clip| run_right.min(clip.right))
                         .unwrap_or(run_right);

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -38,4 +38,5 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
+fission-i18n = { path = "../../core/fission-i18n", version = "0.4.0" }
 fission-widgets = { path = "../../authoring/fission-widgets", version = "0.4.0", default-features = false }

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -13,6 +13,7 @@ use fission_layout::LayoutSize;
 use fission_theme::Theme;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Arc;
 
 pub(crate) type RouteRenderer =
@@ -58,11 +59,16 @@ pub struct ServerRenderContext<'a> {
     pub render_pass_limit: usize,
     pub default_locale: &'a str,
     pub(crate) env: &'a Env,
+    pub(crate) response_status: &'a AtomicU16,
 }
 
 impl<'a> ServerRenderContext<'a> {
     pub fn env(&self) -> &'a Env {
         self.env
+    }
+
+    pub fn set_response_status(&self, status: u16) {
+        self.response_status.store(status, Ordering::Relaxed);
     }
 }
 

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -6,8 +6,8 @@ use crate::{
 use anyhow::Result;
 use fission_core::internal::BuildCtx;
 use fission_core::{
-    ActionInput, Effect, Env, GlobalState, RuntimeResourceDeclaration, RuntimeResourceKind,
-    RuntimeState, View, Widget, WidgetId,
+    ActionInput, AnimationRequest, Effect, Env, GlobalState, RuntimeResourceDeclaration,
+    RuntimeResourceKind, RuntimeState, View, Widget, WidgetId,
 };
 use fission_layout::LayoutSize;
 use fission_theme::Theme;
@@ -26,6 +26,7 @@ type InitialStateLoader<S> =
 pub(crate) struct ServerRenderedNode {
     pub node: Widget,
     pub resources: Vec<RuntimeResourceDeclaration>,
+    pub animation_requests: Vec<(WidgetId, AnimationRequest)>,
 }
 
 #[derive(Clone)]
@@ -311,6 +312,7 @@ where
     let mut pending_action = ctx.action.cloned();
     let mut final_node = None;
     let mut final_resources = Vec::new();
+    let mut final_animation_requests = Vec::new();
 
     for pass in 0..=ctx.render_pass_limit {
         let view = View::new(&state, &runtime, env, None);
@@ -336,6 +338,7 @@ where
         )?;
         final_node = Some(node);
         final_resources = resources;
+        final_animation_requests = build_ctx.take_animation_requests();
         if !dispatched {
             break;
         }
@@ -355,6 +358,7 @@ where
             fission_core::build::enter(&mut build_ctx, &view, || (*widget).clone().into())
         }),
         resources: final_resources,
+        animation_requests: final_animation_requests,
     })
 }
 

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -1,4 +1,4 @@
-use crate::render::{ServerRequest, ServerSession};
+use crate::render::{ServerRequest, ServerResponse, ServerSession};
 use crate::{
     ProgressiveWorker, ServerJobRegistry, ServerRenderPolicy, VerifiedServerAction, WasmIsland,
     WebRoute, WebRouteMode,
@@ -21,6 +21,8 @@ type RequestEnvSync =
     dyn for<'a> Fn(&ServerEnvContext<'a>, &mut Env) -> Result<()> + Send + Sync + 'static;
 type InitialStateLoader<S> =
     dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<S> + Send + Sync + 'static;
+type HttpHandler =
+    dyn for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static;
 
 #[derive(Debug)]
 pub(crate) struct ServerRenderedNode {
@@ -65,9 +67,23 @@ impl<'a> ServerRenderContext<'a> {
 }
 
 #[derive(Clone)]
+pub struct ServerHttpContext<'a> {
+    pub project_dir: &'a Path,
+    pub request: &'a ServerRequest,
+    pub session: &'a ServerSession,
+}
+
+#[derive(Clone)]
 pub(crate) struct ServerRouteEntry {
     pub route: WebRoute,
     pub render: Arc<RouteRenderer>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ServerHttpHandlerEntry {
+    pub method: String,
+    pub path: String,
+    pub handler: Arc<HttpHandler>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -87,6 +103,7 @@ pub struct FissionServerApp {
     pub(crate) request_env_sync: Option<Arc<RequestEnvSync>>,
     pub(crate) jobs: ServerJobRegistry,
     pub(crate) routes: Vec<ServerRouteEntry>,
+    pub(crate) http_handlers: Vec<ServerHttpHandlerEntry>,
     pub(crate) static_mounts: Vec<StaticMount>,
     pub(crate) user_css: Vec<String>,
 }
@@ -101,6 +118,7 @@ impl FissionServerApp {
             request_env_sync: None,
             jobs: ServerJobRegistry::new(),
             routes: Vec::new(),
+            http_handlers: Vec::new(),
             static_mounts: Vec::new(),
             user_css: Vec::new(),
         }
@@ -139,6 +157,30 @@ impl FissionServerApp {
     pub fn user_css(mut self, css: impl Into<String>) -> Self {
         self.user_css.push(css.into());
         self
+    }
+
+    pub fn http_handler<F>(
+        mut self,
+        method: impl Into<String>,
+        path: impl Into<String>,
+        handler: F,
+    ) -> Self
+    where
+        F: for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static,
+    {
+        self.http_handlers.push(ServerHttpHandlerEntry {
+            method: method.into().to_ascii_uppercase(),
+            path: normalize_server_path(&path.into()),
+            handler: Arc::new(handler),
+        });
+        self
+    }
+
+    pub fn form_post<F>(self, path: impl Into<String>, handler: F) -> Self
+    where
+        F: for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static,
+    {
+        self.http_handler("POST", path, handler)
     }
 
     pub fn static_dir(
@@ -272,6 +314,18 @@ impl FissionServerApp {
     pub(crate) fn find_route(&self, path: &str) -> Option<&ServerRouteEntry> {
         let path = normalize_server_path(path);
         self.routes.iter().find(|entry| entry.route.path == path)
+    }
+
+    pub(crate) fn find_http_handler(
+        &self,
+        method: &str,
+        path: &str,
+    ) -> Option<&ServerHttpHandlerEntry> {
+        let method = method.to_ascii_uppercase();
+        let path = normalize_server_path(path);
+        self.http_handlers
+            .iter()
+            .find(|entry| entry.method == method && entry.path == path)
     }
 
     pub(crate) fn apply_default_route_mode(&mut self, mode: WebRouteMode) {

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -12,7 +12,7 @@ use fission_core::{
 use fission_layout::LayoutSize;
 use fission_theme::Theme;
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub(crate) type RouteRenderer =
@@ -69,6 +69,14 @@ pub(crate) struct ServerRouteEntry {
     pub render: Arc<RouteRenderer>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StaticMount {
+    pub url_prefix: String,
+    pub directory: PathBuf,
+    pub index_file: Option<String>,
+    pub fallback_to_index: bool,
+}
+
 #[derive(Clone)]
 pub struct FissionServerApp {
     pub(crate) project_name: String,
@@ -78,6 +86,7 @@ pub struct FissionServerApp {
     pub(crate) request_env_sync: Option<Arc<RequestEnvSync>>,
     pub(crate) jobs: ServerJobRegistry,
     pub(crate) routes: Vec<ServerRouteEntry>,
+    pub(crate) static_mounts: Vec<StaticMount>,
 }
 
 impl FissionServerApp {
@@ -90,6 +99,7 @@ impl FissionServerApp {
             request_env_sync: None,
             jobs: ServerJobRegistry::new(),
             routes: Vec::new(),
+            static_mounts: Vec::new(),
         }
     }
 
@@ -120,6 +130,35 @@ impl FissionServerApp {
 
     pub fn jobs(mut self, jobs: ServerJobRegistry) -> Self {
         self.jobs = jobs;
+        self
+    }
+
+    pub fn static_dir(
+        mut self,
+        url_prefix: impl Into<String>,
+        directory: impl Into<PathBuf>,
+    ) -> Self {
+        self.static_mounts.push(StaticMount {
+            url_prefix: normalize_mount_prefix(&url_prefix.into()),
+            directory: directory.into(),
+            index_file: None,
+            fallback_to_index: false,
+        });
+        self
+    }
+
+    pub fn static_app(
+        mut self,
+        url_prefix: impl Into<String>,
+        directory: impl Into<PathBuf>,
+        index_file: impl Into<String>,
+    ) -> Self {
+        self.static_mounts.push(StaticMount {
+            url_prefix: normalize_mount_prefix(&url_prefix.into()),
+            directory: directory.into(),
+            index_file: Some(index_file.into()),
+            fallback_to_index: true,
+        });
         self
     }
 
@@ -397,6 +436,21 @@ pub(crate) fn normalize_server_path(path: &str) -> String {
     }
     if out.len() > 1 && !out.ends_with('/') {
         out.push('/');
+    }
+    out
+}
+
+fn normalize_mount_prefix(path: &str) -> String {
+    let mut out = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    while out.contains("//") {
+        out = out.replace("//", "/");
+    }
+    if out.len() > 1 {
+        out = out.trim_end_matches('/').to_string();
     }
     out
 }

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -87,6 +87,7 @@ pub struct FissionServerApp {
     pub(crate) jobs: ServerJobRegistry,
     pub(crate) routes: Vec<ServerRouteEntry>,
     pub(crate) static_mounts: Vec<StaticMount>,
+    pub(crate) user_css: Vec<String>,
 }
 
 impl FissionServerApp {
@@ -100,6 +101,7 @@ impl FissionServerApp {
             jobs: ServerJobRegistry::new(),
             routes: Vec::new(),
             static_mounts: Vec::new(),
+            user_css: Vec::new(),
         }
     }
 
@@ -130,6 +132,11 @@ impl FissionServerApp {
 
     pub fn jobs(mut self, jobs: ServerJobRegistry) -> Self {
         self.jobs = jobs;
+        self
+    }
+
+    pub fn user_css(mut self, css: impl Into<String>) -> Self {
+        self.user_css.push(css.into());
         self
     }
 

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -76,7 +76,25 @@ pub struct ServerHttpContext<'a> {
 #[derive(Clone)]
 pub(crate) struct ServerRouteEntry {
     pub route: WebRoute,
+    pub matcher: ServerRouteMatcher,
     pub render: Arc<RouteRenderer>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ServerRouteMatcher {
+    Exact,
+    Prefix { prefix: String },
+}
+
+impl ServerRouteMatcher {
+    pub(crate) fn matches(&self, route_path: &str, request_path: &str) -> bool {
+        match self {
+            Self::Exact => route_path == request_path,
+            Self::Prefix { prefix } => {
+                request_path.starts_with(prefix) && request_path.len() > prefix.len()
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -252,6 +270,42 @@ impl FissionServerApp {
                 workers: Vec::new(),
                 islands: Vec::new(),
             },
+            matcher: ServerRouteMatcher::Exact,
+            render: Arc::new(move |ctx| {
+                let state = initial_state(ctx)?;
+                render_widget_node::<S, W>(widget.as_ref(), ctx, state)
+            }),
+        });
+        self
+    }
+
+    pub fn route_prefix_widget_with_state<S, W, F>(
+        mut self,
+        path_prefix: impl Into<String>,
+        title: impl Into<String>,
+        description: impl Into<Option<String>>,
+        mode: WebRouteMode,
+        widget: W,
+        initial_state: F,
+    ) -> Self
+    where
+        S: GlobalState + 'static,
+        W: Clone + Into<Widget> + Send + Sync + 'static,
+        F: for<'a> Fn(&ServerRenderContext<'a>) -> Result<S> + Send + Sync + 'static,
+    {
+        let prefix = normalize_server_path(&path_prefix.into());
+        let widget = Arc::new(widget);
+        let initial_state: Arc<InitialStateLoader<S>> = Arc::new(initial_state);
+        self.routes.push(ServerRouteEntry {
+            route: WebRoute {
+                path: prefix.clone(),
+                title: title.into(),
+                description: description.into(),
+                mode,
+                workers: Vec::new(),
+                islands: Vec::new(),
+            },
+            matcher: ServerRouteMatcher::Prefix { prefix },
             render: Arc::new(move |ctx| {
                 let state = initial_state(ctx)?;
                 render_widget_node::<S, W>(widget.as_ref(), ctx, state)
@@ -313,7 +367,16 @@ impl FissionServerApp {
 
     pub(crate) fn find_route(&self, path: &str) -> Option<&ServerRouteEntry> {
         let path = normalize_server_path(path);
-        self.routes.iter().find(|entry| entry.route.path == path)
+        self.routes
+            .iter()
+            .find(|entry| {
+                matches!(entry.matcher, ServerRouteMatcher::Exact) && entry.route.path == path
+            })
+            .or_else(|| {
+                self.routes
+                    .iter()
+                    .find(|entry| entry.matcher.matches(&entry.route.path, &path))
+            })
     }
 
     pub(crate) fn find_http_handler(

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 
 pub(crate) type RouteRenderer =
     dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<ServerRenderedNode> + Send + Sync + 'static;
+type RequestEnvSync =
+    dyn for<'a> Fn(&ServerEnvContext<'a>, &mut Env) -> Result<()> + Send + Sync + 'static;
 type InitialStateLoader<S> =
     dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<S> + Send + Sync + 'static;
 
@@ -24,6 +26,20 @@ type InitialStateLoader<S> =
 pub(crate) struct ServerRenderedNode {
     pub node: Widget,
     pub resources: Vec<RuntimeResourceDeclaration>,
+}
+
+#[derive(Clone)]
+pub struct ServerEnvContext<'a> {
+    pub project_dir: &'a Path,
+    pub route_path: &'a str,
+    pub theme: &'a Theme,
+    pub viewport_size: LayoutSize,
+    pub jobs: &'a ServerJobRegistry,
+    pub request: &'a ServerRequest,
+    pub session: &'a ServerSession,
+    pub action: Option<&'a VerifiedServerAction>,
+    pub render_pass_limit: usize,
+    pub default_locale: &'a str,
 }
 
 #[derive(Clone)]
@@ -37,6 +53,14 @@ pub struct ServerRenderContext<'a> {
     pub session: &'a ServerSession,
     pub action: Option<&'a VerifiedServerAction>,
     pub render_pass_limit: usize,
+    pub default_locale: &'a str,
+    pub(crate) env: &'a Env,
+}
+
+impl<'a> ServerRenderContext<'a> {
+    pub fn env(&self) -> &'a Env {
+        self.env
+    }
 }
 
 #[derive(Clone)]
@@ -50,6 +74,8 @@ pub struct FissionServerApp {
     pub(crate) project_name: String,
     pub(crate) project_dir: std::path::PathBuf,
     pub(crate) theme: Theme,
+    pub(crate) env: Env,
+    pub(crate) request_env_sync: Option<Arc<RequestEnvSync>>,
     pub(crate) jobs: ServerJobRegistry,
     pub(crate) routes: Vec<ServerRouteEntry>,
 }
@@ -60,6 +86,8 @@ impl FissionServerApp {
             project_name: project_name.into(),
             project_dir: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             theme: Theme::default(),
+            env: Env::default(),
+            request_env_sync: None,
             jobs: ServerJobRegistry::new(),
             routes: Vec::new(),
         }
@@ -71,7 +99,22 @@ impl FissionServerApp {
     }
 
     pub fn theme(mut self, theme: Theme) -> Self {
+        self.env.theme = theme.clone();
         self.theme = theme;
+        self
+    }
+
+    pub fn with_env(mut self, env: Env) -> Self {
+        self.env = env;
+        self.env.theme = self.theme.clone();
+        self
+    }
+
+    pub fn with_request_env<F>(mut self, sync: F) -> Self
+    where
+        F: for<'a> Fn(&ServerEnvContext<'a>, &mut Env) -> Result<()> + Send + Sync + 'static,
+    {
+        self.request_env_sync = Some(Arc::new(sync));
         self
     }
 
@@ -194,6 +237,17 @@ impl FissionServerApp {
             }
         }
     }
+
+    pub(crate) fn env_for_context(&self, ctx: &ServerEnvContext<'_>) -> Result<Env> {
+        let mut env = self.env.clone();
+        env.theme = ctx.theme.clone();
+        env.viewport_size = ctx.viewport_size;
+        env.locale = ctx.default_locale.into();
+        if let Some(sync) = &self.request_env_sync {
+            sync(ctx, &mut env)?;
+        }
+        Ok(env)
+    }
 }
 
 fn render_widget_node<S, W>(
@@ -206,16 +260,14 @@ where
     W: Clone + Into<Widget>,
 {
     let runtime = RuntimeState::default();
-    let mut env = Env::default();
-    env.theme = ctx.theme.clone();
-    env.viewport_size = ctx.viewport_size;
+    let env = ctx.env();
     let mut executed_jobs = BTreeSet::new();
     let mut pending_action = ctx.action.cloned();
     let mut final_node = None;
     let mut final_resources = Vec::new();
 
     for pass in 0..=ctx.render_pass_limit {
-        let view = View::new(&state, &runtime, &env, None);
+        let view = View::new(&state, &runtime, env, None);
         let mut build_ctx = BuildCtx::<S>::new();
         let node = fission_core::build::enter(&mut build_ctx, &view, || (*widget).clone().into());
 
@@ -252,7 +304,7 @@ where
 
     Ok(ServerRenderedNode {
         node: final_node.unwrap_or_else(|| {
-            let view = View::new(&state, &runtime, &env, None);
+            let view = View::new(&state, &runtime, env, None);
             let mut build_ctx = BuildCtx::<S>::new();
             fission_core::build::enter(&mut build_ctx, &view, || (*widget).clone().into())
         }),

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -269,6 +269,7 @@ impl FissionServerApp {
                 mode,
                 workers: Vec::new(),
                 islands: Vec::new(),
+                structured_data: Vec::new(),
             },
             matcher: ServerRouteMatcher::Exact,
             render: Arc::new(move |ctx| {
@@ -304,6 +305,7 @@ impl FissionServerApp {
                 mode,
                 workers: Vec::new(),
                 islands: Vec::new(),
+                structured_data: Vec::new(),
             },
             matcher: ServerRouteMatcher::Prefix { prefix },
             render: Arc::new(move |ctx| {
@@ -363,6 +365,21 @@ impl FissionServerApp {
             .iter()
             .map(|entry| entry.route.clone())
             .collect()
+    }
+
+    pub fn with_route_structured_data<I, S>(mut self, path: impl Into<String>, data: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let path = normalize_server_path(&path.into());
+        let serialized = data.into_iter().map(Into::into).collect::<Vec<String>>();
+        for entry in &mut self.routes {
+            if entry.route.path == path {
+                entry.route.structured_data = serialized.clone();
+            }
+        }
+        self
     }
 
     pub(crate) fn find_route(&self, path: &str) -> Option<&ServerRouteEntry> {

--- a/crates/shell/fission-shell-server/src/lib.rs
+++ b/crates/shell/fission-shell-server/src/lib.rs
@@ -23,7 +23,7 @@ pub use adapters::actix_adapter;
 #[cfg(feature = "axum-adapter")]
 pub use adapters::axum_adapter;
 pub use adapters::hyper_adapter;
-pub use app::{FissionServerApp, ServerEnvContext, ServerRenderContext};
+pub use app::{FissionServerApp, ServerEnvContext, ServerRenderContext, StaticMount};
 pub use artifacts::{
     BrowserArtifactBuild, BrowserArtifactBuildOptions, BrowserArtifactKind, BrowserArtifactPlan,
 };

--- a/crates/shell/fission-shell-server/src/lib.rs
+++ b/crates/shell/fission-shell-server/src/lib.rs
@@ -23,7 +23,9 @@ pub use adapters::actix_adapter;
 #[cfg(feature = "axum-adapter")]
 pub use adapters::axum_adapter;
 pub use adapters::hyper_adapter;
-pub use app::{FissionServerApp, ServerEnvContext, ServerRenderContext, StaticMount};
+pub use app::{
+    FissionServerApp, ServerEnvContext, ServerHttpContext, ServerRenderContext, StaticMount,
+};
 pub use artifacts::{
     BrowserArtifactBuild, BrowserArtifactBuildOptions, BrowserArtifactKind, BrowserArtifactPlan,
 };

--- a/crates/shell/fission-shell-server/src/lib.rs
+++ b/crates/shell/fission-shell-server/src/lib.rs
@@ -23,7 +23,7 @@ pub use adapters::actix_adapter;
 #[cfg(feature = "axum-adapter")]
 pub use adapters::axum_adapter;
 pub use adapters::hyper_adapter;
-pub use app::{FissionServerApp, ServerRenderContext};
+pub use app::{FissionServerApp, ServerEnvContext, ServerRenderContext};
 pub use artifacts::{
     BrowserArtifactBuild, BrowserArtifactBuildOptions, BrowserArtifactKind, BrowserArtifactPlan,
 };

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -1,5 +1,6 @@
 use crate::app::{
-    normalize_server_path, FissionServerApp, ServerEnvContext, ServerRenderedNode, ServerRouteEntry,
+    normalize_server_path, FissionServerApp, ServerEnvContext, ServerRenderedNode,
+    ServerRouteEntry, StaticMount,
 };
 use crate::{
     Cache, CacheEntry, CacheKey, CacheMetadata, CachePipeline, CacheScope, CacheTag, Freshness,
@@ -285,6 +286,11 @@ impl ServerRenderer {
         if let Some(response) = self.handle_asset_request(&asset_request_path(&request.path))? {
             return Ok(response);
         }
+        if let Some(response) =
+            self.handle_static_mount_request(&asset_request_path(&request.path))?
+        {
+            return Ok(response);
+        }
         let path = normalize_server_path(&request.path);
         let Some(route) = self.app.find_route(&path) else {
             return Ok(ServerResponse::text(
@@ -532,6 +538,58 @@ impl ServerRenderer {
             "text/plain; charset=utf-8",
             "asset not found",
         ))
+    }
+
+    fn handle_static_mount_request(&self, request_path: &str) -> Result<Option<ServerResponse>> {
+        for mount in &self.app.static_mounts {
+            let Some(relative) = static_mount_relative_path(mount, request_path) else {
+                continue;
+            };
+            let Some(relative) = relative else {
+                return Ok(Some(ServerResponse::text(
+                    400,
+                    "text/plain; charset=utf-8",
+                    "invalid static path",
+                )));
+            };
+
+            let root = static_mount_root(&self.app.project_dir, mount);
+            let mut candidate = if relative.as_os_str().is_empty() {
+                match &mount.index_file {
+                    Some(index_file) => root.join(index_file),
+                    None => root.clone(),
+                }
+            } else {
+                root.join(&relative)
+            };
+
+            if candidate.is_dir() {
+                if let Some(index_file) = &mount.index_file {
+                    candidate = candidate.join(index_file);
+                }
+            }
+
+            if candidate.is_file() {
+                return Ok(Some(file_response(&candidate)?));
+            }
+
+            if mount.fallback_to_index && !looks_like_static_file_request(&relative) {
+                if let Some(index_file) = &mount.index_file {
+                    let index = root.join(index_file);
+                    if index.is_file() {
+                        return Ok(Some(file_response(&index)?));
+                    }
+                }
+            }
+
+            return Ok(Some(ServerResponse::text(
+                404,
+                "text/plain; charset=utf-8",
+                "static file not found",
+            )));
+        }
+
+        Ok(None)
     }
 
     fn handle_action(&self, request: ServerRequest) -> Result<ServerResponse> {
@@ -1039,6 +1097,42 @@ fn safe_relative_asset_path(request_path: &str) -> Option<PathBuf> {
     (!out.as_os_str().is_empty()).then_some(out)
 }
 
+fn static_mount_relative_path(mount: &StaticMount, request_path: &str) -> Option<Option<PathBuf>> {
+    let prefix = mount.url_prefix.as_str();
+    let relative = if request_path == prefix {
+        ""
+    } else if prefix == "/" {
+        request_path.trim_start_matches('/')
+    } else {
+        request_path.strip_prefix(&format!("{prefix}/"))?
+    };
+    Some(safe_relative_static_path(relative))
+}
+
+fn safe_relative_static_path(relative: &str) -> Option<PathBuf> {
+    let path = Path::new(relative);
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => out.push(segment),
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+
+fn static_mount_root(project_dir: &Path, mount: &StaticMount) -> PathBuf {
+    if mount.directory.is_absolute() {
+        mount.directory.clone()
+    } else {
+        project_dir.join(&mount.directory)
+    }
+}
+
+fn looks_like_static_file_request(relative: &Path) -> bool {
+    relative.extension().is_some()
+}
+
 fn file_response(path: &Path) -> Result<ServerResponse> {
     let body = fs::read(path)?;
     Ok(ServerResponse {
@@ -1059,8 +1153,9 @@ fn content_type_for_path(path: &Path) -> &'static str {
         .map(|extension| extension.to_ascii_lowercase())
         .as_deref()
     {
+        Some("html") | Some("htm") => "text/html; charset=utf-8",
         Some("css") => "text/css; charset=utf-8",
-        Some("js") => "application/javascript; charset=utf-8",
+        Some("js") | Some("mjs") => "application/javascript; charset=utf-8",
         Some("wasm") => "application/wasm",
         Some("ico") => "image/x-icon",
         Some("svg") => "image/svg+xml",
@@ -1833,6 +1928,83 @@ same_site = "none"
             .handle(ServerRequest::get("/assets/../secret.txt"))
             .unwrap();
         assert_eq!(traversal.status, 400);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn server_renderer_serves_static_app_mount_with_index_and_modules() {
+        let root = temp_project_dir("server-renderer-static-app");
+        let admin_dir = root.join("assets/admin/pkg");
+        fs::create_dir_all(&admin_dir).unwrap();
+        fs::write(
+            root.join("assets/admin/index.html"),
+            "<!doctype html><script type=\"module\" src=\"./bootstrap.mjs\"></script>",
+        )
+        .unwrap();
+        fs::write(
+            root.join("assets/admin/bootstrap.mjs"),
+            "import './pkg/app.js';",
+        )
+        .unwrap();
+        fs::write(
+            root.join("assets/admin/pkg/app.js"),
+            "export const app = true;",
+        )
+        .unwrap();
+        fs::write(root.join("secret.txt"), b"secret").unwrap();
+
+        let renderer = ServerRenderer::new(
+            FissionServerApp::new("Test")
+                .project_dir(&root)
+                .static_app("/admin", "assets/admin", "index.html")
+                .server_route_widget::<TestState, _>("/", "Home", None, TestPage("Mount page")),
+        );
+
+        let index = renderer.handle(ServerRequest::get("/admin/")).unwrap();
+        assert_eq!(index.status, 200);
+        assert_eq!(
+            response_header(&index, "content-type"),
+            Some("text/html; charset=utf-8")
+        );
+        assert!(index.body_string().contains("bootstrap.mjs"));
+
+        let module = renderer
+            .handle(ServerRequest::get("/admin/bootstrap.mjs"))
+            .unwrap();
+        assert_eq!(module.status, 200);
+        assert_eq!(
+            response_header(&module, "content-type"),
+            Some("application/javascript; charset=utf-8")
+        );
+
+        let nested = renderer
+            .handle(ServerRequest::get("/admin/pkg/app.js"))
+            .unwrap();
+        assert_eq!(nested.status, 200);
+        assert_eq!(
+            response_header(&nested, "content-type"),
+            Some("application/javascript; charset=utf-8")
+        );
+
+        let spa_route = renderer
+            .handle(ServerRequest::get("/admin/content/calendar"))
+            .unwrap();
+        assert_eq!(spa_route.status, 200);
+        assert_eq!(spa_route.body, index.body);
+
+        let missing_asset = renderer
+            .handle(ServerRequest::get("/admin/pkg/missing.js"))
+            .unwrap();
+        assert_eq!(missing_asset.status, 404);
+
+        let traversal = renderer
+            .handle(ServerRequest::get("/admin/../secret.txt"))
+            .unwrap();
+        assert_eq!(traversal.status, 400);
+
+        let public_route = renderer.handle(ServerRequest::get("/")).unwrap();
+        assert_eq!(public_route.status, 200);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
 
@@ -120,6 +120,7 @@ pub struct RenderedServerRoute {
     pub css: String,
     pub resources: Vec<RuntimeResourceDeclaration>,
     pub server_action_count: usize,
+    pub status: u16,
 }
 
 pub struct ServerRenderer {
@@ -355,7 +356,7 @@ impl ServerRenderer {
             let page = RenderedPage {
                 html: rendered.html.clone(),
                 css: rendered.css.clone(),
-                status: 200,
+                status: rendered.status,
             };
             let entry = CacheEntry::full_page(
                 cache_key,
@@ -374,7 +375,7 @@ impl ServerRenderer {
 
         let rendered = self.render_uncached(route, None, &request, &session)?;
         let mut response = ServerResponse {
-            status: 200,
+            status: rendered.status,
             headers: vec![(
                 "content-type".to_string(),
                 "text/html; charset=utf-8".to_string(),
@@ -406,6 +407,7 @@ impl ServerRenderer {
         env: Env,
     ) -> Result<RenderedServerRoute> {
         let route_path = matched_route_path(route, request);
+        let response_status = AtomicU16::new(200);
         let ctx = crate::ServerRenderContext {
             project_dir: &self.app.project_dir,
             route_path: &route_path,
@@ -418,6 +420,7 @@ impl ServerRenderer {
             render_pass_limit: self.render_pass_limit,
             default_locale: &self.default_locale,
             env: &env,
+            response_status: &response_status,
         };
         let ServerRenderedNode {
             node,
@@ -482,6 +485,7 @@ impl ServerRenderer {
             css,
             resources,
             server_action_count,
+            status: response_status.load(Ordering::Relaxed),
         })
     }
 
@@ -1548,6 +1552,34 @@ mod tests {
 
         assert_eq!(response.status, 200);
         assert!(response.body_string().contains("/docs/platform/"));
+    }
+
+    #[test]
+    fn route_renderers_can_set_http_response_status() {
+        let app = FissionServerApp::new("Test").route_prefix_widget_with_state::<PathState, _, _>(
+            "/docs/",
+            "Docs",
+            None,
+            WebRouteMode::Server(Default::default()),
+            PathPage,
+            |ctx| {
+                ctx.set_response_status(404);
+                Ok(PathState {
+                    route_path: ctx.route_path.to_string(),
+                })
+            },
+        );
+        let renderer = ServerRenderer::new(app);
+
+        let rendered = renderer.render_route("/docs/missing").unwrap();
+        assert_eq!(rendered.status, 404);
+        assert!(rendered.html.contains("/docs/missing/"));
+
+        let response = renderer
+            .handle(ServerRequest::get("/docs/missing"))
+            .unwrap();
+        assert_eq!(response.status, 404);
+        assert!(response.body_string().contains("/docs/missing/"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -481,6 +481,10 @@ impl ServerRenderer {
             css.push('\n');
             css.push_str(style);
         }
+        for user_css in &self.app.user_css {
+            css.push('\n');
+            css.push_str(user_css);
+        }
         Ok(ServerResponse::text(200, "text/css; charset=utf-8", css))
     }
 
@@ -1860,6 +1864,7 @@ same_site = "none"
         );
         let css = css.body_string();
         assert!(css.contains(".fission-site-root"));
+        assert!(css.contains(".fission-site-positioned > .fission-site-semantics"));
         assert!(css.contains(":root"));
 
         let js = renderer
@@ -1883,6 +1888,24 @@ same_site = "none"
         let runtime = runtime.body_string();
         assert!(runtime.contains("fission_bridge_alloc"));
         assert!(runtime.contains("fission-site-text-run"));
+    }
+
+    #[test]
+    fn server_renderer_appends_user_css_to_site_stylesheet() {
+        let renderer = ServerRenderer::new(
+            FissionServerApp::new("Test")
+                .user_css(".demo-hook{animation:demo 1s linear infinite;}")
+                .server_route_widget::<TestState, _>("/", "Home", None, TestPage("CSS page")),
+        );
+
+        let page = renderer.handle(ServerRequest::get("/")).unwrap();
+        assert_eq!(page.status, 200);
+
+        let css = renderer.handle(ServerRequest::get("/site.css")).unwrap();
+        assert_eq!(css.status, 200);
+        let css = css.body_string();
+        assert!(css.contains(".fission-site-root"));
+        assert!(css.contains(".demo-hook{animation:demo 1s linear infinite;}"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -876,7 +876,7 @@ impl ServerRenderer {
             })
             .unwrap_or_default();
         let theme_hash = blake3::hash(format!("{:?}", env.theme).as_bytes());
-        let build_id = option_env!("FISSION_BUILD_ID").unwrap_or(env!("CARGO_PKG_VERSION"));
+        let build_id = cache_build_id();
         let mut key = format!(
             "page:{}?{}#app:{}#locale:{}#theme:{}#build:{}",
             normalize_server_path(&request.path),
@@ -892,6 +892,41 @@ impl ServerRenderer {
         }
         CacheKey::new(key)
     }
+}
+
+fn cache_build_id() -> String {
+    cache_build_id_from(
+        std::env::var("FISSION_BUILD_ID").ok(),
+        option_env!("FISSION_BUILD_ID"),
+        env!("CARGO_PKG_VERSION"),
+    )
+}
+
+fn cache_build_id_from(
+    runtime_build_id: Option<String>,
+    compile_time_build_id: Option<&'static str>,
+    package_version: &'static str,
+) -> String {
+    runtime_build_id
+        .and_then(|value| {
+            let value = value.trim();
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        })
+        .or_else(|| {
+            compile_time_build_id.and_then(|value| {
+                let value = value.trim();
+                if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                }
+            })
+        })
+        .unwrap_or_else(|| package_version.to_string())
 }
 
 fn matched_route_path(route: &ServerRouteEntry, request: &ServerRequest) -> String {
@@ -1836,6 +1871,19 @@ mod tests {
         );
         assert!(cache.contains_fresh(&en_key, SystemTime::now()).unwrap());
         assert!(cache.contains_fresh(&fr_key, SystemTime::now()).unwrap());
+    }
+
+    #[test]
+    fn cache_build_id_prefers_runtime_env_over_compile_time_env() {
+        assert_eq!(
+            cache_build_id_from(Some("release-42".to_string()), Some("compile-1"), "0.0.0"),
+            "release-42"
+        );
+        assert_eq!(
+            cache_build_id_from(Some("  ".to_string()), Some("compile-1"), "0.0.0"),
+            "compile-1"
+        );
+        assert_eq!(cache_build_id_from(None, Some("  "), "0.0.0"), "0.0.0");
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -1,6 +1,6 @@
 use crate::app::{
-    normalize_server_path, FissionServerApp, ServerEnvContext, ServerRenderedNode,
-    ServerRouteEntry, StaticMount,
+    normalize_server_path, FissionServerApp, ServerEnvContext, ServerHttpContext,
+    ServerRenderedNode, ServerRouteEntry, StaticMount,
 };
 use crate::{
     Cache, CacheEntry, CacheKey, CacheMetadata, CachePipeline, CacheScope, CacheTag, Freshness,
@@ -275,6 +275,16 @@ impl ServerRenderer {
         if request.method == "POST" && normalize_server_path(&request.path) == "/__fission/action/"
         {
             return self.handle_action(request);
+        }
+        if let Some(handler) = self.app.find_http_handler(&request.method, &request.path) {
+            let session = self.session_for_request(&request)?;
+            let mut response = (handler.handler)(&ServerHttpContext {
+                project_dir: &self.app.project_dir,
+                request: &request,
+                session: &session,
+            })?;
+            self.attach_session_cookie(&mut response, &session);
+            return Ok(response);
         }
         if request.method != "GET" {
             return Ok(ServerResponse::text(

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -395,7 +395,11 @@ impl ServerRenderer {
             default_locale: &self.default_locale,
             env: &env,
         };
-        let ServerRenderedNode { node, resources } = (route.render)(&ctx)?;
+        let ServerRenderedNode {
+            node,
+            resources,
+            animation_requests,
+        } = (route.render)(&ctx)?;
         let runtime = RuntimeState::default();
         let mut lowering = InternalLoweringCx::new(&env, &runtime, None, None);
         let root = fission_core::internal::lower_widget(&node, &mut lowering);
@@ -430,6 +434,7 @@ impl ServerRenderer {
             css_variables: CssVariableMap::from_theme(&env.theme),
             server_action_post_path: Some("/__fission/action".to_string()),
             server_action_tokens: action_tokens,
+            animation_requests,
             head_end_html,
             body_end_html,
             ..Default::default()

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -262,11 +262,12 @@ impl ServerRenderer {
     }
 
     pub fn render_route(&self, path: &str) -> Result<RenderedServerRoute> {
+        let path = normalize_server_path(path);
         let route = self
             .app
-            .find_route(path)
+            .find_route(&path)
             .ok_or_else(|| anyhow!("server route `{}` was not found", path))?;
-        let request = ServerRequest::get(&route.route.path);
+        let request = ServerRequest::get(path);
         let session = self.session_for_request(&request)?;
         self.render_uncached(route, None, &request, &session)
     }
@@ -323,6 +324,7 @@ impl ServerRenderer {
         let session = self.session_for_request(&request)?;
 
         if let WebRouteMode::Revalidated(policy) = &route.route.mode {
+            let route_path = matched_route_path(route, &request);
             let env = self.env_for_route(route, None, &request, &session)?;
             let cache_key = self.cache_key_for_route(&route.route, &request, &env);
             let now = SystemTime::now();
@@ -330,7 +332,7 @@ impl ServerRenderer {
                 match entry.freshness(now) {
                     Freshness::Fresh | Freshness::Stale => {
                         if let Some(page) = entry.rendered_page() {
-                            self.remember_route_css(&route.route.path, &page.css)?;
+                            self.remember_route_css(&route_path, &page.css)?;
                             let mut response = page_response(page, entry.freshness(now));
                             response.headers.push((
                                 "x-fission-cache".to_string(),
@@ -362,7 +364,7 @@ impl ServerRenderer {
                 policy.ttl,
                 policy.stale_while_revalidate,
                 policy.tags.clone(),
-                CacheMetadata::full_page(&route.route.path),
+                CacheMetadata::full_page(&route_path),
             );
             self.cache.put(entry)?;
             let mut response = page_response(&page, Freshness::Expired);
@@ -403,9 +405,10 @@ impl ServerRenderer {
         session: &ServerSession,
         env: Env,
     ) -> Result<RenderedServerRoute> {
+        let route_path = matched_route_path(route, request);
         let ctx = crate::ServerRenderContext {
             project_dir: &self.app.project_dir,
-            route_path: &route.route.path,
+            route_path: &route_path,
             theme: &env.theme,
             viewport_size: self.viewport_size,
             jobs: &self.jobs,
@@ -420,7 +423,16 @@ impl ServerRenderer {
             node,
             resources,
             animation_requests,
-        } = (route.render)(&ctx)?;
+        } = if tokio::runtime::Handle::try_current().is_ok() {
+            std::thread::scope(|scope| {
+                scope
+                    .spawn(|| (route.render)(&ctx))
+                    .join()
+                    .map_err(|_| anyhow!("server route renderer panicked"))?
+            })
+        } else {
+            (route.render)(&ctx)
+        }?;
         let runtime = RuntimeState::default();
         let mut lowering = InternalLoweringCx::new(&env, &runtime, None, None);
         let root = fission_core::internal::lower_widget(&node, &mut lowering);
@@ -438,7 +450,7 @@ impl ServerRenderer {
         }
         let action_tokens = collect_server_action_tokens(
             &lowering.ir,
-            &route.route.path,
+            &route_path,
             &self.action_signer,
             Duration::from_secs(10 * 60),
         )?;
@@ -447,11 +459,11 @@ impl ServerRenderer {
             lang: env.locale.0.clone(),
             document_title: route.route.title.clone(),
             description: route.route.description.clone(),
-            canonical_url: self.canonical_url_for_route(&route.route.path, request),
+            canonical_url: self.canonical_url_for_route(&route_path, request),
             site_name: Some(self.app.project_name.clone()),
             favicon_href: None,
             stylesheet_href: "/site.css".to_string(),
-            current_route_path: route.route.path.clone(),
+            current_route_path: route_path.clone(),
             css_variables: CssVariableMap::from_theme(&env.theme),
             server_action_post_path: Some("/__fission/action".to_string()),
             server_action_tokens: action_tokens,
@@ -462,7 +474,7 @@ impl ServerRenderer {
         };
         let rendered = render_ir_to_html_with_styles(&lowering.ir, &render_options, &mut styles)?;
         let css = rendered.css.clone();
-        self.remember_route_css(&route.route.path, &css)?;
+        self.remember_route_css(&route_path, &css)?;
         Ok(RenderedServerRoute {
             route: route.route.clone(),
             html: rendered.html,
@@ -812,9 +824,10 @@ impl ServerRenderer {
         request: &ServerRequest,
         session: &ServerSession,
     ) -> Result<Env> {
+        let route_path = matched_route_path(route, request);
         let ctx = ServerEnvContext {
             project_dir: &self.app.project_dir,
-            route_path: &route.route.path,
+            route_path: &route_path,
             theme: &self.app.theme,
             viewport_size: self.viewport_size,
             jobs: &self.jobs,
@@ -861,7 +874,7 @@ impl ServerRenderer {
         let build_id = option_env!("FISSION_BUILD_ID").unwrap_or(env!("CARGO_PKG_VERSION"));
         let mut key = format!(
             "page:{}?{}#app:{}#locale:{}#theme:{}#build:{}",
-            route.path,
+            normalize_server_path(&request.path),
             query,
             self.app.project_name,
             env.locale.0,
@@ -873,6 +886,15 @@ impl ServerRenderer {
             key.push_str(&vary);
         }
         CacheKey::new(key)
+    }
+}
+
+fn matched_route_path(route: &ServerRouteEntry, request: &ServerRequest) -> String {
+    let request_path = normalize_server_path(&request.path);
+    if route.matcher.matches(&route.route.path, &request_path) {
+        request_path
+    } else {
+        route.route.path.clone()
     }
 }
 
@@ -1334,6 +1356,12 @@ mod tests {
     struct TestState;
     impl GlobalState for TestState {}
 
+    #[derive(Debug, Default)]
+    struct PathState {
+        route_path: String,
+    }
+    impl GlobalState for PathState {}
+
     #[derive(Clone)]
     struct TestPage(&'static str);
 
@@ -1351,6 +1379,16 @@ mod tests {
         fn from(component: KeyPage) -> Self {
             let (_ctx, _view) = fission_core::build::current::<TestState>();
             Text::new(TextContent::Key(component.0.to_string())).into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct PathPage;
+
+    impl From<PathPage> for Widget {
+        fn from(_: PathPage) -> Self {
+            let (_ctx, view) = fission_core::build::current::<PathState>();
+            Text::new(view.state().route_path.clone()).into()
         }
     }
 
@@ -1488,6 +1526,61 @@ mod tests {
     }
 
     #[test]
+    fn prefix_routes_receive_concrete_request_path() {
+        let app = FissionServerApp::new("Test").route_prefix_widget_with_state::<PathState, _, _>(
+            "/docs/",
+            "Docs",
+            None,
+            WebRouteMode::Server(Default::default()),
+            PathPage,
+            |ctx| {
+                Ok(PathState {
+                    route_path: ctx.route_path.to_string(),
+                })
+            },
+        );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer
+            .handle(ServerRequest::get("/docs/platform"))
+            .unwrap();
+
+        assert_eq!(response.status, 200);
+        assert!(response.body_string().contains("/docs/platform/"));
+    }
+
+    #[test]
+    fn exact_routes_win_over_prefix_routes() {
+        let app = FissionServerApp::new("Test")
+            .route_prefix_widget_with_state::<PathState, _, _>(
+                "/docs/",
+                "Docs",
+                None,
+                WebRouteMode::Server(Default::default()),
+                PathPage,
+                |ctx| {
+                    Ok(PathState {
+                        route_path: ctx.route_path.to_string(),
+                    })
+                },
+            )
+            .route_widget::<TestState, _>(
+                "/docs/index/",
+                "Exact",
+                None,
+                WebRouteMode::Server(Default::default()),
+                TestPage("exact docs page"),
+            );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer.handle(ServerRequest::get("/docs/index")).unwrap();
+
+        assert_eq!(response.status, 200);
+        assert!(response.body_string().contains("exact docs page"));
+        assert!(!response.body_string().contains("/docs/index/"));
+    }
+
+    #[test]
     fn http_handlers_can_use_blocking_clients_inside_tokio_runtime() {
         let app = FissionServerApp::new("Test").form_post("/submit", |_ctx| {
             let runtime = tokio::runtime::Builder::new_current_thread()
@@ -1509,6 +1602,32 @@ mod tests {
 
         assert_eq!(response.status, 200);
         assert_eq!(response.body_string(), "stored");
+    }
+
+    #[test]
+    fn route_state_loaders_can_use_blocking_clients_inside_tokio_runtime() {
+        let app = FissionServerApp::new("Test").route_widget_with_state::<TestState, _, _>(
+            "/blocking",
+            "Blocking",
+            None,
+            WebRouteMode::Server(Default::default()),
+            TestPage("blocking state loaded"),
+            |_ctx| {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap();
+                runtime.block_on(async { Ok(TestState) })
+            },
+        );
+        let renderer = ServerRenderer::new(app);
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+
+        let response = runtime
+            .block_on(async { renderer.handle(ServerRequest::get("/blocking")) })
+            .unwrap();
+
+        assert_eq!(response.status, 200);
+        assert!(response.body_string().contains("blocking state loaded"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -1,10 +1,12 @@
-use crate::app::{normalize_server_path, FissionServerApp, ServerRenderedNode, ServerRouteEntry};
+use crate::app::{
+    normalize_server_path, FissionServerApp, ServerEnvContext, ServerRenderedNode, ServerRouteEntry,
+};
 use crate::{
-    Cache, CacheEntry, CacheKey, CacheMetadata, CachePipeline, CacheScope, Freshness, MokaCache,
-    RenderedPage, ServerActionSigner, ServerBrowserArtifactConfig, ServerCacheLayerConfig,
-    ServerCacheProvider, ServerHttpConfig, ServerIslandConfig, ServerIslandPreload,
-    ServerJobRegistry, ServerRuntimeConfig, ServerSameSite, ServerSessionConfig,
-    SignedServerAction, VerifiedServerAction, WebRoute, WebRouteMode,
+    Cache, CacheEntry, CacheKey, CacheMetadata, CachePipeline, CacheScope, CacheTag, Freshness,
+    InvalidationReport, MokaCache, RenderedPage, ServerActionSigner, ServerBrowserArtifactConfig,
+    ServerCacheLayerConfig, ServerCacheProvider, ServerHttpConfig, ServerIslandConfig,
+    ServerIslandPreload, ServerJobRegistry, ServerRuntimeConfig, ServerSameSite,
+    ServerSessionConfig, SignedServerAction, VerifiedServerAction, WebRoute, WebRouteMode,
 };
 use anyhow::{anyhow, Context, Result};
 use fission_core::internal::InternalLoweringCx;
@@ -186,6 +188,28 @@ impl ServerRenderer {
         self
     }
 
+    pub fn cache(&self) -> Arc<dyn Cache> {
+        self.cache.clone()
+    }
+
+    pub fn remove_cache_entry(&self, key: &CacheKey) -> Result<()> {
+        self.cache.remove(key)?;
+        Ok(())
+    }
+
+    pub fn invalidate_cache_tag(&self, tag: impl Into<CacheTag>) -> Result<InvalidationReport> {
+        Ok(self.cache.invalidate_tag(&tag.into())?)
+    }
+
+    pub fn invalidate_cache_tags<I, T>(&self, tags: I) -> Result<InvalidationReport>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<CacheTag>,
+    {
+        let tags = tags.into_iter().map(Into::into).collect::<Vec<_>>();
+        Ok(self.cache.invalidate_tags(&tags)?)
+    }
+
     pub fn with_viewport_size(mut self, size: LayoutSize) -> Self {
         self.viewport_size = size;
         self
@@ -272,7 +296,8 @@ impl ServerRenderer {
         let session = self.session_for_request(&request)?;
 
         if let WebRouteMode::Revalidated(policy) = &route.route.mode {
-            let cache_key = self.cache_key_for_route(&route.route, &request);
+            let env = self.env_for_route(route, None, &request, &session)?;
+            let cache_key = self.cache_key_for_route(&route.route, &request, &env);
             let now = SystemTime::now();
             if let Some(entry) = self.cache.get(&cache_key)? {
                 match entry.freshness(now) {
@@ -291,7 +316,7 @@ impl ServerRenderer {
                     Freshness::Expired => {}
                 }
             }
-            let rendered = self.render_uncached(route, None, &request, &session)?;
+            let rendered = self.render_uncached_with_env(route, None, &request, &session, env)?;
             if rendered.server_action_count > 0 {
                 anyhow::bail!(
                     "revalidated route `{}` renders server action forms; use ServerPrivate/Server mode or move the interactive region into an island before caching the page",
@@ -339,22 +364,33 @@ impl ServerRenderer {
         request: &ServerRequest,
         session: &ServerSession,
     ) -> Result<RenderedServerRoute> {
+        let env = self.env_for_route(route, action, request, session)?;
+        self.render_uncached_with_env(route, action, request, session, env)
+    }
+
+    fn render_uncached_with_env(
+        &self,
+        route: &ServerRouteEntry,
+        action: Option<&VerifiedServerAction>,
+        request: &ServerRequest,
+        session: &ServerSession,
+        env: Env,
+    ) -> Result<RenderedServerRoute> {
         let ctx = crate::ServerRenderContext {
             project_dir: &self.app.project_dir,
             route_path: &route.route.path,
-            theme: &self.app.theme,
+            theme: &env.theme,
             viewport_size: self.viewport_size,
             jobs: &self.jobs,
             request,
             session,
             action,
             render_pass_limit: self.render_pass_limit,
+            default_locale: &self.default_locale,
+            env: &env,
         };
         let ServerRenderedNode { node, resources } = (route.render)(&ctx)?;
         let runtime = RuntimeState::default();
-        let mut env = Env::default();
-        env.theme = self.app.theme.clone();
-        env.viewport_size = self.viewport_size;
         let mut lowering = InternalLoweringCx::new(&env, &runtime, None, None);
         let root = fission_core::internal::lower_widget(&node, &mut lowering);
         lowering.ir.set_root(root);
@@ -377,7 +413,7 @@ impl ServerRenderer {
         )?;
         let server_action_count = action_tokens.len();
         let render_options = HtmlRenderOptions {
-            lang: self.default_locale.clone(),
+            lang: env.locale.0.clone(),
             document_title: route.route.title.clone(),
             description: route.route.description.clone(),
             canonical_url: self.canonical_url_for_route(&route.route.path, request),
@@ -385,7 +421,7 @@ impl ServerRenderer {
             favicon_href: None,
             stylesheet_href: "/site.css".to_string(),
             current_route_path: route.route.path.clone(),
-            css_variables: CssVariableMap::from_theme(&self.app.theme),
+            css_variables: CssVariableMap::from_theme(&env.theme),
             server_action_post_path: Some("/__fission/action".to_string()),
             server_action_tokens: action_tokens,
             head_end_html,
@@ -681,7 +717,34 @@ impl ServerRenderer {
         Ok(())
     }
 
-    fn cache_key_for_route(&self, route: &WebRoute, request: &ServerRequest) -> CacheKey {
+    fn env_for_route(
+        &self,
+        route: &ServerRouteEntry,
+        action: Option<&VerifiedServerAction>,
+        request: &ServerRequest,
+        session: &ServerSession,
+    ) -> Result<Env> {
+        let ctx = ServerEnvContext {
+            project_dir: &self.app.project_dir,
+            route_path: &route.route.path,
+            theme: &self.app.theme,
+            viewport_size: self.viewport_size,
+            jobs: &self.jobs,
+            request,
+            session,
+            action,
+            render_pass_limit: self.render_pass_limit,
+            default_locale: &self.default_locale,
+        };
+        self.app.env_for_context(&ctx)
+    }
+
+    fn cache_key_for_route(
+        &self,
+        route: &WebRoute,
+        request: &ServerRequest,
+        env: &Env,
+    ) -> CacheKey {
         let query = request
             .query
             .iter()
@@ -706,14 +769,14 @@ impl ServerRenderer {
                     .join("&")
             })
             .unwrap_or_default();
-        let theme_hash = blake3::hash(format!("{:?}", self.app.theme).as_bytes());
+        let theme_hash = blake3::hash(format!("{:?}", env.theme).as_bytes());
         let build_id = option_env!("FISSION_BUILD_ID").unwrap_or(env!("CARGO_PKG_VERSION"));
         let mut key = format!(
             "page:{}?{}#app:{}#locale:{}#theme:{}#build:{}",
             route.path,
             query,
             self.app.project_name,
-            self.default_locale,
+            env.locale.0,
             &theme_hash.to_hex().to_string()[..16],
             build_id
         );
@@ -1128,12 +1191,14 @@ mod tests {
         CacheError, CacheTag, InvalidationReport, MokaCache, ProgressiveWorker, RevalidationPolicy,
         WasmIsland, WebRouteMode,
     };
-    use fission_core::ui::{Button, Text};
+    use fission_core::ui::{Button, Text, TextContent};
     use fission_core::{
         Action, ActionId, GlobalState, Handler, JobRef, JobResource, JobSpec, ReducerContext,
         ResourceKey, Widget,
     };
+    use fission_i18n::TranslationBundle;
     use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1153,6 +1218,36 @@ mod tests {
             Text::new(component.0).into()
         }
     }
+
+    #[derive(Clone)]
+    struct KeyPage(&'static str);
+
+    impl From<KeyPage> for Widget {
+        fn from(component: KeyPage) -> Self {
+            let (_ctx, _view) = fission_core::build::current::<TestState>();
+            Text::new(TextContent::Key(component.0.to_string())).into()
+        }
+    }
+
+    fn translated_env() -> Env {
+        let mut env = Env::default();
+        env.i18n.add_bundle(TranslationBundle {
+            locale: "en".into(),
+            messages: HashMap::from([
+                ("page.title".to_string(), "Hello SSR".to_string()),
+                ("catalog.title".to_string(), "Catalog".to_string()),
+            ]),
+        });
+        env.i18n.add_bundle(TranslationBundle {
+            locale: "fr".into(),
+            messages: HashMap::from([
+                ("page.title".to_string(), "Bonjour SSR".to_string()),
+                ("catalog.title".to_string(), "Catalogue".to_string()),
+            ]),
+        });
+        env
+    }
+
     #[derive(Clone)]
     struct TestActionPage;
 
@@ -1213,6 +1308,143 @@ mod tests {
         }
     }
 
+    fn default_render_env(renderer: &ServerRenderer) -> Env {
+        let mut env = renderer.app.env.clone();
+        env.theme = renderer.app.theme.clone();
+        env.locale = renderer.default_locale.as_str().into();
+        env
+    }
+
+    #[test]
+    fn server_renderer_resolves_keyed_text_from_seeded_env() {
+        let app = FissionServerApp::new("Test")
+            .with_env(translated_env())
+            .route_widget::<TestState, _>(
+                "/",
+                "Home",
+                None,
+                WebRouteMode::Server(Default::default()),
+                KeyPage("page.title"),
+            );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer.handle(ServerRequest::get("/")).unwrap();
+
+        assert_eq!(response.status, 200);
+        assert!(response.body_string().contains("Hello SSR"));
+        assert!(!response.body_string().contains("MISSING:page.title"));
+    }
+
+    #[test]
+    fn server_renderer_uses_request_env_locale_for_html_and_text() {
+        let app = FissionServerApp::new("Test")
+            .with_env(translated_env())
+            .with_request_env(|ctx, env| {
+                if ctx.route_path.starts_with("/fr") {
+                    env.locale = "fr".into();
+                }
+                Ok(())
+            })
+            .route_widget::<TestState, _>(
+                "/fr",
+                "Home",
+                None,
+                WebRouteMode::Server(Default::default()),
+                KeyPage("page.title"),
+            );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer.handle(ServerRequest::get("/fr")).unwrap();
+        let body = response.body_string();
+
+        assert_eq!(response.status, 200);
+        assert!(body.contains("Bonjour SSR"));
+        assert!(body.contains("lang=\"fr\""));
+    }
+
+    #[test]
+    fn revalidated_cache_keys_vary_by_resolved_locale() {
+        let cache = Arc::new(MokaCache::default());
+        let app = FissionServerApp::new("Test")
+            .with_env(translated_env())
+            .with_request_env(|ctx, env| {
+                if header_value(&ctx.request.headers, "accept-language")
+                    .is_some_and(|value| value.starts_with("fr"))
+                {
+                    env.locale = "fr".into();
+                }
+                Ok(())
+            })
+            .route_widget::<TestState, _>(
+                "/catalog",
+                "Catalog",
+                None,
+                WebRouteMode::Revalidated(
+                    RevalidationPolicy::new(Duration::from_secs(60)).tag("catalog"),
+                ),
+                KeyPage("catalog.title"),
+            );
+        let renderer = ServerRenderer::new(app).with_cache(cache);
+        let en = ServerRequest::get("/catalog");
+        let mut fr = ServerRequest::get("/catalog");
+        fr.headers
+            .insert("accept-language".to_string(), "fr-FR".to_string());
+
+        let en_first = renderer.handle(en.clone()).unwrap();
+        let fr_first = renderer.handle(fr).unwrap();
+        let en_second = renderer.handle(en).unwrap();
+
+        assert_eq!(en_first.cache_status, Some(Freshness::Expired));
+        assert!(en_first.body_string().contains("Catalog"));
+        assert_eq!(fr_first.cache_status, Some(Freshness::Expired));
+        assert!(fr_first.body_string().contains("Catalogue"));
+        assert_eq!(en_second.cache_status, Some(Freshness::Fresh));
+        assert!(en_second.body_string().contains("Catalog"));
+    }
+
+    #[test]
+    fn renderer_exposes_direct_and_helper_cache_invalidation() {
+        let app = FissionServerApp::new("Test").route_widget::<TestState, _>(
+            "/posts",
+            "Posts",
+            None,
+            WebRouteMode::Revalidated(
+                RevalidationPolicy::new(Duration::from_secs(60)).tags(["posts", "post:1"]),
+            ),
+            TestPage("Posts"),
+        );
+        let renderer = ServerRenderer::new(app);
+
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::get("/posts"))
+                .unwrap()
+                .cache_status,
+            Some(Freshness::Expired)
+        );
+        let direct_report = renderer
+            .cache()
+            .invalidate_tag(&CacheTag::new("posts"))
+            .unwrap();
+        assert_eq!(direct_report.removed_keys, 1);
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::get("/posts"))
+                .unwrap()
+                .cache_status,
+            Some(Freshness::Expired)
+        );
+        let helper_report = renderer.invalidate_cache_tag("post:1").unwrap();
+        assert_eq!(helper_report.removed_keys, 1);
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::get("/posts"))
+                .unwrap()
+                .cache_status,
+            Some(Freshness::Expired)
+        );
+    }
+
     #[test]
     fn server_renderer_caches_revalidated_routes() {
         let cache = Arc::new(MokaCache::default());
@@ -1224,7 +1456,9 @@ mod tests {
             TestPage("Hello cache"),
         );
         let renderer = ServerRenderer::new(app).with_cache(cache.clone());
-        let key = renderer.cache_key_for_route(&renderer.routes()[0], &ServerRequest::get("/"));
+        let env = default_render_env(&renderer);
+        let key =
+            renderer.cache_key_for_route(&renderer.routes()[0], &ServerRequest::get("/"), &env);
 
         let first = renderer.handle(ServerRequest::get("/")).unwrap();
         assert_eq!(first.status, 200);
@@ -1255,7 +1489,8 @@ mod tests {
         second.query.insert("a".to_string(), "1".to_string());
         second.query.insert("b".to_string(), "2".to_string());
 
-        let first_key = renderer.cache_key_for_route(&renderer.routes()[0], &first);
+        let env = default_render_env(&renderer);
+        let first_key = renderer.cache_key_for_route(&renderer.routes()[0], &first, &env);
         assert_eq!(
             renderer.handle(first).unwrap().cache_status,
             Some(Freshness::Expired)
@@ -1287,8 +1522,9 @@ mod tests {
         fr.headers
             .insert("accept-language".to_string(), "fr-FR".to_string());
 
-        let en_key = renderer.cache_key_for_route(&renderer.routes()[0], &en);
-        let fr_key = renderer.cache_key_for_route(&renderer.routes()[0], &fr);
+        let env = default_render_env(&renderer);
+        let en_key = renderer.cache_key_for_route(&renderer.routes()[0], &en, &env);
+        let fr_key = renderer.cache_key_for_route(&renderer.routes()[0], &fr, &env);
         assert_eq!(
             renderer.handle(en).unwrap().cache_status,
             Some(Freshness::Expired)

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -278,11 +278,22 @@ impl ServerRenderer {
         }
         if let Some(handler) = self.app.find_http_handler(&request.method, &request.path) {
             let session = self.session_for_request(&request)?;
-            let mut response = (handler.handler)(&ServerHttpContext {
+            let ctx = ServerHttpContext {
                 project_dir: &self.app.project_dir,
                 request: &request,
                 session: &session,
-            })?;
+            };
+            let response = if tokio::runtime::Handle::try_current().is_ok() {
+                std::thread::scope(|scope| {
+                    scope
+                        .spawn(|| (handler.handler)(&ctx))
+                        .join()
+                        .map_err(|_| anyhow!("server HTTP handler panicked"))?
+                })
+            } else {
+                (handler.handler)(&ctx)
+            };
+            let mut response = response?;
             self.attach_session_cookie(&mut response, &session);
             return Ok(response);
         }
@@ -1474,6 +1485,30 @@ mod tests {
         assert_eq!(response.status, 200);
         assert!(body.contains("Bonjour SSR"));
         assert!(body.contains("lang=\"fr\""));
+    }
+
+    #[test]
+    fn http_handlers_can_use_blocking_clients_inside_tokio_runtime() {
+        let app = FissionServerApp::new("Test").form_post("/submit", |_ctx| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            let value = runtime.block_on(async { "stored" });
+            Ok(ServerResponse::text(
+                200,
+                "text/plain; charset=utf-8",
+                value,
+            ))
+        });
+        let renderer = ServerRenderer::new(app);
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+
+        let response = runtime
+            .block_on(async { renderer.handle(ServerRequest::post("/submit", "email=a@b.test")) })
+            .unwrap();
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body_string(), "stored");
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -467,6 +467,7 @@ impl ServerRenderer {
             css_variables: CssVariableMap::from_theme(&env.theme),
             server_action_post_path: Some("/__fission/action".to_string()),
             server_action_tokens: action_tokens,
+            structured_data: route.route.structured_data.clone(),
             animation_requests,
             head_end_html,
             body_end_html,

--- a/crates/shell/fission-shell-server/src/route.rs
+++ b/crates/shell/fission-shell-server/src/route.rs
@@ -182,4 +182,5 @@ pub struct WebRoute {
     pub mode: WebRouteMode,
     pub workers: Vec<ProgressiveWorker>,
     pub islands: Vec<WasmIsland>,
+    pub structured_data: Vec<String>,
 }

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -19,3 +19,6 @@ fission-widgets = { path = "../../authoring/fission-widgets", version = "0.4.0",
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
+
+[dev-dependencies]
+fission-i18n = { path = "../../core/fission-i18n", version = "0.4.0" }

--- a/crates/shell/fission-shell-site/assets/site.css
+++ b/crates/shell/fission-shell-site/assets/site.css
@@ -13,7 +13,35 @@ img, svg { max-width: 100%; }
 .fission-site-root { min-height: 100vh; }
 .fission-site-node { min-width: 0; }
 .fission-site-route-link,
-.fission-site-heading-link { display: contents; }
+.fission-site-heading-link {
+  display: inline-flex;
+  max-width: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+.fission-site-route-link {
+  cursor: pointer;
+}
+.fission-site-route-link:hover,
+.fission-site-heading-link:hover {
+  text-decoration: none;
+}
+.fission-site-route-link > .fission-site-node,
+.fission-site-heading-link > .fission-site-node {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 720px) {
+  .fission-site-root > .fission-site-box > .fission-site-column {
+    align-items: stretch !important;
+  }
+
+  .fission-site-root .fission-site-box,
+  .fission-site-root .fission-site-row,
+  .fission-site-root .fission-site-column {
+    max-width: 100% !important;
+  }
+}
 .fission-site-markdown-link { display: inline; }
 .fission-site-scroll { overflow: auto; }
 .fission-site-text,

--- a/crates/shell/fission-shell-site/assets/site.css
+++ b/crates/shell/fission-shell-site/assets/site.css
@@ -30,6 +30,13 @@ img, svg { max-width: 100%; }
 .fission-site-heading-link > .fission-site-node {
   flex: 1 1 auto;
 }
+.fission-site-positioned > .fission-site-node,
+.fission-site-positioned > .fission-site-semantics,
+.fission-site-positioned > .fission-site-semantics > .fission-site-node,
+.fission-site-absolute-fill > .fission-site-node {
+  width: 100%;
+  height: 100%;
+}
 
 @media (max-width: 720px) {
   .fission-site-root > .fission-site-box > .fission-site-column {

--- a/crates/shell/fission-shell-site/assets/site.css
+++ b/crates/shell/fission-shell-site/assets/site.css
@@ -49,6 +49,14 @@ img, svg { max-width: 100%; }
 .fission-site-rich-text span { white-space: pre-wrap; }
 .fission-site-img { display: block; height: auto; }
 .fission-site-svg svg { display: inline-block; max-width: 100%; }
+.fission-site-svg-colored svg,
+.fission-site-svg-colored svg * {
+  fill: currentColor;
+}
+
+.fission-site-svg-colored svg [fill="none"] {
+  fill: none;
+}
 
 .fission-server-action-form {
   display: contents;

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1706,6 +1706,7 @@ mod tests {
         let css = site_base_css();
         assert!(css.contains(".fission-site-route-link {\n  cursor: pointer;"));
         assert!(css.contains(".fission-site-route-link > .fission-site-node"));
+        assert!(css.contains(".fission-site-positioned > .fission-site-semantics"));
         assert!(css.contains(".fission-site-svg-colored svg *"));
         assert!(css.contains("fill: currentColor;"));
         assert!(css.contains(".fission-site-svg-colored svg [fill=\"none\"]"));

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1706,6 +1706,9 @@ mod tests {
         let css = site_base_css();
         assert!(css.contains(".fission-site-route-link {\n  cursor: pointer;"));
         assert!(css.contains(".fission-site-route-link > .fission-site-node"));
+        assert!(css.contains(".fission-site-svg-colored svg *"));
+        assert!(css.contains("fill: currentColor;"));
+        assert!(css.contains(".fission-site-svg-colored svg [fill=\"none\"]"));
         assert!(!css.contains(
             ".fission-site-route-link,\n.fission-site-heading-link { display: contents; }"
         ));

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Context, Result};
 use fission_core::internal::BuildCtx;
 use fission_core::internal::InternalLoweringCx;
 use fission_core::ui::Column;
-use fission_core::{Env, RuntimeState, View, Widget};
+use fission_core::{AnimationRequest, Env, RuntimeState, View, Widget, WidgetId};
 use fission_layout::LayoutSize;
 use fission_theme::DesignMode;
 use serde::Deserialize;
@@ -898,6 +898,7 @@ fn render_custom_routes(
             site,
             &env,
             styles,
+            Vec::new(),
         )?;
         routes.push(ContentRoute {
             path: route.path.clone(),
@@ -967,6 +968,7 @@ fn render_route(
         page_node,
         render_footer_node(options, site, &route.path, &env)?,
     );
+    let animation_requests = build_ctx.take_animation_requests();
     render_node_to_html(
         node,
         &format!("{} | {}", route.title, options.site_title),
@@ -979,6 +981,7 @@ fn render_route(
         site,
         &env,
         styles,
+        animation_requests,
     )
 }
 
@@ -999,6 +1002,7 @@ fn render_node_to_html(
     site: &FissionSite,
     env: &Env,
     styles: &mut StyleRegistry,
+    animation_requests: Vec<(WidgetId, AnimationRequest)>,
 ) -> Result<String> {
     let runtime = RuntimeState::default();
     let mut lowering = InternalLoweringCx::new(env, &runtime, None, None);
@@ -1055,6 +1059,7 @@ fn render_node_to_html(
             route_path,
             SitePageElementPlacement::BodyEnd,
         ),
+        animation_requests,
         ..Default::default()
     };
     Ok(render_ir_to_html_with_styles(&lowering.ir, &render_options, styles)?.html)

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1702,6 +1702,16 @@ mod tests {
     }
 
     #[test]
+    fn route_links_render_as_boxed_click_targets() {
+        let css = site_base_css();
+        assert!(css.contains(".fission-site-route-link {\n  cursor: pointer;"));
+        assert!(css.contains(".fission-site-route-link > .fission-site-node"));
+        assert!(!css.contains(
+            ".fission-site-route-link,\n.fission-site-heading-link { display: contents; }"
+        ));
+    }
+
+    #[test]
     fn content_site_build_writes_real_html() {
         let temp = std::env::temp_dir().join(format!(
             "fission-site-test-{}",

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -474,6 +474,7 @@ fn render_footer_node(
     options: &SiteBuildOptions,
     site: &FissionSite,
     route_path: &str,
+    env: &Env,
 ) -> Result<Option<Widget>> {
     let Some(footer) = &site.footer else {
         return Ok(None);
@@ -481,7 +482,9 @@ fn render_footer_node(
     let ctx = SiteRenderContext {
         project_dir: &options.project_dir,
         route_path,
-        theme: &site.theme,
+        theme: &env.theme,
+        default_locale: &options.default_locale,
+        env,
     };
     Ok(Some(footer(&ctx)?))
 }
@@ -873,13 +876,16 @@ fn render_custom_routes(
 ) -> Result<Vec<ContentRoute>> {
     let mut routes = Vec::new();
     for route in &site.custom_routes {
+        let env = site_env_for_route(options, site);
         let ctx = SiteRenderContext {
             project_dir: &options.project_dir,
             route_path: &route.path,
-            theme: &site.theme,
+            theme: &env.theme,
+            default_locale: &options.default_locale,
+            env: &env,
         };
         let node = (route.render)(&ctx)?;
-        let node = append_footer(node, render_footer_node(options, site, &route.path)?);
+        let node = append_footer(node, render_footer_node(options, site, &route.path, &env)?);
         let html = render_node_to_html(
             node,
             &route.title,
@@ -890,6 +896,7 @@ fn render_custom_routes(
             &route.path,
             options,
             site,
+            &env,
             styles,
         )?;
         routes.push(ContentRoute {
@@ -942,9 +949,7 @@ fn render_route(
         return Ok(rendered.clone());
     }
     let runtime = RuntimeState::default();
-    let mut env = Env::default();
-    env.theme = site.theme.clone();
-    env.viewport_size = LayoutSize::new(1280.0, 900.0);
+    let env = site_env_for_route(options, site);
     let state = SitePageState;
     let view = View::new(&state, &runtime, &env, None);
     let mut build_ctx = BuildCtx::<SitePageState>::new();
@@ -958,7 +963,10 @@ fn render_route(
         all_routes: routes,
     };
     let page_node = fission_core::build::enter(&mut build_ctx, &view, || page.into());
-    let node = append_footer(page_node, render_footer_node(options, site, &route.path)?);
+    let node = append_footer(
+        page_node,
+        render_footer_node(options, site, &route.path, &env)?,
+    );
     render_node_to_html(
         node,
         &format!("{} | {}", route.title, options.site_title),
@@ -969,8 +977,17 @@ fn render_route(
         &route.path,
         options,
         site,
+        &env,
         styles,
     )
+}
+
+fn site_env_for_route(options: &SiteBuildOptions, site: &FissionSite) -> Env {
+    let mut env = site.env.clone();
+    env.theme = site.theme.clone();
+    env.viewport_size = LayoutSize::new(1280.0, 900.0);
+    env.locale = options.default_locale.as_str().into();
+    env
 }
 
 fn render_node_to_html(
@@ -980,17 +997,16 @@ fn render_node_to_html(
     route_path: &str,
     options: &SiteBuildOptions,
     site: &FissionSite,
+    env: &Env,
     styles: &mut StyleRegistry,
 ) -> Result<String> {
     let runtime = RuntimeState::default();
-    let mut env = Env::default();
-    env.theme = site.theme.clone();
-    let mut lowering = InternalLoweringCx::new(&env, &runtime, None, None);
+    let mut lowering = InternalLoweringCx::new(env, &runtime, None, None);
     let root = fission_core::internal::lower_widget(&node, &mut lowering);
     lowering.ir.set_root(root);
 
     let render_options = HtmlRenderOptions {
-        lang: options.default_locale.clone(),
+        lang: env.locale.0.clone(),
         document_title: title.to_string(),
         description: description.clone(),
         canonical_url: canonical_url_for_route(options, route_path),
@@ -1639,7 +1655,34 @@ struct SidebarManifestItem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fission_core::ui::{Text, TextContent};
+    use fission_core::GlobalState;
+    use fission_i18n::TranslationBundle;
+    use std::collections::HashMap;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Debug, Default)]
+    struct TestState;
+    impl GlobalState for TestState {}
+
+    #[derive(Clone)]
+    struct KeyPage(&'static str);
+
+    impl From<KeyPage> for Widget {
+        fn from(component: KeyPage) -> Self {
+            let (_ctx, _view) = fission_core::build::current::<TestState>();
+            Text::new(TextContent::Key(component.0.to_string())).into()
+        }
+    }
+
+    fn translated_env() -> Env {
+        let mut env = Env::default();
+        env.i18n.add_bundle(TranslationBundle {
+            locale: "fr".into(),
+            messages: HashMap::from([("page.title".to_string(), "Bonjour static".to_string())]),
+        });
+        env
+    }
 
     #[test]
     fn route_paths_are_derived_from_content_tree() {
@@ -1732,6 +1775,34 @@ mod tests {
             .exists());
         let docs = fs::read_to_string(temp.join("target/fission/site/search/docs.json")).unwrap();
         assert!(docs.contains("Getting started"));
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn custom_site_routes_resolve_keyed_text_from_seeded_env() {
+        let temp = std::env::temp_dir().join(format!(
+            "fission-site-i18n-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&temp).unwrap();
+        fs::create_dir_all(temp.join("content")).unwrap();
+        let mut options = SiteBuildOptions::for_project(&temp, "Test site");
+        options.content_routes = Vec::new();
+        options.default_locale = "fr".to_string();
+        let site = FissionSite::new()
+            .with_env(translated_env())
+            .route_widget::<TestState, _>("/", "Home", None, KeyPage("page.title"));
+
+        let report = build_site(&options, &site).unwrap();
+        let html = fs::read_to_string(temp.join("target/fission/site/index.html")).unwrap();
+
+        assert_eq!(report.routes.len(), 1);
+        assert!(html.contains("Bonjour static"));
+        assert!(html.contains("lang=\"fr\""));
+        assert!(!html.contains("MISSING:page.title"));
         let _ = fs::remove_dir_all(temp);
     }
 

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -95,6 +95,59 @@ pub struct RenderedHtml {
     pub css: String,
 }
 
+#[derive(Clone, Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StaticFormSpec {
+    action: String,
+    #[serde(default = "default_form_method")]
+    method: String,
+    #[serde(default)]
+    fields: Vec<StaticFormField>,
+    #[serde(default)]
+    submit_label: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StaticFormField {
+    name: String,
+    #[serde(default = "default_form_field_kind")]
+    kind: StaticFormFieldKind,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    placeholder: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    max_length: Option<usize>,
+    #[serde(default)]
+    rows: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StaticFormFieldKind {
+    #[default]
+    Text,
+    Email,
+    Tel,
+    Url,
+    Hidden,
+    Textarea,
+    Checkbox,
+}
+
+fn default_form_method() -> String {
+    "post".to_string()
+}
+
+fn default_form_field_kind() -> StaticFormFieldKind {
+    StaticFormFieldKind::Text
+}
+
 pub fn render_ir_to_html(ir: &CoreIR, options: &HtmlRenderOptions) -> Result<RenderedHtml> {
     let mut registry = StyleRegistry::default();
     render_ir_to_html_with_styles(ir, options, &mut registry)
@@ -1174,6 +1227,9 @@ impl HtmlRenderer<'_> {
             if let Some(language) = identifier.strip_prefix("markdown-code-block:") {
                 return self.render_markdown_code_block(node, language, semantics.value.as_deref());
             }
+            if identifier == "site-form" || identifier.starts_with("site-form:") {
+                return self.render_static_form(node, identifier, semantics);
+            }
             if identifier.starts_with("site-") {
                 return self.render_site_semantic_wrapper(
                     node,
@@ -1375,6 +1431,89 @@ impl HtmlRenderer<'_> {
             node.id,
             escape_text(code)
         ))
+    }
+
+    fn render_static_form(
+        &mut self,
+        node: &CoreNode,
+        identifier: &str,
+        semantics: &fission_ir::Semantics,
+    ) -> Result<String> {
+        let Some(value) = semantics.value.as_deref() else {
+            return self.render_site_semantic_wrapper(node, identifier, semantics.label.as_deref());
+        };
+        let spec: StaticFormSpec = serde_json::from_str(value)
+            .map_err(|error| anyhow!("invalid static form spec on node {}: {error}", node.id))?;
+        let method = spec.method.to_ascii_lowercase();
+        let action = self.resolve_link_href(&spec.action);
+        let mut attrs = format!(
+            " method=\"{}\" action=\"{}\" data-fission-semantics=\"{}\"",
+            escape_attr(&method),
+            escape_attr(&action),
+            escape_attr(identifier)
+        );
+        if let Some(label) = semantics.label.as_deref() {
+            attrs.push_str(&format!(" aria-label=\"{}\"", escape_attr(label)));
+        }
+        let mut fields = String::new();
+        for field in &spec.fields {
+            fields.push_str(&self.render_static_form_field(field));
+        }
+        let submit = spec
+            .submit_label
+            .as_deref()
+            .unwrap_or_else(|| semantics.label.as_deref().unwrap_or("Submit"));
+        Ok(format!(
+            "<form class=\"fission-site-node fission-site-form {}\"{attrs} data-fission-node=\"{}\">{fields}<button class=\"fission-site-form-submit\" type=\"submit\">{}</button></form>",
+            site_semantic_class(identifier),
+            node.id,
+            escape_text(submit),
+        ))
+    }
+
+    fn render_static_form_field(&self, field: &StaticFormField) -> String {
+        match field.kind {
+            StaticFormFieldKind::Hidden => format!(
+                "<input type=\"hidden\" name=\"{}\" value=\"{}\">",
+                escape_attr(&field.name),
+                escape_attr(field.value.as_deref().unwrap_or(""))
+            ),
+            StaticFormFieldKind::Textarea => {
+                let mut attrs = static_form_input_attrs(field);
+                let rows = field.rows.unwrap_or(5).max(2);
+                attrs.push_str(&format!(" rows=\"{}\"", rows));
+                let control = format!(
+                    "<textarea class=\"fission-site-form-input fission-site-form-textarea\"{attrs}>{}</textarea>",
+                    escape_text(field.value.as_deref().unwrap_or(""))
+                );
+                static_form_label(field, control)
+            }
+            StaticFormFieldKind::Checkbox => {
+                let mut attrs = static_form_input_attrs(field);
+                attrs.push_str(" type=\"checkbox\"");
+                if field.value.as_deref() == Some("true") {
+                    attrs.push_str(" checked");
+                }
+                let control =
+                    format!("<input class=\"fission-site-form-checkbox\"{attrs} value=\"true\">");
+                static_form_label(field, control)
+            }
+            StaticFormFieldKind::Text
+            | StaticFormFieldKind::Email
+            | StaticFormFieldKind::Tel
+            | StaticFormFieldKind::Url => {
+                let input_type = match field.kind {
+                    StaticFormFieldKind::Email => "email",
+                    StaticFormFieldKind::Tel => "tel",
+                    StaticFormFieldKind::Url => "url",
+                    _ => "text",
+                };
+                let mut attrs = static_form_input_attrs(field);
+                attrs.push_str(&format!(" type=\"{}\"", input_type));
+                let control = format!("<input class=\"fission-site-form-input\"{attrs}>");
+                static_form_label(field, control)
+            }
+        }
     }
 
     fn render_site_semantic_wrapper(
@@ -1724,6 +1863,36 @@ fn site_semantic_class(identifier: &str) -> String {
         })
         .collect::<String>();
     format!("fission-{suffix}")
+}
+
+fn static_form_label(field: &StaticFormField, control: String) -> String {
+    let label = field.label.as_deref().unwrap_or(field.name.as_str());
+    format!(
+        "<label class=\"fission-site-form-field\"><span class=\"fission-site-form-label\">{}</span>{control}</label>",
+        escape_text(label)
+    )
+}
+
+fn static_form_input_attrs(field: &StaticFormField) -> String {
+    let mut attrs = format!(" name=\"{}\"", escape_attr(&field.name));
+    if let Some(placeholder) = field.placeholder.as_deref() {
+        attrs.push_str(&format!(" placeholder=\"{}\"", escape_attr(placeholder)));
+    }
+    if let Some(value) = field.value.as_deref() {
+        if !matches!(
+            field.kind,
+            StaticFormFieldKind::Textarea | StaticFormFieldKind::Checkbox
+        ) {
+            attrs.push_str(&format!(" value=\"{}\"", escape_attr(value)));
+        }
+    }
+    if field.required {
+        attrs.push_str(" required");
+    }
+    if let Some(max_length) = field.max_length {
+        attrs.push_str(&format!(" maxlength=\"{}\"", max_length));
+    }
+    attrs
 }
 
 fn site_semantic_data_attrs(identifier: &str) -> String {
@@ -2435,6 +2604,63 @@ mod tests {
         assert!(rendered.html.contains("action=\"/__fission/action\""));
         assert!(rendered.html.contains("name=\"token\""));
         assert!(rendered.html.contains("signed-token"));
+    }
+
+    #[test]
+    fn site_form_semantics_render_native_post_form() {
+        let root = WidgetId::explicit("static-form");
+        let semantics = Semantics {
+            identifier: Some("site-form:contact".to_string()),
+            label: Some("Contact".to_string()),
+            value: Some(
+                r#"{
+                    "action": "/contact/submit",
+                    "method": "post",
+                    "submitLabel": "Send",
+                    "fields": [
+                        {"kind": "email", "name": "email", "label": "Email", "required": true, "maxLength": 320},
+                        {"kind": "textarea", "name": "message", "label": "Message", "rows": 4},
+                        {"kind": "checkbox", "name": "agree", "label": "Agree"}
+                    ]
+                }"#
+                .to_string(),
+            ),
+            ..Default::default()
+        };
+        let mut ir = CoreIR::new();
+        ir.nodes.insert(
+            root,
+            CoreNode {
+                id: root,
+                op: Op::Semantics(semantics),
+                composite: Default::default(),
+                children: Vec::new(),
+                parent: None,
+                hash: 0,
+            },
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(
+            &ir,
+            &HtmlRenderOptions {
+                current_route_path: "/contact/".to_string(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(rendered.html.contains("<form"));
+        assert!(rendered.html.contains("method=\"post\""));
+        assert!(rendered.html.contains("action=\"../contact/submit\""));
+        assert!(rendered
+            .html
+            .contains("data-fission-semantics=\"site-form:contact\""));
+        assert!(rendered.html.contains("type=\"email\""));
+        assert!(rendered.html.contains("name=\"message\""));
+        assert!(rendered.html.contains("<textarea"));
+        assert!(rendered.html.contains("type=\"checkbox\""));
+        assert!(rendered.html.contains(">Send</button>"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -1,8 +1,10 @@
 use anyhow::{anyhow, bail, Result};
+use fission_core::{AnimationPropertyId, AnimationRequest, AnimationStartValue, EasingFunction};
 use fission_ir::op::{
-    decode_inline_widget_marker, AlignItems, BoxShadow, Color, Fill, FlexDirection, FlexWrap,
-    FontStyle, GridPlacement, GridTrack, ImageFit, ImageSource, JustifyContent, LayoutOp, LineCap,
-    LineJoin, Op, PaintOp, Stroke, TextAlign, TextOverflow, TextRun,
+    decode_inline_widget_marker, AlignItems, BoxShadow, Color, CompositeScalar, Fill,
+    FlexDirection, FlexWrap, FontStyle, GridPlacement, GridTrack, ImageFit, ImageSource,
+    JustifyContent, LayoutOp, LineCap, LineJoin, Op, PaintOp, Stroke, TextAlign, TextOverflow,
+    TextRun,
 };
 use fission_ir::{semantics::ActionTrigger, CoreIR, CoreNode, Role, WidgetId};
 use fission_theme::{DesignMode, Theme};
@@ -32,6 +34,7 @@ pub struct HtmlRenderOptions {
     pub head_end_html: Vec<String>,
     pub body_start_html: Vec<String>,
     pub body_end_html: Vec<String>,
+    pub animation_requests: Vec<(WidgetId, AnimationRequest)>,
 }
 
 impl Default for HtmlRenderOptions {
@@ -59,6 +62,7 @@ impl Default for HtmlRenderOptions {
             head_end_html: Vec::new(),
             body_start_html: Vec::new(),
             body_end_html: Vec::new(),
+            animation_requests: Vec::new(),
         }
     }
 }
@@ -348,6 +352,7 @@ impl CssVariableMap {
 pub struct StyleRegistry {
     style_to_class: BTreeMap<String, String>,
     class_to_style: BTreeMap<String, String>,
+    raw_rules: BTreeMap<String, String>,
 }
 
 impl StyleRegistry {
@@ -382,7 +387,17 @@ impl StyleRegistry {
             out.push_str(style);
             out.push_str("}\n");
         }
+        for rule in self.raw_rules.values() {
+            out.push_str(rule);
+            if !rule.ends_with('\n') {
+                out.push('\n');
+            }
+        }
         out
+    }
+
+    pub fn raw_rule(&mut self, key: impl Into<String>, rule: impl Into<String>) {
+        self.raw_rules.insert(key.into(), rule.into());
     }
 }
 
@@ -578,9 +593,15 @@ impl HtmlRenderer<'_> {
     ) -> Result<String> {
         let mut skip = HashSet::new();
         style.extend(self.coalesced_paint_style(node, &mut skip)?);
-        style.extend(composite_style(node));
+        let (composite_style, animated) = self.composite_style(node);
+        style.extend(composite_style);
         let children = self.render_children(&node.children, &skip)?;
-        let class_name = self.class_name(class_name, style);
+        let class_name = if animated {
+            format!("{class_name} fission-site-animated")
+        } else {
+            class_name.to_string()
+        };
+        let class_name = self.class_name(&class_name, style);
         Ok(format!(
             "<{tag} class=\"{}\" data-fission-node=\"{}\">{children}</{tag}>",
             escape_attr(&class_name),
@@ -594,6 +615,191 @@ impl HtmlRenderer<'_> {
         } else {
             base.to_string()
         }
+    }
+
+    fn composite_style(&mut self, node: &CoreNode) -> (Vec<String>, bool) {
+        let mut style = Vec::new();
+        let mut animations = Vec::new();
+
+        if node.composite.clip_to_bounds {
+            style.push("overflow:hidden".to_string());
+        }
+
+        if let Some(opacity) = node.composite.opacity.as_ref() {
+            style.push(format!("opacity:{}", opacity.base));
+            if let Some(request) = self.animation_request(opacity, AnimationPropertyId::Opacity) {
+                animations.push(self.animation_css(
+                    CssAnimationProperty::Opacity,
+                    opacity.base,
+                    &request,
+                    None,
+                ));
+            }
+        }
+
+        let translate_x = node
+            .composite
+            .translate_x
+            .as_ref()
+            .map(|v| v.base)
+            .unwrap_or(0.0);
+        let translate_y = node
+            .composite
+            .translate_y
+            .as_ref()
+            .map(|v| v.base)
+            .unwrap_or(0.0);
+        let scale = node.composite.scale.as_ref().map(|v| v.base).unwrap_or(1.0);
+        let rotation = node
+            .composite
+            .rotation
+            .as_ref()
+            .map(|v| v.base)
+            .unwrap_or(0.0);
+
+        let translate_x_request = node
+            .composite
+            .translate_x
+            .as_ref()
+            .and_then(|scalar| self.animation_request(scalar, AnimationPropertyId::TranslateX));
+        let translate_y_request = node
+            .composite
+            .translate_y
+            .as_ref()
+            .and_then(|scalar| self.animation_request(scalar, AnimationPropertyId::TranslateY));
+        let scale_request = node
+            .composite
+            .scale
+            .as_ref()
+            .and_then(|scalar| self.animation_request(scalar, AnimationPropertyId::Scale));
+        let rotation_request = node
+            .composite
+            .rotation
+            .as_ref()
+            .and_then(|scalar| self.animation_request(scalar, AnimationPropertyId::Rotation));
+        let has_transform_animation = translate_x_request.is_some()
+            || translate_y_request.is_some()
+            || scale_request.is_some()
+            || rotation_request.is_some();
+
+        if has_transform_animation {
+            style.push(format!(
+                "translate:{}px {}px",
+                px(translate_x),
+                px(translate_y)
+            ));
+            style.push(format!("scale:{}", px(scale)));
+            style.push(format!("rotate:{}rad", px(rotation)));
+        } else if translate_x != 0.0
+            || translate_y != 0.0
+            || (scale - 1.0).abs() > f32::EPSILON
+            || rotation != 0.0
+        {
+            style.push(format!(
+                "transform:translate({}px,{}px) scale({}) rotate({}rad)",
+                px(translate_x),
+                px(translate_y),
+                scale,
+                rotation
+            ));
+        }
+
+        if let Some(request) = translate_x_request {
+            animations.push(self.animation_css(
+                CssAnimationProperty::TranslateX {
+                    other_axis: translate_y,
+                },
+                translate_x,
+                &request,
+                None,
+            ));
+        }
+        if let Some(request) = translate_y_request {
+            animations.push(self.animation_css(
+                CssAnimationProperty::TranslateY {
+                    other_axis: translate_x,
+                },
+                translate_y,
+                &request,
+                None,
+            ));
+        }
+        if let Some(request) = scale_request {
+            animations.push(self.animation_css(CssAnimationProperty::Scale, scale, &request, None));
+        }
+        if let Some(request) = rotation_request {
+            animations.push(self.animation_css(
+                CssAnimationProperty::Rotation,
+                rotation,
+                &request,
+                None,
+            ));
+        }
+
+        if !animations.is_empty() {
+            style.push(format!("animation:{}", animations.join(",")));
+            self.styles.raw_rule(
+                "fission-site-reduced-motion-animations",
+                "@media (prefers-reduced-motion:reduce){.fission-site-animated{animation:none!important;}}\n",
+            );
+        }
+
+        (style, !animations.is_empty())
+    }
+
+    fn animation_request(
+        &self,
+        scalar: &CompositeScalar,
+        property: AnimationPropertyId,
+    ) -> Option<AnimationRequest> {
+        let target = scalar.animation_target?;
+        self.options
+            .animation_requests
+            .iter()
+            .rev()
+            .find_map(|(candidate, request)| {
+                (*candidate == target && request.property == property).then_some(request.clone())
+            })
+    }
+
+    fn animation_css(
+        &mut self,
+        property: CssAnimationProperty,
+        base: f32,
+        request: &AnimationRequest,
+        override_from: Option<f32>,
+    ) -> String {
+        let from = override_from.unwrap_or_else(|| animation_start_value(request, base));
+        let name = self.register_animation_keyframes(property, from, request.to, request);
+        format!(
+            "{} {}ms {} {}ms {} normal both",
+            name,
+            request.duration_ms,
+            easing_css(&request.easing),
+            request.delay_ms,
+            if request.repeat { "infinite" } else { "1" }
+        )
+    }
+
+    fn register_animation_keyframes(
+        &mut self,
+        property: CssAnimationProperty,
+        from: f32,
+        to: f32,
+        request: &AnimationRequest,
+    ) -> String {
+        let key = format!(
+            "{property:?}:{from:?}:{to:?}:{:?}:{}:{}:{}",
+            request.easing, request.duration_ms, request.delay_ms, request.repeat
+        );
+        let name = format!("fission_anim_{:016x}", stable_hash(key.as_bytes()));
+        let rule = format!(
+            "@keyframes {name}{{from{{{}}}to{{{}}}}}\n",
+            property.css_declaration(from),
+            property.css_declaration(to)
+        );
+        self.styles.raw_rule(name.clone(), rule);
+        name
     }
 
     fn render_layout(&mut self, node: &CoreNode, layout: &LayoutOp) -> Result<String> {
@@ -809,6 +1015,10 @@ impl HtmlRenderer<'_> {
                 ..
             } => {
                 let mut style = self.text_style(*size, *color, *underline, *wrap);
+                if paragraph_needs_text_box(paragraph_style.as_ref()) {
+                    style.push("display:block".to_string());
+                    style.push("width:100%".to_string());
+                }
                 push_paragraph_style(&mut style, paragraph_style.as_ref());
                 let class_name = self.class_name("fission-site-text", style);
                 Ok(format!(
@@ -824,10 +1034,17 @@ impl HtmlRenderer<'_> {
                 paragraph_style,
                 ..
             } => {
-                let mut style = vec![
-                    "display:inline".to_string(),
-                    format!("white-space:{}", if *wrap { "pre-wrap" } else { "pre" }),
-                ];
+                let mut style = Vec::new();
+                if paragraph_needs_text_box(paragraph_style.as_ref()) {
+                    style.push("display:block".to_string());
+                    style.push("width:100%".to_string());
+                } else {
+                    style.push("display:inline".to_string());
+                }
+                style.push(format!(
+                    "white-space:{}",
+                    if *wrap { "pre-wrap" } else { "pre" }
+                ));
                 push_paragraph_style(&mut style, paragraph_style.as_ref());
                 let mut content = String::new();
                 for run in runs {
@@ -1587,6 +1804,13 @@ fn push_paragraph_style(
     }
 }
 
+fn paragraph_needs_text_box(paragraph: Option<&fission_ir::op::TextParagraphStyle>) -> bool {
+    matches!(
+        paragraph.map(|style| style.text_align),
+        Some(TextAlign::Center | TextAlign::Right | TextAlign::End | TextAlign::Justify)
+    )
+}
+
 fn push_box_constraints(
     style: &mut Vec<String>,
     width: Option<f32>,
@@ -1639,47 +1863,54 @@ fn push_grid_placement(style: &mut Vec<String>, name: &str, value: GridPlacement
     }
 }
 
-fn composite_style(node: &CoreNode) -> Vec<String> {
-    let mut style = Vec::new();
-    if let Some(opacity) = node.composite.opacity.as_ref() {
-        style.push(format!("opacity:{}", opacity.base));
+#[derive(Clone, Copy, Debug)]
+enum CssAnimationProperty {
+    Opacity,
+    TranslateX { other_axis: f32 },
+    TranslateY { other_axis: f32 },
+    Scale,
+    Rotation,
+}
+
+impl CssAnimationProperty {
+    fn css_declaration(self, value: f32) -> String {
+        match self {
+            Self::Opacity => format!("opacity:{}", px(value)),
+            Self::TranslateX { other_axis } => {
+                format!("translate:{}px {}px", px(value), px(other_axis))
+            }
+            Self::TranslateY { other_axis } => {
+                format!("translate:{}px {}px", px(other_axis), px(value))
+            }
+            Self::Scale => format!("scale:{}", px(value)),
+            Self::Rotation => format!("rotate:{}rad", px(value)),
+        }
     }
-    if node.composite.clip_to_bounds {
-        style.push("overflow:hidden".to_string());
+}
+
+fn animation_start_value(request: &AnimationRequest, base: f32) -> f32 {
+    match request.from {
+        AnimationStartValue::Explicit(value) => value,
+        AnimationStartValue::Current => base,
     }
-    let translate_x = node
-        .composite
-        .translate_x
-        .as_ref()
-        .map(|v| v.base)
-        .unwrap_or(0.0);
-    let translate_y = node
-        .composite
-        .translate_y
-        .as_ref()
-        .map(|v| v.base)
-        .unwrap_or(0.0);
-    let scale = node.composite.scale.as_ref().map(|v| v.base).unwrap_or(1.0);
-    let rotation = node
-        .composite
-        .rotation
-        .as_ref()
-        .map(|v| v.base)
-        .unwrap_or(0.0);
-    if translate_x != 0.0
-        || translate_y != 0.0
-        || (scale - 1.0).abs() > f32::EPSILON
-        || rotation != 0.0
-    {
-        style.push(format!(
-            "transform:translate({}px,{}px) scale({}) rotate({}rad)",
-            px(translate_x),
-            px(translate_y),
-            scale,
-            rotation
-        ));
+}
+
+fn easing_css(easing: &EasingFunction) -> String {
+    match easing {
+        EasingFunction::Linear => "linear".to_string(),
+        EasingFunction::EaseIn => "ease-in".to_string(),
+        EasingFunction::EaseOut => "ease-out".to_string(),
+        EasingFunction::EaseInOut => "ease-in-out".to_string(),
+        EasingFunction::CubicBezier(x1, y1, x2, y2) => {
+            format!(
+                "cubic-bezier({},{},{},{})",
+                px(*x1),
+                px(*y1),
+                px(*x2),
+                px(*y2)
+            )
+        }
     }
-    style
 }
 
 fn raw_color_css(color: Color) -> String {
@@ -1834,7 +2065,10 @@ fn escape_attr(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fission_ir::{ActionEntry, ActionSet, CoreIR, CoreNode, Op, Semantics, WidgetId};
+    use fission_ir::{
+        ActionEntry, ActionSet, CompositeScalar, CompositeStyle, CoreIR, CoreNode, Op, Semantics,
+        WidgetId,
+    };
 
     #[test]
     fn renders_text_from_core_ir() {
@@ -1938,6 +2172,183 @@ mod tests {
         assert!(css.contains(&format!(".{class_name}")));
         assert!(css.contains("display:block;overflow:hidden"));
         assert!(!css.contains("overflow:auto"));
+    }
+
+    #[test]
+    fn repeated_rotation_animation_lowers_to_css_keyframes() {
+        let root = WidgetId::explicit("root");
+        let spinner = WidgetId::explicit("spinner-node");
+        let target = WidgetId::explicit("spinner-animation");
+        let mut ir = CoreIR::new();
+        ir.nodes.insert(
+            spinner,
+            CoreNode {
+                id: spinner,
+                op: Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 7 }),
+                composite: CompositeStyle {
+                    rotation: Some(CompositeScalar::new(0.0).animated(target)),
+                    ..Default::default()
+                },
+                children: Vec::new(),
+                parent: None,
+                hash: 0,
+            },
+        );
+        ir.add_node(
+            root,
+            Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 1 }),
+            vec![spinner],
+        );
+        ir.set_root(root);
+        let options = HtmlRenderOptions {
+            animation_requests: vec![(
+                target,
+                AnimationRequest {
+                    property: AnimationPropertyId::Rotation,
+                    from: AnimationStartValue::Explicit(0.0),
+                    to: std::f32::consts::TAU,
+                    duration_ms: 7000,
+                    repeat: true,
+                    delay_ms: 120,
+                    frame_interval_ms: None,
+                    easing: EasingFunction::Linear,
+                },
+            )],
+            ..Default::default()
+        };
+
+        let rendered = render_ir_to_html(&ir, &options).unwrap();
+
+        assert!(rendered.html.contains("fission-site-animated"));
+        assert!(rendered.css.contains("@keyframes fission_anim_"));
+        assert!(rendered.css.contains("rotate:0rad"));
+        assert!(rendered.css.contains("rotate:6.283rad"));
+        assert!(rendered
+            .css
+            .contains("7000ms linear 120ms infinite normal both"));
+        assert!(rendered.css.contains("prefers-reduced-motion:reduce"));
+    }
+
+    #[test]
+    fn scale_and_opacity_animations_share_one_dom_node() {
+        let root = WidgetId::explicit("root");
+        let pulse = WidgetId::explicit("pulse-node");
+        let target = WidgetId::explicit("pulse-animation");
+        let mut ir = CoreIR::new();
+        ir.nodes.insert(
+            pulse,
+            CoreNode {
+                id: pulse,
+                op: Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 7 }),
+                composite: CompositeStyle {
+                    opacity: Some(CompositeScalar::new(0.72).animated(target)),
+                    scale: Some(CompositeScalar::new(0.92).animated(target)),
+                    ..Default::default()
+                },
+                children: Vec::new(),
+                parent: None,
+                hash: 0,
+            },
+        );
+        ir.add_node(
+            root,
+            Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 1 }),
+            vec![pulse],
+        );
+        ir.set_root(root);
+        let options = HtmlRenderOptions {
+            animation_requests: vec![
+                (
+                    target,
+                    AnimationRequest {
+                        property: AnimationPropertyId::Opacity,
+                        from: AnimationStartValue::Explicit(0.72),
+                        to: 1.0,
+                        duration_ms: 1400,
+                        repeat: true,
+                        delay_ms: 0,
+                        frame_interval_ms: None,
+                        easing: EasingFunction::EaseInOut,
+                    },
+                ),
+                (
+                    target,
+                    AnimationRequest {
+                        property: AnimationPropertyId::Scale,
+                        from: AnimationStartValue::Explicit(0.92),
+                        to: 1.08,
+                        duration_ms: 1400,
+                        repeat: true,
+                        delay_ms: 0,
+                        frame_interval_ms: None,
+                        easing: EasingFunction::EaseInOut,
+                    },
+                ),
+            ],
+            ..Default::default()
+        };
+
+        let rendered = render_ir_to_html(&ir, &options).unwrap();
+
+        assert!(rendered.css.contains("opacity:0.720"));
+        assert!(rendered.css.contains("opacity:1"));
+        assert!(rendered.css.contains("scale:0.920"));
+        assert!(rendered.css.contains("scale:1.080"));
+        assert!(rendered.css.matches("@keyframes fission_anim_").count() >= 2);
+        assert!(rendered.css.contains(",fission_anim_"));
+    }
+
+    #[test]
+    fn centered_rich_text_lowers_to_width_bearing_block() {
+        let root = WidgetId::explicit("root");
+        let text = WidgetId::explicit("centered-text");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            text,
+            Op::Paint(PaintOp::DrawRichText {
+                runs: vec![TextRun {
+                    text: "Centered\ncopy".into(),
+                    style: fission_ir::op::TextStyle {
+                        font_size: 24.0,
+                        color: Color::WHITE,
+                        underline: false,
+                        font_family: None,
+                        locale: None,
+                        font_weight: 700,
+                        font_style: FontStyle::Normal,
+                        line_height: Some(28.0),
+                        letter_spacing: 0.0,
+                        background_color: None,
+                    },
+                }],
+                wrap: true,
+                caret_index: None,
+                caret_color: None,
+                caret_width: None,
+                caret_height: None,
+                caret_radius: None,
+                paragraph_style: Some(fission_ir::op::TextParagraphStyle {
+                    text_align: TextAlign::Center,
+                    ..Default::default()
+                }),
+            }),
+            Vec::new(),
+        );
+        ir.add_node(
+            root,
+            Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 1 }),
+            vec![text],
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered.css.contains("display:block"));
+        assert!(rendered.css.contains("width:100%"));
+        assert!(rendered.css.contains("text-align:center"));
+        assert!(!rendered
+            .css
+            .contains("display:inline;white-space:pre-wrap;text-align:center"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -875,12 +875,23 @@ impl HtmlRenderer<'_> {
             }
             PaintOp::DrawSvg {
                 content,
-                fill: _,
-                stroke: _,
-            } => Ok(format!(
-                "<span class=\"fission-site-svg\" data-fission-node=\"{}\">{}</span>",
-                node.id, content
-            )),
+                fill,
+                stroke,
+            } => {
+                let base = if fill.is_some() || stroke.is_some() {
+                    "fission-site-svg fission-site-svg-colored"
+                } else {
+                    "fission-site-svg"
+                };
+                let class_name =
+                    self.class_name(base, self.svg_paint_style(fill.as_ref(), stroke.as_ref()));
+                Ok(format!(
+                    "<span class=\"{}\" data-fission-node=\"{}\">{}</span>",
+                    escape_attr(&class_name),
+                    node.id,
+                    content
+                ))
+            }
         }
     }
 

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -250,7 +250,7 @@ fn render_document(body_html: &str, options: &HtmlRenderOptions, has_code_blocks
     }
     for json in &options.structured_data {
         metadata.push_str("\n    <script type=\"application/ld+json\">");
-        metadata.push_str(json);
+        metadata.push_str(&escape_script_data(json));
         metadata.push_str("</script>");
     }
     if let Some(favicon) = options.favicon_href.as_ref() {
@@ -332,6 +332,38 @@ fn code_highlighting_assets(options: &HtmlRenderOptions, has_code_blocks: bool) 
         escape_attr(&options.code_highlighting.stylesheet_href),
         escape_attr(&options.code_highlighting.script_src),
     )
+}
+
+fn escape_script_data(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = String::with_capacity(value.len() + 1);
+    let mut index = 0;
+    while index < bytes.len() {
+        let is_script_end = index + 8 <= bytes.len()
+            && bytes[index] == b'<'
+            && bytes[index + 1] == b'/'
+            && is_case_insensitive_eq(&bytes[index + 2..index + 8], b"script");
+        if is_script_end {
+            out.push_str("<\\/script");
+            index += 8;
+            continue;
+        }
+        let ch = value[index..]
+            .chars()
+            .next()
+            .expect("non-empty string slice has first char");
+        out.push(ch);
+        index += ch.len_utf8();
+    }
+    out
+}
+
+fn is_case_insensitive_eq(value: &[u8], target: &[u8]) -> bool {
+    value.len() == target.len()
+        && value
+            .iter()
+            .zip(target.iter())
+            .all(|(left, right)| left.to_ascii_lowercase() == right.to_ascii_lowercase())
 }
 
 fn search_script(options: &HtmlRenderOptions) -> String {
@@ -2661,6 +2693,18 @@ mod tests {
         assert!(rendered.html.contains("<textarea"));
         assert!(rendered.html.contains("type=\"checkbox\""));
         assert!(rendered.html.contains(">Send</button>"));
+    }
+
+    #[test]
+    fn escape_script_data_is_case_insensitive() {
+        let escaped = escape_script_data(
+            "<script>{\"value\":\"</script\",\"alt\":\"</Script\",\"upper\":\"</SCRIPT\"}</script>",
+        );
+        assert_eq!(
+            escaped,
+            "<script>{\"value\":\"<\\/script\",\"alt\":\"<\\/script\",\"upper\":\"<\\/script\"}<\\/script>",
+        );
+        assert_eq!(escaped.matches("<\\/script").count(), 4);
     }
 
     #[test]

--- a/crates/shell/fission-shell-site/src/site.rs
+++ b/crates/shell/fission-shell-site/src/site.rs
@@ -2,7 +2,6 @@ use crate::build::{build_site, check_site, list_site_routes, SiteBuildOptions};
 use anyhow::{bail, Context, Result};
 use fission_core::internal::BuildCtx;
 use fission_core::{Env, GlobalState, RuntimeState, View, Widget};
-use fission_layout::LayoutSize;
 use fission_theme::{DesignMode, Theme};
 use std::fs;
 use std::io::{self, BufRead, Write};
@@ -178,6 +177,14 @@ pub struct SiteRenderContext<'a> {
     pub project_dir: &'a Path,
     pub route_path: &'a str,
     pub theme: &'a Theme,
+    pub default_locale: &'a str,
+    pub(crate) env: &'a Env,
+}
+
+impl<'a> SiteRenderContext<'a> {
+    pub fn env(&self) -> &'a Env {
+        self.env
+    }
 }
 
 #[derive(Clone)]
@@ -185,6 +192,7 @@ pub struct FissionSite {
     pub(crate) custom_routes: Vec<CustomRoute>,
     pub(crate) content_transform: Option<Arc<ContentTransform>>,
     pub(crate) theme: Theme,
+    pub(crate) env: Env,
     pub(crate) light_theme: Option<Theme>,
     pub(crate) dark_theme: Option<Theme>,
     pub(crate) default_theme_mode: Option<DesignMode>,
@@ -200,6 +208,7 @@ impl Default for FissionSite {
             custom_routes: Vec::new(),
             content_transform: None,
             theme: Theme::default(),
+            env: Env::default(),
             light_theme: None,
             dark_theme: None,
             default_theme_mode: None,
@@ -217,7 +226,14 @@ impl FissionSite {
     }
 
     pub fn theme(mut self, theme: Theme) -> Self {
+        self.env.theme = theme.clone();
         self.theme = theme;
+        self
+    }
+
+    pub fn with_env(mut self, env: Env) -> Self {
+        self.env = env;
+        self.env.theme = self.theme.clone();
         self
     }
 
@@ -231,6 +247,7 @@ impl FissionSite {
             DesignMode::Light => light.clone(),
             DesignMode::Dark => dark.clone(),
         };
+        self.env.theme = self.theme.clone();
         self.light_theme = Some(light);
         self.dark_theme = Some(dark);
         self.default_theme_mode = Some(default_mode);
@@ -291,11 +308,8 @@ impl FissionSite {
             description: description.into(),
             render: Arc::new(move |ctx| {
                 let runtime = RuntimeState::default();
-                let mut env = Env::default();
-                env.theme = ctx.theme.clone();
-                env.viewport_size = LayoutSize::new(1280.0, 900.0);
                 let state = S::default();
-                let view = View::new(&state, &runtime, &env, None);
+                let view = View::new(&state, &runtime, ctx.env(), None);
                 let mut build_ctx = BuildCtx::<S>::new();
                 Ok(fission_core::build::enter(&mut build_ctx, &view, || {
                     widget.as_ref().clone().into()
@@ -332,11 +346,8 @@ where
     W: Clone + Into<Widget>,
 {
     let runtime = RuntimeState::default();
-    let mut env = Env::default();
-    env.theme = ctx.theme.clone();
-    env.viewport_size = LayoutSize::new(1280.0, 900.0);
     let state = S::default();
-    let view = View::new(&state, &runtime, &env, None);
+    let view = View::new(&state, &runtime, ctx.env(), None);
     let mut build_ctx = BuildCtx::<S>::new();
     Ok(fission_core::build::enter(&mut build_ctx, &view, || {
         (*widget).clone().into()

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -92,6 +92,26 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 fission = { version = "0.3", features = ["server", "server-redis"] }
 ```
 
+## Invalidate cached pages after writes
+
+Route tags are the contract between your app data and the page cache. If changing a post should refresh the blog landing page, the post page, and a topic page, tag those routes with values such as `posts`, `post:<id>`, and `topic:<slug>`.
+
+Application-owned services can use the cache handle directly when they already own the invalidation policy:
+
+```rust
+renderer
+    .cache()
+    .invalidate_tags(&[CacheTag::new("posts"), CacheTag::new("post:hello-world")])?;
+```
+
+Admin and publishing workflows can call the renderer helpers instead:
+
+```rust
+renderer.invalidate_cache_tags(["posts", "post:hello-world"])?;
+```
+
+Both paths return an `InvalidationReport` so the caller can log how many cache keys and tag indexes were removed.
+
 ## 3. Configure sessions before using private routes
 
 `ServerPrivate` routes use a cookie-backed session id. For production HTTPS deployments, sign the cookie value and mark it secure.

--- a/documentation/content/docs/guides/theming-and-i18n.mdx
+++ b/documentation/content/docs/guides/theming-and-i18n.mdx
@@ -290,6 +290,21 @@ DesktopApp::new(MyApp)
     .run()?;
 ```
 
+Server-rendered apps and static sites use the same `Env` data, but they resolve it at request time or build time instead of once per frame:
+
+```rust
+FissionServerApp::new("Docs")
+    .with_env(create_env()?)
+    .with_request_env(|ctx, env| {
+        if ctx.route_path.starts_with("/fr/") {
+            env.locale = "fr".into();
+        }
+        Ok(())
+    });
+```
+
+For a static site, call `FissionSite::with_env(create_env()?)`. The static-site shell seeds `env.locale` from `site.default_locale` while rendering. The server shell seeds `env.locale` from `server.default_locale` and then runs `.with_request_env(...)`, so request-owned choices such as locale from a route prefix, cookie, session, or header can override the default.
+
 This example has two separate jobs.
 
 First, `.with_env(create_env()?)` installs the base environment that already contains your translation bundles. The `?` after `create_env()` means "if building the environment fails, return the error instead of continuing."

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -341,6 +341,8 @@ url_env = "REDIS_URL"
 prefix = "shop"
 ```
 
+Revalidated route tags are set in code through `RevalidationPolicy::tag(...)` or `RevalidationPolicy::tags(...)`. After a write, invalidate those tags through `ServerRenderer::invalidate_cache_tag(...)`, `ServerRenderer::invalidate_cache_tags(...)`, or the direct cache handle returned by `ServerRenderer::cache()`.
+
 ### `[[server.cache.layers]]`
 
 Use a cache pipeline when you want multiple cache layers, such as a small process-local hot cache in front of Redis. The table is valid only when `[server.cache].provider = "pipeline"`.

--- a/documentation/content/reference/core/environment-input-and-ime.mdx
+++ b/documentation/content/reference/core/environment-input-and-ime.mdx
@@ -36,11 +36,13 @@ A widget should read environment through `ViewHandle`, for example with `view.vi
 
 ## How `Env` reaches the app
 
-Desktop currently exposes public `with_env(...)` and `with_sync_env(...)` builders. Mobile and web expose public `with_sync_env(...)`.
+Desktop currently exposes public `with_env(...)` and `with_sync_env(...)` builders. Mobile and web expose public `with_sync_env(...)`. Server-rendered apps expose `with_env(...)` and `with_request_env(...)`; static sites expose `with_env(...)`.
 
 Use `with_env(...)` when you want to seed a prepared environment, such as an environment that already contains translation bundles.
 
 Use `with_sync_env(...)` when values in `GlobalState` should be mirrored into `Env`, such as a user-selected locale or theme mode.
+
+Use `with_request_env(...)` on server-rendered apps when request data should select presentation context before rendering, such as a locale stored in a route prefix, header, cookie, or session.
 
 The important contract is that environment remains explicit and shell-managed, not hidden behind global process state.
 

--- a/documentation/content/reference/core/platform-runtime.mdx
+++ b/documentation/content/reference/core/platform-runtime.mdx
@@ -111,7 +111,7 @@ The wrappers are intentionally similar, but not identical.
 - `register_reducer(...)`
 - `absorb_registry(...)`
 
-`with_env(...)` is the desktop-only public hook for replacing the default `Env` up front. `register_reducer(...)` and `absorb_registry(...)` are direct reducer-registration helpers on the desktop wrapper. `with_test_control_port(...)` is the desktop live-shell testing entrypoint.
+`with_env(...)` replaces the default `Env` up front on shells that expose a base environment, including desktop, server-rendered apps, and static sites. `register_reducer(...)` and `absorb_registry(...)` are direct reducer-registration helpers on the desktop wrapper. `with_test_control_port(...)` is the desktop live-shell testing entrypoint.
 
 `MobileApp` keeps the same overall model but exposes a smaller public surface. It currently supports:
 

--- a/documentation/content/reference/core/theming-and-i18n.mdx
+++ b/documentation/content/reference/core/theming-and-i18n.mdx
@@ -55,11 +55,13 @@ Use a preset when it matches the platform or brand direction you want. Copy it i
 
 `Env` carries the active theme, internationalization registry, locale, and other app-wide presentation context. During component conversion, widgets can read those values through `view.env` or convenience helpers such as `view.theme()`.
 
-Desktop exposes both `with_env(...)` and `with_sync_env(...)`. Mobile and web expose `with_sync_env(...)`.
+Desktop exposes both `with_env(...)` and `with_sync_env(...)`. Mobile and web expose `with_sync_env(...)`. Server-rendered apps expose `with_env(...)` and `with_request_env(...)`. Static sites expose `with_env(...)`.
 
 Use `with_env(...)` to seed a base environment before the first frame, such as one that already contains translation bundles.
 
 Use `with_sync_env(...)` when app state should update environment values every frame, such as mirroring a user-selected theme mode, locale, or window title into `Env`.
+
+Use `with_request_env(...)` on `FissionServerApp` when request data should select presentation context before SSR, such as choosing `env.locale` from a path prefix, header, cookie, or session. The server shell uses the resolved request `Env` for both widget building and lowering, so `TextContent::Key` resolves consistently in rendered HTML.
 
 ```rust
 DesktopApp::new(MyApp)


### PR DESCRIPTION
## Summary

This branch rounds out several pieces of Fission's server-rendered/static-site path so it can support production content sites, documentation sites, and mixed static/admin deployments without requiring applications to bypass the server shell.

The main areas are:

- environment hooks and cache invalidation APIs for SSR routes
- more faithful SSR lowering for links, images, SVG icons, positioned layout, text, animation, forms, and Markdown media
- static app mounts for colocated web apps
- prefix server routes for route families such as content detail pages
- structured data emission for SEO metadata
- HTTP response status control from SSR route renderers
- safer execution of custom server HTTP handlers
- runtime build identifiers in SSR cache keys

## Motivation

Fission already has the right application model for building one UI across multiple shells, but production SSR has a few extra requirements that are easy for frameworks to miss:

- A server-rendered page needs to behave like an HTTP page, not only like a rendered widget tree. Dynamic route families must be able to produce a valid page with a non-200 status when content is missing.
- Static and revalidated pages need clear cache boundaries and application-level invalidation hooks. Publishing, editing, or withdrawing content should be able to invalidate the exact routes/tags affected without replacing Fission's renderer.
- The SSR output needs to preserve the same semantics and visual affordances as the native shell: links should be links, forms should post, responsive images should remain responsive, icons should preserve coloring, Markdown media should remain media, and animations/text/layout should lower predictably to HTML/CSS.
- Production sites often have more than one surface. A public SSR site may need to mount a separately built admin app or other static bundle under a clean path without treating everything as a downloadable asset.
- Search and social crawlers need metadata that is emitted by the route layer, including structured data, canonical URLs, and per-route document data.
- Rebuilt deployments need a cache namespace that can change at runtime. Containerized deployments commonly promote one binary/image through environments with a runtime release id; the SSR cache key should be able to use that id rather than only a compile-time value.

The goal of these changes is to keep those concerns inside Fission's server shell instead of forcing downstream applications to wrap or fork the renderer.

## Changes

### SSR environment hooks and cache invalidation

Adds server environment hooks and cache invalidation APIs so applications can adjust route environment from request context and invalidate cached SSR output by policy.

This is useful for sites that cache aggressively but still need deterministic invalidation when related content changes. For example, publishing a new article may need to invalidate the article page, the writing index, the home page's recent-content region, and sitemap output. Fission should expose those primitives directly rather than requiring applications to manage an unrelated cache layer around the renderer.

The related docs are updated to cover server site caching/jobs/actions, theming/i18n, and the relevant config surface.

### Runtime build ids in SSR cache keys

Changes SSR cache-key generation to prefer a runtime `FISSION_BUILD_ID` environment value, then fall back to the compile-time value, then the crate version.

This keeps cache namespaces aligned with deployments where the same binary or image is run with an environment-specific release id. It also makes local and containerized development less surprising: restarting a service with a new runtime build id no longer reuses old page entries just because the binary was compiled with the same default value.

Blank runtime or compile-time values are ignored so accidental empty environment configuration does not collapse all cache keys into an empty build namespace.

### Responsive SSR links and images

Improves SSR lowering for links and images so generated HTML keeps the expected route-link behavior and responsive image constraints.

This matters because static HTML is the thing users and crawlers see first. If a Fission route link becomes inert markup, or if an image lowers with desktop-only sizing, the SSR shell diverges from the app shell. These changes make the server output a better representation of the same UI model.

### Markdown linked images

Updates `MarkdownViewer` so image-only paragraphs render as native Fission image nodes even when the Markdown image is wrapped in a link, as in `[![alt](thumb)](full)`. Multiple linked images in one paragraph render as a wrapping image gallery rather than text placeholders.

This keeps imported or authored Markdown content in the Fission rendering pipeline without degrading media to `[image: ...]` text. Linked images preserve `markdown-link:` semantics so SSR lowers them to conventional anchors around images.

### SVG icon coloring

Fixes SSR output for SVG icons so the generated markup and CSS preserve expected icon coloring.

Fission can render icon widgets correctly in native shells, but SSR also needs to emit usable inline/vector output. Without this, production pages lose visual hierarchy and affordance because icons collapse to unstyled or incorrectly colored assets.

### Static app mounts

Adds server static app mounts so applications can mount a static bundle at a route prefix.

This supports deployments where a public SSR site and a colocated web application share the same server. The server can serve an app under a clean path while still preserving SSR routes, assets, and fallback behavior. Keeping this in Fission avoids every application inventing its own path handling around the shell.

### CSS extension and positioned layout support

Improves the server CSS extension points and positioned layout lowering.

Several production layouts rely on absolute/relative positioning, overlays, badges, background grids, and other composed visual elements. The native shell can express these patterns; SSR needs to lower them consistently so the HTML/CSS output does not drift from the intended design.

### Animation and text lowering

Improves Fission animation requests and text output in the SSR/static shell.

The intent is that animation authored through Fission remains Fission-native while still becoming suitable CSS in the static output. This keeps app code portable across shells while allowing a server-rendered page to retain motion, interaction affordances, and typographic fidelity.

### Static form lowering

Adds SSR lowering for static forms and extends semantics support around form controls.

This gives server-rendered pages usable HTML forms for common workflows such as subscription forms, contact forms, booking forms, and other non-island interactions. The form can be represented in Fission while still producing conventional SSR HTML.

### Server HTTP handlers off runtime threads

Adjusts custom server HTTP handler execution so handler work is not run directly on runtime threads.

This keeps Fission's server path more robust when applications add custom HTTP handlers for endpoints such as metadata, feeds, sitemap/robots, webhooks, or other server-owned routes.

### Prefix server routes

Adds prefix server routes for route families where a single route definition owns a subtree.

This is needed for content detail pages, documentation trees, user-facing archives, and similar routes where the application resolves the specific page from the path. It keeps route setup compact while still letting the server renderer receive the matched path and produce the correct state/widget tree.

### Structured data

Adds route structured-data support and emits JSON-LD from the SSR HTML renderer.

This lets applications attach schema.org metadata at the route layer instead of hand-writing document fragments. It is important for articles, documentation, talks/events, product pages, and other pages where search engines need machine-readable context beyond Open Graph tags.

### SSR response status control

Adds response status control to `ServerRenderContext` via `set_response_status`, carries that status through `RenderedServerRoute`, and uses it for both uncached and cached/revalidated page responses.

This closes a gap in prefix/dynamic SSR routes. A route renderer may successfully render a not-found state, but the HTTP response must still be a `404`. Before this change, Fission always returned `200` for rendered SSR pages. That made it impossible for applications to implement correct HTTP semantics for missing content without wrapping the renderer.

The status defaults to `200`, so existing routes keep the current behavior. Routes that need different semantics can opt in during render-state loading.

## Testing

- Added a server renderer test proving an SSR route renderer can set `404` and that the status is visible through both `render_route` and normal request handling.
- Added a cache build-id test covering runtime, compile-time, and package-version fallback behavior.
- Added Markdown viewer tests proving linked image paragraphs render real image nodes and image-only paragraphs render as wrapping galleries.
- Existing server shell tests cover routing, rendering, handlers, static mounts, forms, structured data, and cache behavior touched by the branch.
