### PR TITLE
Add server i18n, cache invalidation, and route params

### DIFF
--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -24,6 +24,7 @@ base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"
 fission-core = { path = "../../core/fission-core", version = "0.5.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.5.0" }
 fission-ir = { path = "../../core/fission-ir", version = "0.5.0" }
 fission-layout = { path = "../../core/fission-layout", version = "0.5.0" }
 fission-shell-site = { path = "../fission-shell-site", version = "0.5.0" }
@@ -38,5 +39,4 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
-fission-i18n = { path = "../../core/fission-i18n", version = "0.5.0" }
 fission-widgets = { path = "../../authoring/fission-widgets", version = "0.5.0", default-features = false }

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -9,17 +9,22 @@ use fission_core::{
     ActionInput, Effect, Env, GlobalState, MotionDeclaration, RuntimeResourceDeclaration,
     RuntimeResourceKind, RuntimeState, View, Widget, WidgetId,
 };
+use fission_i18n::{I18nRegistry, Locale, TranslationBundle};
 use fission_layout::LayoutSize;
 use fission_theme::Theme;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Arc;
+
+pub type ServerRouteParams = BTreeMap<String, String>;
 
 pub(crate) type RouteRenderer =
     dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<ServerRenderedNode> + Send + Sync + 'static;
 type RequestEnvSync =
     dyn for<'a> Fn(&ServerEnvContext<'a>, &mut Env) -> Result<()> + Send + Sync + 'static;
+type RequestLocaleResolver =
+    dyn for<'a> Fn(&ServerEnvContext<'a>) -> Result<Locale> + Send + Sync + 'static;
 type InitialStateLoader<S> =
     dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<S> + Send + Sync + 'static;
 type HttpHandler =
@@ -44,6 +49,7 @@ pub struct ServerEnvContext<'a> {
     pub action: Option<&'a VerifiedServerAction>,
     pub render_pass_limit: usize,
     pub default_locale: &'a str,
+    pub route_params: ServerRouteParams,
 }
 
 #[derive(Clone)]
@@ -58,6 +64,7 @@ pub struct ServerRenderContext<'a> {
     pub action: Option<&'a VerifiedServerAction>,
     pub render_pass_limit: usize,
     pub default_locale: &'a str,
+    pub route_params: ServerRouteParams,
     pub(crate) env: &'a Env,
     pub(crate) response_status: &'a AtomicU16,
 }
@@ -89,17 +96,40 @@ pub(crate) struct ServerRouteEntry {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ServerRouteMatcher {
     Exact,
+    Dynamic { pattern: String },
     Prefix { prefix: String },
 }
 
 impl ServerRouteMatcher {
-    pub(crate) fn matches(&self, route_path: &str, request_path: &str) -> bool {
+    pub(crate) fn match_request(
+        &self,
+        route_path: &str,
+        request_path: &str,
+    ) -> Option<ServerRouteParams> {
         match self {
-            Self::Exact => route_path == request_path,
-            Self::Prefix { prefix } => {
-                request_path.starts_with(prefix) && request_path.len() > prefix.len()
-            }
+            Self::Exact => (route_path == request_path).then(ServerRouteParams::new),
+            Self::Dynamic { pattern } => match_dynamic_route(pattern, request_path),
+            Self::Prefix { prefix } => (request_path.starts_with(prefix)
+                && request_path.len() > prefix.len())
+            .then(ServerRouteParams::new),
         }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ServerRouteMatch {
+    pub path: String,
+    pub params: ServerRouteParams,
+}
+
+impl ServerRouteEntry {
+    pub(crate) fn match_request(&self, request_path: &str) -> Option<ServerRouteMatch> {
+        self.matcher
+            .match_request(&self.route.path, request_path)
+            .map(|params| ServerRouteMatch {
+                path: request_path.to_string(),
+                params,
+            })
     }
 }
 
@@ -108,6 +138,12 @@ pub(crate) struct ServerHttpHandlerEntry {
     pub method: String,
     pub path: String,
     pub handler: Arc<HttpHandler>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CacheInvalidationEndpoint {
+    pub path: String,
+    pub bearer_token: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -125,9 +161,12 @@ pub struct FissionServerApp {
     pub(crate) theme: Theme,
     pub(crate) env: Env,
     pub(crate) request_env_sync: Option<Arc<RequestEnvSync>>,
+    pub(crate) locale_resolver: Option<Arc<RequestLocaleResolver>>,
+    pub(crate) default_locale: Locale,
     pub(crate) jobs: ServerJobRegistry,
     pub(crate) routes: Vec<ServerRouteEntry>,
     pub(crate) http_handlers: Vec<ServerHttpHandlerEntry>,
+    pub(crate) cache_invalidation_endpoints: Vec<CacheInvalidationEndpoint>,
     pub(crate) static_mounts: Vec<StaticMount>,
     pub(crate) user_css: Vec<String>,
 }
@@ -140,9 +179,12 @@ impl FissionServerApp {
             theme: Theme::default(),
             env: Env::default(),
             request_env_sync: None,
+            locale_resolver: None,
+            default_locale: Locale::from("en"),
             jobs: ServerJobRegistry::new(),
             routes: Vec::new(),
             http_handlers: Vec::new(),
+            cache_invalidation_endpoints: Vec::new(),
             static_mounts: Vec::new(),
             user_css: Vec::new(),
         }
@@ -162,6 +204,31 @@ impl FissionServerApp {
     pub fn with_env(mut self, env: Env) -> Self {
         self.env = env;
         self.env.theme = self.theme.clone();
+        self
+    }
+
+    pub fn i18n(mut self, i18n: I18nRegistry) -> Self {
+        self.env.i18n = i18n;
+        self
+    }
+
+    pub fn translation_bundle(mut self, bundle: TranslationBundle) -> Self {
+        self.env.i18n.add_bundle(bundle);
+        self
+    }
+
+    pub fn default_locale(mut self, locale: impl Into<Locale>) -> Self {
+        let locale = locale.into();
+        self.env.locale = locale.clone();
+        self.default_locale = locale;
+        self
+    }
+
+    pub fn locale_resolver<F>(mut self, resolver: F) -> Self
+    where
+        F: for<'a> Fn(&ServerEnvContext<'a>) -> Result<Locale> + Send + Sync + 'static,
+    {
+        self.locale_resolver = Some(Arc::new(resolver));
         self
     }
 
@@ -205,6 +272,19 @@ impl FissionServerApp {
         F: for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static,
     {
         self.http_handler("POST", path, handler)
+    }
+
+    pub fn cache_invalidation_endpoint(
+        mut self,
+        path: impl Into<String>,
+        bearer_token: impl Into<String>,
+    ) -> Self {
+        self.cache_invalidation_endpoints
+            .push(CacheInvalidationEndpoint {
+                path: normalize_server_path(&path.into()),
+                bearer_token: bearer_token.into(),
+            });
+        self
     }
 
     pub fn static_dir(
@@ -267,9 +347,10 @@ impl FissionServerApp {
     {
         let widget = Arc::new(widget);
         let initial_state: Arc<InitialStateLoader<S>> = Arc::new(initial_state);
+        let route_path = normalize_server_path(&path.into());
         self.routes.push(ServerRouteEntry {
             route: WebRoute {
-                path: normalize_server_path(&path.into()),
+                path: route_path.clone(),
                 title: title.into(),
                 description: description.into(),
                 mode,
@@ -277,7 +358,7 @@ impl FissionServerApp {
                 islands: Vec::new(),
                 structured_data: Vec::new(),
             },
-            matcher: ServerRouteMatcher::Exact,
+            matcher: matcher_for_route_path(&route_path),
             render: Arc::new(move |ctx| {
                 let state = initial_state(ctx)?;
                 render_widget_node::<S, W>(widget.as_ref(), ctx, state)
@@ -396,9 +477,16 @@ impl FissionServerApp {
                 matches!(entry.matcher, ServerRouteMatcher::Exact) && entry.route.path == path
             })
             .or_else(|| {
-                self.routes
-                    .iter()
-                    .find(|entry| entry.matcher.matches(&entry.route.path, &path))
+                self.routes.iter().find(|entry| {
+                    matches!(entry.matcher, ServerRouteMatcher::Dynamic { .. })
+                        && entry.match_request(&path).is_some()
+                })
+            })
+            .or_else(|| {
+                self.routes.iter().find(|entry| {
+                    matches!(entry.matcher, ServerRouteMatcher::Prefix { .. })
+                        && entry.match_request(&path).is_some()
+                })
             })
     }
 
@@ -412,6 +500,16 @@ impl FissionServerApp {
         self.http_handlers
             .iter()
             .find(|entry| entry.method == method && entry.path == path)
+    }
+
+    pub(crate) fn find_cache_invalidation_endpoint(
+        &self,
+        path: &str,
+    ) -> Option<&CacheInvalidationEndpoint> {
+        let path = normalize_server_path(path);
+        self.cache_invalidation_endpoints
+            .iter()
+            .find(|entry| entry.path == path)
     }
 
     pub(crate) fn apply_default_route_mode(&mut self, mode: WebRouteMode) {
@@ -430,11 +528,54 @@ impl FissionServerApp {
         env.theme = ctx.theme.clone();
         env.viewport_size = ctx.viewport_size;
         env.locale = ctx.default_locale.into();
+        env.current_route.pathname = ctx.route_path.to_string();
+        if let Some(resolve_locale) = &self.locale_resolver {
+            env.locale = resolve_locale(ctx)?;
+        }
         if let Some(sync) = &self.request_env_sync {
             sync(ctx, &mut env)?;
         }
         Ok(env)
     }
+}
+
+fn matcher_for_route_path(path: &str) -> ServerRouteMatcher {
+    if path
+        .trim_matches('/')
+        .split('/')
+        .any(|segment| segment.starts_with(':') && segment.len() > 1)
+    {
+        ServerRouteMatcher::Dynamic {
+            pattern: path.to_string(),
+        }
+    } else {
+        ServerRouteMatcher::Exact
+    }
+}
+
+fn match_dynamic_route(pattern: &str, path: &str) -> Option<ServerRouteParams> {
+    let pattern = pattern.trim_matches('/');
+    let path = path.trim_matches('/');
+    if pattern.is_empty() || path.is_empty() {
+        return (pattern == path).then(ServerRouteParams::new);
+    }
+    let pattern_segments = pattern.split('/').collect::<Vec<_>>();
+    let path_segments = path.split('/').collect::<Vec<_>>();
+    if pattern_segments.len() != path_segments.len() {
+        return None;
+    }
+    let mut params = ServerRouteParams::new();
+    for (pattern_segment, path_segment) in pattern_segments.into_iter().zip(path_segments) {
+        if let Some(name) = pattern_segment.strip_prefix(':') {
+            if name.is_empty() {
+                return None;
+            }
+            params.insert(name.to_string(), path_segment.to_string());
+        } else if pattern_segment != path_segment {
+            return None;
+        }
+    }
+    Some(params)
 }
 
 fn render_widget_node<S, W>(

--- a/crates/shell/fission-shell-server/src/cache.rs
+++ b/crates/shell/fission-shell-server/src/cache.rs
@@ -186,10 +186,11 @@ pub enum Freshness {
     Expired,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InvalidationReport {
     pub removed_keys: usize,
     pub removed_tags: usize,
+    pub layers_affected: usize,
 }
 
 pub trait Cache: Send + Sync + 'static {
@@ -204,6 +205,7 @@ pub trait Cache: Send + Sync + 'static {
             let report = self.invalidate_tag(tag)?;
             out.removed_keys += report.removed_keys;
             out.removed_tags += report.removed_tags;
+            out.layers_affected += report.layers_affected;
         }
         Ok(out)
     }
@@ -301,6 +303,7 @@ impl Cache for MokaCache {
         Ok(InvalidationReport {
             removed_keys: keys.len(),
             removed_tags: usize::from(!keys.is_empty()),
+            layers_affected: usize::from(!keys.is_empty()),
         })
     }
 }
@@ -421,6 +424,7 @@ impl Cache for RedisCache {
         Ok(InvalidationReport {
             removed_keys: keys.len(),
             removed_tags: usize::from(!keys.is_empty()),
+            layers_affected: usize::from(!keys.is_empty()),
         })
     }
 }
@@ -491,6 +495,7 @@ impl Cache for CachePipeline {
             let report = layer.invalidate_tag(tag)?;
             out.removed_keys += report.removed_keys;
             out.removed_tags += report.removed_tags;
+            out.layers_affected += report.layers_affected;
         }
         Ok(out)
     }
@@ -536,6 +541,7 @@ mod tests {
         assert!(cache.get(&key).unwrap().is_some());
         let report = cache.invalidate_tag(&CacheTag::new("catalog")).unwrap();
         assert_eq!(report.removed_keys, 1);
+        assert_eq!(report.layers_affected, 1);
         assert!(cache.get(&key).unwrap().is_none());
     }
 
@@ -627,6 +633,7 @@ mod tests {
         let report = pipeline.invalidate_tag(&CacheTag::new("catalog")).unwrap();
 
         assert_eq!(report.removed_keys, 2);
+        assert_eq!(report.layers_affected, 2);
         assert!(hot.get(&key).unwrap().is_none());
         assert!(shared.get(&key).unwrap().is_none());
     }

--- a/crates/shell/fission-shell-server/src/lib.rs
+++ b/crates/shell/fission-shell-server/src/lib.rs
@@ -24,7 +24,8 @@ pub use adapters::actix_adapter;
 pub use adapters::axum_adapter;
 pub use adapters::hyper_adapter;
 pub use app::{
-    FissionServerApp, ServerEnvContext, ServerHttpContext, ServerRenderContext, StaticMount,
+    FissionServerApp, ServerEnvContext, ServerHttpContext, ServerRenderContext, ServerRouteParams,
+    StaticMount,
 };
 pub use artifacts::{
     BrowserArtifactBuild, BrowserArtifactBuildOptions, BrowserArtifactKind, BrowserArtifactPlan,

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -1,6 +1,6 @@
 use crate::app::{
-    normalize_server_path, FissionServerApp, ServerEnvContext, ServerHttpContext,
-    ServerRenderedNode, ServerRouteEntry, StaticMount,
+    normalize_server_path, CacheInvalidationEndpoint, FissionServerApp, ServerEnvContext,
+    ServerHttpContext, ServerRenderedNode, ServerRouteEntry, ServerRouteMatch, StaticMount,
 };
 use crate::{
     Cache, CacheEntry, CacheKey, CacheMetadata, CachePipeline, CacheScope, CacheTag, Freshness,
@@ -18,7 +18,7 @@ use fission_shell_site::{
     render_ir_to_html_with_styles, site_base_css, site_enhancement_js, theme_variables_css,
     CssVariableMap, HtmlRenderOptions, StyleRegistry,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -113,6 +113,14 @@ impl ServerSession {
     }
 }
 
+#[derive(Clone, Debug, Default, Deserialize)]
+struct CacheInvalidationPayload {
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    keys: Vec<String>,
+}
+
 #[derive(Clone, Debug)]
 pub struct RenderedServerRoute {
     pub route: WebRoute,
@@ -143,6 +151,7 @@ pub struct ServerRenderer {
 impl ServerRenderer {
     pub fn new(app: FissionServerApp) -> Self {
         let jobs = app.jobs.clone();
+        let default_locale = app.default_locale.0.clone();
         Self {
             app,
             cache: Arc::new(MokaCache::default()),
@@ -152,7 +161,7 @@ impl ServerRenderer {
             allowed_action_origins: BTreeSet::new(),
             render_pass_limit: 4,
             viewport_size: LayoutSize::new(1280.0, 900.0),
-            default_locale: "en".to_string(),
+            default_locale,
             http_config: ServerHttpConfig::default(),
             session_config: ServerSessionConfig::default(),
             session_signing_key: None,
@@ -197,6 +206,23 @@ impl ServerRenderer {
     pub fn remove_cache_entry(&self, key: &CacheKey) -> Result<()> {
         self.cache.remove(key)?;
         Ok(())
+    }
+
+    pub fn remove_cache_entries<I, K>(&self, keys: I) -> Result<InvalidationReport>
+    where
+        I: IntoIterator<Item = K>,
+        K: Into<String>,
+    {
+        let mut report = InvalidationReport::default();
+        for key in keys {
+            let key = CacheKey::new(key.into());
+            if self.cache.get(&key)?.is_some() {
+                report.removed_keys += 1;
+                report.layers_affected = report.layers_affected.max(1);
+            }
+            self.cache.remove(&key)?;
+        }
+        Ok(report)
     }
 
     pub fn invalidate_cache_tag(&self, tag: impl Into<CacheTag>) -> Result<InvalidationReport> {
@@ -278,6 +304,11 @@ impl ServerRenderer {
         {
             return self.handle_action(request);
         }
+        if request.method == "POST" {
+            if let Some(endpoint) = self.app.find_cache_invalidation_endpoint(&request.path) {
+                return self.handle_cache_invalidation(endpoint, &request);
+            }
+        }
         if let Some(handler) = self.app.find_http_handler(&request.method, &request.path) {
             let session = self.session_for_request(&request)?;
             let ctx = ServerHttpContext {
@@ -325,7 +356,7 @@ impl ServerRenderer {
         let session = self.session_for_request(&request)?;
 
         if let WebRouteMode::Revalidated(policy) = &route.route.mode {
-            let route_path = matched_route_path(route, &request);
+            let route_path = matched_route(route, &request).path;
             let env = self.env_for_route(route, None, &request, &session)?;
             let cache_key = self.cache_key_for_route(&route.route, &request, &env);
             let now = SystemTime::now();
@@ -387,6 +418,41 @@ impl ServerRenderer {
         Ok(response)
     }
 
+    fn handle_cache_invalidation(
+        &self,
+        endpoint: &CacheInvalidationEndpoint,
+        request: &ServerRequest,
+    ) -> Result<ServerResponse> {
+        let expected = format!("Bearer {}", endpoint.bearer_token);
+        if header_value(&request.headers, "authorization").map(String::as_str) != Some(&expected) {
+            return Ok(ServerResponse::text(
+                401,
+                "application/json; charset=utf-8",
+                r#"{"error":"unauthorized"}"#,
+            ));
+        }
+        let payload: CacheInvalidationPayload = serde_json::from_slice(&request.body)
+            .map_err(|error| anyhow!("invalid cache invalidation request body: {error}"))?;
+        if payload.tags.is_empty() && payload.keys.is_empty() {
+            return Ok(ServerResponse::text(
+                400,
+                "application/json; charset=utf-8",
+                r#"{"error":"no tags or keys provided"}"#,
+            ));
+        }
+
+        let mut report = self.invalidate_cache_tags(payload.tags)?;
+        let key_report = self.remove_cache_entries(payload.keys)?;
+        report.removed_keys += key_report.removed_keys;
+        report.removed_tags += key_report.removed_tags;
+        report.layers_affected += key_report.layers_affected;
+        Ok(ServerResponse::text(
+            200,
+            "application/json; charset=utf-8",
+            serde_json::to_vec(&report)?,
+        ))
+    }
+
     fn render_uncached(
         &self,
         route: &ServerRouteEntry,
@@ -406,7 +472,8 @@ impl ServerRenderer {
         session: &ServerSession,
         env: Env,
     ) -> Result<RenderedServerRoute> {
-        let route_path = matched_route_path(route, request);
+        let route_match = matched_route(route, request);
+        let route_path = route_match.path;
         let response_status = AtomicU16::new(200);
         let ctx = crate::ServerRenderContext {
             project_dir: &self.app.project_dir,
@@ -419,6 +486,7 @@ impl ServerRenderer {
             action,
             render_pass_limit: self.render_pass_limit,
             default_locale: &self.default_locale,
+            route_params: route_match.params,
             env: &env,
             response_status: &response_status,
         };
@@ -829,10 +897,10 @@ impl ServerRenderer {
         request: &ServerRequest,
         session: &ServerSession,
     ) -> Result<Env> {
-        let route_path = matched_route_path(route, request);
+        let route_match = matched_route(route, request);
         let ctx = ServerEnvContext {
             project_dir: &self.app.project_dir,
-            route_path: &route_path,
+            route_path: &route_match.path,
             theme: &self.app.theme,
             viewport_size: self.viewport_size,
             jobs: &self.jobs,
@@ -841,6 +909,7 @@ impl ServerRenderer {
             action,
             render_pass_limit: self.render_pass_limit,
             default_locale: &self.default_locale,
+            route_params: route_match.params,
         };
         self.app.env_for_context(&ctx)
     }
@@ -929,13 +998,14 @@ fn cache_build_id_from(
         .unwrap_or_else(|| package_version.to_string())
 }
 
-fn matched_route_path(route: &ServerRouteEntry, request: &ServerRequest) -> String {
+fn matched_route(route: &ServerRouteEntry, request: &ServerRequest) -> ServerRouteMatch {
     let request_path = normalize_server_path(&request.path);
-    if route.matcher.matches(&route.route.path, &request_path) {
-        request_path
-    } else {
-        route.route.path.clone()
-    }
+    route
+        .match_request(&request_path)
+        .unwrap_or_else(|| ServerRouteMatch {
+            path: route.route.path.clone(),
+            params: Default::default(),
+        })
 }
 
 fn cache_from_config(config: &crate::ServerCacheConfig) -> Result<Arc<dyn Cache>> {
@@ -1566,6 +1636,55 @@ mod tests {
     }
 
     #[test]
+    fn server_app_registers_i18n_bundle_and_default_locale() {
+        let app = FissionServerApp::new("Test")
+            .translation_bundle(TranslationBundle {
+                locale: "fr".into(),
+                messages: HashMap::from([("page.title".to_string(), "Bonjour SSR".to_string())]),
+            })
+            .default_locale("fr")
+            .route_widget::<TestState, _>(
+                "/",
+                "Home",
+                None,
+                WebRouteMode::Server(Default::default()),
+                KeyPage("page.title"),
+            );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer.handle(ServerRequest::get("/")).unwrap();
+        let body = response.body_string();
+
+        assert_eq!(response.status, 200);
+        assert!(body.contains("Bonjour SSR"));
+        assert!(body.contains("lang=\"fr\""));
+    }
+
+    #[test]
+    fn locale_resolver_can_use_dynamic_route_params() {
+        let app = FissionServerApp::new("Test")
+            .with_env(translated_env())
+            .locale_resolver(|ctx| Ok(ctx.route_params["locale"].as_str().into()))
+            .route_widget::<TestState, _>(
+                "/locale/:locale/catalog",
+                "Catalog",
+                None,
+                WebRouteMode::Server(Default::default()),
+                KeyPage("catalog.title"),
+            );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer
+            .handle(ServerRequest::get("/locale/fr/catalog"))
+            .unwrap();
+        let body = response.body_string();
+
+        assert_eq!(response.status, 200);
+        assert!(body.contains("Catalogue"));
+        assert!(body.contains("lang=\"fr\""));
+    }
+
+    #[test]
     fn prefix_routes_receive_concrete_request_path() {
         let app = FissionServerApp::new("Test").route_prefix_widget_with_state::<PathState, _, _>(
             "/docs/",
@@ -1587,6 +1706,59 @@ mod tests {
 
         assert_eq!(response.status, 200);
         assert!(response.body_string().contains("/docs/platform/"));
+    }
+
+    #[test]
+    fn dynamic_routes_expose_route_params() {
+        let app = FissionServerApp::new("Test").route_widget_with_state::<PathState, _, _>(
+            "/items/:item_id",
+            "Item",
+            None,
+            WebRouteMode::Server(Default::default()),
+            PathPage,
+            |ctx| {
+                Ok(PathState {
+                    route_path: ctx.route_params["item_id"].clone(),
+                })
+            },
+        );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer.handle(ServerRequest::get("/items/42")).unwrap();
+
+        assert_eq!(response.status, 200);
+        assert!(response.body_string().contains("42"));
+    }
+
+    #[test]
+    fn exact_routes_win_over_dynamic_routes() {
+        let app = FissionServerApp::new("Test")
+            .route_widget::<TestState, _>(
+                "/items/new",
+                "New",
+                None,
+                WebRouteMode::Server(Default::default()),
+                TestPage("exact new item page"),
+            )
+            .route_widget_with_state::<PathState, _, _>(
+                "/items/:item_id",
+                "Item",
+                None,
+                WebRouteMode::Server(Default::default()),
+                PathPage,
+                |ctx| {
+                    Ok(PathState {
+                        route_path: ctx.route_params["item_id"].clone(),
+                    })
+                },
+            );
+        let renderer = ServerRenderer::new(app);
+
+        let response = renderer.handle(ServerRequest::get("/items/new")).unwrap();
+
+        assert_eq!(response.status, 200);
+        assert!(response.body_string().contains("exact new item page"));
+        assert!(!response.body_string().contains(">new<"));
     }
 
     #[test]
@@ -1772,6 +1944,64 @@ mod tests {
         );
         let helper_report = renderer.invalidate_cache_tag("post:1").unwrap();
         assert_eq!(helper_report.removed_keys, 1);
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::get("/posts"))
+                .unwrap()
+                .cache_status,
+            Some(Freshness::Expired)
+        );
+    }
+
+    #[test]
+    fn protected_cache_invalidation_endpoint_invalidates_tags() {
+        let app = FissionServerApp::new("Test")
+            .cache_invalidation_endpoint("/admin/cache/invalidate", "secret")
+            .route_widget::<TestState, _>(
+                "/posts",
+                "Posts",
+                None,
+                WebRouteMode::Revalidated(
+                    RevalidationPolicy::new(Duration::from_secs(60)).tag("posts"),
+                ),
+                TestPage("Posts"),
+            );
+        let renderer = ServerRenderer::new(app);
+
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::get("/posts"))
+                .unwrap()
+                .cache_status,
+            Some(Freshness::Expired)
+        );
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::get("/posts"))
+                .unwrap()
+                .cache_status,
+            Some(Freshness::Fresh)
+        );
+
+        let denied = renderer
+            .handle(ServerRequest::post(
+                "/admin/cache/invalidate",
+                br#"{"tags":["posts"]}"#.to_vec(),
+            ))
+            .unwrap();
+        assert_eq!(denied.status, 401);
+
+        let mut request =
+            ServerRequest::post("/admin/cache/invalidate", br#"{"tags":["posts"]}"#.to_vec());
+        request
+            .headers
+            .insert("authorization".to_string(), "Bearer secret".to_string());
+        let invalidated = renderer.handle(request).unwrap();
+
+        assert_eq!(invalidated.status, 200);
+        let report: InvalidationReport = serde_json::from_slice(&invalidated.body).unwrap();
+        assert_eq!(report.removed_keys, 1);
+        assert_eq!(report.layers_affected, 1);
         assert_eq!(
             renderer
                 .handle(ServerRequest::get("/posts"))

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -89,7 +89,7 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 
 ```toml
 [dependencies]
-fission = { version = "0.3", features = ["server", "server-redis"] }
+fission = { version = "0.5.0", features = ["server", "server-redis"] }
 ```
 
 ## Invalidate cached pages after writes
@@ -110,7 +110,42 @@ Admin and publishing workflows can call the renderer helpers instead:
 renderer.invalidate_cache_tags(["posts", "post:hello-world"])?;
 ```
 
-Both paths return an `InvalidationReport` so the caller can log how many cache keys and tag indexes were removed.
+Both paths return an `InvalidationReport` so the caller can log how many cache keys, tag indexes, and cache layers were affected.
+
+For an external publisher, register a protected invalidation endpoint on the app:
+
+```rust
+let app = FissionServerApp::new("Docs")
+    .cache_invalidation_endpoint(
+        "/admin/cache/invalidate",
+        std::env::var("CACHE_INVALIDATION_TOKEN")?,
+    )
+    .route_widget::<DocsState, _>(
+        "/posts/:slug",
+        "Post",
+        None,
+        WebRouteMode::Revalidated(
+            RevalidationPolicy::new(Duration::from_secs(300))
+                .tags(["posts", "post:hello-world"]),
+        ),
+        PostPage,
+    );
+```
+
+Then the publishing workflow can invalidate related entries without knowing whether the active provider is Moka, Redis, or a cache pipeline:
+
+```bash
+curl -X POST https://example.com/admin/cache/invalidate \
+  -H "Authorization: Bearer $CACHE_INVALIDATION_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"tags":["posts","post:hello-world"]}'
+```
+
+The endpoint also accepts explicit cache keys when a workflow owns the exact key:
+
+```json
+{"tags":["posts"],"keys":["page:/posts/?#app:Docs#..."]}
+```
 
 ## 3. Configure sessions before using private routes
 

--- a/documentation/content/docs/guides/server-sites.mdx
+++ b/documentation/content/docs/guides/server-sites.mdx
@@ -79,6 +79,24 @@ pub fn pokemon_card_store_server() -> FissionServerApp {
 
 The route widget remains the page's source of truth. Jobs describe when data is prepared before HTML is returned. Route mode describes whether the rendered page is public, revalidated, request-rendered, or session-private. Workers and islands describe browser-side enhancement without turning the whole page into one large browser app.
 
+Server routes use the same `:param` segment syntax as the widget router. A route such as `/cards/:slug` receives extracted parameters in `ServerRenderContext::route_params`, so the initial state loader can fetch the correct product before the widget tree is built:
+
+```rust
+.route_widget_with_state::<StoreState, _, _>(
+    "/cards/:slug",
+    "Card detail",
+    None,
+    WebRouteMode::ServerPrivate(ServerPrivatePolicy::default()),
+    CardDetailPage,
+    |ctx| {
+        let slug = ctx.route_params["slug"].clone();
+        Ok(StoreState::for_card(ctx.session.id(), slug))
+    },
+)
+```
+
+Exact routes take precedence over dynamic routes, so `/cards/new` can still be registered as its own route before `/cards/:slug`.
+
 ## 3. Use a normal CLI entrypoint
 
 The binary delegates to the server shell's CLI runner.

--- a/documentation/content/docs/guides/theming-and-i18n.mdx
+++ b/documentation/content/docs/guides/theming-and-i18n.mdx
@@ -295,15 +295,17 @@ Server-rendered apps and static sites use the same `Env` data, but they resolve 
 ```rust
 FissionServerApp::new("Docs")
     .with_env(create_env()?)
-    .with_request_env(|ctx, env| {
-        if ctx.route_path.starts_with("/fr/") {
-            env.locale = "fr".into();
-        }
-        Ok(())
+    .default_locale("en-US")
+    .locale_resolver(|ctx| {
+        Ok(if ctx.route_path.starts_with("/fr/") {
+            "fr".into()
+        } else {
+            ctx.default_locale.into()
+        })
     });
 ```
 
-For a static site, call `FissionSite::with_env(create_env()?)`. The static-site shell seeds `env.locale` from `site.default_locale` while rendering. The server shell seeds `env.locale` from `server.default_locale` and then runs `.with_request_env(...)`, so request-owned choices such as locale from a route prefix, cookie, session, or header can override the default.
+For a static site, call `FissionSite::with_env(create_env()?)`. The static-site shell seeds `env.locale` from `site.default_locale` while rendering. The server shell seeds `env.locale` from `server.default_locale` or `.default_locale(...)`, then runs `.locale_resolver(...)` and `.with_request_env(...)`, so request-owned choices such as locale from a route prefix, cookie, session, or header can override the default.
 
 This example has two separate jobs.
 

--- a/documentation/content/reference/core/theming-and-i18n.mdx
+++ b/documentation/content/reference/core/theming-and-i18n.mdx
@@ -55,13 +55,13 @@ Use a preset when it matches the platform or brand direction you want. Copy it i
 
 `Env` carries the active theme, internationalization registry, locale, and other app-wide presentation context. During component conversion, widgets can read those values through `view.env` or convenience helpers such as `view.theme()`.
 
-Desktop exposes both `with_env(...)` and `with_sync_env(...)`. Mobile and web expose `with_sync_env(...)`. Server-rendered apps expose `with_env(...)` and `with_request_env(...)`. Static sites expose `with_env(...)`.
+Desktop exposes both `with_env(...)` and `with_sync_env(...)`. Mobile and web expose `with_sync_env(...)`. Server-rendered apps expose `with_env(...)`, `i18n(...)`, `translation_bundle(...)`, `default_locale(...)`, `locale_resolver(...)`, and `with_request_env(...)`. Static sites expose `with_env(...)`.
 
 Use `with_env(...)` to seed a base environment before the first frame, such as one that already contains translation bundles.
 
 Use `with_sync_env(...)` when app state should update environment values every frame, such as mirroring a user-selected theme mode, locale, or window title into `Env`.
 
-Use `with_request_env(...)` on `FissionServerApp` when request data should select presentation context before SSR, such as choosing `env.locale` from a path prefix, header, cookie, or session. The server shell uses the resolved request `Env` for both widget building and lowering, so `TextContent::Key` resolves consistently in rendered HTML.
+Use `translation_bundle(...)` or `i18n(...)` on `FissionServerApp` to register server-side bundles. Use `default_locale(...)` for the fallback locale and `locale_resolver(...)` when request data should select the locale before SSR, such as choosing from a path prefix, route parameter, header, cookie, or session. Use `with_request_env(...)` for other request-owned `Env` values. The server shell uses the resolved request `Env` for both widget building and lowering, so `TextContent::Key` resolves consistently in rendered HTML.
 
 ```rust
 DesktopApp::new(MyApp)


### PR DESCRIPTION
## Summary
- add server app APIs for i18n registries, translation bundles, default locale, and request locale resolution
- expose dynamic SSR route params on server env/render contexts while preserving exact-route precedence
- add protected batched cache invalidation endpoints and layer-aware invalidation reports
- document the server i18n, dynamic route, and publishing invalidation flows

## Verification
- cargo fmt --check
- cargo test -p fission-shell-server
- cargo test -p fission-shell-server --features redis

Closes #66
Closes #67
Closes #74