### PR TITLE
Add ScrollIntoView runtime effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-07-03
+
+### Added
+
+- **ScrollIntoView runtime effect** - Reducers can now call `ctx.effects.scroll_into_view(...)` or `ctx.effects.ensure_visible(...)` to reveal a target widget inside an explicit scroll container or nearest matching scroll ancestor after layout.
+- **Programmatic scroll API types** - Added `ScrollIntoViewRequest`, `ScrollAxis`, `ScrollAlignment`, and `ScrollBehavior` to the public API and prelude so document canvases, editors, outlines, tabs, and validation errors can request deterministic runtime scrolling without mutating scroll state during widget conversion.
+
+### Changed
+
+- **Post-layout runtime work** - The winit shell now keeps post-layout hooks active even when the widget tree is unchanged, allowing layout-dependent runtime effects to resolve against the current snapshot and schedule a follow-up layout frame when scroll offsets change.
+- **Scroll documentation** - The `Scroll` reference now documents stable IDs and reducer-driven reveal requests for cases such as selecting a page in a document editor.
+
+### Fixed
+
+- **Side-effect-free scroll control** - App code no longer needs to reorder content or reach into runtime scroll maps to reveal a selected child. Scroll offsets are updated by the runtime after layout and clamped to the container's content bounds.
+
 ## [0.6.2] - 2026-07-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "animation-gallery"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fission"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "chart-gallery"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "counter"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "embed-3d"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "embed-video"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "embed-webview"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "field-inspector"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2620,7 +2620,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fission"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "fission-3d",
  "fission-charts",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "fission-3d"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "fission-charts"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "fission-core",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-package"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-release"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-run"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-command-core",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "toml",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-site"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-shell-site",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-ui"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "fission-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "fission-credentials"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "fission-design-system-codegen"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "fission-diagnostics"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bitflags 2.13.0",
  "once_cell",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "fission-documentation"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "fission-editor"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -2863,14 +2863,14 @@ dependencies = [
 
 [[package]]
 name = "fission-i18n"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fission-icons"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "heck 0.4.1",
  "serde_json",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "fission-ir"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "blake3",
  "serde",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "fission-layout"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "fission-macros"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-ir",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render-vello"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "fission-semantics"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "fission-ir",
  "serde",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-desktop"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-mobile"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-site"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-terminal"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-web"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-winit"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test-driver"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -3156,14 +3156,14 @@ dependencies = [
 
 [[package]]
 name = "fission-text-engine"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "fission-theme"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "fission-design-system-codegen",
  "fission-ir",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "fission-widgets"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "icons_gallery"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -4443,7 +4443,7 @@ checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "inbox"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-smoke"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -5094,7 +5094,7 @@ dependencies = [
 
 [[package]]
 name = "motion-memory-repro"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "pokemon-card-store"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -6279,7 +6279,7 @@ dependencies = [
 
 [[package]]
 name = "product-browser"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -7881,7 +7881,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -7913,7 +7913,7 @@ dependencies = [
 
 [[package]]
 name = "text-lab"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -8073,7 +8073,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todo-design-system"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "web-smoke"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "widget-gallery"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "fission",

--- a/crates/authoring/fission-charts/Cargo.toml
+++ b/crates/authoring/fission-charts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-charts"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 license = "MIT"
@@ -11,9 +11,9 @@ description = "Native chart widgets and data visualization primitives for Fissio
 readme = "README.md"
 [dependencies]
 chrono = "0.4.44"
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-widgets = { path = "../fission-widgets", version = "0.6.2" }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-widgets = { path = "../fission-widgets", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/authoring/fission-charts/README.md
+++ b/crates/authoring/fission-charts/README.md
@@ -6,7 +6,7 @@ Chart widgets and data-visualization primitives for Fission applications.
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["desktop", "charts"] }
+fission = { version = "0.6.3", features = ["desktop", "charts"] }
 ```
 
 Most application code should import from `fission::prelude::*` and `fission::charts::*` rather than depending on this crate directly. Depend on `fission-charts` only when you are extending the chart layer itself.

--- a/crates/authoring/fission-icons/Cargo.toml
+++ b/crates/authoring/fission-icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-icons"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-macros/Cargo.toml
+++ b/crates/authoring/fission-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-macros"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-widgets"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -19,22 +19,22 @@ terminal = [
 ]
 
 [dependencies]
-fission-macros = { path = "../fission-macros", version = "0.6.2" }
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
-fission-icons = { path = "../fission-icons", version = "0.6.2" }
+fission-macros = { path = "../fission-macros", version = "0.6.3" }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
+fission-icons = { path = "../fission-icons", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.2" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.3" }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 
 [dev-dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -40,30 +40,30 @@ three-d = [
 web = ["dep:fission-shell-web"]
 
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-3d = { path = "../../core/fission-3d", version = "0.6.2", optional = true }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-text-engine = { path = "../../core/fission-text-engine", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.6.2" }
-fission-widgets = { path = "../fission-widgets", version = "0.6.2" }
-fission-macros = { path = "../fission-macros", version = "0.6.2" }
-fission-icons = { path = "../fission-icons", version = "0.6.2" }
-fission-charts = { path = "../fission-charts", version = "0.6.2", optional = true }
-fission-render = { path = "../../rendering/fission-render", version = "0.6.2" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.2" }
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.6.2", optional = true }
-fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.6.2", optional = true }
-fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.6.2", optional = true }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.6.2", optional = true }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-3d = { path = "../../core/fission-3d", version = "0.6.3", optional = true }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-text-engine = { path = "../../core/fission-text-engine", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.6.3" }
+fission-widgets = { path = "../fission-widgets", version = "0.6.3" }
+fission-macros = { path = "../fission-macros", version = "0.6.3" }
+fission-icons = { path = "../fission-icons", version = "0.6.3" }
+fission-charts = { path = "../fission-charts", version = "0.6.3", optional = true }
+fission-render = { path = "../../rendering/fission-render", version = "0.6.3" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.3" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.6.3", optional = true }
+fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.6.3", optional = true }
+fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.6.3", optional = true }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.6.3", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.6.2", optional = true }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.6.3", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.6.2", optional = true }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.6.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.6.2", optional = true }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.6.3", optional = true }

--- a/crates/authoring/fission/README.md
+++ b/crates/authoring/fission/README.md
@@ -15,7 +15,7 @@ This crate is the public facade. Application code should normally depend on `fis
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["desktop"] }
+fission = { version = "0.6.3", features = ["desktop"] }
 ```
 
 For the full developer workflow, install the Fission command:

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fission = { version = "0.6.2", default-features = false, features = ["desktop"] }
+//! fission = { version = "0.6.3", default-features = false, features = ["desktop"] }
 //! ```
 //!
 //! Then use via:
@@ -180,14 +180,15 @@ pub use fission_core::{
     NotificationResponseReceived, NotificationSchedule, NotificationSettings, NotificationSound,
     Op, PortalLayer, PushPlatform, PushRegistration, PushRegistrationRequest, ReducerContext,
     RegisterPushNotificationsCapability, RequestNotificationPermissionCapability, Role,
-    ScanNfcTagCapability, ScheduleNotificationCapability, Selector, Semantics,
-    SetBadgeCountCapability, SetBadgeCountRequest, ShowNotificationCapability,
-    UnregisterPushNotificationsCapability, ValueView, ViewHandle, WidgetId, WriteNfcTagCapability,
-    AUTHENTICATE_BIOMETRIC, CANCEL_ALL_NOTIFICATIONS, CANCEL_BIOMETRIC_AUTHENTICATION,
-    CANCEL_NFC_SESSION, CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_BIOMETRIC_AVAILABILITY,
-    GET_NFC_AVAILABILITY, GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS,
-    REQUEST_NOTIFICATION_PERMISSION, SCAN_NFC_TAG, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT,
-    SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS, WRITE_NFC_TAG,
+    ScanNfcTagCapability, ScheduleNotificationCapability, ScrollAlignment, ScrollAxis,
+    ScrollBehavior, ScrollIntoViewRequest, Selector, Semantics, SetBadgeCountCapability,
+    SetBadgeCountRequest, ShowNotificationCapability, UnregisterPushNotificationsCapability,
+    ValueView, ViewHandle, WidgetId, WriteNfcTagCapability, AUTHENTICATE_BIOMETRIC,
+    CANCEL_ALL_NOTIFICATIONS, CANCEL_BIOMETRIC_AUTHENTICATION, CANCEL_NFC_SESSION,
+    CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_BIOMETRIC_AVAILABILITY, GET_NFC_AVAILABILITY,
+    GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
+    SCAN_NFC_TAG, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION,
+    UNREGISTER_PUSH_NOTIFICATIONS, WRITE_NFC_TAG,
 };
 pub use fission_core::{
     AdjustVolumeLevelCapability, GetVolumeLevelCapability, SetVolumeLevelCapability,
@@ -401,14 +402,15 @@ pub mod prelude {
         NotificationSound, Op, PortalLayer, Provider, PushPlatform, PushRegistration,
         PushRegistrationRequest, ReducerContext, RegisterPushNotificationsCapability,
         RequestNotificationPermissionCapability, Role, ScanNfcTagCapability,
-        ScheduleNotificationCapability, Selector, Semantics, SetBadgeCountCapability,
-        SetBadgeCountRequest, ShowNotificationCapability, UnregisterPushNotificationsCapability,
-        ValueView, ViewHandle, WidgetId, WindowEnv, WindowTitle, WriteNfcTagCapability,
-        AUTHENTICATE_BIOMETRIC, CANCEL_ALL_NOTIFICATIONS, CANCEL_BIOMETRIC_AUTHENTICATION,
-        CANCEL_NFC_SESSION, CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_BIOMETRIC_AVAILABILITY,
-        GET_NFC_AVAILABILITY, GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS,
-        REQUEST_NOTIFICATION_PERMISSION, SCAN_NFC_TAG, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT,
-        SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS, WRITE_NFC_TAG,
+        ScheduleNotificationCapability, ScrollAlignment, ScrollAxis, ScrollBehavior,
+        ScrollIntoViewRequest, Selector, Semantics, SetBadgeCountCapability, SetBadgeCountRequest,
+        ShowNotificationCapability, UnregisterPushNotificationsCapability, ValueView, ViewHandle,
+        WidgetId, WindowEnv, WindowTitle, WriteNfcTagCapability, AUTHENTICATE_BIOMETRIC,
+        CANCEL_ALL_NOTIFICATIONS, CANCEL_BIOMETRIC_AUTHENTICATION, CANCEL_NFC_SESSION,
+        CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_BIOMETRIC_AVAILABILITY, GET_NFC_AVAILABILITY,
+        GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
+        SCAN_NFC_TAG, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION,
+        UNREGISTER_PUSH_NOTIFICATIONS, WRITE_NFC_TAG,
     };
     pub use fission_core::{
         AdjustVolumeLevelCapability, GetVolumeLevelCapability, SetVolumeLevelCapability,

--- a/crates/core/fission-3d/Cargo.toml
+++ b/crates/core/fission-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-3d"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 license = "MIT"
@@ -10,8 +10,8 @@ documentation = "https://fission.rs"
 description = "3D scene primitives and rendering data types for Fission applications"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../fission-core", version = "0.6.2" }
-fission-ir = { path = "../fission-ir", version = "0.6.2" }
+fission-core = { path = "../fission-core", version = "0.6.3" }
+fission-ir = { path = "../fission-ir", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 wgpu = "26.0"
 bytemuck = { version = "1.18", features = ["derive"] }

--- a/crates/core/fission-3d/README.md
+++ b/crates/core/fission-3d/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["desktop", "three-d"] }
+fission = { version = "0.6.3", features = ["desktop", "three-d"] }
 ```
 
 Use this crate directly only when you are extending the framework's 3D model or renderer integration.

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-core"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,13 +10,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.6.2" }
-fission-layout = { path = "../fission-layout", version = "0.6.2" }
-fission-semantics = { path = "../fission-semantics", version = "0.6.2" }
-fission-theme = { path = "../fission-theme", version = "0.6.2" }
-fission-i18n = { path = "../fission-i18n", version = "0.6.2" }
-fission-text-engine = { path = "../fission-text-engine", version = "0.6.2" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.6.2" }
+fission-ir = { path = "../fission-ir", version = "0.6.3" }
+fission-layout = { path = "../fission-layout", version = "0.6.3" }
+fission-semantics = { path = "../fission-semantics", version = "0.6.3" }
+fission-theme = { path = "../fission-theme", version = "0.6.3" }
+fission-i18n = { path = "../fission-i18n", version = "0.6.3" }
+fission-text-engine = { path = "../fission-text-engine", version = "0.6.3" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -25,6 +25,6 @@ lazy_static = "1.4"
 blake3 = "1.5"
 unicode-segmentation = "1.10"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.2" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.3" }
 
 [dev-dependencies]

--- a/crates/core/fission-core/src/context.rs
+++ b/crates/core/fission-core/src/context.rs
@@ -13,7 +13,7 @@ use crate::async_runtime::{
 use crate::capability::{
     CapabilityInvocationPayload, CapabilityType, OperationCapability, OperationCapabilityInvocation,
 };
-use crate::effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect};
+use crate::effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect, ScrollIntoViewRequest};
 use crate::platform::{
     CancelNotificationRequest, NotificationPermissionRequest, NotificationRequest,
     PushRegistrationRequest, SetBadgeCountRequest, CANCEL_ALL_NOTIFICATIONS, CANCEL_NOTIFICATION,
@@ -449,6 +449,20 @@ impl<'a, S: GlobalState> Effects<'a, S> {
         self.add(Effect::Runtime(RuntimeEffect::ReleaseResource {
             resource_id,
         }));
+    }
+
+    /// Reveals a widget inside a scroll container after the next layout pass.
+    ///
+    /// This is safe to emit from reducers because the runtime resolves widget
+    /// rectangles later, after layout has produced stable geometry.
+    pub fn scroll_into_view(&mut self, request: ScrollIntoViewRequest) -> u64 {
+        self.add(Effect::Runtime(RuntimeEffect::ScrollIntoView(request)))
+    }
+
+    /// Alias for [`Effects::scroll_into_view`] when the caller cares about
+    /// visibility rather than a specific scroll operation.
+    pub fn ensure_visible(&mut self, request: ScrollIntoViewRequest) -> u64 {
+        self.scroll_into_view(request)
     }
 }
 

--- a/crates/core/fission-core/src/effect.rs
+++ b/crates/core/fission-core/src/effect.rs
@@ -31,13 +31,91 @@ pub struct ReqId(pub u64);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ResourceId(pub u64);
 
+/// Axis selection for runtime scroll positioning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScrollAxis {
+    /// Adjust vertical scroll offsets.
+    Vertical,
+    /// Adjust horizontal scroll offsets.
+    Horizontal,
+    /// Adjust any matching scroll axis.
+    Both,
+}
+
+/// Desired placement of a target inside a scroll viewport.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum ScrollAlignment {
+    /// Align the target's leading edge with the viewport's leading edge.
+    Start,
+    /// Center the target in the viewport.
+    Center,
+    /// Align the target's trailing edge with the viewport's trailing edge.
+    End,
+    /// Use the smallest scroll delta that makes the target visible.
+    Nearest,
+    /// Place the target at a fractional position in the viewport.
+    ///
+    /// `0.0` behaves like [`ScrollAlignment::Start`], `0.5` centers the target,
+    /// and `1.0` behaves like [`ScrollAlignment::End`].
+    Fraction(f32),
+}
+
+/// Runtime behavior for a scroll request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScrollBehavior {
+    /// Apply the computed offset immediately.
+    Instant,
+    /// Reserve a smooth-scroll request. Current shells resolve this immediately.
+    Smooth,
+}
+
+/// Request a post-layout scroll adjustment that reveals a target widget.
+///
+/// Reducers can emit this as a runtime effect when application state changes.
+/// The runtime resolves it after the next layout pass, when target and container
+/// rectangles are available, then mutates the scroll state and schedules another
+/// frame so paint, hit testing, and semantics see the new offset.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// ctx.effects.scroll_into_view(ScrollIntoViewRequest {
+///     container: Some(WidgetId::explicit("document.canvas.scroll")),
+///     target: WidgetId::explicit("document.page.3"),
+///     axis: ScrollAxis::Vertical,
+///     alignment: ScrollAlignment::Start,
+///     padding: [24.0, 24.0, 24.0, 24.0],
+///     behavior: ScrollBehavior::Instant,
+///     if_needed: false,
+/// });
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScrollIntoViewRequest {
+    /// Explicit scroll container, or `None` to use the nearest matching scroll ancestor.
+    pub container: Option<WidgetId>,
+    /// Descendant widget that should become visible.
+    pub target: WidgetId,
+    /// Axis to scroll.
+    pub axis: ScrollAxis,
+    /// Alignment to use when computing the new offset.
+    pub alignment: ScrollAlignment,
+    /// Reveal margin as `[left, right, top, bottom]`.
+    pub padding: [f32; 4],
+    /// Whether to jump immediately or request smooth behavior.
+    pub behavior: ScrollBehavior,
+    /// If `true`, leave the offset unchanged when the target is already fully visible.
+    pub if_needed: bool,
+}
+
 /// Runtime-managed effects that are not host capabilities.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum RuntimeEffect {
     /// Cancel a previously issued effect by its request id.
     Cancel { req_id: u64 },
     /// Release a platform-managed resource.
     ReleaseResource { resource_id: u64 },
+    /// Reveal a widget inside a scroll container after the next layout pass.
+    ScrollIntoView(ScrollIntoViewRequest),
 }
 
 /// A side-effect emitted by a reducer.

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -208,7 +208,10 @@ pub mod public {
         Effects, GeolocationEffects, HapticEffects, MicrophoneEffects, NfcEffects,
         NotificationEffects, PasskeyEffects, ReducerContext, VolumeEffects, WifiEffects,
     }; // New
-    pub use crate::effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect};
+    pub use crate::effect::{
+        ActionInput, Effect, EffectEnvelope, RuntimeEffect, ScrollAlignment, ScrollAxis,
+        ScrollBehavior, ScrollIntoViewRequest,
+    };
     pub use crate::env::{
         Clipboard, Env, ImeHandler, InteractionStateMap, RuntimeState, ScrollStateMap, WindowEnv,
         WindowTitle,
@@ -365,7 +368,10 @@ pub use context::{
     Effects, GeolocationEffects, HapticEffects, MicrophoneEffects, NfcEffects, NotificationEffects,
     PasskeyEffects, ReducerContext, VolumeEffects, WifiEffects,
 }; // New
-pub use effect::{ActionInput, Effect, EffectEnvelope, RuntimeEffect};
+pub use effect::{
+    ActionInput, Effect, EffectEnvelope, RuntimeEffect, ScrollAlignment, ScrollAxis,
+    ScrollBehavior, ScrollIntoViewRequest,
+};
 pub use env::{
     Clipboard, Env, ImeHandler, InteractionStateMap, RouteLocation, RuntimeState, ScrollStateMap,
     WindowEnv, WindowTitle,

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -1,6 +1,9 @@
 use crate::action::{ActionEnvelope, ActionId, GlobalState};
 use crate::async_runtime::ServiceStopPayload;
-use crate::effect::{ActionInput, EffectEnvelope};
+use crate::effect::{
+    ActionInput, Effect, EffectEnvelope, RuntimeEffect, ScrollAlignment, ScrollAxis,
+    ScrollBehavior, ScrollIntoViewRequest,
+};
 use crate::env::{RuntimeState, VideoStatus};
 use crate::registry::{
     ActionRegistry, ResourcePolicy, RuntimeResourceDeclaration, RuntimeResourceKind, TimerResource,
@@ -47,6 +50,19 @@ struct ActiveResource {
     deps: Option<Vec<u8>>,
     policy: ResourcePolicy,
     kind: ActiveResourceKind,
+}
+
+#[derive(Debug, Clone)]
+struct PendingScrollIntoView {
+    request: ScrollIntoViewRequest,
+    retries_remaining: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScrollIntoViewOutcome {
+    Applied { changed: bool },
+    Retry,
+    Ignored,
 }
 
 /// The core runtime that owns application state, reducers, and the effect queue.
@@ -100,6 +116,8 @@ pub struct Runtime {
     pub ime_handler: Option<Arc<dyn ImeHandler>>,
     /// Effects emitted by reducers, awaiting platform execution.
     pub pending_effects: Vec<EffectEnvelope>,
+    /// Post-layout scroll requests that need computed geometry before applying.
+    pending_scroll_into_view: Vec<PendingScrollIntoView>,
     /// Monotonically increasing counter for deterministic request id generation.
     pub next_req_id: u64,
     /// Declarative runtime resources that currently exist.
@@ -119,6 +137,7 @@ impl Default for Runtime {
             clipboard_backend: None,
             ime_handler: None,
             pending_effects: Vec::new(),
+            pending_scroll_into_view: Vec::new(),
             next_req_id: 0,
             active_resources: HashMap::new(),
             next_resource_generation: 1,
@@ -527,7 +546,314 @@ impl Runtime {
             .retain(|node_id, _| seen.contains(node_id));
     }
 
-    pub fn post_layout_hook(&mut self, ir: &CoreIR, layout: &LayoutSnapshot) {
+    /// Queues a runtime effect that must be resolved by the core runtime.
+    ///
+    /// Shells call this for effects that require runtime-owned state or a
+    /// post-layout pass instead of a host capability executor.
+    pub fn queue_runtime_effect(&mut self, effect: RuntimeEffect) -> bool {
+        match effect {
+            RuntimeEffect::ScrollIntoView(request) => {
+                self.queue_scroll_into_view(request);
+                true
+            }
+            RuntimeEffect::Cancel { .. } | RuntimeEffect::ReleaseResource { .. } => false,
+        }
+    }
+
+    /// Queues a post-layout request to reveal a widget in a scroll container.
+    pub fn queue_scroll_into_view(&mut self, request: ScrollIntoViewRequest) {
+        self.pending_scroll_into_view.push(PendingScrollIntoView {
+            request,
+            retries_remaining: 1,
+        });
+    }
+
+    fn drain_scroll_into_view_effects(&mut self) {
+        let pending = std::mem::take(&mut self.pending_effects);
+
+        for env in pending {
+            let EffectEnvelope {
+                req_id,
+                effect,
+                on_ok,
+                on_err,
+                service_bindings,
+                resource,
+            } = env;
+
+            match effect {
+                Effect::Runtime(RuntimeEffect::ScrollIntoView(request)) => {
+                    self.queue_scroll_into_view(request);
+                }
+                retained => self.pending_effects.push(EffectEnvelope {
+                    req_id,
+                    effect: retained,
+                    on_ok,
+                    on_err,
+                    service_bindings,
+                    resource,
+                }),
+            }
+        }
+    }
+
+    fn apply_pending_scroll_into_view(&mut self, ir: &CoreIR, layout: &LayoutSnapshot) -> bool {
+        self.drain_scroll_into_view_effects();
+
+        let mut needs_follow_up_frame = false;
+        let pending = std::mem::take(&mut self.pending_scroll_into_view);
+
+        for mut pending_request in pending {
+            match self.apply_scroll_into_view(&pending_request.request, ir, layout) {
+                ScrollIntoViewOutcome::Applied { changed } => {
+                    needs_follow_up_frame |= changed;
+                }
+                ScrollIntoViewOutcome::Retry if pending_request.retries_remaining > 0 => {
+                    pending_request.retries_remaining -= 1;
+                    self.pending_scroll_into_view.push(pending_request);
+                    needs_follow_up_frame = true;
+                }
+                ScrollIntoViewOutcome::Retry | ScrollIntoViewOutcome::Ignored => {}
+            }
+        }
+
+        needs_follow_up_frame
+    }
+
+    fn apply_scroll_into_view(
+        &mut self,
+        request: &ScrollIntoViewRequest,
+        ir: &CoreIR,
+        layout: &LayoutSnapshot,
+    ) -> ScrollIntoViewOutcome {
+        let Some(target_geom) = layout.get_node_geometry(request.target) else {
+            Self::emit_scroll_into_view_diag("missing_target", request, None);
+            return ScrollIntoViewOutcome::Retry;
+        };
+
+        let Some(container_id) = self.resolve_scroll_container(request, ir, layout) else {
+            Self::emit_scroll_into_view_diag("missing_container", request, None);
+            return ScrollIntoViewOutcome::Retry;
+        };
+
+        if !Self::is_descendant_or_self(ir, request.target, container_id) {
+            Self::emit_scroll_into_view_diag("target_not_descendant", request, Some(container_id));
+            return ScrollIntoViewOutcome::Ignored;
+        }
+
+        let Some(container_geom) = layout.get_node_geometry(container_id) else {
+            Self::emit_scroll_into_view_diag(
+                "missing_container_layout",
+                request,
+                Some(container_id),
+            );
+            return ScrollIntoViewOutcome::Retry;
+        };
+
+        let Some(direction) = Self::scroll_direction(ir, container_id) else {
+            Self::emit_scroll_into_view_diag("not_scroll_container", request, Some(container_id));
+            return ScrollIntoViewOutcome::Ignored;
+        };
+
+        if !Self::axis_matches(request.axis, direction) {
+            Self::emit_scroll_into_view_diag("axis_mismatch", request, Some(container_id));
+            return ScrollIntoViewOutcome::Ignored;
+        }
+
+        if matches!(request.behavior, ScrollBehavior::Smooth) {
+            Self::emit_scroll_into_view_diag(
+                "smooth_resolved_as_instant",
+                request,
+                Some(container_id),
+            );
+        }
+
+        let current_offset = self.runtime_state.scroll.get_offset(container_id);
+        let new_offset = match direction {
+            FlexDirection::Column => Self::compute_scroll_offset(
+                current_offset,
+                target_geom.rect.y() - container_geom.rect.y(),
+                target_geom.rect.height(),
+                container_geom.rect.height(),
+                container_geom.content_size.height,
+                request.padding[2],
+                request.padding[3],
+                request.alignment,
+                request.if_needed,
+            ),
+            FlexDirection::Row => Self::compute_scroll_offset(
+                current_offset,
+                target_geom.rect.x() - container_geom.rect.x(),
+                target_geom.rect.width(),
+                container_geom.rect.width(),
+                container_geom.content_size.width,
+                request.padding[0],
+                request.padding[1],
+                request.alignment,
+                request.if_needed,
+            ),
+        };
+
+        if (new_offset - current_offset).abs() > f32::EPSILON {
+            self.runtime_state
+                .scroll
+                .set_offset(container_id, new_offset);
+            ScrollIntoViewOutcome::Applied { changed: true }
+        } else {
+            ScrollIntoViewOutcome::Applied { changed: false }
+        }
+    }
+
+    fn resolve_scroll_container(
+        &self,
+        request: &ScrollIntoViewRequest,
+        ir: &CoreIR,
+        layout: &LayoutSnapshot,
+    ) -> Option<WidgetId> {
+        if let Some(container) = request.container {
+            return ir
+                .nodes
+                .contains_key(&container)
+                .then_some(container)
+                .filter(|id| layout.get_node_geometry(*id).is_some());
+        }
+
+        let mut current = ir.nodes.get(&request.target)?.parent;
+        while let Some(node_id) = current {
+            if let Some(direction) = Self::scroll_direction(ir, node_id) {
+                if Self::axis_matches(request.axis, direction)
+                    && layout.get_node_geometry(node_id).is_some()
+                {
+                    return Some(node_id);
+                }
+            }
+            current = ir.nodes.get(&node_id).and_then(|node| node.parent);
+        }
+
+        None
+    }
+
+    fn scroll_direction(ir: &CoreIR, node_id: WidgetId) -> Option<FlexDirection> {
+        match ir.nodes.get(&node_id).map(|node| &node.op) {
+            Some(Op::Layout(LayoutOp::Scroll { direction, .. })) => Some(*direction),
+            _ => None,
+        }
+    }
+
+    fn axis_matches(axis: ScrollAxis, direction: FlexDirection) -> bool {
+        matches!(
+            (axis, direction),
+            (ScrollAxis::Both, _)
+                | (ScrollAxis::Vertical, FlexDirection::Column)
+                | (ScrollAxis::Horizontal, FlexDirection::Row)
+        )
+    }
+
+    fn is_descendant_or_self(ir: &CoreIR, target: WidgetId, ancestor: WidgetId) -> bool {
+        let mut current = Some(target);
+        while let Some(node_id) = current {
+            if node_id == ancestor {
+                return true;
+            }
+            current = ir.nodes.get(&node_id).and_then(|node| node.parent);
+        }
+        false
+    }
+
+    fn compute_scroll_offset(
+        current_offset: f32,
+        target_content_start: f32,
+        target_size: f32,
+        viewport_size: f32,
+        content_size: f32,
+        padding_start: f32,
+        padding_end: f32,
+        alignment: ScrollAlignment,
+        if_needed: bool,
+    ) -> f32 {
+        let current_offset = Self::finite_or_zero(current_offset).max(0.0);
+        let viewport_size = Self::finite_or_zero(viewport_size).max(0.0);
+        let content_size = Self::finite_or_zero(content_size).max(0.0);
+        let target_size = Self::finite_or_zero(target_size).max(0.0);
+        let padding_start = Self::finite_or_zero(padding_start).max(0.0);
+        let padding_end = Self::finite_or_zero(padding_end).max(0.0);
+        let max_offset = (content_size - viewport_size).max(0.0);
+
+        if viewport_size <= f32::EPSILON || max_offset <= f32::EPSILON {
+            return 0.0;
+        }
+
+        let target_start = Self::finite_or_zero(target_content_start);
+        let target_end = target_start + target_size;
+        let reveal_start = target_start - padding_start;
+        let reveal_end = target_end + padding_end;
+        let viewport_start = current_offset;
+        let viewport_end = current_offset + viewport_size;
+
+        if if_needed && reveal_start >= viewport_start && reveal_end <= viewport_end {
+            return current_offset.min(max_offset);
+        }
+
+        let desired = match alignment {
+            ScrollAlignment::Start => reveal_start,
+            ScrollAlignment::Center => {
+                let padded_viewport = (viewport_size - padding_start - padding_end).max(0.0);
+                target_start - padding_start - (padded_viewport - target_size) * 0.5
+            }
+            ScrollAlignment::End => reveal_end - viewport_size,
+            ScrollAlignment::Nearest => {
+                if reveal_start < viewport_start {
+                    reveal_start
+                } else if reveal_end > viewport_end {
+                    reveal_end - viewport_size
+                } else {
+                    current_offset
+                }
+            }
+            ScrollAlignment::Fraction(fraction) => {
+                let fraction = Self::finite_or_zero(fraction).clamp(0.0, 1.0);
+                let padded_viewport = (viewport_size - padding_start - padding_end).max(0.0);
+                target_start - padding_start - (padded_viewport - target_size) * fraction
+            }
+        };
+
+        Self::finite_or_zero(desired).clamp(0.0, max_offset)
+    }
+
+    fn finite_or_zero(value: f32) -> f32 {
+        if value.is_finite() {
+            value
+        } else {
+            0.0
+        }
+    }
+
+    fn emit_scroll_into_view_diag(
+        kind: &'static str,
+        request: &ScrollIntoViewRequest,
+        container: Option<WidgetId>,
+    ) {
+        diag::emit(
+            diag::DiagCategory::Input,
+            diag::DiagLevel::Debug,
+            diag::DiagEventKind::InputEvent {
+                kind: format!(
+                    "scroll_into_view:{kind}:target={:?}:container={:?}",
+                    request.target,
+                    container.or(request.container)
+                ),
+                target: Some(request.target.as_u128()),
+                position: None,
+            },
+        );
+    }
+
+    /// Runs runtime work that depends on a freshly computed layout snapshot.
+    ///
+    /// Returns `true` when the hook changed runtime state and the shell should
+    /// schedule another frame.
+    pub fn post_layout_hook(&mut self, ir: &CoreIR, layout: &LayoutSnapshot) -> bool {
+        let needs_follow_up_frame = self.apply_pending_scroll_into_view(ir, layout);
         let mut current_heroes = HashMap::new();
 
         for (id, node) in &ir.nodes {
@@ -565,6 +891,7 @@ impl Runtime {
         }
 
         self.runtime_state.hero.positions = current_heroes;
+        needs_follow_up_frame
     }
 
     pub fn handle_input(

--- a/crates/core/fission-core/tests/scroll_into_view.rs
+++ b/crates/core/fission-core/tests/scroll_into_view.rs
@@ -1,0 +1,203 @@
+use fission_core::{
+    Effect, EffectEnvelope, Effects, GlobalState, Runtime, RuntimeEffect, ScrollAlignment,
+    ScrollAxis, ScrollBehavior, ScrollIntoViewRequest,
+};
+use fission_ir::{CoreIR, FlexDirection, LayoutOp, Op, WidgetId};
+use fission_layout::{LayoutNodeGeometry, LayoutRect, LayoutSize, LayoutSnapshot};
+
+fn box_op() -> Op {
+    Op::Layout(LayoutOp::Box {
+        width: None,
+        height: None,
+        min_width: None,
+        max_width: None,
+        min_height: None,
+        max_height: None,
+        padding: [0.0; 4],
+        flex_grow: 0.0,
+        flex_shrink: 0.0,
+        aspect_ratio: None,
+    })
+}
+
+fn scroll_op(direction: FlexDirection) -> Op {
+    Op::Layout(LayoutOp::Scroll {
+        direction,
+        show_scrollbar: true,
+        width: Some(100.0),
+        height: Some(100.0),
+        min_width: None,
+        max_width: None,
+        min_height: None,
+        max_height: None,
+        padding: [0.0; 4],
+        flex_grow: 0.0,
+        flex_shrink: 0.0,
+    })
+}
+
+fn vertical_scroll_tree() -> (CoreIR, LayoutSnapshot, WidgetId, WidgetId) {
+    let root = WidgetId::from_u128(1);
+    let scroll = WidgetId::from_u128(2);
+    let target = WidgetId::from_u128(3);
+
+    let mut ir = CoreIR::new();
+    ir.add_node(target, box_op(), vec![]);
+    ir.add_node(scroll, scroll_op(FlexDirection::Column), vec![target]);
+    ir.add_node(root, box_op(), vec![scroll]);
+    ir.set_root(root);
+
+    let mut layout = LayoutSnapshot::new(LayoutSize::new(100.0, 100.0));
+    layout.nodes.insert(
+        root,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(0.0, 0.0, 100.0, 100.0),
+            content_size: LayoutSize::new(100.0, 100.0),
+        },
+    );
+    layout.nodes.insert(
+        scroll,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(0.0, 0.0, 100.0, 100.0),
+            content_size: LayoutSize::new(100.0, 500.0),
+        },
+    );
+    layout.nodes.insert(
+        target,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(0.0, 260.0, 100.0, 40.0),
+            content_size: LayoutSize::new(100.0, 40.0),
+        },
+    );
+
+    (ir, layout, scroll, target)
+}
+
+fn request(container: Option<WidgetId>, target: WidgetId) -> ScrollIntoViewRequest {
+    ScrollIntoViewRequest {
+        container,
+        target,
+        axis: ScrollAxis::Vertical,
+        alignment: ScrollAlignment::Start,
+        padding: [0.0, 0.0, 24.0, 12.0],
+        behavior: ScrollBehavior::Instant,
+        if_needed: false,
+    }
+}
+
+#[derive(Debug, Default)]
+struct TestState;
+
+impl GlobalState for TestState {}
+
+#[test]
+fn effects_builder_emits_scroll_into_view_runtime_effect() {
+    let target = WidgetId::from_u128(99);
+    let mut effects = Effects::<TestState>::new_headless(10);
+
+    let req_id = effects.scroll_into_view(ScrollIntoViewRequest {
+        container: None,
+        target,
+        axis: ScrollAxis::Vertical,
+        alignment: ScrollAlignment::Start,
+        padding: [0.0; 4],
+        behavior: ScrollBehavior::Instant,
+        if_needed: true,
+    });
+
+    assert_eq!(req_id, 10);
+    assert!(matches!(
+        effects.out.first().map(|env| &env.effect),
+        Some(Effect::Runtime(RuntimeEffect::ScrollIntoView(request))) if request.target == target
+    ));
+}
+
+#[test]
+fn explicit_vertical_scroll_into_view_aligns_target_to_start_padding() {
+    let (ir, layout, scroll, target) = vertical_scroll_tree();
+    let mut runtime = Runtime::default();
+
+    runtime.queue_scroll_into_view(request(Some(scroll), target));
+
+    assert!(runtime.post_layout_hook(&ir, &layout));
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 236.0);
+}
+
+#[test]
+fn runtime_effect_queue_is_drained_after_layout() {
+    let (ir, layout, scroll, target) = vertical_scroll_tree();
+    let mut runtime = Runtime::default();
+    runtime.pending_effects.push(EffectEnvelope {
+        req_id: 7,
+        effect: Effect::Runtime(RuntimeEffect::ScrollIntoView(request(Some(scroll), target))),
+        on_ok: None,
+        on_err: None,
+        service_bindings: None,
+        resource: None,
+    });
+
+    assert!(runtime.post_layout_hook(&ir, &layout));
+    assert!(runtime.pending_effects.is_empty());
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 236.0);
+}
+
+#[test]
+fn omitted_container_uses_nearest_matching_scroll_ancestor() {
+    let (ir, mut layout, scroll, target) = vertical_scroll_tree();
+    layout.nodes.get_mut(&target).unwrap().rect = LayoutRect::new(0.0, 160.0, 100.0, 30.0);
+    let mut runtime = Runtime::default();
+
+    runtime.queue_scroll_into_view(ScrollIntoViewRequest {
+        container: None,
+        target,
+        axis: ScrollAxis::Vertical,
+        alignment: ScrollAlignment::Nearest,
+        padding: [0.0; 4],
+        behavior: ScrollBehavior::Instant,
+        if_needed: false,
+    });
+
+    assert!(runtime.post_layout_hook(&ir, &layout));
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 90.0);
+}
+
+#[test]
+fn nearest_alignment_keeps_already_visible_target_stationary() {
+    let (ir, mut layout, scroll, target) = vertical_scroll_tree();
+    layout.nodes.get_mut(&target).unwrap().rect = LayoutRect::new(0.0, 220.0, 100.0, 30.0);
+    let mut runtime = Runtime::default();
+    runtime.runtime_state.scroll.set_offset(scroll, 200.0);
+
+    runtime.queue_scroll_into_view(ScrollIntoViewRequest {
+        container: Some(scroll),
+        target,
+        axis: ScrollAxis::Vertical,
+        alignment: ScrollAlignment::Nearest,
+        padding: [0.0; 4],
+        behavior: ScrollBehavior::Instant,
+        if_needed: false,
+    });
+
+    assert!(!runtime.post_layout_hook(&ir, &layout));
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 200.0);
+}
+
+#[test]
+fn missing_target_is_retried_once_after_next_layout() {
+    let (mut ir, mut layout, scroll, target) = vertical_scroll_tree();
+    ir.nodes.remove(&target);
+    layout.nodes.remove(&target);
+    let mut runtime = Runtime::default();
+
+    runtime.queue_scroll_into_view(request(Some(scroll), target));
+
+    assert!(runtime.post_layout_hook(&ir, &layout));
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 0.0);
+
+    let (complete_ir, complete_layout, _, _) = vertical_scroll_tree();
+    ir = complete_ir;
+    layout = complete_layout;
+
+    assert!(runtime.post_layout_hook(&ir, &layout));
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 236.0);
+}

--- a/crates/core/fission-i18n/Cargo.toml
+++ b/crates/core/fission-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-i18n"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-ir/Cargo.toml
+++ b/crates/core/fission-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-ir"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-layout"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,9 +10,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.6.2" }
+fission-ir = { path = "../fission-ir", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.2" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.3" }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/Cargo.toml
+++ b/crates/core/fission-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-semantics"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,7 +10,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.6.2" }
+fission-ir = { path = "../fission-ir", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/core/fission-text-engine/Cargo.toml
+++ b/crates/core/fission-text-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-text-engine"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 license = "MIT"

--- a/crates/core/fission-theme/Cargo.toml
+++ b/crates/core/fission-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-theme"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -19,8 +19,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.6.2" }
+fission-ir = { path = "../fission-ir", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.6.2" }
+fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.6.3" }

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-vello"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,13 +10,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
+fission-render = { path = "../fission-render", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
 anyhow = "1.0"
 vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2", features = ["wgpu"] }
 parley = "0.7.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.2" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.3" }
 image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"

--- a/crates/rendering/fission-render-wgpu2d/Cargo.toml
+++ b/crates/rendering/fission-render-wgpu2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-wgpu2d"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -9,7 +9,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.6.2" }
+fission-render = { path = "../fission-render", version = "0.6.3" }
 anyhow = "1.0"
 bytemuck = { version = "1.16", features = ["derive"] }
 wgpu = { version = "26.0.1", default-features = false, features = ["std", "wgsl"] }

--- a/crates/rendering/fission-render/Cargo.toml
+++ b/crates/rendering/fission-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,8 +10,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-desktop"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 license = "MIT"
@@ -15,19 +15,19 @@ tray = ["fission-shell-winit/tray"]
 three-d = ["fission-shell-winit/three-d"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.6.2" }
-fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.6.2" }
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
+fission-shell = { path = "../fission-shell", version = "0.6.3" }
+fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.6.3" }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
 anyhow = "1.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.6.2" }
-fission-render = { path = "../../rendering/fission-render", version = "0.6.2" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.6.2" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.6.3" }
+fission-render = { path = "../../rendering/fission-render", version = "0.6.3" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.6.3" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.3" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-mobile"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -14,10 +14,10 @@ default = []
 three-d = ["fission-shell-winit/three-d"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.6.2" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.6.2", default-features = false }
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
+fission-shell = { path = "../fission-shell", version = "0.6.3" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.6.3", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/shell/fission-shell-mobile/README.md
+++ b/crates/shell/fission-shell-mobile/README.md
@@ -8,9 +8,9 @@ Most application developers should use the public facade instead of depending on
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["android"] }
+fission = { version = "0.6.3", features = ["android"] }
 # or
-fission = { version = "0.6.2", features = ["ios"] }
+fission = { version = "0.6.3", features = ["ios"] }
 ```
 
 ## What it provides

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-server"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -23,12 +23,12 @@ axum = { version = "0.7", optional = true, default-features = false }
 base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-shell-site = { path = "../fission-shell-site", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-shell-site = { path = "../fission-shell-site", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
 getrandom = { version = "0.2", features = ["std"] }
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 moka = { version = "0.12", features = ["sync"] }
@@ -39,4 +39,4 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.2", default-features = false }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.3", default-features = false }

--- a/crates/shell/fission-shell-server/README.md
+++ b/crates/shell/fission-shell-server/README.md
@@ -14,7 +14,7 @@ Most applications should depend on the public `fission` facade with the
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["server"] }
+fission = { version = "0.6.3", features = ["server"] }
 ```
 
 Enable adapter features through the facade when you want to host the renderer
@@ -22,7 +22,7 @@ inside an existing HTTP stack:
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["server", "server-axum"] }
+fission = { version = "0.6.3", features = ["server", "server-axum"] }
 ```
 
 See the guides and reference at <https://fission.rs> for the server app model,

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-site"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -12,14 +12,14 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.2", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.3", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 
 [dev-dependencies]
-fission-i18n = { path = "../../core/fission-i18n", version = "0.6.2" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.6.3" }

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -6,7 +6,7 @@ Static site shell for Fission applications and documentation sites.
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["site"] }
+fission = { version = "0.6.3", features = ["site"] }
 ```
 
 ```sh

--- a/crates/shell/fission-shell-terminal/Cargo.toml
+++ b/crates/shell/fission-shell-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-terminal"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,7 +16,7 @@ crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["png"] }
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }

--- a/crates/shell/fission-shell-terminal/README.md
+++ b/crates/shell/fission-shell-terminal/README.md
@@ -8,7 +8,7 @@ Application developers normally enable it through the facade crate:
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["terminal-shell"] }
+fission = { version = "0.6.3", features = ["terminal-shell"] }
 ```
 
 ## What it contains

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-web"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ three-d = ["fission-shell-winit/three-d"]
 
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
-fission-shell = { path = "../fission-shell", version = "0.6.2" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.6.2", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
+fission-shell = { path = "../fission-shell", version = "0.6.3" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.6.3", default-features = false }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-winit"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Shared winit shell runtime for desktop and mobile Fission hosts"
 
@@ -15,18 +15,18 @@ tray = ["dep:tray-icon"]
 three-d = ["dep:fission-3d"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.6.2" }
-fission-render = { path = "../../rendering/fission-render", version = "0.6.2" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.6.2" }
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
-fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.6.2" }
+fission-shell = { path = "../fission-shell", version = "0.6.3" }
+fission-render = { path = "../../rendering/fission-render", version = "0.6.3" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.6.3" }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
+fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.6.3" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.2" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.6.2" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.6.3" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.6.3" }
 image = "0.25"
 tiny-skia = "0.11.4"
 fontdue = "0.9.3"
@@ -81,6 +81,6 @@ dispatch = "0.2"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.6.2" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.2" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.6.3" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.3" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -39,7 +39,7 @@ use fission_core::{
     Action, ActionId, ActionRegistry, DeepLink, DeepLinkConfig, DeepLinkReceived, Env, GlobalState,
     InputEvent, KeyCode, KeyEvent as FissionKeyEvent, NotificationResponse,
     NotificationResponseReceived, OpenUrlRequest, PointerButton, PointerEvent, Runtime,
-    RuntimeEffect, ServiceBindings, View, Widget, WidgetIdExt, OPEN_URL,
+    ServiceBindings, View, Widget, WidgetIdExt, OPEN_URL,
 };
 use fission_core::{ActionInput, CapabilityInvocationPayload, Effect};
 use fission_diagnostics::prelude as diag;
@@ -1521,7 +1521,7 @@ fn process_pending_effects(
         return false;
     }
 
-    let dispatched_callback = false;
+    let mut dispatched_callback = false;
     let wake = {
         let proxy = Arc::new(Mutex::new(event_proxy.clone()));
         Arc::new(move || {
@@ -1543,8 +1543,9 @@ fn process_pending_effects(
                         position: None,
                     },
                 );
-                match runtime_effect {
-                    RuntimeEffect::Cancel { .. } | RuntimeEffect::ReleaseResource { .. } => {}
+                if runtime.queue_runtime_effect(runtime_effect.clone()) {
+                    dispatched_callback = true;
+                    (wake)();
                 }
             }
             Effect::Capability(capability) => match capability {
@@ -5577,7 +5578,7 @@ where
                                 last_built_viewport = Some(build_viewport);
                             }
 
-                            let layout_updates = match pipeline.ensure_layout(
+                            let _layout_updates = match pipeline.ensure_layout(
                                 LayoutRect::new(
                                     0.0,
                                     0.0,
@@ -5595,11 +5596,11 @@ where
                                 }
                             };
 
-                            if layout_updates > 0 {
-                                if let (Some(ir), Some(layout)) =
-                                    (pipeline.prev_ir.as_ref(), pipeline.last_snapshot.as_ref())
-                                {
-                                    runtime.post_layout_hook(ir, layout);
+                            if let (Some(ir), Some(layout)) =
+                                (pipeline.prev_ir.as_ref(), pipeline.last_snapshot.as_ref())
+                            {
+                                if runtime.post_layout_hook(ir, layout) {
+                                    invalidations.mark_layout();
                                 }
                             }
                             if let (Some(ir), Some(layout)) =

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,9 +10,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-render = { path = "../../rendering/fission-render", version = "0.6.2" } # Corrected path
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-render = { path = "../../rendering/fission-render", version = "0.6.3" } # Corrected path
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/tools/cargo-fission/Cargo.toml
+++ b/crates/tools/cargo-fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fission"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -24,10 +24,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.6.2" }
-fission-command-package = { path = "../fission-command-package", version = "0.6.2" }
-fission-command-release = { path = "../fission-command-release", version = "0.6.2" }
-fission-command-run = { path = "../fission-command-run", version = "0.6.2" }
-fission-command-server = { path = "../fission-command-server", version = "0.6.2" }
-fission-command-site = { path = "../fission-command-site", version = "0.6.2" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.6.2" }
+fission-command-core = { path = "../fission-command-core", version = "0.6.3" }
+fission-command-package = { path = "../fission-command-package", version = "0.6.3" }
+fission-command-release = { path = "../fission-command-release", version = "0.6.3" }
+fission-command-run = { path = "../fission-command-run", version = "0.6.3" }
+fission-command-server = { path = "../fission-command-server", version = "0.6.3" }
+fission-command-site = { path = "../fission-command-site", version = "0.6.3" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.6.3" }

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -1061,7 +1061,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fission = { version = "0.6.2", default-features = false, features = ["desktop"] }
+fission = { version = "0.6.3", default-features = false, features = ["desktop"] }
 "#,
         )
         .unwrap();
@@ -1088,7 +1088,7 @@ edition = "2021"
 anyhow = "1"
 
 [dependencies.fission]
-version = "0.6.2"
+version = "0.6.3"
 default-features = true
 features = ["desktop"]
 "#,

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-core"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-core/assets/AGENTS.md
+++ b/crates/tools/fission-command-core/assets/AGENTS.md
@@ -139,7 +139,7 @@ Outside the Fission source workspace, prefer the published crate pinned to the s
 
 ```toml
 [build-dependencies]
-fission-design-system-codegen = { version = "0.6.2" }
+fission-design-system-codegen = { version = "0.6.3" }
 ```
 
 Generate a typed design system from the copied DSP file in `build.rs`:

--- a/crates/tools/fission-command-package/Cargo.toml
+++ b/crates/tools/fission-command-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-package"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -14,10 +14,10 @@ anyhow = "1.0"
 aws-config = "1"
 aws-sdk-s3 = "1"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.6.2" }
-fission-command-run = { path = "../fission-command-run", version = "0.6.2" }
-fission-command-site = { path = "../fission-command-site", version = "0.6.2" }
-fission-credentials = { path = "../fission-credentials", version = "0.6.2" }
+fission-command-core = { path = "../fission-command-core", version = "0.6.3" }
+fission-command-run = { path = "../fission-command-run", version = "0.6.3" }
+fission-command-site = { path = "../fission-command-site", version = "0.6.3" }
+fission-credentials = { path = "../fission-credentials", version = "0.6.3" }
 flate2 = "1.0"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-release/Cargo.toml
+++ b/crates/tools/fission-command-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-release"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -13,10 +13,10 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.6.2" }
-fission-command-package = { path = "../fission-command-package", version = "0.6.2" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.6.2" }
-fission-credentials = { path = "../fission-credentials", version = "0.6.2" }
+fission-command-core = { path = "../fission-command-core", version = "0.6.3" }
+fission-command-package = { path = "../fission-command-package", version = "0.6.3" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.6.3" }
+fission-credentials = { path = "../fission-credentials", version = "0.6.3" }
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-run"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,8 +11,8 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-command-core = { path = "../fission-command-core", version = "0.6.2" }
-fission-command-server = { path = "../fission-command-server", version = "0.6.2" }
-fission-command-site = { path = "../fission-command-site", version = "0.6.2" }
+fission-command-core = { path = "../fission-command-core", version = "0.6.3" }
+fission-command-server = { path = "../fission-command-server", version = "0.6.3" }
+fission-command-site = { path = "../fission-command-site", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-server"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-site"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,6 +11,6 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.6.2" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.6.3" }
 serde_json = "1"
 toml = "0.8"

--- a/crates/tools/fission-command-ui/Cargo.toml
+++ b/crates/tools/fission-command-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-ui"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,7 +11,7 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../authoring/fission", version = "0.6.2", default-features = false, features = ["terminal-shell"] }
-fission-command-core = { path = "../fission-command-core", version = "0.6.2" }
-fission-command-run = { path = "../fission-command-run", version = "0.6.2" }
+fission = { path = "../../authoring/fission", version = "0.6.3", default-features = false, features = ["terminal-shell"] }
+fission-command-core = { path = "../fission-command-core", version = "0.6.3" }
+fission-command-run = { path = "../fission-command-run", version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/tools/fission-credentials/Cargo.toml
+++ b/crates/tools/fission-credentials/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-credentials"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -13,7 +13,7 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.22"
 chacha20poly1305 = "0.10"
-fission-command-core = { path = "../fission-command-core", version = "0.6.2" }
+fission-command-core = { path = "../fission-command-core", version = "0.6.3" }
 getrandom = { version = "0.2", features = ["std"] }
 keyring = { version = "3", default-features = false, features = ["apple-native", "windows-native", "linux-native", "crypto-rust"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/tools/fission-design-system-codegen/Cargo.toml
+++ b/crates/tools/fission-design-system-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-design-system-codegen"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-diagnostics"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test-driver/Cargo.toml
+++ b/crates/tools/fission-test-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test-driver"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test/Cargo.toml
+++ b/crates/tools/fission-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,22 +10,22 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.6.2" }
-fission-ir = { path = "../../core/fission-ir", version = "0.6.2" }
-fission-layout = { path = "../../core/fission-layout", version = "0.6.2" }
-fission-render = { path = "../../rendering/fission-render", version = "0.6.2" }
-fission-shell = { path = "../../shell/fission-shell", version = "0.6.2" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.2" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.6.2" }
+fission-core = { path = "../../core/fission-core", version = "0.6.3" }
+fission-ir = { path = "../../core/fission-ir", version = "0.6.3" }
+fission-layout = { path = "../../core/fission-layout", version = "0.6.3" }
+fission-render = { path = "../../rendering/fission-render", version = "0.6.3" }
+fission-shell = { path = "../../shell/fission-shell", version = "0.6.3" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.6.3" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.6.3" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
-fission-macros = { path = "../../authoring/fission-macros", version = "0.6.2" }
-fission-diagnostics = { path = "../fission-diagnostics", version = "0.6.2" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.6.2" }
-fission-theme = { path = "../../core/fission-theme", version = "0.6.2" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.6.3" }
+fission-diagnostics = { path = "../fission-diagnostics", version = "0.6.3" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.6.3" }
+fission-theme = { path = "../../core/fission-theme", version = "0.6.3" }
 fontique = "0.7"
 serde_json = "1.0"
 
 [dev-dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.6.2" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.6.3" }

--- a/documentation/Cargo.toml
+++ b/documentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-documentation"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/documentation/content/blog/2026-07-03-fission-0-6-3-scroll-into-view.mdx
+++ b/documentation/content/blog/2026-07-03-fission-0-6-3-scroll-into-view.mdx
@@ -1,0 +1,96 @@
+---
+title: Fission 0.6.3: ScrollIntoView runtime effects
+authors:
+  - fission
+tags:
+  - release
+  - runtime
+  - scroll
+  - documents
+categories:
+  - Releases
+---
+
+Fission 0.6.3 adds a small but important runtime feature: reducers can now ask the runtime to reveal a widget inside a scroll container after layout.
+
+That is the missing piece for document editors, page outlines, validation summaries, search results, sidebars, and any app where a user action selects something that may already exist lower in a scrollable surface.
+
+## Why this belongs in the runtime
+
+Fission already had scroll primitives:
+
+- `Scroll` owns a scrollable viewport;
+- `RuntimeState.scroll` stores offsets;
+- pointer wheels, scrollbars, and text-input caret tracking can mutate those offsets internally;
+- app code can read previous layout through `View::get_rect(...)`.
+
+The missing feature was a safe way for application intent to say: after the next layout pass, scroll this viewport so that widget is visible.
+
+Reducers cannot safely mutate scroll offsets because they do not own layout geometry. Widget conversion must stay side-effect free. `ScrollIntoViewRequest` keeps that boundary intact.
+
+## The API
+
+A reducer can now emit:
+
+```rust
+ctx.effects.scroll_into_view(ScrollIntoViewRequest {
+    container: Some(WidgetId::explicit("document.canvas.scroll")),
+    target: WidgetId::explicit("document.page.3"),
+    axis: ScrollAxis::Vertical,
+    alignment: ScrollAlignment::Start,
+    padding: [24.0, 24.0, 24.0, 24.0],
+    behavior: ScrollBehavior::Instant,
+    if_needed: false,
+});
+```
+
+The request is resolved after layout, when Fission can see both the target rect and the scroll container geometry. If `container` is omitted, the runtime uses the nearest matching scroll ancestor.
+
+`ScrollAlignment` supports `Start`, `Center`, `End`, `Nearest`, and `Fraction(f32)`. `Nearest` keeps already visible content stationary and otherwise uses the smallest offset change needed to reveal the target.
+
+## Document editor flow
+
+A document app can keep pages in natural order:
+
+```rust
+Scroll {
+    id: Some(WidgetId::explicit("document.canvas.scroll")),
+    direction: FlexDirection::Column,
+    flex_grow: 1.0,
+    child: Some(DocumentPages { pages: state.pages.clone() }.into()),
+    ..Default::default()
+}
+.into()
+```
+
+Each page wrapper gets a stable explicit ID such as `document.page.3`. When the user selects page 3 from a page rail or outline, the reducer updates selected state and emits `ScrollIntoViewRequest`. Fission handles the offset after layout and schedules another frame so rendering, hit testing, semantics, and test-control tree output converge on the new scroll position.
+
+That avoids the wrong workaround: reordering rendered pages just to make the selected page appear near the top.
+
+## Runtime behavior
+
+The runtime now:
+
+1. queues `ScrollIntoViewRequest` as a runtime effect;
+2. waits for the next layout snapshot;
+3. resolves the target and container;
+4. computes the requested offset in scroll-content coordinates;
+5. clamps the offset to the scrollable range;
+6. writes `RuntimeState.scroll`;
+7. schedules a follow-up frame when the offset changes.
+
+Missing targets are retried once on the next frame. That covers common route or conditional-render cases where the state change that selects a target also causes it to appear.
+
+## Migration notes
+
+Applications using 0.6.2 can update the Rust dependency in the usual way:
+
+```toml
+fission = { version = "0.6.3", default-features = false, features = ["desktop"] }
+```
+
+Use stable explicit widget IDs for both the scroll container and reveal targets when the request comes from app state, route state, search state, or external document navigation.
+
+## Verification
+
+0.6.3 includes focused runtime tests for explicit containers, nearest scroll ancestors, alignment, visibility no-ops, queued runtime effects, and one-frame retry behavior. The release also runs formatting, workspace checks, and documentation-site checks before publishing the crate set.

--- a/documentation/content/docs/guides/design-system.mdx
+++ b/documentation/content/docs/guides/design-system.mdx
@@ -69,10 +69,10 @@ Add the generator as a build dependency:
 
 ```toml title="Cargo.toml"
 [dependencies]
-fission = { version = "0.6.2", default-features = false, features = ["desktop"] }
+fission = { version = "0.6.3", default-features = false, features = ["desktop"] }
 
 [build-dependencies]
-fission-design-system-codegen = "0.6.2"
+fission-design-system-codegen = "0.6.3"
 ```
 
 ## What you should have working

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -89,7 +89,7 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["server", "server-redis"] }
+fission = { version = "0.6.3", features = ["server", "server-redis"] }
 ```
 
 ## Invalidate cached pages after writes

--- a/documentation/content/docs/guides/server-site-security.mdx
+++ b/documentation/content/docs/guides/server-site-security.mdx
@@ -78,14 +78,14 @@ Hyper is available with the normal `server` feature:
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["server"] }
+fission = { version = "0.6.3", features = ["server"] }
 ```
 
 Axum and Actix adapters are feature-gated to avoid pulling those dependencies into projects that do not use them:
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["server", "server-axum"] }
+fission = { version = "0.6.3", features = ["server", "server-axum"] }
 tower = "0.5"
 ```
 

--- a/documentation/content/docs/guides/static-sites.mdx
+++ b/documentation/content/docs/guides/static-sites.mdx
@@ -221,7 +221,7 @@ Use front matter to describe each post:
 
 ```mdx
 ---
-title: Fission 0.6.2
+title: Fission 0.6.3
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -232,7 +232,7 @@ tags:
   - authoring
 ---
 
-# Fission 0.6.2
+# Fission 0.6.3
 
 Write the post body here.
 ```

--- a/documentation/content/docs/guides/terminal-user-interfaces.mdx
+++ b/documentation/content/docs/guides/terminal-user-interfaces.mdx
@@ -21,7 +21,7 @@ Use the Fission facade crate and enable the terminal shell feature for tools tha
 
 ```toml
 [dependencies]
-fission = { version = "0.6.2", features = ["terminal-shell"] }
+fission = { version = "0.6.3", features = ["terminal-shell"] }
 ```
 
 ## What you should have working

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -188,7 +188,7 @@ Example:
 
 ```mdx
 ---
-title: Fission 0.6.2
+title: Fission 0.6.3
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -200,7 +200,7 @@ tags:
 show_adjacent_posts: true
 ---
 
-# Fission 0.6.2
+# Fission 0.6.3
 
 Write the post body here.
 ```

--- a/documentation/content/reference/widgets/widget-pages/scroll.mdx
+++ b/documentation/content/reference/widgets/widget-pages/scroll.mdx
@@ -62,6 +62,31 @@ Give the scroll area room to exist. In many screen layouts, that means setting `
 
 Also avoid nesting two vertical scroll containers unless you are deliberately designing nested scroll behavior. It is usually harder to use and harder to test.
 
+## Programmatic reveal
+
+Use `ctx.effects.scroll_into_view(...)` when a reducer needs to reveal a widget after state changes. The reducer only records the request. The runtime applies it after the next layout pass, when both the scroll container and target rectangles are known.
+
+```rust
+use fission::prelude::*;
+
+#[fission_reducer(SelectPage)]
+fn select_page(state: &mut DocumentState, action: SelectPage, ctx: &mut ReducerContext<DocumentState>) {
+    state.selected_page = action.page;
+
+    ctx.effects.scroll_into_view(ScrollIntoViewRequest {
+        container: Some(WidgetId::explicit("document.canvas.scroll")),
+        target: WidgetId::explicit(&format!("document.page.{}", action.page)),
+        axis: ScrollAxis::Vertical,
+        alignment: ScrollAlignment::Start,
+        padding: [24.0, 24.0, 24.0, 24.0],
+        behavior: ScrollBehavior::Instant,
+        if_needed: false,
+    });
+}
+```
+
+Keep the scroll container and reveal targets on stable explicit IDs. If `container` is `None`, Fission uses the nearest matching scroll ancestor. `ScrollAlignment::Nearest` uses the smallest offset change that makes the target visible; `Start`, `Center`, `End`, and `Fraction(_)` place it deliberately inside the viewport.
+
 ## Production checklist
 
 For `Scroll`, review the fields that change behavior before treating the widget as finished: `id`, `child`, `direction`, `width`, `height`, `show_scrollbar`. The goal is to make the product rule visible in state and actions, not hidden inside ad-hoc construction code.

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -147,7 +147,7 @@ fn footer_identity(_ctx: BuildCtxHandle<DocsState>, view: ViewHandle<DocsState>)
                     ..Default::default()
                 }
                 .into(),
-                Text::new("Fission 0.6.2")
+                Text::new("Fission 0.6.3")
                     .size(tokens.typography.font_size_sm)
                     .family(tokens.typography.font_family_mono.clone())
                     .color(tokens.colors.text_muted)

--- a/examples/animation-gallery/Cargo.toml
+++ b/examples/animation-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animation-gallery"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/chart-gallery/Cargo.toml
+++ b/examples/chart-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chart-gallery"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "counter"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-editor"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/embed-3d/Cargo.toml
+++ b/examples/embed-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-3d"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/examples/embed-video/Cargo.toml
+++ b/examples/embed-video/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-video"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/examples/embed-webview/Cargo.toml
+++ b/examples/embed-webview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-webview"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/Cargo.toml
+++ b/examples/field-inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-inspector"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/examples/icons_gallery/Cargo.toml
+++ b/examples/icons_gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icons_gallery"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/inbox/Cargo.toml
+++ b/examples/inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inbox"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/mobile-smoke/Cargo.toml
+++ b/examples/mobile-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-smoke"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/examples/motion-memory-repro/Cargo.toml
+++ b/examples/motion-memory-repro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion-memory-repro"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/pokemon-card-store/Cargo.toml
+++ b/examples/pokemon-card-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pokemon-card-store"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 publish = false
 

--- a/examples/pokemon-card-store/fission.toml
+++ b/examples/pokemon-card-store/fission.toml
@@ -19,7 +19,7 @@ preload = "route"
 
 [package.docker]
 port = 8080
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.6.2"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.6.3"]
 
 [distribution.docker_registry.production]
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.6.2"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.6.3"]

--- a/examples/product-browser/Cargo.toml
+++ b/examples/product-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product-browser"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/text-lab/Cargo.toml
+++ b/examples/text-lab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-lab"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/todo-design-system/Cargo.toml
+++ b/examples/todo-design-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-design-system"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]

--- a/examples/web-smoke/Cargo.toml
+++ b/examples/web-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-smoke"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "widget-gallery"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

This PR adds a general post-layout `ScrollIntoView` runtime effect and prepares the 0.6.3 release.

The new API lets reducers express product intent like "select page 3 and reveal it in the document canvas" without mutating scroll state from reducers and without doing side effects during widget conversion.

## What changed

- Added public scroll reveal API types:
  - `ScrollIntoViewRequest`
  - `ScrollAxis`
  - `ScrollAlignment`
  - `ScrollBehavior`
- Added reducer helpers:
  - `ctx.effects.scroll_into_view(...)`
  - `ctx.effects.ensure_visible(...)`
- Added runtime handling that:
  - resolves target and scroll container after layout;
  - falls back to the nearest matching scroll ancestor when `container` is omitted;
  - computes offsets for `Start`, `Center`, `End`, `Nearest`, and `Fraction(_)` alignment;
  - clamps offsets to scrollable content bounds;
  - retries a missing target once on the next frame;
  - schedules a follow-up layout frame when offsets change.
- Updated the winit shell so post-layout runtime hooks can run even when the IR did not change.
- Documented reducer-driven reveal requests on the `Scroll` reference page.
- Added focused runtime tests for explicit containers, nearest ancestors, visibility no-ops, queued runtime effects, and retry behavior.
- Bumped the crate set and docs to `0.6.3`, with changelog and blog release notes.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo test -p fission-core --test scroll_into_view`
- `cargo run -p cargo-fission --bin fission -- site check --project-dir documentation --release`
