### PR TITLE
Use patched winit and add native accessibility bridge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,3 @@
 	path = third_party/vello
 	url = git@github.com:worka-ai/vello.git
 	branch = worka/dynamic-gpu-buffers
-[submodule "third_party/winit"]
-	path = third_party/winit
-	url = git@github.com:worka-ai/winit.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e98018dbef3583d751dbb96e07b8728fb99581360e1c3df408af16f4a80b821"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf 0.13.1",
+ "serde",
+ "zvariant 5.12.0",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_ios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02ecb52198c7cf5f8d3e9ffc03d2ca0a5c7201926befd96721437829da4c5c6a"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cb8b66cef272d48161b02a6317cc2bdd5f98bb0a5e79c68f704a5862aa396b"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376ba4cc23312587634abb5250b1ce8618f01a55915608209aafd01efb4bf8c"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus 5.16.0",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e93ac7bf50b964f1cbb75f741629a4e950571baa1ef1274457ab5a80d9bcc2"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,7 +463,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -443,6 +536,20 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -575,6 +682,43 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus 5.16.0",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus 5.16.0",
+]
 
 [[package]]
 name = "autocfg"
@@ -2110,7 +2254,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2146,7 +2290,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2163,11 +2307,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "dpi"
-version = "0.1.1"
-
 
 [[package]]
 name = "dpi"
@@ -2326,7 +2465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2516,6 +2655,21 @@ dependencies = [
  "fission-ir",
  "serde",
  "wgpu",
+]
+
+[[package]]
+name = "fission-accesskit-winit"
+version = "0.33.1-fission.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eedc8942090cd55b5fc4064a6eafb5035f62d1d5e6fff6a9ffcd4f27fb6cdd6"
+dependencies = [
+ "accesskit",
+ "accesskit_ios",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "fission-winit",
+ "raw-window-handle",
 ]
 
 [[package]]
@@ -2826,9 +2980,9 @@ dependencies = [
  "fission-shell-winit",
  "fission-theme",
  "fission-widgets",
+ "fission-winit",
  "lazy_static",
  "serde",
- "winit",
 ]
 
 [[package]]
@@ -2840,7 +2994,7 @@ dependencies = [
  "fission-shell",
  "fission-shell-winit",
  "fission-theme",
- "winit",
+ "fission-winit",
 ]
 
 [[package]]
@@ -2918,6 +3072,7 @@ dependencies = [
 name = "fission-shell-winit"
 version = "0.6.1"
 dependencies = [
+ "accesskit",
  "anyhow",
  "arboard",
  "base64",
@@ -2928,6 +3083,7 @@ dependencies = [
  "core-graphics",
  "dispatch",
  "fission-3d",
+ "fission-accesskit-winit",
  "fission-core",
  "fission-diagnostics",
  "fission-ir",
@@ -2941,6 +3097,7 @@ dependencies = [
  "fission-theme",
  "fission-vello",
  "fission-widgets",
+ "fission-winit",
  "fontdue",
  "fontique",
  "image 0.25.8",
@@ -2961,7 +3118,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "winit",
 ]
 
 [[package]]
@@ -3077,6 +3233,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "fission-winit"
+version = "0.30.13-fission.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee53e43ee2bd2a3b827d78df30d1519d08da0eee82cb5cd8ce3a8a6944acdc3"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop",
+ "cfg_aliases 0.2.1",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,7 +3364,7 @@ dependencies = [
  "read-fonts 0.35.0",
  "roxmltree",
  "smallvec",
- "windows",
+ "windows 0.58.0",
  "windows-core 0.58.0",
  "yeslogic-fontconfig-sys",
 ]
@@ -3582,7 +3790,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -5158,7 +5366,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5701,7 +5909,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -5711,7 +5919,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -5762,6 +5972,19 @@ checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6113,6 +6336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -6167,7 +6391,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6617,7 +6841,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6630,7 +6854,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6863,7 +7087,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "sha2 0.10.9",
- "zbus",
+ "zbus 4.4.0",
 ]
 
 [[package]]
@@ -7643,7 +7867,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8287,6 +8511,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -8758,7 +8983,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
+ "windows 0.58.0",
  "windows-core 0.58.0",
 ]
 
@@ -8822,7 +9047,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8839,6 +9064,27 @@ checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8865,6 +9111,17 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -8916,6 +9173,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -9045,6 +9312,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -9184,56 +9460,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winit"
-version = "0.30.13"
-dependencies = [
- "ahash",
- "android-activity",
- "atomic-waker",
- "bitflags 2.13.0",
- "block2 0.5.1",
- "bytemuck",
- "calloop",
- "cfg_aliases 0.2.1",
- "concurrent-queue",
- "core-foundation 0.9.4",
- "core-graphics",
- "cursor-icon",
- "dpi 0.1.1",
- "js-sys",
- "libc",
- "memmap2",
- "ndk",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit",
- "orbclient",
- "percent-encoding",
- "pin-project",
- "raw-window-handle",
- "redox_syscall 0.4.1",
- "rustix 0.38.44",
- "sctk-adwaita",
- "smithay-client-toolkit",
- "smol_str",
- "tracing",
- "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-plasma",
- "web-sys",
- "web-time",
- "windows-sys 0.52.0",
- "x11-dl",
- "x11rb",
- "xkbcommon-dl",
-]
 
 [[package]]
 name = "winnow"
@@ -9449,9 +9675,68 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.52.0",
  "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros 5.16.0",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant 5.12.0",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant 5.12.0",
 ]
 
 [[package]]
@@ -9464,7 +9749,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "zvariant_utils",
+ "zvariant_utils 2.1.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
+ "zvariant_utils 3.4.0",
 ]
 
 [[package]]
@@ -9475,7 +9775,30 @@ checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant 5.12.0",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
+dependencies = [
+ "quick-xml",
+ "serde",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
 ]
 
 [[package]]
@@ -9648,7 +9971,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zvariant_derive",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive 5.12.0",
+ "zvariant_utils 3.4.0",
 ]
 
 [[package]]
@@ -9661,7 +9998,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "zvariant_utils",
+ "zvariant_utils 2.1.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils 3.4.0",
 ]
 
 [[package]]
@@ -9673,4 +10023,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
     "documentation",
     "examples/*"
 ]
-exclude = ["third_party/vello", "third_party/winit"]
+exclude = ["third_party/vello"]
 resolver = "2"
 
 [workspace.lints.rust]
@@ -59,4 +59,3 @@ panic = "abort"
 
 [patch.crates-io]
 android-activity = { path = "third_party/android-activity/android-activity" }
-winit = { path = "third_party/winit" }

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -19,7 +19,7 @@ fission-shell = { path = "../fission-shell", version = "0.6.1" }
 fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.6.1" }
 fission-core = { path = "../../core/fission-core", version = "0.6.1" }
 fission-theme = { path = "../../core/fission-theme", version = "0.6.1" }
-winit = "0.30.13"
+winit = { package = "fission-winit", version = "0.30.13-fission.1" }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -21,6 +21,6 @@ fission-theme = { path = "../../core/fission-theme", version = "0.6.1" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.30.13", features = ["android-native-activity"] }
+winit = { package = "fission-winit", version = "0.30.13-fission.1", features = ["android-native-activity"] }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -24,7 +24,7 @@ fission-ir = { path = "../../core/fission-ir", version = "0.6.1" }
 fission-semantics = { path = "../../core/fission-semantics", version = "0.6.1" }
 fission-theme = { path = "../../core/fission-theme", version = "0.6.1" }
 fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.6.1" }
-winit = "0.30.13"
+winit = { package = "fission-winit", version = "0.30.13-fission.1" }
 fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.1" }
 fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.6.1" }
 image = "0.25"
@@ -49,9 +49,13 @@ ureq = "2"
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 arboard = "3.4"
 
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
+accesskit = "0.24.1"
+accesskit_winit = { package = "fission-accesskit-winit", version = "0.33.1-fission.1" }
+
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"
-winit = { version = "0.30.13", features = ["android-native-activity"] }
+winit = { package = "fission-winit", version = "0.30.13-fission.1", features = ["android-native-activity"] }
 
 [target.'cfg(any(target_os = "android", target_os = "ios", target_os = "macos"))'.dependencies]
 rxing = { version = "0.9", default-features = false, features = ["image", "image_formats", "decoders", "encoding_rs", "full_barcode_format_support", "multi_barcode_readers"] }

--- a/crates/shell/fission-shell-winit/src/accessibility.rs
+++ b/crates/shell/fission-shell-winit/src/accessibility.rs
@@ -1,0 +1,1156 @@
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
+mod imp {
+    use std::collections::{HashMap, HashSet, VecDeque};
+    use std::sync::{Arc, Mutex};
+
+    use accesskit::{
+        Action, ActionData, ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler,
+        Node, NodeId, Rect, Role as AccessRole, TextSelection, Toggled, Tree, TreeId, TreeUpdate,
+    };
+    use accesskit_winit::Adapter;
+    use fission_core::event::ImeEvent;
+    use fission_core::{ActionEnvelope, ActionId, ActionInput, InputEvent, Runtime};
+    use fission_ir::semantics::{ActionTrigger, Role, TextInputType};
+    use fission_ir::{CoreIR, Op, PaintOp, Semantics, WidgetId};
+    use fission_layout::{LayoutRect, LayoutSnapshot};
+    use fission_test_driver::TestEvent;
+    use winit::event::WindowEvent;
+    use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
+    use winit::window::Window;
+
+    const ROOT_NODE_ID: NodeId = NodeId(1);
+
+    #[derive(Debug)]
+    enum QueuedAccessibilityEvent {
+        ActionRequested(ActionRequest),
+        Deactivated,
+    }
+
+    struct AccessibilityShared {
+        latest_update: Mutex<TreeUpdate>,
+        latest_node_map: Mutex<HashMap<NodeId, WidgetId>>,
+        events: Mutex<VecDeque<QueuedAccessibilityEvent>>,
+        proxy: EventLoopProxy<TestEvent>,
+    }
+
+    impl AccessibilityShared {
+        fn wake(&self) {
+            let _ = self.proxy.send_event(TestEvent::Wake);
+        }
+    }
+
+    struct FissionActivationHandler {
+        shared: Arc<AccessibilityShared>,
+    }
+
+    impl ActivationHandler for FissionActivationHandler {
+        fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+            self.shared
+                .latest_update
+                .lock()
+                .ok()
+                .map(|update| update.clone())
+        }
+    }
+
+    struct FissionActionHandler {
+        shared: Arc<AccessibilityShared>,
+    }
+
+    impl ActionHandler for FissionActionHandler {
+        fn do_action(&mut self, request: ActionRequest) {
+            if let Ok(mut events) = self.shared.events.lock() {
+                events.push_back(QueuedAccessibilityEvent::ActionRequested(request));
+            }
+            self.shared.wake();
+        }
+    }
+
+    struct FissionDeactivationHandler {
+        shared: Arc<AccessibilityShared>,
+    }
+
+    impl DeactivationHandler for FissionDeactivationHandler {
+        fn deactivate_accessibility(&mut self) {
+            if let Ok(mut events) = self.shared.events.lock() {
+                events.push_back(QueuedAccessibilityEvent::Deactivated);
+            }
+            self.shared.wake();
+        }
+    }
+
+    pub struct AccessibilityBridge {
+        adapter: Option<Adapter>,
+        shared: Arc<AccessibilityShared>,
+        active: bool,
+    }
+
+    impl AccessibilityBridge {
+        pub fn new(proxy: EventLoopProxy<TestEvent>) -> Self {
+            Self {
+                adapter: None,
+                shared: Arc::new(AccessibilityShared {
+                    latest_update: Mutex::new(placeholder_update()),
+                    latest_node_map: Mutex::new(HashMap::new()),
+                    events: Mutex::new(VecDeque::new()),
+                    proxy,
+                }),
+                active: false,
+            }
+        }
+
+        pub fn ensure_adapter(&mut self, event_loop: &ActiveEventLoop, window: &Window) {
+            if self.adapter.is_some() {
+                return;
+            }
+            let activation_handler = FissionActivationHandler {
+                shared: self.shared.clone(),
+            };
+            let action_handler = FissionActionHandler {
+                shared: self.shared.clone(),
+            };
+            let deactivation_handler = FissionDeactivationHandler {
+                shared: self.shared.clone(),
+            };
+            self.adapter = Some(Adapter::with_direct_handlers(
+                event_loop,
+                window,
+                activation_handler,
+                action_handler,
+                deactivation_handler,
+            ));
+        }
+
+        pub fn process_window_event(&mut self, window: &Window, event: &WindowEvent) {
+            if let Some(adapter) = self.adapter.as_mut() {
+                adapter.process_event(window, event);
+            }
+        }
+
+        pub fn update_tree(
+            &mut self,
+            ir: &CoreIR,
+            layout: &LayoutSnapshot,
+            runtime: &Runtime,
+            scale_factor: f64,
+        ) {
+            let built = build_tree_update(ir, layout, runtime, scale_factor);
+            if let Ok(mut latest) = self.shared.latest_update.lock() {
+                *latest = built.update.clone();
+            }
+            if let Ok(mut node_map) = self.shared.latest_node_map.lock() {
+                *node_map = built.node_map;
+            }
+            if let Some(adapter) = self.adapter.as_mut() {
+                let update = built.update;
+                adapter.update_if_active(|| update);
+            }
+        }
+
+        pub fn drain_events(
+            &mut self,
+            runtime: &mut Runtime,
+            ir: Option<&CoreIR>,
+            layout: Option<&LayoutSnapshot>,
+        ) -> bool {
+            let mut changed = false;
+            loop {
+                let event = self
+                    .shared
+                    .events
+                    .lock()
+                    .ok()
+                    .and_then(|mut events| events.pop_front());
+                let Some(event) = event else {
+                    break;
+                };
+                match event {
+                    QueuedAccessibilityEvent::ActionRequested(request) => {
+                        let Some(ir) = ir else {
+                            continue;
+                        };
+                        let Some(layout) = layout else {
+                            continue;
+                        };
+                        if self.handle_action_request(request, runtime, ir, layout) {
+                            changed = true;
+                        }
+                    }
+                    QueuedAccessibilityEvent::Deactivated => {
+                        self.active = false;
+                    }
+                }
+            }
+            changed
+        }
+
+        fn handle_action_request(
+            &mut self,
+            request: ActionRequest,
+            runtime: &mut Runtime,
+            ir: &CoreIR,
+            layout: &LayoutSnapshot,
+        ) -> bool {
+            self.active = true;
+            let node_map = self.shared.latest_node_map.lock().ok();
+            let Some(target) = node_map
+                .as_ref()
+                .and_then(|map| map.get(&request.target_node).copied())
+            else {
+                return false;
+            };
+            let Some(semantics) = semantics_for(ir, target) else {
+                return false;
+            };
+
+            match request.action {
+                Action::Click => dispatch_semantics_action(
+                    runtime,
+                    target,
+                    semantics,
+                    ActionTrigger::Default,
+                    ActionInput::None,
+                ),
+                Action::Focus => set_focus(runtime, ir, Some(target)),
+                Action::Blur => set_focus(runtime, ir, None),
+                Action::ReplaceSelectedText => {
+                    let Some(text) = value_action_data(&request.data) else {
+                        return false;
+                    };
+                    set_focus(runtime, ir, Some(target));
+                    runtime
+                        .handle_input(
+                            InputEvent::Ime(ImeEvent::Commit {
+                                text: text.to_string(),
+                            }),
+                            ir,
+                            layout,
+                        )
+                        .is_ok()
+                }
+                Action::SetValue => match &request.data {
+                    Some(ActionData::Value(value)) => {
+                        set_text_input_value(runtime, ir, target, semantics, value)
+                    }
+                    Some(ActionData::NumericValue(value)) => set_numeric_value(
+                        runtime,
+                        target,
+                        semantics,
+                        (*value as f32).clamp(
+                            semantics.min_value.unwrap_or(f32::NEG_INFINITY),
+                            semantics.max_value.unwrap_or(f32::INFINITY),
+                        ),
+                    ),
+                    _ => false,
+                },
+                Action::SetTextSelection => {
+                    let Some(ActionData::SetTextSelection(selection)) = &request.data else {
+                        return false;
+                    };
+                    set_text_selection(runtime, ir, target, semantics, selection)
+                }
+                Action::ScrollDown
+                | Action::ScrollUp
+                | Action::ScrollLeft
+                | Action::ScrollRight => {
+                    handle_scroll_action(runtime, ir, layout, target, request.action, &request.data)
+                }
+                Action::Increment => adjust_numeric_value(runtime, target, semantics, 1.0),
+                Action::Decrement => adjust_numeric_value(runtime, target, semantics, -1.0),
+                _ => false,
+            }
+        }
+    }
+
+    pub fn window_must_start_hidden() -> bool {
+        true
+    }
+
+    fn placeholder_update() -> TreeUpdate {
+        let mut root = Node::new(AccessRole::Window);
+        root.set_bounds(Rect::ZERO);
+        TreeUpdate {
+            nodes: vec![(ROOT_NODE_ID, root)],
+            tree: Some(Tree {
+                root: ROOT_NODE_ID,
+                toolkit_name: Some("Fission".to_string()),
+                toolkit_version: option_env!("CARGO_PKG_VERSION").map(str::to_string),
+            }),
+            tree_id: TreeId::ROOT,
+            focus: ROOT_NODE_ID,
+        }
+    }
+
+    struct BuiltTreeUpdate {
+        update: TreeUpdate,
+        node_map: HashMap<NodeId, WidgetId>,
+    }
+
+    fn build_tree_update(
+        ir: &CoreIR,
+        layout: &LayoutSnapshot,
+        runtime: &Runtime,
+        scale_factor: f64,
+    ) -> BuiltTreeUpdate {
+        let mut builder = TreeUpdateBuilder::new(ir, layout, runtime, scale_factor);
+        let root_children = ir
+            .root
+            .map(|root| builder.collect_subtree(root, false))
+            .unwrap_or_default();
+
+        let mut root = Node::new(AccessRole::Window);
+        root.set_bounds(Rect::new(
+            0.0,
+            0.0,
+            layout.viewport_size.width as f64 * scale_factor,
+            layout.viewport_size.height as f64 * scale_factor,
+        ));
+        root.set_children(root_children);
+        builder.nodes.push((ROOT_NODE_ID, root));
+
+        let focus = runtime
+            .runtime_state
+            .interaction
+            .focused
+            .and_then(|id| builder.widget_to_node.get(&id).copied())
+            .unwrap_or(ROOT_NODE_ID);
+
+        BuiltTreeUpdate {
+            update: TreeUpdate {
+                nodes: builder.nodes,
+                tree: Some(Tree {
+                    root: ROOT_NODE_ID,
+                    toolkit_name: Some("Fission".to_string()),
+                    toolkit_version: option_env!("CARGO_PKG_VERSION").map(str::to_string),
+                }),
+                tree_id: TreeId::ROOT,
+                focus,
+            },
+            node_map: builder.node_to_widget,
+        }
+    }
+
+    struct TreeUpdateBuilder<'a> {
+        ir: &'a CoreIR,
+        layout: &'a LayoutSnapshot,
+        runtime: &'a Runtime,
+        scale_factor: f64,
+        nodes: Vec<(NodeId, Node)>,
+        used_node_ids: HashSet<NodeId>,
+        widget_to_node: HashMap<WidgetId, NodeId>,
+        node_to_widget: HashMap<NodeId, WidgetId>,
+    }
+
+    impl<'a> TreeUpdateBuilder<'a> {
+        fn new(
+            ir: &'a CoreIR,
+            layout: &'a LayoutSnapshot,
+            runtime: &'a Runtime,
+            scale_factor: f64,
+        ) -> Self {
+            let mut used_node_ids = HashSet::new();
+            used_node_ids.insert(ROOT_NODE_ID);
+            Self {
+                ir,
+                layout,
+                runtime,
+                scale_factor,
+                nodes: Vec::new(),
+                used_node_ids,
+                widget_to_node: HashMap::new(),
+                node_to_widget: HashMap::new(),
+            }
+        }
+
+        fn collect_subtree(&mut self, node_id: WidgetId, inside_semantics: bool) -> Vec<NodeId> {
+            let Some(core_node) = self.ir.nodes.get(&node_id) else {
+                return Vec::new();
+            };
+
+            match &core_node.op {
+                Op::Semantics(semantics) if include_semantics(semantics) => {
+                    let child_ids = core_node
+                        .children
+                        .iter()
+                        .flat_map(|child| self.collect_subtree(*child, true))
+                        .collect::<Vec<_>>();
+                    let access_id = self.node_id_for(node_id);
+                    let mut node = self.access_node_for_semantics(node_id, semantics);
+                    node.set_children(child_ids);
+                    self.nodes.push((access_id, node));
+                    vec![access_id]
+                }
+                Op::Paint(PaintOp::DrawText { text, .. }) if !text.is_empty() => {
+                    let access_id = self.node_id_for(node_id);
+                    let mut node = Node::new(AccessRole::Label);
+                    node.set_value(text.clone());
+                    if let Some(rect) = self.layout.get_node_rect(node_id) {
+                        node.set_bounds(accesskit_rect(rect, self.scale_factor));
+                    }
+                    if inside_semantics {
+                        node.set_read_only();
+                    }
+                    self.nodes.push((access_id, node));
+                    vec![access_id]
+                }
+                Op::Paint(PaintOp::DrawRichText { runs, .. }) => {
+                    let text = runs.iter().map(|run| run.text.as_str()).collect::<String>();
+                    if text.is_empty() {
+                        return Vec::new();
+                    }
+                    let access_id = self.node_id_for(node_id);
+                    let mut node = Node::new(AccessRole::Label);
+                    node.set_value(text);
+                    if let Some(rect) = self.layout.get_node_rect(node_id) {
+                        node.set_bounds(accesskit_rect(rect, self.scale_factor));
+                    }
+                    if inside_semantics {
+                        node.set_read_only();
+                    }
+                    self.nodes.push((access_id, node));
+                    vec![access_id]
+                }
+                _ => core_node
+                    .children
+                    .iter()
+                    .flat_map(|child| self.collect_subtree(*child, inside_semantics))
+                    .collect(),
+            }
+        }
+
+        fn node_id_for(&mut self, widget_id: WidgetId) -> NodeId {
+            if let Some(node_id) = self.widget_to_node.get(&widget_id) {
+                return *node_id;
+            }
+            let raw = widget_id.as_u128();
+            let mut candidate = NodeId(((raw >> 64) as u64) ^ raw as u64);
+            if candidate.0 <= ROOT_NODE_ID.0 {
+                candidate.0 = candidate.0.saturating_add(2);
+            }
+            while self.used_node_ids.contains(&candidate) {
+                candidate.0 = candidate.0.wrapping_add(1).max(2);
+            }
+            self.used_node_ids.insert(candidate);
+            self.widget_to_node.insert(widget_id, candidate);
+            self.node_to_widget.insert(candidate, widget_id);
+            candidate
+        }
+
+        fn access_node_for_semantics(&self, node_id: WidgetId, semantics: &Semantics) -> Node {
+            let mut node = Node::new(access_role_for(semantics));
+            if let Some(rect) = self.layout.get_node_rect(node_id) {
+                node.set_bounds(accesskit_rect(rect, self.scale_factor));
+            }
+            if let Some(identifier) = semantics.identifier.as_deref() {
+                node.set_author_id(identifier);
+            }
+            let value = semantic_value(self.runtime, node_id, semantics);
+            let label = semantics
+                .label
+                .clone()
+                .or_else(|| collect_descendant_text(self.ir, node_id));
+
+            match semantics.role {
+                Role::Text => {
+                    if let Some(text) = label.or(value.clone()) {
+                        node.set_value(text);
+                    }
+                    node.set_read_only();
+                }
+                Role::TextInput => {
+                    if let Some(label) = label {
+                        node.set_label(label);
+                    }
+                    if let Some(value) = value {
+                        node.set_value(value.clone());
+                        node.set_character_lengths(
+                            value
+                                .chars()
+                                .map(|ch| ch.len_utf8() as u8)
+                                .collect::<Vec<_>>(),
+                        );
+                    }
+                    node.add_action(Action::ReplaceSelectedText);
+                    node.add_action(Action::SetValue);
+                    node.add_action(Action::SetTextSelection);
+                    if semantics.read_only {
+                        node.set_read_only();
+                    }
+                }
+                _ => {
+                    if let Some(label) = label {
+                        node.set_label(label);
+                    }
+                    if let Some(value) = value {
+                        node.set_value(value);
+                    }
+                }
+            }
+
+            if semantics.focusable && !semantics.disabled {
+                node.add_action(Action::Focus);
+                node.add_action(Action::Blur);
+            }
+            if semantics.disabled {
+                node.set_disabled();
+            }
+            if let Some(checked) = semantics.checked {
+                node.set_toggled(Toggled::from(checked));
+            }
+            if let Some(min) = semantics.min_value {
+                node.set_min_numeric_value(min as f64);
+            }
+            if let Some(max) = semantics.max_value {
+                node.set_max_numeric_value(max as f64);
+            }
+            if let Some(current) = semantics.current_value {
+                node.set_numeric_value(current as f64);
+            }
+            if semantics.current_value.is_some() {
+                node.add_action(Action::Increment);
+                node.add_action(Action::Decrement);
+                node.add_action(Action::SetValue);
+            }
+            if semantics.scrollable_y {
+                node.add_action(Action::ScrollDown);
+                node.add_action(Action::ScrollUp);
+                if let Some((offset, max)) =
+                    scroll_offset_and_max(self.ir, self.layout, self.runtime, node_id, false)
+                {
+                    node.set_scroll_y(offset as f64);
+                    node.set_scroll_y_min(0.0);
+                    node.set_scroll_y_max(max as f64);
+                }
+            }
+            if semantics.scrollable_x {
+                node.add_action(Action::ScrollLeft);
+                node.add_action(Action::ScrollRight);
+                if let Some((offset, max)) =
+                    scroll_offset_and_max(self.ir, self.layout, self.runtime, node_id, true)
+                {
+                    node.set_scroll_x(offset as f64);
+                    node.set_scroll_x_min(0.0);
+                    node.set_scroll_x_max(max as f64);
+                }
+            }
+            if semantics
+                .actions
+                .entries
+                .iter()
+                .any(|entry| entry.trigger == ActionTrigger::Default)
+                && !semantics.disabled
+            {
+                node.add_action(Action::Click);
+            }
+            node
+        }
+    }
+
+    fn include_semantics(semantics: &Semantics) -> bool {
+        semantics.role != Role::Generic
+            || semantics.label.is_some()
+            || semantics.identifier.is_some()
+            || semantics.value.is_some()
+            || semantics.focusable
+            || semantics.checked.is_some()
+            || semantics.current_value.is_some()
+            || semantics.scrollable_x
+            || semantics.scrollable_y
+            || !semantics.actions.entries.is_empty()
+    }
+
+    fn access_role_for(semantics: &Semantics) -> AccessRole {
+        match semantics.role {
+            Role::Button => AccessRole::Button,
+            Role::Text => AccessRole::Label,
+            Role::TextInput if semantics.masked => AccessRole::PasswordInput,
+            Role::TextInput if semantics.multiline => AccessRole::MultilineTextInput,
+            Role::TextInput => match semantics.text_input_type {
+                TextInputType::EmailAddress => AccessRole::EmailInput,
+                TextInputType::Number => AccessRole::NumberInput,
+                TextInputType::Phone => AccessRole::PhoneNumberInput,
+                TextInputType::Url => AccessRole::UrlInput,
+                TextInputType::Multiline => AccessRole::MultilineTextInput,
+                _ => AccessRole::TextInput,
+            },
+            Role::Image => AccessRole::Image,
+            Role::Checkbox => AccessRole::CheckBox,
+            Role::Switch => AccessRole::Switch,
+            Role::Dialog => AccessRole::Dialog,
+            Role::Slider => AccessRole::Slider,
+            Role::Input => AccessRole::TextInput,
+            Role::List => AccessRole::List,
+            Role::ListItem => AccessRole::ListItem,
+            Role::Generic => AccessRole::GenericContainer,
+        }
+    }
+
+    fn accesskit_rect(rect: LayoutRect, scale_factor: f64) -> Rect {
+        let x0 = rect.x() as f64 * scale_factor;
+        let y0 = rect.y() as f64 * scale_factor;
+        Rect::new(
+            x0,
+            y0,
+            x0 + rect.width() as f64 * scale_factor,
+            y0 + rect.height() as f64 * scale_factor,
+        )
+    }
+
+    fn semantics_for(ir: &CoreIR, id: WidgetId) -> Option<&Semantics> {
+        ir.nodes.get(&id).and_then(|node| match &node.op {
+            Op::Semantics(semantics) => Some(semantics),
+            _ => None,
+        })
+    }
+
+    fn semantic_value(
+        runtime: &Runtime,
+        node_id: WidgetId,
+        semantics: &Semantics,
+    ) -> Option<String> {
+        if semantics.role == Role::TextInput {
+            runtime
+                .runtime_state
+                .text_edit
+                .get(node_id)
+                .map(|state| state.committed_text())
+                .or_else(|| semantics.value.clone())
+        } else {
+            semantics.value.clone()
+        }
+    }
+
+    fn collect_descendant_text(ir: &CoreIR, node_id: WidgetId) -> Option<String> {
+        let mut out = String::new();
+        collect_descendant_text_inner(ir, node_id, &mut out);
+        let trimmed = out.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    }
+
+    fn collect_descendant_text_inner(ir: &CoreIR, node_id: WidgetId, out: &mut String) {
+        let Some(node) = ir.nodes.get(&node_id) else {
+            return;
+        };
+        match &node.op {
+            Op::Paint(PaintOp::DrawText { text, .. }) => {
+                if !text.is_empty() {
+                    if !out.is_empty() {
+                        out.push(' ');
+                    }
+                    out.push_str(text);
+                }
+            }
+            Op::Paint(PaintOp::DrawRichText { runs, .. }) => {
+                let text = runs.iter().map(|run| run.text.as_str()).collect::<String>();
+                if !text.is_empty() {
+                    if !out.is_empty() {
+                        out.push(' ');
+                    }
+                    out.push_str(&text);
+                }
+            }
+            _ => {
+                for child in &node.children {
+                    collect_descendant_text_inner(ir, *child, out);
+                }
+            }
+        }
+    }
+
+    fn set_focus(runtime: &mut Runtime, ir: &CoreIR, focus: Option<WidgetId>) -> bool {
+        let old_focus = runtime.runtime_state.interaction.focused;
+        if old_focus == focus {
+            return false;
+        }
+        if let Some(old_id) = old_focus {
+            if let Some(state) = runtime.runtime_state.text_edit.states.get_mut(&old_id) {
+                state.pending_model_sync = false;
+                state.clear_preedit();
+            }
+            if let Some(old_semantics) = semantics_for(ir, old_id) {
+                let _ = dispatch_semantics_action(
+                    runtime,
+                    old_id,
+                    old_semantics,
+                    ActionTrigger::Blur,
+                    ActionInput::None,
+                );
+            }
+        }
+        runtime.runtime_state.interaction.set_focused(focus);
+        if let Some(ime_handler) = &runtime.ime_handler {
+            let allow_ime = focus
+                .and_then(|id| semantics_for(ir, id))
+                .map(|semantics| {
+                    semantics.role == Role::TextInput && !semantics.disabled && !semantics.read_only
+                })
+                .unwrap_or(false);
+            ime_handler.set_ime_allowed(allow_ime);
+        }
+        if let Some(new_id) = focus {
+            if let Some(new_semantics) = semantics_for(ir, new_id) {
+                let _ = dispatch_semantics_action(
+                    runtime,
+                    new_id,
+                    new_semantics,
+                    ActionTrigger::Focus,
+                    ActionInput::None,
+                );
+            }
+        }
+        true
+    }
+
+    fn dispatch_semantics_action(
+        runtime: &mut Runtime,
+        target: WidgetId,
+        semantics: &Semantics,
+        trigger: ActionTrigger,
+        input: ActionInput,
+    ) -> bool {
+        let Some(entry) = semantics
+            .actions
+            .entries
+            .iter()
+            .find(|entry| entry.trigger == trigger)
+        else {
+            return false;
+        };
+        let envelope = ActionEnvelope {
+            id: ActionId::from_u128(entry.action_id),
+            payload: entry.payload_data.clone().unwrap_or_default(),
+        };
+        runtime
+            .dispatch_with_input(envelope, target, &input)
+            .is_ok()
+    }
+
+    fn value_action_data(data: &Option<ActionData>) -> Option<&str> {
+        match data {
+            Some(ActionData::Value(value)) => Some(value),
+            _ => None,
+        }
+    }
+
+    fn set_text_input_value(
+        runtime: &mut Runtime,
+        ir: &CoreIR,
+        target: WidgetId,
+        semantics: &Semantics,
+        value: &str,
+    ) -> bool {
+        if semantics.role != Role::TextInput || semantics.disabled || semantics.read_only {
+            return false;
+        }
+        set_focus(runtime, ir, Some(target));
+        runtime.runtime_state.text_edit.sync_from_runtime(
+            target,
+            semantics.value.as_deref().unwrap_or_default(),
+            None,
+            None,
+        );
+        {
+            let state = runtime.runtime_state.text_edit.get_mut_or_default(target);
+            let old_len = state.buffer.len_bytes();
+            state.buffer.replace(0..old_len, value);
+            state.caret = value.len();
+            state.anchor = value.len();
+            state.pending_model_sync = true;
+            state.clear_preedit();
+        }
+        let mut changed = dispatch_text_change(runtime, target, semantics, value.to_string());
+        changed |= dispatch_cursor_change(runtime, target, semantics, value.len(), value.len());
+        changed
+    }
+
+    fn set_text_selection(
+        runtime: &mut Runtime,
+        ir: &CoreIR,
+        target: WidgetId,
+        semantics: &Semantics,
+        selection: &TextSelection,
+    ) -> bool {
+        if semantics.role != Role::TextInput {
+            return false;
+        }
+        set_focus(runtime, ir, Some(target));
+        runtime.runtime_state.text_edit.sync_from_runtime(
+            target,
+            semantics.value.as_deref().unwrap_or_default(),
+            None,
+            None,
+        );
+        let value = runtime
+            .runtime_state
+            .text_edit
+            .get(target)
+            .map(|state| state.committed_text())
+            .unwrap_or_default();
+        let caret = char_to_byte(&value, selection.focus.character_index);
+        let anchor = char_to_byte(&value, selection.anchor.character_index);
+        runtime
+            .runtime_state
+            .text_edit
+            .set_caret(target, caret, Some(anchor));
+        dispatch_cursor_change(runtime, target, semantics, caret, anchor)
+    }
+
+    fn char_to_byte(value: &str, character_index: usize) -> usize {
+        value
+            .char_indices()
+            .map(|(index, _)| index)
+            .chain(std::iter::once(value.len()))
+            .nth(character_index)
+            .unwrap_or(value.len())
+    }
+
+    fn dispatch_text_change(
+        runtime: &mut Runtime,
+        target: WidgetId,
+        semantics: &Semantics,
+        new_text: String,
+    ) -> bool {
+        let Some(entry) = semantics
+            .actions
+            .entries
+            .iter()
+            .find(|entry| entry.trigger == ActionTrigger::Change)
+        else {
+            return false;
+        };
+        let Ok(payload) = serde_json::to_vec(&new_text) else {
+            return false;
+        };
+        runtime
+            .dispatch_with_input(
+                ActionEnvelope {
+                    id: ActionId::from_u128(entry.action_id),
+                    payload,
+                },
+                target,
+                &ActionInput::None,
+            )
+            .is_ok()
+    }
+
+    fn dispatch_cursor_change(
+        runtime: &mut Runtime,
+        target: WidgetId,
+        semantics: &Semantics,
+        caret: usize,
+        anchor: usize,
+    ) -> bool {
+        let Some(entry) = semantics
+            .actions
+            .entries
+            .iter()
+            .find(|entry| entry.trigger == ActionTrigger::CursorChange)
+        else {
+            return false;
+        };
+        let cursor_changed = fission_core::action::CursorChanged { caret, anchor };
+        let Ok(payload) = serde_json::to_vec(&cursor_changed) else {
+            return false;
+        };
+        runtime
+            .dispatch_with_input(
+                ActionEnvelope {
+                    id: ActionId::from_u128(entry.action_id),
+                    payload,
+                },
+                target,
+                &ActionInput::None,
+            )
+            .is_ok()
+    }
+
+    fn adjust_numeric_value(
+        runtime: &mut Runtime,
+        target: WidgetId,
+        semantics: &Semantics,
+        direction: f32,
+    ) -> bool {
+        let Some(current) = semantics.current_value else {
+            return false;
+        };
+        let min = semantics.min_value.unwrap_or(f32::NEG_INFINITY);
+        let max = semantics.max_value.unwrap_or(f32::INFINITY);
+        let next = (current + direction).clamp(min, max);
+        set_numeric_value(runtime, target, semantics, next)
+    }
+
+    fn set_numeric_value(
+        runtime: &mut Runtime,
+        target: WidgetId,
+        semantics: &Semantics,
+        value: f32,
+    ) -> bool {
+        if semantics.current_value.is_none() {
+            return false;
+        }
+        let Ok(payload) = serde_json::to_vec(&value) else {
+            return false;
+        };
+        let Some(entry) = semantics
+            .actions
+            .entries
+            .iter()
+            .find(|entry| entry.trigger == ActionTrigger::Change)
+        else {
+            return false;
+        };
+        runtime
+            .dispatch_with_input(
+                ActionEnvelope {
+                    id: ActionId::from_u128(entry.action_id),
+                    payload,
+                },
+                target,
+                &ActionInput::None,
+            )
+            .is_ok()
+    }
+
+    fn handle_scroll_action(
+        runtime: &mut Runtime,
+        ir: &CoreIR,
+        layout: &LayoutSnapshot,
+        target: WidgetId,
+        action: Action,
+        data: &Option<ActionData>,
+    ) -> bool {
+        let horizontal = matches!(action, Action::ScrollLeft | Action::ScrollRight);
+        let Some(scroll_node) = find_scroll_node(ir, target, horizontal) else {
+            return false;
+        };
+        let Some(geometry) = layout.get_node_geometry(scroll_node) else {
+            return false;
+        };
+        let max_offset = if horizontal {
+            (geometry.content_size.width - geometry.rect.width()).max(0.0)
+        } else {
+            (geometry.content_size.height - geometry.rect.height()).max(0.0)
+        };
+        let current = runtime.runtime_state.scroll.get_offset(scroll_node);
+        let amount = match data {
+            Some(ActionData::ScrollUnit(accesskit::ScrollUnit::Item)) => 40.0,
+            _ => {
+                if horizontal {
+                    geometry.rect.width() * 0.8
+                } else {
+                    geometry.rect.height() * 0.8
+                }
+            }
+        };
+        let signed = match action {
+            Action::ScrollUp | Action::ScrollLeft => -amount,
+            _ => amount,
+        };
+        let next = (current + signed).clamp(0.0, max_offset);
+        if (next - current).abs() <= 0.001 {
+            return false;
+        }
+        runtime.runtime_state.scroll.set_offset(scroll_node, next);
+        true
+    }
+
+    fn scroll_offset_and_max(
+        ir: &CoreIR,
+        layout: &LayoutSnapshot,
+        runtime: &Runtime,
+        target: WidgetId,
+        horizontal: bool,
+    ) -> Option<(f32, f32)> {
+        let scroll_node = find_scroll_node(ir, target, horizontal)?;
+        let geometry = layout.get_node_geometry(scroll_node)?;
+        let max = if horizontal {
+            (geometry.content_size.width - geometry.rect.width()).max(0.0)
+        } else {
+            (geometry.content_size.height - geometry.rect.height()).max(0.0)
+        };
+        Some((runtime.runtime_state.scroll.get_offset(scroll_node), max))
+    }
+
+    fn find_scroll_node(ir: &CoreIR, target: WidgetId, horizontal: bool) -> Option<WidgetId> {
+        let target_direction = if horizontal {
+            fission_ir::FlexDirection::Row
+        } else {
+            fission_ir::FlexDirection::Column
+        };
+        let mut stack = vec![target];
+        while let Some(id) = stack.pop() {
+            let Some(node) = ir.nodes.get(&id) else {
+                continue;
+            };
+            if let Op::Layout(fission_ir::LayoutOp::Scroll { direction, .. }) = &node.op {
+                if *direction == target_direction {
+                    return Some(id);
+                }
+            }
+            stack.extend(node.children.iter().rev().copied());
+        }
+        None
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use fission_ir::{ActionEntry, ActionSet, CoreIR, CoreNode, Op};
+        use fission_layout::{LayoutNodeGeometry, LayoutPoint, LayoutSize};
+
+        fn add_node(ir: &mut CoreIR, id: WidgetId, op: Op, children: Vec<WidgetId>) {
+            ir.nodes.insert(
+                id,
+                CoreNode {
+                    id,
+                    op,
+                    composite: Default::default(),
+                    children: children.clone(),
+                    parent: None,
+                    hash: 0,
+                },
+            );
+            for child in children {
+                ir.nodes.get_mut(&child).unwrap().parent = Some(id);
+            }
+        }
+
+        #[test]
+        fn derives_button_label_from_descendant_text() {
+            let root = WidgetId::from_u128(10);
+            let button = WidgetId::from_u128(11);
+            let text = WidgetId::from_u128(12);
+            let mut ir = CoreIR::new();
+            add_node(
+                &mut ir,
+                text,
+                Op::Paint(PaintOp::DrawText {
+                    text: "Save".into(),
+                    size: 14.0,
+                    color: fission_ir::op::Color::BLACK,
+                    underline: false,
+                    wrap: true,
+                    caret_index: None,
+                    caret_color: None,
+                    caret_width: None,
+                    caret_height: None,
+                    caret_radius: None,
+                    paragraph_style: None,
+                }),
+                vec![],
+            );
+            add_node(
+                &mut ir,
+                button,
+                Op::Semantics(Semantics {
+                    role: Role::Button,
+                    actions: ActionSet {
+                        entries: vec![ActionEntry {
+                            trigger: ActionTrigger::Default,
+                            action_id: 42,
+                            payload_data: Some(Vec::new()),
+                        }],
+                    },
+                    focusable: true,
+                    ..Semantics::default()
+                }),
+                vec![text],
+            );
+            add_node(
+                &mut ir,
+                root,
+                Op::Layout(fission_ir::LayoutOp::Box {
+                    width: None,
+                    height: None,
+                    min_width: None,
+                    max_width: None,
+                    min_height: None,
+                    max_height: None,
+                    padding: [0.0; 4],
+                    flex_grow: 0.0,
+                    flex_shrink: 1.0,
+                    aspect_ratio: None,
+                }),
+                vec![button],
+            );
+            ir.root = Some(root);
+
+            let mut layout = LayoutSnapshot::new(LayoutSize::new(100.0, 50.0));
+            layout.nodes.insert(
+                button,
+                LayoutNodeGeometry {
+                    rect: LayoutRect::new(10.0, 5.0, 80.0, 30.0),
+                    content_size: LayoutSize::new(80.0, 30.0),
+                },
+            );
+            layout.nodes.insert(
+                text,
+                LayoutNodeGeometry {
+                    rect: LayoutRect {
+                        origin: LayoutPoint::new(12.0, 8.0),
+                        size: LayoutSize::new(40.0, 20.0),
+                    },
+                    content_size: LayoutSize::new(40.0, 20.0),
+                },
+            );
+
+            let runtime = Runtime::default();
+            let update = build_tree_update(&ir, &layout, &runtime, 2.0).update;
+            let (_, node) = update
+                .nodes
+                .iter()
+                .find(|(_, node)| node.role() == AccessRole::Button)
+                .expect("button node");
+            assert_eq!(node.label(), Some("Save"));
+            assert!(node.supports_action(Action::Click));
+            assert_eq!(node.bounds(), Some(Rect::new(20.0, 10.0, 180.0, 70.0)));
+        }
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", target_os = "android"))]
+mod imp {
+    use fission_core::Runtime;
+    use fission_ir::CoreIR;
+    use fission_layout::LayoutSnapshot;
+    use fission_test_driver::TestEvent;
+    use winit::event::WindowEvent;
+    use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
+    use winit::window::Window;
+
+    pub struct AccessibilityBridge;
+
+    impl AccessibilityBridge {
+        pub fn new(_proxy: EventLoopProxy<TestEvent>) -> Self {
+            Self
+        }
+
+        pub fn ensure_adapter(&mut self, _event_loop: &ActiveEventLoop, _window: &Window) {}
+
+        pub fn process_window_event(&mut self, _window: &Window, _event: &WindowEvent) {}
+
+        pub fn update_tree(
+            &mut self,
+            _ir: &CoreIR,
+            _layout: &LayoutSnapshot,
+            _runtime: &Runtime,
+            _scale_factor: f64,
+        ) {
+        }
+
+        pub fn drain_events(
+            &mut self,
+            _runtime: &mut Runtime,
+            _ir: Option<&CoreIR>,
+            _layout: Option<&LayoutSnapshot>,
+        ) -> bool {
+            false
+        }
+    }
+
+    pub fn window_must_start_hidden() -> bool {
+        false
+    }
+}
+
+pub use imp::{window_must_start_hidden, AccessibilityBridge};

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -77,6 +77,8 @@ use web_time::Instant;
 
 mod compositor;
 use compositor::TextureLayerCompositor;
+mod accessibility;
+use accessibility::AccessibilityBridge;
 mod pipeline;
 pub use pipeline::{InvalidationSet, Pipeline};
 mod renderer_diagnostics;
@@ -1152,6 +1154,11 @@ fn build_window_attributes(
     }
     if background_test_mode {
         window_attributes = window_attributes.with_active(false).with_visible(false);
+    } else if accessibility::window_must_start_hidden() {
+        // AccessKit's winit adapter has to be installed before the native
+        // window is ever shown. The Resumed handler creates the adapter and
+        // then makes the window visible.
+        window_attributes = window_attributes.with_visible(false);
     }
     Ok(window_attributes)
 }
@@ -3546,6 +3553,7 @@ where
             .build()
             .map_err(|e| anyhow::anyhow!("Event loop error: {}", e))?;
         let event_proxy = event_loop.create_proxy();
+        let mut accessibility_bridge = AccessibilityBridge::new(event_proxy.clone());
         #[cfg(feature = "tray")]
         let tray_event_rx = self
             .tray_config
@@ -4156,6 +4164,24 @@ where
                     }
                     TestEvent::Wake => {
                         if let Some(window) = platform_window.active_window() {
+                            if accessibility_bridge.drain_events(
+                                &mut runtime,
+                                pipeline.prev_ir.as_ref(),
+                                pipeline.last_snapshot.as_ref(),
+                            ) {
+                                invalidations.mark_build();
+                                if process_pending_effects(
+                                    &mut runtime,
+                                    &effect_result_tx,
+                                    &event_proxy,
+                                    &async_registry,
+                                    &mut active_services,
+                                    &mut service_bindings,
+                                    &mut next_service_instance_id,
+                                ) {
+                                    invalidations.mark_build();
+                                }
+                            }
                             request_redraw_logged(
                                 window,
                                 elwt,
@@ -4236,6 +4262,10 @@ where
                     let Some(window) = platform_window.active_window() else {
                         return;
                     };
+                    accessibility_bridge.ensure_adapter(elwt, window);
+                    if accessibility::window_must_start_hidden() && !background_test_mode {
+                        window.set_visible(true);
+                    }
                     let current_viewport = WindowViewportState::from_window(window);
                     #[cfg(not(target_os = "android"))]
                     {
@@ -4926,6 +4956,7 @@ where
                     let Some(window) = platform_window.active_window() else {
                         return;
                     };
+                    accessibility_bridge.process_window_event(window, &event);
                     match event {
                         WindowEvent::Resized(size) => {
                             if size.width > 0 && size.height > 0 {
@@ -5465,6 +5496,16 @@ where
                                 {
                                     runtime.post_layout_hook(ir, layout);
                                 }
+                            }
+                            if let (Some(ir), Some(layout)) =
+                                (pipeline.prev_ir.as_ref(), pipeline.last_snapshot.as_ref())
+                            {
+                                accessibility_bridge.update_tree(
+                                    ir,
+                                    layout,
+                                    &runtime,
+                                    scale_factor,
+                                );
                             }
 
                             match pipeline.prepare_current(

--- a/documentation/content/reference/platform/accessibility-and-i18n.mdx
+++ b/documentation/content/reference/platform/accessibility-and-i18n.mdx
@@ -24,6 +24,25 @@ Fission widgets can carry semantic metadata. That metadata is used by tests, dia
 
 Accessibility should be visible in tests. A test that finds a button by semantic label is usually stronger than a test that depends on an internal node path.
 
+## Current shell support
+
+The winit shell exposes Fission semantics through AccessKit on supported native targets. The bridge is built from the same `CoreIR` and layout snapshot used for rendering, so the accessibility tree follows the rendered widget tree instead of being maintained as a separate app-specific model.
+
+The bridge currently exports:
+
+| Fission semantic data | AccessKit output |
+| --- | --- |
+| Roles | Buttons, labels, text inputs, password inputs, multiline inputs, email/number/phone/URL inputs, images, checkboxes, switches, dialogs, sliders, lists, and list items. |
+| Labels and values | Explicit semantic labels, descendant text labels, text input values, numeric values, and toggle state. |
+| Bounds | Layout bounds converted into platform accessibility coordinates. |
+| Focus | Runtime focus is mirrored into the accessibility tree. Focus and blur actions update Fission focus. |
+| Text input actions | Replace selected text, set value, and set text selection dispatch through Fission's text input pipeline. |
+| Control actions | Click/default action, increment/decrement, set numeric value, and scroll actions dispatch through semantics and runtime state. |
+
+Android is intentionally excluded from this AccessKit bridge for now because the current `accesskit_winit` Android adapter requires winit's GameActivity path, while Fission's Android shell uses NativeActivity. Web, Static site, SSR, and Terminal targets do not use the winit AccessKit bridge; they need target-specific accessibility output appropriate to those hosts.
+
+The native bridge is best understood as a shell integration. App code should still use normal Fission widgets and semantics. The shell translates those semantics into the host accessibility tree.
+
 ## Internationalization contract
 
 Internationalization, often shortened to i18n, means making the app capable of supporting multiple languages and locale-sensitive behavior. Localization means providing the actual translated content for a locale.


### PR DESCRIPTION
## Summary

- switches Fission from the temporary vendored winit submodule to published `fission-winit 0.30.13-fission.1`
- uses `fission-accesskit-winit 0.33.1-fission.1` so AccessKit and Fission share the same patched winit type graph
- adds a native AccessKit bridge for the winit shell, mapping Fission semantics/layout/runtime state into an accessibility tree
- documents the current native accessibility support surface and target caveats

Closes #87.

## Published crates

- `fission-winit 0.30.13-fission.1`
- `fission-accesskit-winit 0.33.1-fission.1`

`fission-accesskit-winit` is required because upstream `accesskit_winit` depends on upstream `winit`; using `fission-winit` directly with upstream `accesskit_winit` creates two incompatible winit type graphs.

## Accessibility bridge

The winit shell now exports Fission semantics through AccessKit on supported non-Android native targets. The bridge currently covers:

- roles, labels, values, toggled state, numeric state, and bounds
- focus/blur actions
- click/default actions
- text input replace/set-value/selection actions
- scroll actions and numeric increment/decrement actions

Android remains excluded because the current AccessKit winit Android adapter requires the GameActivity path, while Fission uses NativeActivity.

## Validation

- `cargo fmt --all`
- `cargo check -p fission-shell-winit --tests`
- `cargo check -p fission-shell-desktop`
- `cargo check -p fission-shell-mobile`
