### PR TITLE
Fix iOS Vello GPU rendering

### DIFF
--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -736,27 +736,8 @@ fn create_native_main_renderer(
         ));
     }
 
-    if matches!(request, RendererRequest::Auto)
-        && cfg!(target_os = "ios")
-        && !supports_indirect_execution
-    {
-        return Ok((
-            MainRenderer::Software,
-            RendererReport::new(
-                "native-software-upload",
-                request,
-                backend,
-                adapter,
-                Some("ios_adapter_missing_indirect_execution".to_string()),
-                width,
-                height,
-                scale_factor,
-            ),
-        ));
-    }
-
     let cpu_requested = matches!(request, RendererRequest::NativeVelloCpu);
-    match create_vello_main_renderer(device_handle, cpu_requested) {
+    match create_vello_main_renderer(device_handle, cpu_requested, supports_indirect_execution) {
         Ok(renderer) => {
             let active = if cpu_requested {
                 "native-vello-cpu"
@@ -774,6 +755,8 @@ fn create_native_main_renderer(
                     adapter,
                     if matches!(request, RendererRequest::NativeVelloCpu) {
                         Some("forced_cpu_vello".to_string())
+                    } else if !supports_indirect_execution {
+                        Some("direct_dispatch_fallback".to_string())
                     } else if cpu_requested {
                         Some("missing_indirect_execution".to_string())
                     } else {
@@ -788,7 +771,7 @@ fn create_native_main_renderer(
         Err(gpu_error) if request.is_explicit_gpu() => Err(anyhow::anyhow!(
             "requested native Vello GPU renderer but initialization failed: {gpu_error}"
         )),
-        Err(gpu_error) => match create_vello_main_renderer(device_handle, true) {
+        Err(gpu_error) => match create_vello_main_renderer(device_handle, true, true) {
             Ok(renderer) => Ok((
                 renderer,
                 RendererReport::new(
@@ -825,11 +808,13 @@ fn create_native_main_renderer(
 fn create_vello_main_renderer(
     device_handle: &vello::util::DeviceHandle,
     use_cpu: bool,
+    use_indirect_dispatch: bool,
 ) -> anyhow::Result<MainRenderer> {
     let renderer = VelloSceneRenderer::new(
         &device_handle.device,
         RendererOptions {
             use_cpu,
+            use_indirect_dispatch,
             antialiasing_support: AaSupport::all(),
             num_init_threads: None,
             pipeline_cache: None,
@@ -951,6 +936,7 @@ fn create_webgpu_main_renderer(
         &device_handle.device,
         RendererOptions {
             use_cpu: false,
+            use_indirect_dispatch: true,
             antialiasing_support: AaSupport::all(),
             num_init_threads: None,
             pipeline_cache: None,

--- a/crates/shell/fission-shell-winit/src/software_renderer.rs
+++ b/crates/shell/fission-shell-winit/src/software_renderer.rs
@@ -138,7 +138,6 @@ fn pixmap_byte_len(image: &Pixmap) -> u64 {
 fn image_request_with_default_cache_size(
     request: &ImageRequest,
     rect: fission_render::LayoutRect,
-    scale_factor: f32,
 ) -> ImageRequest {
     if request.cache_width.is_some() && request.cache_height.is_some() {
         return request.clone();
@@ -147,10 +146,12 @@ fn image_request_with_default_cache_size(
         return request.clone();
     }
 
-    let scale = normalized_scale_factor(scale_factor).max(1.0);
+    // tiny-skia applies the renderer scale through the draw transform. Keeping
+    // cache dimensions in logical pixels prevents high-DPI images from being
+    // over-sized and then clipped as pattern fills.
     let mut request = request.clone();
-    request.cache_width = Some(cache_dimension_from_extent(rect.width() * scale));
-    request.cache_height = Some(cache_dimension_from_extent(rect.height() * scale));
+    request.cache_width = Some(cache_dimension_from_extent(rect.width()));
+    request.cache_height = Some(cache_dimension_from_extent(rect.height()));
     request
 }
 
@@ -665,6 +666,24 @@ mod image_tests {
         bytes.into_inner()
     }
 
+    fn centered_mark_png(width: u32, height: u32) -> Vec<u8> {
+        let mut image = image::RgbaImage::from_pixel(width, height, image::Rgba([8, 8, 12, 255]));
+        let mark_x0 = width / 3;
+        let mark_x1 = width - mark_x0;
+        let mark_y0 = height / 3;
+        let mark_y1 = height - mark_y0;
+        for y in mark_y0..mark_y1 {
+            for x in mark_x0..mark_x1 {
+                image.put_pixel(x, y, image::Rgba([245, 245, 245, 255]));
+            }
+        }
+        let mut bytes = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(image)
+            .write_to(&mut bytes, image::ImageFormat::Png)
+            .expect("encode centered mark png");
+        bytes.into_inner()
+    }
+
     fn serve_once(body: Vec<u8>) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test image server");
         let url = format!("http://{}", listener.local_addr().expect("local addr"));
@@ -865,6 +884,71 @@ mod image_tests {
         assert!(
             pixel_at(4, 4)[3] > 0 && pixel_at(4, 4)[0] > 0,
             "expected destination rect to contain image pixels"
+        );
+    }
+
+    #[test]
+    fn scaled_memory_image_paints_center_pixels() {
+        let rect = fission_render::LayoutRect::new(40.0, 161.55, 144.0, 144.0);
+        let request = ImageRequest {
+            source: ImageSource::Memory {
+                bytes: centered_mark_png(256, 256),
+                mime_type: Some("image/png".into()),
+            },
+            ..Default::default()
+        };
+        let request = image_request_with_default_cache_size(&request, rect);
+        let key = request.stable_cache_key();
+        image_cache().invalidate(&key);
+        image_cache().run_pending_tasks();
+        let before = image_cache_generation();
+        spawn_image_load(key.clone(), request.clone());
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while image_cache_generation() == before && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let mut display_list =
+            DisplayList::new(fission_render::LayoutRect::new(0.0, 0.0, 320.0, 480.0));
+        display_list.push(DisplayOp::DrawImage {
+            rect,
+            request,
+            fit: ImageFit::Contain,
+            alignment: ImageAlignment::Center,
+            bounds: rect,
+            node_id: None,
+        });
+        let scene = RenderScene::from_display_list(display_list);
+        let pixels = SoftwareRenderer::render(
+            &scene,
+            960,
+            1440,
+            RenderColor {
+                r: 34,
+                g: 39,
+                b: 52,
+                a: 255,
+            },
+            3.0,
+        )
+        .expect("render scale probe");
+
+        let mut bright_pixels = 0;
+        for y in 660..735 {
+            for x in 300..375 {
+                let offset = ((y * 960 + x) * 4) as usize;
+                let r = pixels[offset];
+                let g = pixels[offset + 1];
+                let b = pixels[offset + 2];
+                if r > 200 && g > 200 && b > 200 {
+                    bright_pixels += 1;
+                }
+            }
+        }
+        assert!(
+            bright_pixels > 500,
+            "expected scaled image center to remain visible, found {bright_pixels} bright pixels"
         );
     }
 }
@@ -1395,7 +1479,7 @@ impl SoftwareRenderer {
             return Ok(());
         }
 
-        let request = image_request_with_default_cache_size(request, rect, self.scale_factor);
+        let request = image_request_with_default_cache_size(request, rect);
         let image = match cached_image(&request) {
             Some(image) => image,
             None => return Ok(()),
@@ -1434,7 +1518,6 @@ impl SoftwareRenderer {
             }
             ImageFit::None => (1.0, 1.0, rect.origin.x, rect.origin.y),
         };
-
         let transform = self.device_transform(
             self.current_state()
                 .transform

--- a/examples/mobile-smoke/src/lib.rs
+++ b/examples/mobile-smoke/src/lib.rs
@@ -1,5 +1,7 @@
 use fission::prelude::*;
 
+const FISSION_LOGO_PNG: &[u8] = include_bytes!("../../../docs/fission_logo.png");
+
 #[cfg(target_os = "android")]
 const ANDROID_TEST_CONTROL_PORT: u16 = 48761;
 
@@ -56,6 +58,28 @@ impl From<MobileSmokeApp> for Widget {
                     .color(body)
                     .max_width(content_width)
                     .into(),
+                Text::new("Image probe")
+                    .size(14.0)
+                    .color(body)
+                    .max_width(content_width)
+                    .into(),
+                Container::new(
+                    Image::memory(FISSION_LOGO_PNG.to_vec())
+                        .size(144.0, 144.0)
+                        .fit(fission::core::op::ImageFit::Contain)
+                        .semantic_label("Fission logo image probe"),
+                )
+                .size(content_width, 176.0)
+                .padding_all(16.0)
+                .bg(Color {
+                    r: 34,
+                    g: 39,
+                    b: 52,
+                    a: 255,
+                })
+                .border(accent, 1.0)
+                .border_radius(20.0)
+                .into(),
                 Text::new(format!("Taps: {}", view.state().taps))
                     .size(22.0)
                     .color(accent)


### PR DESCRIPTION
## Summary

- keep iOS on the Vello GPU renderer instead of falling back to the software upload path when the adapter lacks indirect execution
- pass the adapter's indirect-dispatch capability into the Fission Vello fork
- update the vendored Vello fork to avoid `INDIRECT` buffer usage on direct-dispatch fallback paths and conservatively direct-dispatch Vello's indirect stages

## Evidence

- `cargo test -p fission-vello direct_dispatch_fallback --lib`
- `cargo check -p fission-shell-winit`
- iOS simulator `MobileSmoke` with `FISSION_RENDERER=native-vello-gpu` renders non-black output and image content
- test-control `TapText("Tap")` updates the counter from `Taps: 0` to `Taps: 1` on the iOS simulator

## Root Cause

On the iOS simulator adapter, compute itself worked, but Vello's old path created every transient storage buffer with `BufferUsages::INDIRECT`. The adapter does not support indirect execution, and the first Vello compute stage effectively lost the uploaded scene data. Removing indirect usage from non-indirect fallback paths and replacing the two indirect dispatches with conservative direct dispatches keeps the GPU path usable.
