### PR TITLE
Implement native video backends

### DIFF
--- a/.github/workflows/platform-checks.yml
+++ b/.github/workflows/platform-checks.yml
@@ -74,6 +74,7 @@ jobs:
       ANDROID_TARGET_API_LEVEL: '35'
       ANDROID_BUILD_TOOLS_VERSION: '35.0.0'
       ANDROID_NDK_VERSION: '26.3.11579264'
+      GRADLE_VERSION: '9.5.0'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -87,6 +88,13 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        run: |
+          curl -fsSLo "$RUNNER_TEMP/gradle.zip" "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+          unzip -q "$RUNNER_TEMP/gradle.zip" -d "$RUNNER_TEMP/gradle"
+          echo "$RUNNER_TEMP/gradle/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/gradle/gradle-${GRADLE_VERSION}/bin/gradle" --version
 
       - name: Install Android SDK packages
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
 dependencies = [
  "atk-sys",
- "glib",
+ "glib 0.18.5",
  "libc",
 ]
 
@@ -702,10 +702,10 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -722,6 +722,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
 
 [[package]]
 name = "atspi"
@@ -1543,7 +1549,7 @@ checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
  "bitflags 2.13.0",
  "cairo-sys-rs",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "thiserror 1.0.69",
@@ -1555,9 +1561,9 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1635,7 +1641,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -2732,7 +2748,7 @@ dependencies = [
  "anyhow",
  "clap",
  "serde",
- "toml",
+ "toml 0.8.2",
  "toml_edit 0.23.10+spec-1.0.0",
 ]
 
@@ -2756,7 +2772,7 @@ dependencies = [
  "sha2 0.10.9",
  "tar",
  "tokio",
- "toml",
+ "toml 0.8.2",
  "zip",
 ]
 
@@ -2776,7 +2792,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "toml",
+ "toml 0.8.2",
  "toml_edit 0.23.10+spec-1.0.0",
 ]
 
@@ -2797,7 +2813,7 @@ name = "fission-command-server"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "toml",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -2807,7 +2823,7 @@ dependencies = [
  "anyhow",
  "fission-shell-site",
  "serde_json",
- "toml",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -3063,7 +3079,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -3080,7 +3096,7 @@ dependencies = [
  "fission-widgets",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -3143,11 +3159,14 @@ dependencies = [
  "fontdue",
  "fontique",
  "futures-core",
+ "gstreamer",
+ "gstreamer-video",
  "image 0.25.8",
  "jni 0.21.1",
  "js-sys",
  "lazy_static",
  "moka",
+ "ndk-context",
  "objc",
  "pollster",
  "raw-window-handle",
@@ -3162,6 +3181,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3561,7 +3581,7 @@ dependencies = [
  "gdk-pixbuf",
  "gdk-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "pango",
 ]
@@ -3574,7 +3594,7 @@ checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
 ]
@@ -3585,11 +3605,11 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
 dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3600,13 +3620,13 @@ checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3688,8 +3708,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "gio-sys",
- "glib",
+ "gio-sys 0.18.1",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pin-project-lite",
@@ -3703,11 +3723,24 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353fdc7da7cd16da916104b1e0e4e7de380ec9c8aaa20d4d742d66310ab4b0d5"
+dependencies = [
+ "glib-sys 0.22.8",
+ "gobject-sys 0.22.6",
+ "libc",
+ "system-deps 7.0.8",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3739,15 +3772,36 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-macros 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "memchr",
  "once_cell",
  "smallvec",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddbcf514bd1881fc1b960e4e52b4e82873f4da3bceddbd58d42827b508888100"
+dependencies = [
+ "bitflags 2.13.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys 0.22.8",
+ "glib-macros 0.22.6",
+ "glib-sys 0.22.8",
+ "gobject-sys 0.22.6",
+ "libc",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]
@@ -3765,13 +3819,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "glib-macros"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506d23499707c7142898429757e8d9a3871d965239a2cb66dfa05052be6d6f19"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "glib-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030967459f9f676851872c6304adea7825c6d462ec9b72554c733cf0c5952233"
+dependencies = [
+ "libc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -3801,9 +3877,20 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a861859b887a79cf461359c192c97a57d8fb0229dd291232e57aa11f6fa72c"
+dependencies = [
+ "glib-sys 0.22.8",
+ "libc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -3869,6 +3956,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "gstreamer"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4527e1b9bae8d29ce137bde5b8eec8ae8f78f13ad00fc6e70cbe227d6ad027"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib 0.22.8",
+ "gstreamer-sys",
+ "itertools 0.15.0",
+ "kstring",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "option-operations",
+ "pastey",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gstreamer-base"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91c94a4d3047d05dd6e1f6d91c74f61f56384c7ea1c9d0c1051572eeeb0138d"
+dependencies = [
+ "atomic_refcell",
+ "cfg-if",
+ "glib 0.22.8",
+ "gstreamer",
+ "gstreamer-base-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-base-sys"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fbbc623dc066908ba10c43d629c21096508dea04796592a206c4edd864e37"
+dependencies = [
+ "glib-sys 0.22.8",
+ "gobject-sys 0.22.6",
+ "gstreamer-sys",
+ "libc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533fa8d28fc830eafccbcfcfddb390563ea5d3a351af2c3aab99e197e5f5b1ba"
+dependencies = [
+ "cfg-if",
+ "glib-sys 0.22.8",
+ "gobject-sys 0.22.6",
+ "libc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "gstreamer-video"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7907cb8a73edc98cf279e5de7370bb2c245b7bedf623ba8c7e59648cd4739133"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "glib 0.22.8",
+ "gstreamer",
+ "gstreamer-base",
+ "gstreamer-video-sys",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gstreamer-video-sys"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6753d53c9a5e274f33441bee2c7dabef82edefb39605b75c834d24af89e7e"
+dependencies = [
+ "glib-sys 0.22.8",
+ "gobject-sys 0.22.6",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3881,7 +4063,7 @@ dependencies = [
  "gdk",
  "gdk-pixbuf",
  "gio",
- "glib",
+ "glib 0.18.5",
  "gtk-sys",
  "gtk3-macros",
  "libc",
@@ -3899,12 +4081,12 @@ dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4465,7 +4647,7 @@ dependencies = [
  "approx",
  "getrandom 0.2.17",
  "image 0.25.8",
- "itertools",
+ "itertools 0.12.1",
  "nalgebra",
  "num",
  "rand 0.8.6",
@@ -4549,6 +4731,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -4724,6 +4915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4764,7 +4964,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
 dependencies = [
- "glib",
+ "glib 0.18.5",
  "gtk",
  "gtk-sys",
  "libappindicator-sys",
@@ -5175,6 +5375,12 @@ dependencies = [
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "muldiv"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "naga"
@@ -5758,6 +5964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "option-operations"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca39cf52b03268400c16eeb9b56382ea3c3353409309b63f5c8f0b1faf42754"
+dependencies = [
+ "pastey",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5820,7 +6035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
 dependencies = [
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pango-sys",
@@ -5832,10 +6047,10 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -5886,6 +6101,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -6568,7 +6789,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.12.1",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -6583,7 +6804,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "simd_helpers",
- "system-deps",
+ "system-deps 6.2.2",
  "thiserror 1.0.69",
  "v_frame",
  "wasm-bindgen",
@@ -7295,6 +7516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7719,10 +7949,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
- "toml",
+ "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.8",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -7748,6 +7991,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tattoy-termwiz"
@@ -8223,9 +8472,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8274,7 +8538,7 @@ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]

--- a/crates/authoring/fission-widgets/src/lib.rs
+++ b/crates/authoring/fission-widgets/src/lib.rs
@@ -36,8 +36,10 @@
 pub use fission_core::ui::widgets::Icon;
 pub use fission_core::ui::{
     Button, ButtonContentAlign, ButtonMotion, ButtonVariant, Checkbox, Column, Container,
-    CustomWidget, FocusScope, Grid, GridItem, Image, LazyColumn, Overlay, Positioned, Radio, Row,
-    SafeArea, Scroll, Slider, Spacer, Switch, Text, TextContent, TextInput, Video, Widget, ZStack,
+    CustomWidget, FocusScope, Grid, GridItem, Image, IosAudioSessionCategory,
+    IosAudioSessionCategoryOption, IosAudioSessionMode, IosVideoAudioOptions, LazyColumn, Overlay,
+    Positioned, Radio, Row, SafeArea, Scroll, Slider, Spacer, Switch, Text, TextContent, TextInput,
+    Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, Widget, ZStack,
 };
 pub use fission_core::{BuildCtxHandle, Selector, ViewHandle};
 

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -159,9 +159,11 @@ pub use fission_core::ui::{
     ButtonMotion, ButtonVariant, CardPattern, Checkbox, Column, ComponentSize, ComponentState,
     Composite, Container, CustomWidget, FocusScope, GestureDetector, Grid, GridItem, HttpHeader,
     Icon, Image, ImageAlignment, ImageCachePolicy, ImageErrorBehavior, ImageLoadingBehavior,
-    ImageRequest, ImageSource, LayoutBuilder, LazyColumn, Overlay, Positioned, Provider, Radio,
-    RichText, RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text,
-    TextContent, TextFontStyle, TextInput, TextRunStyle, Video, Widget, WidgetIdExt, ZStack,
+    ImageRequest, ImageSource, IosAudioSessionCategory, IosAudioSessionCategoryOption,
+    IosAudioSessionMode, IosVideoAudioOptions, LayoutBuilder, LazyColumn, Overlay, Positioned,
+    Provider, Radio, RichText, RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer,
+    Switch, Text, TextContent, TextFontStyle, TextInput, TextRunStyle, Video, VideoAudioActivation,
+    VideoAudioOptions, VideoAudioPolicy, Widget, WidgetIdExt, ZStack,
 };
 
 // Core action/state types
@@ -378,9 +380,11 @@ pub mod prelude {
         ButtonMotion, ButtonVariant, CardPattern, Checkbox, Column, ComponentSize, ComponentState,
         Composite, Container, CustomWidget, FocusScope, GestureDetector, Grid, GridItem,
         HttpHeader, Icon, Image, ImageAlignment, ImageCachePolicy, ImageErrorBehavior,
-        ImageLoadingBehavior, ImageRequest, ImageSource, LayoutBuilder, LazyColumn, Overlay,
-        Positioned, Radio, RichText, RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider,
-        Spacer, Switch, Text, TextContent, TextFontStyle, TextInput, TextRunStyle, Video, Widget,
+        ImageLoadingBehavior, ImageRequest, ImageSource, IosAudioSessionCategory,
+        IosAudioSessionCategoryOption, IosAudioSessionMode, IosVideoAudioOptions, LayoutBuilder,
+        LazyColumn, Overlay, Positioned, Radio, RichText, RichTextRun, Row, SafeArea, Scroll,
+        SemanticsRegion, Slider, Spacer, Switch, Text, TextContent, TextFontStyle, TextInput,
+        TextRunStyle, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, Widget,
         WidgetIdExt, ZStack,
     };
     pub use fission_widgets::*;

--- a/crates/core/fission-core/src/effect.rs
+++ b/crates/core/fission-core/src/effect.rs
@@ -284,7 +284,7 @@ pub enum ActionInput {
 }
 
 impl ActionInput {
-    pub(crate) fn scoped_raw(scope_id: u128, target: WidgetId, input: ActionInput) -> Self {
+    pub fn scoped_raw(scope_id: u128, target: WidgetId, input: ActionInput) -> Self {
         Self::ScopedRaw {
             scope_id,
             target: target.into(),

--- a/crates/core/fission-core/src/env.rs
+++ b/crates/core/fission-core/src/env.rs
@@ -1,4 +1,6 @@
-use crate::{action::GlobalState, motion::MotionStateMap, state::LocalStateStore};
+use crate::{
+    action::GlobalState, motion::MotionStateMap, state::LocalStateStore, ui::VideoAudioOptions,
+};
 use fission_i18n::{I18nRegistry, Locale};
 use fission_ir::op::RichTextAnnotation;
 use fission_ir::semantics::MouseCursor;
@@ -676,6 +678,7 @@ pub struct VideoState {
     pub muted: bool,
     pub looped: bool,
     pub asset_source: String,
+    pub audio: VideoAudioOptions,
     pub surface_id: Option<u64>,
     pub pending_seek: Option<u64>,
 }
@@ -691,6 +694,7 @@ impl Default for VideoState {
             muted: false,
             looped: false,
             asset_source: String::new(),
+            audio: VideoAudioOptions::default(),
             surface_id: None,
             pending_seek: None,
         }

--- a/crates/core/fission-core/src/registry.rs
+++ b/crates/core/fission-core/src/registry.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     context::{Effects, ReducerContext},
     effect::{ActionInput, Effect, EffectEnvelope},
-    ui::Widget,
+    ui::{VideoAudioOptions, Widget},
     Action, ActionEnvelope, ActionId, BoxedReducer, GlobalState,
 };
 use anyhow::{anyhow, Result};
@@ -225,6 +225,8 @@ pub struct VideoRegistration {
     pub autoplay: bool,
     /// Whether to loop playback.
     pub loop_playback: bool,
+    /// Audio-session behavior requested by this video.
+    pub audio: VideoAudioOptions,
 }
 
 /// Registration data for a platform web view collected during widget building.

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -509,6 +509,7 @@ impl Runtime {
                 .or_insert_with(crate::env::VideoState::default);
             entry.asset_source = reg.source.clone();
             entry.looped = reg.loop_playback;
+            entry.audio = reg.audio.clone();
             if reg.autoplay && entry.status == VideoStatus::Stopped {
                 entry.status = VideoStatus::Playing;
             }

--- a/crates/core/fission-core/src/ui/mod.rs
+++ b/crates/core/fission-core/src/ui/mod.rs
@@ -12,7 +12,9 @@ pub use widgets::{
     ButtonMotion, ButtonVariant, CardPattern, Checkbox, Column, ComponentSize, ComponentState,
     Composite, Container, FocusScope, GestureDetector, Grid, GridItem, HttpHeader, Icon, Image,
     ImageAlignment, ImageCachePolicy, ImageErrorBehavior, ImageLoadingBehavior, ImageRequest,
-    ImageSource, LayoutBuilder, LazyColumn, Overlay, Positioned, Provider, Radio, RichText,
-    RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text, TextContent,
-    TextFontStyle, TextInput, TextInputChangePayload, TextRunStyle, Video, ZStack,
+    ImageSource, IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,
+    IosVideoAudioOptions, LayoutBuilder, LazyColumn, Overlay, Positioned, Provider, Radio,
+    RichText, RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text,
+    TextContent, TextFontStyle, TextInput, TextInputChangePayload, TextRunStyle, Video,
+    VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, ZStack,
 };

--- a/crates/core/fission-core/src/ui/node.rs
+++ b/crates/core/fission-core/src/ui/node.rs
@@ -586,6 +586,7 @@ impl From<Video> for Widget {
             source: w.source.clone(),
             autoplay: w.autoplay,
             loop_playback: w.loop_playback,
+            audio: w.audio.clone(),
         });
         Self {
             kind: Box::new(WidgetKind::Video(w)),

--- a/crates/core/fission-core/src/ui/widgets/mod.rs
+++ b/crates/core/fission-core/src/ui/widgets/mod.rs
@@ -58,7 +58,10 @@ pub use switch::Switch;
 pub use text::{RichText, RichTextRun, Text, TextContent, TextFontStyle, TextRunStyle};
 pub use text_input::{TextInput, TextInputChangePayload};
 pub use transform::Transform;
-pub use video::Video;
+pub use video::{
+    IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,
+    IosVideoAudioOptions, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy,
+};
 
 pub mod gesture_detector;
 pub use gesture_detector::GestureDetector;

--- a/crates/core/fission-core/src/ui/widgets/video.rs
+++ b/crates/core/fission-core/src/ui/widgets/video.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 ///     height: Some(360.0),
 ///     autoplay: true,
 ///     loop_playback: false,
+///     audio: VideoAudioOptions::playback(),
 ///     ..Default::default()
 /// }
 /// .into();

--- a/crates/core/fission-core/src/ui/widgets/video.rs
+++ b/crates/core/fission-core/src/ui/widgets/video.rs
@@ -40,9 +40,212 @@ pub struct Video {
     pub autoplay: bool,
     /// Whether to loop playback when the video ends.
     pub loop_playback: bool,
+    /// Platform-neutral audio-session behavior for this video.
+    ///
+    /// The default is [`VideoAudioOptions::system_default`], which lets the
+    /// host platform keep its normal audio policy. Use
+    /// [`VideoAudioOptions::playback`] for foreground media playback that
+    /// should behave like a video player rather than incidental UI audio.
+    #[serde(default)]
+    pub audio: VideoAudioOptions,
 }
 
 impl Video {}
+
+/// Audio-session behavior requested by a [`Video`] widget.
+///
+/// This describes product intent independently from any single host API. Shells
+/// translate the policy into their native platform API where one exists, and
+/// ignore unsupported fields rather than changing the product default globally.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VideoAudioOptions {
+    /// Cross-platform audio-session policy.
+    pub policy: VideoAudioPolicy,
+    /// When the shell should activate the platform audio session.
+    pub activation: VideoAudioActivation,
+    /// Whether this video may mix with other active audio where supported.
+    pub mix_with_others: bool,
+    /// Whether this video may temporarily duck other active audio where supported.
+    pub duck_others: bool,
+    /// iOS-specific AVAudioSession overrides.
+    #[serde(default)]
+    pub ios: IosVideoAudioOptions,
+}
+
+impl Default for VideoAudioOptions {
+    fn default() -> Self {
+        Self::system_default()
+    }
+}
+
+impl VideoAudioOptions {
+    /// Uses the platform's default audio-session behavior.
+    ///
+    /// This is Fission's default because whether video should ignore the iOS
+    /// silent switch, mix with background audio, or claim exclusive playback is
+    /// a product decision.
+    pub fn system_default() -> Self {
+        Self {
+            policy: VideoAudioPolicy::SystemDefault,
+            activation: VideoAudioActivation::OnDemand,
+            mix_with_others: false,
+            duck_others: false,
+            ios: IosVideoAudioOptions::default(),
+        }
+    }
+
+    /// Requests ambient media behavior: mixable, non-disruptive playback that
+    /// respects platform silent/mute conventions where supported.
+    pub fn ambient() -> Self {
+        Self {
+            policy: VideoAudioPolicy::Ambient,
+            mix_with_others: true,
+            ..Self::system_default()
+        }
+    }
+
+    /// Requests foreground playback behavior for a primary media player.
+    ///
+    /// On iOS this maps to `AVAudioSessionCategoryPlayback`, so it may play
+    /// even when the silent switch is engaged.
+    pub fn playback() -> Self {
+        Self {
+            policy: VideoAudioPolicy::Playback,
+            ..Self::system_default()
+        }
+    }
+
+    /// Adds the platform "mix with others" hint.
+    pub fn mix_with_others(mut self, value: bool) -> Self {
+        self.mix_with_others = value;
+        self
+    }
+
+    /// Adds the platform "duck others" hint.
+    pub fn duck_others(mut self, value: bool) -> Self {
+        self.duck_others = value;
+        self
+    }
+
+    /// Overrides the default activation behavior.
+    pub fn activation(mut self, activation: VideoAudioActivation) -> Self {
+        self.activation = activation;
+        self
+    }
+
+    /// Adds iOS-specific AVAudioSession overrides.
+    pub fn ios(mut self, ios: IosVideoAudioOptions) -> Self {
+        self.ios = ios;
+        self
+    }
+}
+
+/// Cross-platform audio-session policy for host-backed video.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VideoAudioPolicy {
+    /// Do not configure platform audio-session state.
+    SystemDefault,
+    /// Non-disruptive media that should respect silent/mute conventions where possible.
+    Ambient,
+    /// Foreground media playback that may ignore silent/mute conventions where supported.
+    Playback,
+}
+
+/// When a platform audio session should be activated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VideoAudioActivation {
+    /// Activate only when playback is requested.
+    OnDemand,
+    /// Configure eagerly when the host player is created.
+    OnPlayerCreate,
+    /// Configure category/options, but do not activate automatically.
+    Manual,
+}
+
+/// iOS AVAudioSession-specific overrides for [`VideoAudioOptions`].
+///
+/// Use this only when the cross-platform policy is not precise enough. Raw
+/// strings are accepted so apps can adopt new AVAudioSession categories or
+/// modes before Fission grows first-class enum variants.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IosVideoAudioOptions {
+    /// Overrides the AVAudioSession category derived from [`VideoAudioPolicy`].
+    pub category: Option<IosAudioSessionCategory>,
+    /// Overrides the AVAudioSession mode. Defaults to `Default`.
+    pub mode: Option<IosAudioSessionMode>,
+    /// Additional AVAudioSession category options.
+    #[serde(default)]
+    pub category_options: Vec<IosAudioSessionCategoryOption>,
+}
+
+impl IosVideoAudioOptions {
+    /// Creates an override that forces an AVAudioSession category.
+    pub fn category(category: IosAudioSessionCategory) -> Self {
+        Self {
+            category: Some(category),
+            ..Default::default()
+        }
+    }
+
+    /// Creates an override that forces an AVAudioSession mode.
+    pub fn mode(mode: IosAudioSessionMode) -> Self {
+        Self {
+            mode: Some(mode),
+            ..Default::default()
+        }
+    }
+
+    /// Adds an AVAudioSession category option.
+    pub fn with_option(mut self, option: IosAudioSessionCategoryOption) -> Self {
+        self.category_options.push(option);
+        self
+    }
+}
+
+/// iOS AVAudioSession categories exposed by Fission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IosAudioSessionCategory {
+    Ambient,
+    SoloAmbient,
+    Playback,
+    Record,
+    PlayAndRecord,
+    MultiRoute,
+    /// Raw AVAudioSession category constant name, for example
+    /// `"AVAudioSessionCategoryPlayback"`.
+    Raw(String),
+}
+
+/// iOS AVAudioSession modes exposed by Fission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IosAudioSessionMode {
+    Default,
+    MoviePlayback,
+    SpokenAudio,
+    VideoRecording,
+    Measurement,
+    VoiceChat,
+    VideoChat,
+    GameChat,
+    /// Raw AVAudioSession mode constant name, for example
+    /// `"AVAudioSessionModeMoviePlayback"`.
+    Raw(String),
+}
+
+/// iOS AVAudioSession category options exposed by Fission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IosAudioSessionCategoryOption {
+    MixWithOthers,
+    DuckOthers,
+    AllowBluetoothHfp,
+    DefaultToSpeaker,
+    InterruptSpokenAudioAndMixWithOthers,
+    AllowBluetoothA2dp,
+    AllowAirPlay,
+    OverrideMutedMicrophoneInterruption,
+    /// Raw AVAudioSessionCategoryOptions bit.
+    Raw(u64),
+}
 
 impl InternalLower for Video {
     fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -9,12 +9,13 @@ use crate::html::{
 use crate::search::{write_search_index, SiteSearchOptions};
 use crate::site::{
     normalize_site_path, ContentTransform, FissionSite, SitePageElement, SitePageElementFilter,
-    SitePageElementPlacement, SiteRenderContext,
+    SitePageElementPlacement, SiteRenderContext, SiteRouteRender,
 };
 use crate::tabs::expand_mdx_tabs;
 use anyhow::{bail, Context, Result};
 use fission_core::internal::BuildCtx;
 use fission_core::internal::InternalLoweringCx;
+use fission_core::registry::VideoRegistration;
 use fission_core::ui::Column;
 use fission_core::{Env, MotionDeclaration, RuntimeState, View, Widget};
 use fission_layout::LayoutSize;
@@ -476,7 +477,7 @@ fn render_footer_node(
     site: &FissionSite,
     route_path: &str,
     env: &Env,
-) -> Result<Option<Widget>> {
+) -> Result<Option<SiteRouteRender>> {
     let Some(footer) = &site.footer else {
         return Ok(None);
     };
@@ -886,8 +887,18 @@ fn render_custom_routes(
             default_locale: &options.default_locale,
             env: &env,
         };
-        let node = (route.render)(&ctx)?;
-        let node = append_footer(node, render_footer_node(options, site, &route.path, &env)?);
+        let mut rendered = (route.render)(&ctx)?;
+        let footer = render_footer_node(options, site, &route.path, &env)?;
+        let footer_widget = footer.as_ref().map(|footer| footer.widget.clone());
+        let node = append_footer(rendered.widget, footer_widget);
+        if let Some(footer) = footer {
+            rendered
+                .motion_declarations
+                .extend(footer.motion_declarations);
+            rendered
+                .video_registrations
+                .extend(footer.video_registrations);
+        }
         let html = render_node_to_html(
             node,
             &route.title,
@@ -900,7 +911,8 @@ fn render_custom_routes(
             site,
             &env,
             styles,
-            Vec::new(),
+            rendered.motion_declarations,
+            rendered.video_registrations,
         )?;
         routes.push(ContentRoute {
             path: route.path.clone(),
@@ -966,11 +978,15 @@ fn render_route(
         all_routes: routes,
     };
     let page_node = fission_core::build::enter(&mut build_ctx, &view, || page.into());
-    let node = append_footer(
-        page_node,
-        render_footer_node(options, site, &route.path, &env)?,
-    );
-    let motion_declarations = build_ctx.take_motion_declarations();
+    let footer = render_footer_node(options, site, &route.path, &env)?;
+    let footer_widget = footer.as_ref().map(|footer| footer.widget.clone());
+    let node = append_footer(page_node, footer_widget);
+    let mut motion_declarations = build_ctx.take_motion_declarations();
+    let mut video_registrations = build_ctx.take_video_registrations();
+    if let Some(footer) = footer {
+        motion_declarations.extend(footer.motion_declarations);
+        video_registrations.extend(footer.video_registrations);
+    }
     render_node_to_html(
         node,
         &format!("{} | {}", route.title, options.site_title),
@@ -984,6 +1000,7 @@ fn render_route(
         &env,
         styles,
         motion_declarations,
+        video_registrations,
     )
 }
 
@@ -1005,6 +1022,7 @@ fn render_node_to_html(
     env: &Env,
     styles: &mut StyleRegistry,
     motion_declarations: Vec<MotionDeclaration>,
+    video_registrations: Vec<VideoRegistration>,
 ) -> Result<String> {
     let runtime = RuntimeState::default();
     let mut lowering = InternalLoweringCx::new(env, &runtime, None, None);
@@ -1062,6 +1080,10 @@ fn render_node_to_html(
             SitePageElementPlacement::BodyEnd,
         ),
         motion_declarations,
+        video_registrations: video_registrations
+            .into_iter()
+            .map(|registration| (registration.node_id, registration))
+            .collect(),
         ..Default::default()
     };
     Ok(render_ir_to_html_with_styles(&lowering.ir, &render_options, styles)?.html)
@@ -1662,8 +1684,8 @@ struct SidebarManifestItem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fission_core::ui::{Text, TextContent};
-    use fission_core::GlobalState;
+    use fission_core::ui::{Text, TextContent, Video};
+    use fission_core::{GlobalState, WidgetId};
     use fission_i18n::TranslationBundle;
     use std::collections::HashMap;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1679,6 +1701,24 @@ mod tests {
         fn from(component: KeyPage) -> Self {
             let (_ctx, _view) = fission_core::build::current::<TestState>();
             Text::new(TextContent::Key(component.0.to_string())).into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct VideoPage;
+
+    impl From<VideoPage> for Widget {
+        fn from(_component: VideoPage) -> Self {
+            let (_ctx, _view) = fission_core::build::current::<TestState>();
+            Video {
+                id: Some(WidgetId::explicit("site-video")),
+                source: "https://example.com/demo.mp4".to_string(),
+                width: Some(320.0),
+                height: Some(180.0),
+                autoplay: true,
+                loop_playback: true,
+            }
+            .into()
         }
     }
 
@@ -1829,6 +1869,31 @@ mod tests {
         assert!(html.contains("Bonjour static"));
         assert!(html.contains("lang=\"fr\""));
         assert!(!html.contains("MISSING:page.title"));
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn custom_site_routes_render_video_as_html_video() {
+        let temp = std::env::temp_dir().join(format!(
+            "fission-site-video-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&temp).unwrap();
+        fs::create_dir_all(temp.join("content")).unwrap();
+        let mut options = SiteBuildOptions::for_project(&temp, "Test site");
+        options.content_routes = Vec::new();
+        let site = FissionSite::new().route_widget::<TestState, _>("/", "Video", None, VideoPage);
+
+        build_site(&options, &site).unwrap();
+        let html = fs::read_to_string(temp.join("target/fission/site/index.html")).unwrap();
+
+        assert!(html.contains("<video"));
+        assert!(html.contains("src=\"https://example.com/demo.mp4\""));
+        assert!(html.contains("autoplay muted"));
+        assert!(html.contains("loop"));
         let _ = fs::remove_dir_all(temp);
     }
 

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1717,6 +1717,7 @@ mod tests {
                 height: Some(180.0),
                 autoplay: true,
                 loop_playback: true,
+                ..Default::default()
             }
             .into()
         }

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -2986,6 +2986,7 @@ mod tests {
                 source: "/media/demo.mp4".into(),
                 autoplay: true,
                 loop_playback: true,
+                audio: Default::default(),
             },
         );
 

--- a/crates/shell/fission-shell-site/src/site.rs
+++ b/crates/shell/fission-shell-site/src/site.rs
@@ -1,7 +1,8 @@
 use crate::build::{build_site, check_site, list_site_routes, SiteBuildOptions};
 use anyhow::{bail, Context, Result};
 use fission_core::internal::BuildCtx;
-use fission_core::{Env, GlobalState, RuntimeState, View, Widget};
+use fission_core::registry::VideoRegistration;
+use fission_core::{Env, GlobalState, MotionDeclaration, RuntimeState, View, Widget};
 use fission_theme::{DesignMode, Theme};
 use std::fs;
 use std::io::{self, BufRead, Write};
@@ -12,7 +13,13 @@ use std::sync::Arc;
 pub type ContentTransform = dyn Fn(&str, &Path, &Path) -> Result<String> + Send + Sync + 'static;
 
 type RouteRenderer =
-    dyn for<'a> Fn(&SiteRenderContext<'a>) -> Result<Widget> + Send + Sync + 'static;
+    dyn for<'a> Fn(&SiteRenderContext<'a>) -> Result<SiteRouteRender> + Send + Sync + 'static;
+
+pub(crate) struct SiteRouteRender {
+    pub widget: Widget,
+    pub motion_declarations: Vec<MotionDeclaration>,
+    pub video_registrations: Vec<VideoRegistration>,
+}
 
 /// Position where raw static-site page markup is inserted.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -311,9 +318,14 @@ impl FissionSite {
                 let state = S::default();
                 let view = View::new(&state, &runtime, ctx.env(), None);
                 let mut build_ctx = BuildCtx::<S>::new();
-                Ok(fission_core::build::enter(&mut build_ctx, &view, || {
+                let widget = fission_core::build::enter(&mut build_ctx, &view, || {
                     widget.as_ref().clone().into()
-                }))
+                });
+                Ok(SiteRouteRender {
+                    widget,
+                    motion_declarations: build_ctx.take_motion_declarations(),
+                    video_registrations: build_ctx.take_video_registrations(),
+                })
             }),
         });
         self
@@ -340,7 +352,7 @@ impl FissionSite {
     }
 }
 
-fn render_widget_node<S, W>(widget: &W, ctx: &SiteRenderContext<'_>) -> Result<Widget>
+fn render_widget_node<S, W>(widget: &W, ctx: &SiteRenderContext<'_>) -> Result<SiteRouteRender>
 where
     S: GlobalState + Default + 'static,
     W: Clone + Into<Widget>,
@@ -349,9 +361,12 @@ where
     let state = S::default();
     let view = View::new(&state, &runtime, ctx.env(), None);
     let mut build_ctx = BuildCtx::<S>::new();
-    Ok(fission_core::build::enter(&mut build_ctx, &view, || {
-        (*widget).clone().into()
-    }))
+    let widget = fission_core::build::enter(&mut build_ctx, &view, || (*widget).clone().into());
+    Ok(SiteRouteRender {
+        widget,
+        motion_declarations: build_ctx.take_motion_declarations(),
+        video_registrations: build_ctx.take_video_registrations(),
+    })
 }
 
 pub fn build_from_cli(site: FissionSite) -> Result<()> {

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -57,7 +57,15 @@ accesskit_winit = { package = "fission-accesskit-winit", version = "0.33.1-fissi
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"
+ndk-context = "0.1"
 winit = { package = "fission-winit", version = "0.30.13-fission.1", features = ["android-native-activity"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Media_MediaFoundation", "Win32_System_Com", "Win32_UI_WindowsAndMessaging"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gstreamer = "0.25"
+gstreamer-video = "0.25"
 
 [target.'cfg(any(target_os = "android", target_os = "ios", target_os = "macos"))'.dependencies]
 rxing = { version = "0.9", default-features = false, features = ["image", "image_formats", "decoders", "encoding_rs", "full_barcode_format_support", "multi_barcode_readers"] }
@@ -67,16 +75,16 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 web-time = "1.1"
-web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "console", "Document", "Element", "Headers", "HtmlCanvasElement", "ImageData", "Location", "Request", "RequestInit", "RequestMode", "Response", "Window"] }
+web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "console", "CssStyleDeclaration", "Document", "Element", "Headers", "HtmlCanvasElement", "HtmlElement", "HtmlMediaElement", "HtmlVideoElement", "ImageData", "Location", "Node", "Request", "RequestInit", "RequestMode", "Response", "Window"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
 cocoa = "0.25"
-core-graphics = "0.23"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2"
 block = "0.1"
+core-graphics = "0.23"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 dispatch = "0.2"

--- a/crates/shell/fission-shell-winit/src/accessibility.rs
+++ b/crates/shell/fission-shell-winit/src/accessibility.rs
@@ -738,9 +738,22 @@ mod imp {
             id: ActionId::from_u128(entry.action_id),
             payload: entry.payload_data.clone().unwrap_or_default(),
         };
+        let input = scoped_semantics_input(target, semantics, input);
         runtime
             .dispatch_with_input(envelope, target, &input)
             .is_ok()
+    }
+
+    fn scoped_semantics_input(
+        target: WidgetId,
+        semantics: &Semantics,
+        input: ActionInput,
+    ) -> ActionInput {
+        if let Some(scope_id) = semantics.action_scope_id {
+            ActionInput::scoped_raw(scope_id, target, input)
+        } else {
+            input
+        }
     }
 
     fn value_action_data(data: &Option<ActionData>) -> Option<&str> {
@@ -847,6 +860,7 @@ mod imp {
         let Ok(payload) = serde_json::to_vec(&new_text) else {
             return false;
         };
+        let input = scoped_semantics_input(target, semantics, ActionInput::None);
         runtime
             .dispatch_with_input(
                 ActionEnvelope {
@@ -854,7 +868,7 @@ mod imp {
                     payload,
                 },
                 target,
-                &ActionInput::None,
+                &input,
             )
             .is_ok()
     }
@@ -878,6 +892,7 @@ mod imp {
         let Ok(payload) = serde_json::to_vec(&cursor_changed) else {
             return false;
         };
+        let input = scoped_semantics_input(target, semantics, ActionInput::None);
         runtime
             .dispatch_with_input(
                 ActionEnvelope {
@@ -885,7 +900,7 @@ mod imp {
                     payload,
                 },
                 target,
-                &ActionInput::None,
+                &input,
             )
             .is_ok()
     }
@@ -925,6 +940,7 @@ mod imp {
         else {
             return false;
         };
+        let input = scoped_semantics_input(target, semantics, ActionInput::None);
         runtime
             .dispatch_with_input(
                 ActionEnvelope {
@@ -932,7 +948,7 @@ mod imp {
                     payload,
                 },
                 target,
-                &ActionInput::None,
+                &input,
             )
             .is_ok()
     }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -5734,8 +5734,16 @@ where
                                         }
                                     }
                                     VideoEvent::Ended => {
-                                        video_state.status = VideoStatus::Ended;
-                                        active_player.last_status = Some(VideoStatus::Ended);
+                                        if video_state.looped {
+                                            player.seek_to(0);
+                                            player.play();
+                                            video_state.status = VideoStatus::Playing;
+                                            video_state.pending_seek = None;
+                                            active_player.last_status = None;
+                                        } else {
+                                            video_state.status = VideoStatus::Ended;
+                                            active_player.last_status = Some(VideoStatus::Ended);
+                                        }
                                         request_redraw_logged(
                                             &window,
                                             elwt,

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -35,6 +35,7 @@ use winit::{
 use fission_core::env::{VideoStatus, WindowInsets};
 use fission_core::internal::downcast_render_object;
 use fission_core::internal::InternalLoweringCx;
+use fission_core::ui::VideoAudioOptions;
 use fission_core::{
     Action, ActionEnvelope, ActionId, ActionRegistry, DeepLink, DeepLinkConfig, DeepLinkReceived,
     Env, GlobalState, InputEvent, KeyCode, KeyEvent as FissionKeyEvent, NotificationResponse,
@@ -322,6 +323,8 @@ fn js_error_to_string(error: wasm_bindgen::JsValue) -> String {
 
 struct ActivePlayer {
     player: Box<dyn VideoPlayer>,
+    source: String,
+    audio: VideoAudioOptions,
     last_status: Option<VideoStatus>,
     last_rate: Option<f32>,
     last_volume: Option<f32>,
@@ -5654,37 +5657,43 @@ where
                     for surface in &mut surfaces {
                         active_nodes.insert(surface.widget_id);
 
-                        // Create player if missing
-                        if !players.contains_key(&surface.widget_id) {
-                            if let Some(state) =
-                                runtime.runtime_state.video.states.get(&surface.widget_id)
-                            {
-                                let source = &state.asset_source;
-                                if !source.is_empty() {
-                                    let player =
-                                        video_backend.create_player(source, &state.audio);
-                                    surface.surface_id = player.surface_id();
-                                    if let Some(state) = runtime
-                                        .runtime_state
-                                        .video
-                                        .states
-                                        .get_mut(&surface.widget_id)
-                                    {
-                                        state.surface_id = Some(surface.surface_id);
-                                    }
-                                    players.insert(
-                                        surface.widget_id,
-                                        ActivePlayer {
-                                            player,
-                                            last_status: None,
-                                            last_rate: None,
-                                            last_volume: None,
-                                            last_muted: None,
-                                        },
-                                    );
+                        if let Some(state) =
+                            runtime.runtime_state.video.states.get(&surface.widget_id)
+                        {
+                            let source = state.asset_source.clone();
+                            let audio = state.audio.clone();
+                            let needs_player = players
+                                .get(&surface.widget_id)
+                                .map(|active| active.source != source || active.audio != audio)
+                                .unwrap_or(true);
+                            if source.is_empty() {
+                                players.remove(&surface.widget_id);
+                            } else if needs_player {
+                                let player = video_backend.create_player(&source, &audio);
+                                surface.surface_id = player.surface_id();
+                                if let Some(state) = runtime
+                                    .runtime_state
+                                    .video
+                                    .states
+                                    .get_mut(&surface.widget_id)
+                                {
+                                    state.surface_id = Some(surface.surface_id);
                                 }
+                                players.insert(
+                                    surface.widget_id,
+                                    ActivePlayer {
+                                        player,
+                                        source,
+                                        audio,
+                                        last_status: None,
+                                        last_rate: None,
+                                        last_volume: None,
+                                        last_muted: None,
+                                    },
+                                );
                             }
-                        } else if let Some(active_player) = players.get(&surface.widget_id) {
+                        }
+                        if let Some(active_player) = players.get(&surface.widget_id) {
                             surface.surface_id = active_player.player.surface_id();
                         }
                     }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -3221,6 +3221,7 @@ fn selector_center(record: &SemanticRecord) -> Option<LayoutPoint> {
 }
 
 fn dispatch_semantics_action(
+    ir: &CoreIR,
     runtime: &mut Runtime,
     target: WidgetId,
     semantics: &Semantics,
@@ -3235,6 +3236,7 @@ fn dispatch_semantics_action(
     else {
         return false;
     };
+    let input = scoped_action_input_for_node(ir, target, input);
     runtime
         .dispatch_with_input(
             ActionEnvelope {
@@ -3247,7 +3249,28 @@ fn dispatch_semantics_action(
         .is_ok()
 }
 
+fn scoped_action_input_for_node(
+    ir: &CoreIR,
+    target: WidgetId,
+    input: ActionInput,
+) -> ActionInput {
+    let mut current_id = Some(target);
+    while let Some(id) = current_id {
+        let Some(node) = ir.nodes.get(&id) else {
+            break;
+        };
+        if let Op::Semantics(semantics) = &node.op {
+            if let Some(scope_id) = semantics.action_scope_id {
+                return ActionInput::scoped_raw(scope_id, target, input);
+            }
+        }
+        current_id = node.parent;
+    }
+    input
+}
+
 fn dispatch_text_change(
+    ir: &CoreIR,
     runtime: &mut Runtime,
     target: WidgetId,
     semantics: &Semantics,
@@ -3264,6 +3287,7 @@ fn dispatch_text_change(
     let Ok(payload) = serde_json::to_vec(&new_text) else {
         return false;
     };
+    let input = scoped_action_input_for_node(ir, target, ActionInput::None);
     runtime
         .dispatch_with_input(
             ActionEnvelope {
@@ -3271,12 +3295,13 @@ fn dispatch_text_change(
                 payload,
             },
             target,
-            &ActionInput::None,
+            &input,
         )
         .is_ok()
 }
 
 fn dispatch_cursor_change(
+    ir: &CoreIR,
     runtime: &mut Runtime,
     target: WidgetId,
     semantics: &Semantics,
@@ -3295,6 +3320,7 @@ fn dispatch_cursor_change(
     let Ok(payload) = serde_json::to_vec(&cursor_changed) else {
         return false;
     };
+    let input = scoped_action_input_for_node(ir, target, ActionInput::None);
     runtime
         .dispatch_with_input(
             ActionEnvelope {
@@ -3302,7 +3328,7 @@ fn dispatch_cursor_change(
                 payload,
             },
             target,
-            &ActionInput::None,
+            &input,
         )
         .is_ok()
 }
@@ -3329,6 +3355,7 @@ fn set_focus_for_test(
             }
         }) {
             let _ = dispatch_semantics_action(
+                ir,
                 runtime,
                 previous_id,
                 &previous_semantics,
@@ -3339,6 +3366,7 @@ fn set_focus_for_test(
     }
     runtime.runtime_state.interaction.set_focused(Some(target));
     let _ = dispatch_semantics_action(
+        ir,
         runtime,
         target,
         semantics,
@@ -3380,8 +3408,9 @@ fn set_text_value_for_test(
         state.clear_preedit();
     }
     let mut changed =
-        dispatch_text_change(runtime, record.id, &record.semantics, value.to_string());
+        dispatch_text_change(ir, runtime, record.id, &record.semantics, value.to_string());
     changed |= dispatch_cursor_change(
+        ir,
         runtime,
         record.id,
         &record.semantics,
@@ -3506,6 +3535,10 @@ fn handle_activate_selector(
         );
     }
     if !dispatch_semantics_action(
+        pipeline
+            .prev_ir
+            .as_ref()
+            .expect("selector resolved from rendered IR"),
         runtime,
         record.id,
         &record.semantics,
@@ -3631,6 +3664,10 @@ fn handle_toggle_selector(
         );
     }
     if !dispatch_semantics_action(
+        pipeline
+            .prev_ir
+            .as_ref()
+            .expect("selector resolved from rendered IR"),
         runtime,
         record.id,
         &record.semantics,
@@ -5337,6 +5374,25 @@ where
                             });
                             return;
                         };
+                        if drain_effect_results(
+                            &mut runtime,
+                            &effect_result_rx,
+                            &mut active_services,
+                            &mut service_bindings,
+                        ) {
+                            invalidations.mark_build();
+                            if process_pending_effects(
+                                &mut runtime,
+                                &effect_result_tx,
+                                &event_proxy,
+                                &async_registry,
+                                &mut active_services,
+                                &mut service_bindings,
+                                &mut next_service_instance_id,
+                            ) {
+                                invalidations.mark_build();
+                            }
+                        }
                         pending_screenshot_path = Some("__pump__".into());
                         pending_screenshot_response_tx = Some(response_tx);
                         pending_capture_settle = resize_is_unsettled(

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -3249,11 +3249,7 @@ fn dispatch_semantics_action(
         .is_ok()
 }
 
-fn scoped_action_input_for_node(
-    ir: &CoreIR,
-    target: WidgetId,
-    input: ActionInput,
-) -> ActionInput {
+fn scoped_action_input_for_node(ir: &CoreIR, target: WidgetId, input: ActionInput) -> ActionInput {
     let mut current_id = Some(target);
     while let Some(id) = current_id {
         let Some(node) = ir.nodes.get(&id) else {
@@ -5665,7 +5661,8 @@ where
                             {
                                 let source = &state.asset_source;
                                 if !source.is_empty() {
-                                    let player = video_backend.create_player(source);
+                                    let player =
+                                        video_backend.create_player(source, &state.audio);
                                     surface.surface_id = player.surface_id();
                                     if let Some(state) = runtime
                                         .runtime_state

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -661,7 +661,10 @@ mod mac {
 mod ios {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
     use core_graphics::geometry::{CGPoint, CGRect, CGSize};
-    use fission_core::ui::VideoAudioOptions;
+    use fission_core::ui::{
+        IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,
+        VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy,
+    };
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
@@ -778,7 +781,22 @@ mod ios {
     impl VideoBackend for IosVideoBackend {
         fn create_player(&self, source: &str, audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let resolved_source = resolve_video_source(source);
-            let pending_error = resolved_source.error_message();
+            let mut pending_error = resolved_source.error_message();
+            let mut audio_session_configured = false;
+            if matches!(
+                audio.activation,
+                VideoAudioActivation::OnPlayerCreate | VideoAudioActivation::Manual
+            ) {
+                match unsafe {
+                    configure_audio_session(
+                        audio,
+                        matches!(audio.activation, VideoAudioActivation::OnPlayerCreate),
+                    )
+                } {
+                    Ok(configured) => audio_session_configured = configured,
+                    Err(error) => pending_error = pending_error.or(Some(error)),
+                }
+            }
             let player = unsafe {
                 create_av_player(
                     resolved_source
@@ -794,6 +812,9 @@ mod ios {
                 ready_sent: false,
                 error_sent: false,
                 pending_error,
+                audio: audio.clone(),
+                audio_session_configured,
+                audio_error: None,
             })
         }
 
@@ -929,6 +950,9 @@ mod ios {
         ready_sent: bool,
         error_sent: bool,
         pending_error: Option<String>,
+        audio: VideoAudioOptions,
+        audio_session_configured: bool,
+        audio_error: Option<String>,
     }
 
     impl Drop for IosVideoPlayer {
@@ -945,6 +969,14 @@ mod ios {
 
     impl VideoPlayer for IosVideoPlayer {
         fn play(&mut self) {
+            if !self.audio_session_configured
+                && matches!(self.audio.activation, VideoAudioActivation::OnDemand)
+            {
+                match unsafe { configure_audio_session(&self.audio, true) } {
+                    Ok(configured) => self.audio_session_configured = configured,
+                    Err(error) => self.audio_error = Some(error),
+                }
+            }
             if let Some(player) = self.registry.get(self.player_id) {
                 unsafe {
                     let () = msg_send![player.as_id(), play];
@@ -988,7 +1020,11 @@ mod ios {
 
         fn poll_events(&mut self) -> Vec<VideoEvent> {
             if !self.error_sent {
-                if let Some(message) = self.pending_error.take() {
+                if let Some(message) = self
+                    .pending_error
+                    .take()
+                    .or_else(|| self.audio_error.take())
+                {
                     self.error_sent = true;
                     return vec![VideoEvent::Error(message)];
                 }
@@ -1050,6 +1086,108 @@ mod ios {
         let sanitized = value.replace('\0', "");
         let cstr = CString::new(sanitized).unwrap();
         unsafe { msg_send![class!(NSString), stringWithUTF8String: cstr.as_ptr()] }
+    }
+
+    unsafe fn configure_audio_session(
+        audio: &VideoAudioOptions,
+        activate: bool,
+    ) -> Result<bool, String> {
+        let Some(category) = ios_audio_session_category(audio) else {
+            return Ok(false);
+        };
+        let session: Id = msg_send![class!(AVAudioSession), sharedInstance];
+        if session == NIL {
+            return Err("failed to access AVAudioSession shared instance".to_string());
+        }
+        let category = ns_string(&category);
+        let mode = ns_string(&ios_audio_session_mode(audio));
+        let options = ios_audio_session_options(audio);
+        let category_ok: i8 =
+            msg_send![session, setCategory: category mode: mode options: options error: NIL];
+        if category_ok == NO {
+            return Err("failed to configure AVAudioSession category".to_string());
+        }
+        if activate {
+            let active_ok: i8 = msg_send![session, setActive: YES error: NIL];
+            if active_ok == NO {
+                return Err("failed to activate AVAudioSession".to_string());
+            }
+        }
+        Ok(true)
+    }
+
+    fn ios_audio_session_category(audio: &VideoAudioOptions) -> Option<String> {
+        audio
+            .ios
+            .category
+            .as_ref()
+            .map(ios_audio_session_category_name)
+            .or_else(|| match audio.policy {
+                VideoAudioPolicy::SystemDefault => None,
+                VideoAudioPolicy::Ambient => Some("AVAudioSessionCategoryAmbient".to_string()),
+                VideoAudioPolicy::Playback => Some("AVAudioSessionCategoryPlayback".to_string()),
+            })
+    }
+
+    fn ios_audio_session_category_name(category: &IosAudioSessionCategory) -> String {
+        match category {
+            IosAudioSessionCategory::Ambient => "AVAudioSessionCategoryAmbient".to_string(),
+            IosAudioSessionCategory::SoloAmbient => "AVAudioSessionCategorySoloAmbient".to_string(),
+            IosAudioSessionCategory::Playback => "AVAudioSessionCategoryPlayback".to_string(),
+            IosAudioSessionCategory::Record => "AVAudioSessionCategoryRecord".to_string(),
+            IosAudioSessionCategory::PlayAndRecord => {
+                "AVAudioSessionCategoryPlayAndRecord".to_string()
+            }
+            IosAudioSessionCategory::MultiRoute => "AVAudioSessionCategoryMultiRoute".to_string(),
+            IosAudioSessionCategory::Raw(value) => value.clone(),
+        }
+    }
+
+    fn ios_audio_session_mode(audio: &VideoAudioOptions) -> String {
+        audio
+            .ios
+            .mode
+            .as_ref()
+            .map(ios_audio_session_mode_name)
+            .unwrap_or_else(|| "AVAudioSessionModeDefault".to_string())
+    }
+
+    fn ios_audio_session_mode_name(mode: &IosAudioSessionMode) -> String {
+        match mode {
+            IosAudioSessionMode::Default => "AVAudioSessionModeDefault".to_string(),
+            IosAudioSessionMode::MoviePlayback => "AVAudioSessionModeMoviePlayback".to_string(),
+            IosAudioSessionMode::SpokenAudio => "AVAudioSessionModeSpokenAudio".to_string(),
+            IosAudioSessionMode::VideoRecording => "AVAudioSessionModeVideoRecording".to_string(),
+            IosAudioSessionMode::Measurement => "AVAudioSessionModeMeasurement".to_string(),
+            IosAudioSessionMode::VoiceChat => "AVAudioSessionModeVoiceChat".to_string(),
+            IosAudioSessionMode::VideoChat => "AVAudioSessionModeVideoChat".to_string(),
+            IosAudioSessionMode::GameChat => "AVAudioSessionModeGameChat".to_string(),
+            IosAudioSessionMode::Raw(value) => value.clone(),
+        }
+    }
+
+    fn ios_audio_session_options(audio: &VideoAudioOptions) -> u64 {
+        let mut options = 0u64;
+        if audio.mix_with_others {
+            options |= 0x1;
+        }
+        if audio.duck_others {
+            options |= 0x2;
+        }
+        for option in &audio.ios.category_options {
+            options |= match option {
+                IosAudioSessionCategoryOption::MixWithOthers => 0x1,
+                IosAudioSessionCategoryOption::DuckOthers => 0x2,
+                IosAudioSessionCategoryOption::AllowBluetoothHfp => 0x4,
+                IosAudioSessionCategoryOption::DefaultToSpeaker => 0x8,
+                IosAudioSessionCategoryOption::InterruptSpokenAudioAndMixWithOthers => 0x11,
+                IosAudioSessionCategoryOption::AllowBluetoothA2dp => 0x20,
+                IosAudioSessionCategoryOption::AllowAirPlay => 0x40,
+                IosAudioSessionCategoryOption::OverrideMutedMicrophoneInterruption => 0x80,
+                IosAudioSessionCategoryOption::Raw(value) => *value,
+            };
+        }
+        options
     }
 
     struct ResolvedVideoSource {
@@ -1194,10 +1332,10 @@ mod ios {
 #[cfg(target_os = "windows")]
 mod windows {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use fission_core::ui::VideoAudioOptions;
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
-    use fission_core::ui::VideoAudioOptions;
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
@@ -1633,8 +1771,8 @@ mod windows {
 #[cfg(target_os = "linux")]
 mod linux {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
-    use fission_shell::VideoSurfaceFrame;
     use fission_core::ui::VideoAudioOptions;
+    use fission_shell::VideoSurfaceFrame;
     use gst::prelude::*;
     use gst_video::prelude::*;
     use gstreamer as gst;
@@ -2020,8 +2158,8 @@ mod linux {
 #[cfg(target_os = "android")]
 mod android {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
-    use fission_shell::VideoSurfaceFrame;
     use fission_core::ui::VideoAudioOptions;
+    use fission_shell::VideoSurfaceFrame;
     use jni::objects::{JClass, JObject, JString, JValue};
     use jni::sys::jobject;
     use jni::{JNIEnv, JavaVM};
@@ -2336,8 +2474,8 @@ mod android {
 #[cfg(target_arch = "wasm32")]
 mod web {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
-    use fission_shell::VideoSurfaceFrame;
     use fission_core::ui::VideoAudioOptions;
+    use fission_shell::VideoSurfaceFrame;
     use std::collections::{HashMap, HashSet};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -88,6 +88,7 @@ mod mac {
 
     use core_graphics::geometry::{CGPoint, CGRect, CGSize};
 
+    use fission_core::ui::VideoAudioOptions;
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
@@ -206,7 +207,7 @@ mod mac {
     }
 
     impl VideoBackend for MacVideoBackend {
-        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+        fn create_player(&self, source: &str, _audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let resolved_source = resolve_video_source(source);
             let pending_error = resolved_source.error_message();
             let player = unsafe {
@@ -660,6 +661,7 @@ mod mac {
 mod ios {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
     use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+    use fission_core::ui::VideoAudioOptions;
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
@@ -774,7 +776,7 @@ mod ios {
     }
 
     impl VideoBackend for IosVideoBackend {
-        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+        fn create_player(&self, source: &str, audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let resolved_source = resolve_video_source(source);
             let pending_error = resolved_source.error_message();
             let player = unsafe {
@@ -1195,6 +1197,7 @@ mod windows {
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
+    use fission_core::ui::VideoAudioOptions;
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
@@ -1248,7 +1251,7 @@ mod windows {
     }
 
     impl VideoBackend for WindowsVideoBackend {
-        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+        fn create_player(&self, source: &str, _audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let id = self.next_id.fetch_add(1, Ordering::Relaxed);
             let resolved = resolve_source(source);
             let pending_error = resolved.error_message();
@@ -1631,6 +1634,7 @@ mod windows {
 mod linux {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
     use fission_shell::VideoSurfaceFrame;
+    use fission_core::ui::VideoAudioOptions;
     use gst::prelude::*;
     use gst_video::prelude::*;
     use gstreamer as gst;
@@ -1664,7 +1668,7 @@ mod linux {
     }
 
     impl VideoBackend for LinuxVideoBackend {
-        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+        fn create_player(&self, source: &str, _audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let id = self.next_id.fetch_add(1, Ordering::Relaxed);
             let resolved = resolve_source(source);
             let pending_error = resolved.error_message();
@@ -2017,6 +2021,7 @@ mod linux {
 mod android {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
     use fission_shell::VideoSurfaceFrame;
+    use fission_core::ui::VideoAudioOptions;
     use jni::objects::{JClass, JObject, JString, JValue};
     use jni::sys::jobject;
     use jni::{JNIEnv, JavaVM};
@@ -2039,7 +2044,7 @@ mod android {
     }
 
     impl VideoBackend for AndroidVideoBackend {
-        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+        fn create_player(&self, source: &str, _audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let id = self.next_id.fetch_add(1, Ordering::Relaxed);
             let pending_error = call_with_env(|env, activity_class| {
                 let source = env.new_string(source)?;
@@ -2332,6 +2337,7 @@ mod android {
 mod web {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
     use fission_shell::VideoSurfaceFrame;
+    use fission_core::ui::VideoAudioOptions;
     use std::collections::{HashMap, HashSet};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
@@ -2366,7 +2372,7 @@ mod web {
     }
 
     impl VideoBackend for WebVideoBackend {
-        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+        fn create_player(&self, source: &str, _audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let id = self.next_id.fetch_add(1, Ordering::Relaxed);
             let video = create_video_element(source);
             self.registry.lock().unwrap().insert(id, video.clone());

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -4,10 +4,18 @@ use fission_shell::{VideoBackend, VideoEvent, VideoPlayer};
 use std::sync::Arc;
 use winit::window::Window;
 
+#[cfg(target_os = "android")]
+pub use android::AndroidVideoBackend;
+#[cfg(target_os = "ios")]
+pub use ios::IosVideoBackend;
+#[cfg(target_os = "linux")]
+pub use linux::LinuxVideoBackend;
 #[cfg(target_os = "macos")]
 pub use mac::MacVideoBackend;
-
-pub use mock::MockVideoBackend;
+#[cfg(target_arch = "wasm32")]
+pub use web::WebVideoBackend;
+#[cfg(target_os = "windows")]
+pub use windows::WindowsVideoBackend;
 
 pub fn create_video_backend(window: Option<&Window>) -> Arc<dyn VideoBackend> {
     #[cfg(target_os = "macos")]
@@ -17,10 +25,57 @@ pub fn create_video_backend(window: Option<&Window>) -> Arc<dyn VideoBackend> {
         }
     }
 
-    #[cfg(not(target_os = "macos"))]
-    let _ = window;
+    #[cfg(target_os = "ios")]
+    if let Some(window) = window {
+        if let Some(backend) = IosVideoBackend::try_new(window) {
+            return Arc::new(backend);
+        }
+    }
 
-    Arc::new(MockVideoBackend::new())
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = window;
+        return Arc::new(WebVideoBackend::new());
+    }
+
+    #[cfg(target_os = "windows")]
+    if let Some(window) = window {
+        if let Some(backend) = WindowsVideoBackend::try_new(window) {
+            return Arc::new(backend);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    panic!("Fission Video for Windows requires a Win32 window handle");
+
+    #[cfg(target_os = "linux")]
+    if let Some(window) = window {
+        if let Some(backend) = LinuxVideoBackend::try_new(window) {
+            return Arc::new(backend);
+        }
+    }
+    #[cfg(target_os = "linux")]
+    panic!("Fission Video for Linux requires an X11 or Wayland window handle");
+
+    #[cfg(target_os = "android")]
+    {
+        let _ = window;
+        return Arc::new(AndroidVideoBackend::new());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    panic!(
+        "Fission Video requires a native window on this target; no state-only mock fallback exists"
+    );
+
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "windows",
+        target_os = "linux",
+        target_os = "android",
+        target_arch = "wasm32"
+    )))]
+    panic!("Fission Video is unsupported on this platform");
 }
 
 #[cfg(target_os = "macos")]
@@ -600,202 +655,399 @@ mod mac {
     }
 }
 
-mod mock {
+#[cfg(target_os = "ios")]
+#[allow(unexpected_cfgs)]
+mod ios {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+    use fission_ir::WidgetId;
+    use fission_render::LayoutRect;
+    use fission_shell::VideoSurfaceFrame;
+    use objc::rc::StrongPtr;
+    use objc::runtime::Object;
+    use objc::{class, msg_send, sel, sel_impl};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use std::collections::{HashMap, HashSet};
+    use std::ffi::CString;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
-    #[cfg(not(target_arch = "wasm32"))]
-    use std::time::Instant;
-    #[cfg(target_arch = "wasm32")]
-    use web_time::Instant;
+    use std::sync::{Arc, Mutex};
+    use winit::window::Window;
 
-    pub struct MockVideoBackend;
+    type Id = *mut Object;
+    const NIL: Id = std::ptr::null_mut();
+    const YES: i8 = 1;
+    const NO: i8 = 0;
 
-    impl MockVideoBackend {
-        pub fn new() -> Self {
-            Self
+    #[link(name = "AVFoundation", kind = "framework")]
+    extern "C" {}
+    #[link(name = "Foundation", kind = "framework")]
+    extern "C" {}
+    #[link(name = "QuartzCore", kind = "framework")]
+    extern "C" {}
+    #[link(name = "UIKit", kind = "framework")]
+    extern "C" {}
+
+    #[derive(Clone)]
+    struct RetainedId(StrongPtr);
+
+    unsafe impl Send for RetainedId {}
+    unsafe impl Sync for RetainedId {}
+
+    impl RetainedId {
+        unsafe fn retain(ptr: Id) -> Self {
+            Self(StrongPtr::retain(ptr))
+        }
+
+        unsafe fn owned(ptr: Id) -> Self {
+            Self(StrongPtr::new(ptr))
+        }
+
+        fn as_id(&self) -> Id {
+            *self.0
         }
     }
 
-    impl VideoBackend for MockVideoBackend {
+    impl From<StrongPtr> for RetainedId {
+        fn from(value: StrongPtr) -> Self {
+            Self(value)
+        }
+    }
+
+    struct LayerContext {
+        parent_view: Id,
+        scale_factor: f64,
+    }
+
+    pub struct IosVideoBackend {
+        view: RetainedId,
+        layers: Mutex<HashMap<WidgetId, VideoLayer>>,
+        registry: Arc<PlayerRegistry>,
+    }
+
+    impl IosVideoBackend {
+        pub fn try_new(window: &Window) -> Option<Self> {
+            let ui_view = ui_view_from_window(window)?;
+            Some(Self {
+                view: unsafe { RetainedId::retain(ui_view) },
+                layers: Mutex::new(HashMap::new()),
+                registry: Arc::new(PlayerRegistry::new()),
+            })
+        }
+
+        fn context(&self) -> Option<LayerContext> {
+            unsafe {
+                let parent_view = self.view.as_id();
+                if parent_view == NIL {
+                    return None;
+                }
+                let scale: f64 = msg_send![parent_view, contentScaleFactor];
+                Some(LayerContext {
+                    parent_view,
+                    scale_factor: if scale == 0.0 { 1.0 } else { scale },
+                })
+            }
+        }
+
+        fn update_video_layer(
+            &self,
+            layer_map: &mut HashMap<WidgetId, VideoLayer>,
+            frame: &VideoSurfaceFrame,
+            ctx: &LayerContext,
+        ) {
+            if let Some(player) = self.registry.get(frame.surface_id) {
+                let widget_id = frame.widget_id;
+                let entry = layer_map
+                    .entry(widget_id)
+                    .or_insert_with(|| VideoLayer::new(&player, ctx));
+                entry.update(&player, ctx, frame.rect);
+            }
+        }
+    }
+
+    fn ui_view_from_window(window: &Window) -> Option<Id> {
+        let handle = window.window_handle().ok()?;
+        match handle.as_raw() {
+            RawWindowHandle::UiKit(handle) => Some(handle.ui_view.as_ptr() as Id),
+            _ => None,
+        }
+    }
+
+    impl VideoBackend for IosVideoBackend {
         fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
-            Box::new(MockPlayer::new(source))
+            let resolved_source = resolve_video_source(source);
+            let pending_error = resolved_source.error_message();
+            let player = unsafe {
+                create_av_player(
+                    resolved_source
+                        .resolved_path
+                        .as_deref()
+                        .unwrap_or_else(|| Path::new(source)),
+                )
+            };
+            let player_id = self.registry.register(player);
+            Box::new(IosVideoPlayer {
+                registry: Arc::clone(&self.registry),
+                player_id,
+                ready_sent: false,
+                error_sent: false,
+                pending_error,
+            })
         }
 
-        fn present_surfaces(&self, _frames: &[fission_shell::VideoSurfaceFrame]) {}
+        fn present_surfaces(&self, frames: &[VideoSurfaceFrame]) {
+            let mut layers = self.layers.lock().unwrap();
+            if frames.is_empty() {
+                for layer in layers.values() {
+                    unsafe { layer.detach() };
+                }
+                layers.clear();
+                return;
+            }
+
+            let Some(ctx) = self.context() else {
+                for layer in layers.values() {
+                    unsafe { layer.detach() };
+                }
+                layers.clear();
+                return;
+            };
+
+            let mut seen = HashSet::new();
+            for frame in frames {
+                seen.insert(frame.widget_id);
+                self.update_video_layer(&mut layers, frame, &ctx);
+            }
+
+            layers.retain(|widget_id, layer| {
+                if seen.contains(widget_id) {
+                    true
+                } else {
+                    unsafe { layer.detach() };
+                    false
+                }
+            });
+        }
     }
 
-    static NEXT_SURFACE_ID: AtomicU64 = AtomicU64::new(1);
+    impl Drop for IosVideoBackend {
+        fn drop(&mut self) {
+            if let Ok(mut layers) = self.layers.lock() {
+                for layer in layers.values() {
+                    unsafe { layer.detach() };
+                }
+                layers.clear();
+            }
+        }
+    }
 
-    struct MockPlayer {
-        _source: String,
-        state: PlayerState,
-        start_time: Instant,
-        play_start_time: Option<Instant>,
-        accumulated_play_time: u64,
-        surface_id: u64,
-        duration: u64,
-        sent_ready: bool,
-        sent_ended: bool,
-        playback_rate: f32,
-        volume: f32,
-        muted: bool,
+    struct VideoLayer {
+        view: RetainedId,
+        layer: RetainedId,
+    }
+
+    impl VideoLayer {
+        fn new(player: &RetainedId, ctx: &LayerContext) -> Self {
+            unsafe {
+                let frame = CGRect::new(&CGPoint::new(0.0, 0.0), &CGSize::new(1.0, 1.0));
+                let view_alloc: Id = msg_send![class!(UIView), alloc];
+                let view: Id = msg_send![view_alloc, initWithFrame: frame];
+                let () = msg_send![view, setUserInteractionEnabled: NO];
+                let layer: Id =
+                    msg_send![class!(AVPlayerLayer), playerLayerWithPlayer: player.as_id()];
+                let gravity = ns_string("AVLayerVideoGravityResizeAspect");
+                let () = msg_send![layer, setVideoGravity: gravity];
+                let () = msg_send![layer, setMasksToBounds: YES];
+                let () = msg_send![layer, setContentsScale: ctx.scale_factor];
+                let view_layer: Id = msg_send![view, layer];
+                let () = msg_send![view_layer, addSublayer: layer];
+                let () = msg_send![ctx.parent_view, addSubview: view];
+                Self {
+                    view: RetainedId::owned(view),
+                    layer: RetainedId::retain(layer),
+                }
+            }
+        }
+
+        fn update(&mut self, player: &RetainedId, ctx: &LayerContext, rect: LayoutRect) {
+            unsafe {
+                let view = self.view.as_id();
+                let layer = self.layer.as_id();
+                let frame = cg_rect_from_layout(rect);
+                let () = msg_send![view, setFrame: frame];
+                let bounds: CGRect = msg_send![view, bounds];
+                let () = msg_send![layer, setFrame: bounds];
+                let () = msg_send![layer, setContentsScale: ctx.scale_factor];
+                let () = msg_send![layer, setPlayer: player.as_id()];
+                let () = msg_send![ctx.parent_view, addSubview: view];
+            }
+        }
+
+        unsafe fn detach(&self) {
+            let layer = self.layer.as_id();
+            let () = msg_send![layer, setPlayer: NIL];
+            let () = msg_send![self.view.as_id(), removeFromSuperview];
+        }
+    }
+
+    struct PlayerRegistry {
+        next_id: AtomicU64,
+        map: Mutex<HashMap<u64, RetainedId>>,
+    }
+
+    impl PlayerRegistry {
+        fn new() -> Self {
+            Self {
+                next_id: AtomicU64::new(1),
+                map: Mutex::new(HashMap::new()),
+            }
+        }
+
+        fn register(&self, player: StrongPtr) -> u64 {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            self.map
+                .lock()
+                .unwrap()
+                .insert(id, RetainedId::from(player));
+            id
+        }
+
+        fn unregister(&self, id: u64) {
+            self.map.lock().unwrap().remove(&id);
+        }
+
+        fn get(&self, id: u64) -> Option<RetainedId> {
+            self.map.lock().unwrap().get(&id).cloned()
+        }
+    }
+
+    pub struct IosVideoPlayer {
+        registry: Arc<PlayerRegistry>,
+        player_id: u64,
+        ready_sent: bool,
         error_sent: bool,
         pending_error: Option<String>,
     }
 
-    #[derive(PartialEq)]
-    enum PlayerState {
-        Loading,
-        Ready,
-        Playing,
-        Paused,
-        Ended,
-    }
-
-    impl MockPlayer {
-        fn new(source: &str) -> Self {
-            let resolved_source = resolve_video_source(source);
-            let pending_error = resolved_source.error_message();
-            Self {
-                _source: resolved_source
-                    .resolved_path
-                    .as_ref()
-                    .map(|path| path.to_string_lossy().to_string())
-                    .unwrap_or_else(|| source.to_string()),
-                state: if pending_error.is_some() {
-                    PlayerState::Ready
-                } else {
-                    PlayerState::Loading
-                },
-                start_time: Instant::now(),
-                play_start_time: None,
-                accumulated_play_time: 0,
-                surface_id: NEXT_SURFACE_ID.fetch_add(1, Ordering::Relaxed),
-                duration: 5000,
-                sent_ready: false,
-                sent_ended: false,
-                playback_rate: 1.0,
-                volume: 1.0,
-                muted: false,
-                error_sent: false,
-                pending_error,
+    impl Drop for IosVideoPlayer {
+        fn drop(&mut self) {
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe {
+                    let () = msg_send![player.as_id(), pause];
+                    let () = msg_send![player.as_id(), setRate: 0.0f32];
+                }
             }
-        }
-
-        fn current_elapsed_ms(&self) -> u64 {
-            if let (PlayerState::Playing, Some(start)) = (&self.state, self.play_start_time) {
-                let elapsed = start.elapsed().as_millis() as f64;
-                (elapsed * self.playback_rate as f64) as u64
-            } else {
-                0
-            }
+            self.registry.unregister(self.player_id);
         }
     }
 
-    impl VideoPlayer for MockPlayer {
+    impl VideoPlayer for IosVideoPlayer {
         fn play(&mut self) {
-            if self.state == PlayerState::Ready || self.state == PlayerState::Paused {
-                self.state = PlayerState::Playing;
-                self.play_start_time = Some(Instant::now());
-            } else if self.state == PlayerState::Ended {
-                self.state = PlayerState::Playing;
-                self.accumulated_play_time = 0;
-                self.play_start_time = Some(Instant::now());
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe {
+                    let () = msg_send![player.as_id(), play];
+                }
             }
         }
 
         fn pause(&mut self) {
-            if self.state == PlayerState::Playing {
-                self.accumulated_play_time += self.current_elapsed_ms();
-                self.state = PlayerState::Paused;
-                self.play_start_time = None;
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe {
+                    let () = msg_send![player.as_id(), pause];
+                }
             }
         }
 
         fn stop(&mut self) {
-            self.state = PlayerState::Ready;
-            self.play_start_time = None;
-            self.accumulated_play_time = 0;
-            self.sent_ended = false;
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe {
+                    let () = msg_send![player.as_id(), pause];
+                    seek_to_ms(player.as_id(), 0);
+                }
+            }
         }
 
         fn position(&self) -> u64 {
-            (self.accumulated_play_time + self.current_elapsed_ms()).min(self.duration)
+            self.registry
+                .get(self.player_id)
+                .and_then(|player| unsafe { current_time_ms(player.as_id()) })
+                .unwrap_or(0)
         }
 
         fn duration(&self) -> Option<u64> {
-            Some(self.duration)
+            self.registry
+                .get(self.player_id)
+                .and_then(|player| unsafe { item_duration_ms(player.as_id()) })
         }
 
         fn surface_id(&self) -> u64 {
-            self.surface_id
+            self.player_id
         }
 
         fn poll_events(&mut self) -> Vec<VideoEvent> {
-            let mut events = Vec::new();
             if !self.error_sent {
                 if let Some(message) = self.pending_error.take() {
                     self.error_sent = true;
-                    self.sent_ready = true;
-                    events.push(VideoEvent::Error(message));
-                    return events;
+                    return vec![VideoEvent::Error(message)];
                 }
             }
-            let elapsed = self.start_time.elapsed().as_millis() as u64;
-
-            if !self.sent_ready && elapsed > 500 {
-                if self.state == PlayerState::Loading {
-                    self.state = PlayerState::Ready;
-                }
-                self.sent_ready = true;
-                events.push(VideoEvent::Ready {
-                    duration: self.duration,
-                });
+            if !self.ready_sent {
+                self.ready_sent = true;
+                let duration = self.duration().unwrap_or(0);
+                vec![VideoEvent::Ready { duration }]
+            } else {
+                Vec::new()
             }
-
-            if self.state == PlayerState::Playing && self.position() >= self.duration {
-                self.state = PlayerState::Ended;
-                self.play_start_time = None;
-                if !self.sent_ended {
-                    self.sent_ended = true;
-                    events.push(VideoEvent::Ended);
-                }
-            }
-
-            events
         }
 
         fn seek_to(&mut self, position_ms: u64) {
-            let clamped = position_ms.min(self.duration);
-            self.accumulated_play_time = clamped;
-            if self.state == PlayerState::Playing {
-                self.play_start_time = Some(Instant::now());
-            } else {
-                self.play_start_time = None;
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe { seek_to_ms(player.as_id(), position_ms) }
             }
-            self.sent_ended = false;
         }
 
         fn set_rate(&mut self, rate: f32) {
-            let new_rate = rate.max(0.1);
-            if self.state == PlayerState::Playing {
-                self.accumulated_play_time = self.position();
-                self.play_start_time = Some(Instant::now());
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe {
+                    let () = msg_send![player.as_id(), setRate: rate];
+                }
             }
-            self.playback_rate = new_rate;
         }
 
         fn set_volume(&mut self, volume: f32) {
-            self.volume = volume.clamp(0.0, 1.0);
-            if self.volume == 0.0 {
-                self.muted = true;
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe {
+                    let () = msg_send![player.as_id(), setVolume: volume];
+                }
             }
         }
 
         fn set_muted(&mut self, muted: bool) {
-            self.muted = muted;
+            if let Some(player) = self.registry.get(self.player_id) {
+                unsafe {
+                    let () = msg_send![player.as_id(), setMuted: muted];
+                }
+            }
         }
+    }
+
+    unsafe fn create_av_player(source_path: &Path) -> StrongPtr {
+        let url = file_url_from_path(source_path);
+        let player: Id = msg_send![class!(AVPlayer), playerWithURL: url];
+        StrongPtr::retain(player)
+    }
+
+    fn file_url_from_path(path: &Path) -> Id {
+        unsafe {
+            let ns_path = ns_string(path.to_string_lossy().as_ref());
+            msg_send![class!(NSURL), fileURLWithPath: ns_path]
+        }
+    }
+
+    fn ns_string(value: &str) -> Id {
+        let sanitized = value.replace('\0', "");
+        let cstr = CString::new(sanitized).unwrap();
+        unsafe { msg_send![class!(NSString), stringWithUTF8String: cstr.as_ptr()] }
     }
 
     struct ResolvedVideoSource {
@@ -835,12 +1087,11 @@ mod mock {
                 requested,
                 resolved_path: None,
                 diagnostic: Some(
-                    "video backend only supports local filesystem paths for media sources"
+                    "native Apple video backend only supports local filesystem paths for media sources"
                         .to_string(),
                 ),
             };
         }
-
         let candidate = if Path::new(trimmed).is_absolute() {
             PathBuf::from(trimmed)
         } else {
@@ -857,7 +1108,6 @@ mod mock {
                 }
             }
         };
-
         let resolved_path = candidate
             .canonicalize()
             .ok()
@@ -868,42 +1118,1449 @@ mod mock {
         } else {
             Some("video source path does not exist".to_string())
         };
-
         ResolvedVideoSource {
             requested,
             resolved_path: Some(resolved_path),
             diagnostic,
         }
     }
+
+    unsafe fn current_time_ms(player: Id) -> Option<u64> {
+        let current: CMTime = msg_send![player, currentTime];
+        current.to_millis()
+    }
+
+    unsafe fn item_duration_ms(player: Id) -> Option<u64> {
+        let item: Id = msg_send![player, currentItem];
+        if item == NIL {
+            return None;
+        }
+        let duration: CMTime = msg_send![item, duration];
+        duration.to_millis()
+    }
+
+    unsafe fn seek_to_ms(player: Id, position_ms: u64) {
+        let time = CMTime::from_millis(position_ms);
+        let zero_a = CMTime::zero();
+        let zero_b = CMTime::zero();
+        let () = msg_send![player, seekToTime: time toleranceBefore: zero_a toleranceAfter: zero_b];
+    }
+
+    fn cg_rect_from_layout(rect: LayoutRect) -> CGRect {
+        CGRect::new(
+            &CGPoint::new(rect.origin.x as f64, rect.origin.y as f64),
+            &CGSize::new(rect.size.width as f64, rect.size.height as f64),
+        )
+    }
+
+    #[repr(C)]
+    struct CMTime {
+        value: i64,
+        timescale: i32,
+        flags: i32,
+        epoch: i64,
+    }
+
+    impl CMTime {
+        fn zero() -> Self {
+            Self {
+                value: 0,
+                timescale: 1,
+                flags: 1,
+                epoch: 0,
+            }
+        }
+
+        fn from_millis(ms: u64) -> Self {
+            Self {
+                value: ms as i64,
+                timescale: 1000,
+                flags: 1,
+                epoch: 0,
+            }
+        }
+
+        fn to_millis(&self) -> Option<u64> {
+            if self.timescale <= 0 {
+                return None;
+            }
+            Some(((self.value as f64 / self.timescale as f64) * 1000.0) as u64)
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use fission_ir::WidgetId;
+    use fission_render::LayoutRect;
+    use fission_shell::VideoSurfaceFrame;
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use std::collections::{HashMap, HashSet};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+    use winit::window::Window;
+
+    use ::windows::core::{PCWSTR, PROPVARIANT};
+    use ::windows::Win32::Foundation::{HINSTANCE, HWND};
+    use ::windows::Win32::Media::MediaFoundation::{
+        IMFPMediaPlayer, IMFPMediaPlayerCallback, MFPCreateMediaPlayer, MFStartup, MFP_OPTION_NONE,
+        MFP_POSITIONTYPE_100NS, MF_VERSION,
+    };
+    use ::windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DestroyWindow, SetWindowPos, ShowWindow, HWND_TOP, SWP_NOZORDER, SW_HIDE,
+        SW_SHOW, WINDOW_EX_STYLE, WS_CHILD, WS_CLIPSIBLINGS, WS_VISIBLE,
+    };
+
+    #[derive(Clone, Copy)]
+    struct NativeHwnd(HWND);
+
+    unsafe impl Send for NativeHwnd {}
+    unsafe impl Sync for NativeHwnd {}
+
+    pub struct WindowsVideoBackend {
+        parent: NativeHwnd,
+        hinstance: HINSTANCE,
+        next_id: AtomicU64,
+        registry: Arc<Mutex<HashMap<u64, PlayerEntry>>>,
+    }
+
+    impl WindowsVideoBackend {
+        pub fn try_new(window: &Window) -> Option<Self> {
+            let handle = window.window_handle().ok()?;
+            let RawWindowHandle::Win32(handle) = handle.as_raw() else {
+                return None;
+            };
+            unsafe {
+                let _ = MFStartup(MF_VERSION, 0);
+            }
+            Some(Self {
+                parent: NativeHwnd(HWND(handle.hwnd.get() as isize)),
+                hinstance: handle
+                    .hinstance
+                    .map(|hinstance| HINSTANCE(hinstance.get() as isize))
+                    .unwrap_or(HINSTANCE(0)),
+                next_id: AtomicU64::new(1),
+                registry: Arc::new(Mutex::new(HashMap::new())),
+            })
+        }
+    }
+
+    impl VideoBackend for WindowsVideoBackend {
+        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let resolved = resolve_source(source);
+            let pending_error = resolved.error_message();
+            let entry = PlayerEntry::new(self.parent, self.hinstance, &resolved.uri)
+                .unwrap_or_else(|error| PlayerEntry::failed(error.to_string()));
+            self.registry.lock().unwrap().insert(id, entry);
+            Box::new(WindowsVideoPlayer {
+                registry: Arc::clone(&self.registry),
+                surface_id: id,
+                ready_sent: false,
+                ended_sent: false,
+                error_sent: false,
+                pending_error,
+            })
+        }
+
+        fn present_surfaces(&self, frames: &[VideoSurfaceFrame]) {
+            let mut seen = HashSet::new();
+            let mut registry = self.registry.lock().unwrap();
+            for frame in frames {
+                seen.insert(frame.surface_id);
+                if let Some(entry) = registry.get_mut(&frame.surface_id) {
+                    entry.present(frame.rect);
+                }
+            }
+            for (id, entry) in registry.iter_mut() {
+                if !seen.contains(id) {
+                    entry.hide();
+                }
+            }
+        }
+    }
+
+    struct PlayerEntry {
+        hwnd: Option<NativeHwnd>,
+        player: Option<IMFPMediaPlayer>,
+        creation_error: Option<String>,
+    }
+
+    unsafe impl Send for PlayerEntry {}
+    unsafe impl Sync for PlayerEntry {}
+
+    impl PlayerEntry {
+        fn new(
+            parent: NativeHwnd,
+            hinstance: HINSTANCE,
+            uri: &str,
+        ) -> ::windows::core::Result<Self> {
+            let child = unsafe { create_child_window(parent, hinstance)? };
+            let wide_uri = wide_null(uri);
+            let mut player: Option<IMFPMediaPlayer> = None;
+            unsafe {
+                MFPCreateMediaPlayer(
+                    PCWSTR(wide_uri.as_ptr()),
+                    false,
+                    MFP_OPTION_NONE,
+                    None::<&IMFPMediaPlayerCallback>,
+                    child.0,
+                    Some(&mut player),
+                )?;
+            }
+            Ok(Self {
+                hwnd: Some(child),
+                player,
+                creation_error: None,
+            })
+        }
+
+        fn failed(error: String) -> Self {
+            Self {
+                hwnd: None,
+                player: None,
+                creation_error: Some(error),
+            }
+        }
+
+        fn present(&mut self, rect: LayoutRect) {
+            if let Some(hwnd) = self.hwnd {
+                unsafe {
+                    let _ = SetWindowPos(
+                        hwnd.0,
+                        HWND_TOP,
+                        rect.origin.x.round() as i32,
+                        rect.origin.y.round() as i32,
+                        rect.size.width.max(1.0).round() as i32,
+                        rect.size.height.max(1.0).round() as i32,
+                        SWP_NOZORDER,
+                    );
+                    let _ = ShowWindow(hwnd.0, SW_SHOW);
+                }
+                if let Some(player) = &self.player {
+                    unsafe {
+                        let _ = player.UpdateVideo();
+                    }
+                }
+            }
+        }
+
+        fn hide(&mut self) {
+            if let Some(hwnd) = self.hwnd {
+                unsafe {
+                    let _ = ShowWindow(hwnd.0, SW_HIDE);
+                }
+            }
+        }
+    }
+
+    impl Drop for PlayerEntry {
+        fn drop(&mut self) {
+            if let Some(player) = &self.player {
+                unsafe {
+                    let _ = player.Shutdown();
+                }
+            }
+            if let Some(hwnd) = self.hwnd {
+                unsafe {
+                    let _ = DestroyWindow(hwnd.0);
+                }
+            }
+        }
+    }
+
+    pub struct WindowsVideoPlayer {
+        registry: Arc<Mutex<HashMap<u64, PlayerEntry>>>,
+        surface_id: u64,
+        ready_sent: bool,
+        ended_sent: bool,
+        error_sent: bool,
+        pending_error: Option<String>,
+    }
+
+    impl Drop for WindowsVideoPlayer {
+        fn drop(&mut self) {
+            self.registry.lock().unwrap().remove(&self.surface_id);
+        }
+    }
+
+    impl WindowsVideoPlayer {
+        fn with_entry<R>(&self, f: impl FnOnce(&PlayerEntry) -> R) -> Option<R> {
+            self.registry.lock().unwrap().get(&self.surface_id).map(f)
+        }
+
+        fn with_entry_mut<R>(&self, f: impl FnOnce(&mut PlayerEntry) -> R) -> Option<R> {
+            self.registry
+                .lock()
+                .unwrap()
+                .get_mut(&self.surface_id)
+                .map(f)
+        }
+    }
+
+    impl VideoPlayer for WindowsVideoPlayer {
+        fn play(&mut self) {
+            self.with_entry(|entry| {
+                if let Some(player) = &entry.player {
+                    unsafe {
+                        let _ = player.Play();
+                    }
+                }
+            });
+        }
+
+        fn pause(&mut self) {
+            self.with_entry(|entry| {
+                if let Some(player) = &entry.player {
+                    unsafe {
+                        let _ = player.Pause();
+                    }
+                }
+            });
+        }
+
+        fn stop(&mut self) {
+            self.with_entry(|entry| {
+                if let Some(player) = &entry.player {
+                    unsafe {
+                        let _ = player.Stop();
+                    }
+                }
+            });
+        }
+
+        fn position(&self) -> u64 {
+            self.with_entry(|entry| {
+                entry
+                    .player
+                    .as_ref()
+                    .and_then(|player| unsafe {
+                        player
+                            .GetPosition(&MFP_POSITIONTYPE_100NS)
+                            .ok()
+                            .and_then(|value| i64::try_from(&value).ok())
+                    })
+                    .map(hundred_ns_to_ms)
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0)
+        }
+
+        fn duration(&self) -> Option<u64> {
+            self.with_entry(|entry| {
+                entry.player.as_ref().and_then(|player| unsafe {
+                    player
+                        .GetDuration(&MFP_POSITIONTYPE_100NS)
+                        .ok()
+                        .and_then(|value| i64::try_from(&value).ok())
+                        .map(hundred_ns_to_ms)
+                })
+            })
+            .flatten()
+        }
+
+        fn surface_id(&self) -> u64 {
+            self.surface_id
+        }
+
+        fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
+            if !self.error_sent {
+                if let Some(message) = self.pending_error.take().or_else(|| {
+                    self.with_entry_mut(|entry| entry.creation_error.take())
+                        .flatten()
+                }) {
+                    self.error_sent = true;
+                    events.push(VideoEvent::Error(message));
+                }
+            }
+            if !self.ready_sent {
+                let duration = self.duration().unwrap_or(0);
+                self.ready_sent = true;
+                events.push(VideoEvent::Ready { duration });
+            }
+            let stopped = self
+                .with_entry(|entry| {
+                    entry
+                        .player
+                        .as_ref()
+                        .and_then(|player| unsafe { player.GetState().ok() })
+                })
+                .flatten()
+                .map(|state| state.0 == 1)
+                .unwrap_or(false);
+            if stopped && self.position() > 0 && !self.ended_sent {
+                self.ended_sent = true;
+                events.push(VideoEvent::Ended);
+            }
+            if !stopped {
+                self.ended_sent = false;
+            }
+            events
+        }
+
+        fn seek_to(&mut self, position_ms: u64) {
+            self.with_entry(|entry| {
+                if let Some(player) = &entry.player {
+                    let value = PROPVARIANT::from((position_ms as i64).saturating_mul(10_000));
+                    unsafe {
+                        let _ = player.SetPosition(&MFP_POSITIONTYPE_100NS, &value);
+                    }
+                }
+            });
+        }
+
+        fn set_rate(&mut self, rate: f32) {
+            self.with_entry(|entry| {
+                if let Some(player) = &entry.player {
+                    unsafe {
+                        let _ = player.SetRate(rate.max(0.1));
+                    }
+                }
+            });
+        }
+
+        fn set_volume(&mut self, volume: f32) {
+            self.with_entry(|entry| {
+                if let Some(player) = &entry.player {
+                    unsafe {
+                        let _ = player.SetVolume(volume.clamp(0.0, 1.0));
+                    }
+                }
+            });
+        }
+
+        fn set_muted(&mut self, muted: bool) {
+            self.with_entry(|entry| {
+                if let Some(player) = &entry.player {
+                    unsafe {
+                        let _ = player.SetMute(muted);
+                    }
+                }
+            });
+        }
+    }
+
+    unsafe fn create_child_window(
+        parent: NativeHwnd,
+        hinstance: HINSTANCE,
+    ) -> ::windows::core::Result<NativeHwnd> {
+        let class_name = wide_null("STATIC");
+        let title = wide_null("");
+        let hwnd = CreateWindowExW(
+            WINDOW_EX_STYLE(0),
+            PCWSTR(class_name.as_ptr()),
+            PCWSTR(title.as_ptr()),
+            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS,
+            0,
+            0,
+            1,
+            1,
+            parent.0,
+            None,
+            hinstance,
+            None,
+        )?;
+        Ok(NativeHwnd(hwnd))
+    }
+
+    fn hundred_ns_to_ms(value: i64) -> u64 {
+        (value.max(0) as u64) / 10_000
+    }
+
+    fn wide_null(value: &str) -> Vec<u16> {
+        value.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    struct ResolvedSource {
+        requested: String,
+        uri: String,
+        diagnostic: Option<String>,
+    }
+
+    impl ResolvedSource {
+        fn error_message(&self) -> Option<String> {
+            self.diagnostic.as_ref().map(|diagnostic| {
+                format!(
+                    "{diagnostic} (requested='{}', resolved='{}')",
+                    self.requested, self.uri
+                )
+            })
+        }
+    }
+
+    fn resolve_source(source: &str) -> ResolvedSource {
+        let requested = source.to_string();
+        let trimmed = source.trim();
+        if trimmed.is_empty() {
+            return ResolvedSource {
+                requested,
+                uri: String::new(),
+                diagnostic: Some("video source path is empty".to_string()),
+            };
+        }
+        if trimmed.contains("://") {
+            return ResolvedSource {
+                requested,
+                uri: trimmed.to_string(),
+                diagnostic: None,
+            };
+        }
+        let candidate = if Path::new(trimmed).is_absolute() {
+            PathBuf::from(trimmed)
+        } else {
+            std::env::current_dir()
+                .map(|dir| dir.join(trimmed))
+                .unwrap_or_else(|_| PathBuf::from(trimmed))
+        };
+        let resolved = candidate.canonicalize().unwrap_or(candidate);
+        let diagnostic =
+            (!resolved.exists()).then(|| "video source path does not exist".to_string());
+        let path = resolved.to_string_lossy().replace('\\', "/");
+        ResolvedSource {
+            requested,
+            uri: format!("file:///{}", path.trim_start_matches('/')),
+            diagnostic,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use fission_shell::VideoSurfaceFrame;
+    use gst::prelude::*;
+    use gst_video::prelude::*;
+    use gstreamer as gst;
+    use gstreamer_video as gst_video;
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use std::collections::{HashMap, HashSet};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex, OnceLock};
+    use winit::window::Window;
+
+    pub struct LinuxVideoBackend {
+        native_window_handle: usize,
+        next_id: AtomicU64,
+        registry: Arc<Mutex<HashMap<u64, PlayerEntry>>>,
+    }
+
+    impl LinuxVideoBackend {
+        pub fn try_new(window: &Window) -> Option<Self> {
+            if let Err(error) = init_gstreamer() {
+                eprintln!("Fission Linux video backend failed to initialize GStreamer: {error}");
+                return None;
+            }
+            let native_window_handle = native_window_handle(window)?;
+            Some(Self {
+                native_window_handle,
+                next_id: AtomicU64::new(1),
+                registry: Arc::new(Mutex::new(HashMap::new())),
+            })
+        }
+    }
+
+    impl VideoBackend for LinuxVideoBackend {
+        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let resolved = resolve_source(source);
+            let pending_error = resolved.error_message();
+            let entry =
+                PlayerEntry::new(&resolved.uri).unwrap_or_else(|error| PlayerEntry::failed(error));
+            self.registry.lock().unwrap().insert(id, entry);
+            Box::new(LinuxVideoPlayer {
+                registry: Arc::clone(&self.registry),
+                surface_id: id,
+                ready_sent: false,
+                ended_sent: false,
+                error_sent: false,
+                pending_error,
+            })
+        }
+
+        fn present_surfaces(&self, frames: &[VideoSurfaceFrame]) {
+            let mut seen = HashSet::new();
+            let mut registry = self.registry.lock().unwrap();
+            for frame in frames {
+                seen.insert(frame.surface_id);
+                if let Some(entry) = registry.get_mut(&frame.surface_id) {
+                    entry.present(self.native_window_handle, frame);
+                }
+            }
+            for (id, entry) in registry.iter_mut() {
+                if !seen.contains(id) {
+                    entry.hide();
+                }
+            }
+        }
+    }
+
+    struct PlayerEntry {
+        playbin: Option<gst::Element>,
+        overlay: Option<gst_video::VideoOverlay>,
+        bus: Option<gst::Bus>,
+        creation_error: Option<String>,
+        window_handle_set: bool,
+    }
+
+    unsafe impl Send for PlayerEntry {}
+    unsafe impl Sync for PlayerEntry {}
+
+    impl PlayerEntry {
+        fn new(uri: &str) -> Result<Self, String> {
+            let playbin = gst::ElementFactory::make("playbin")
+                .build()
+                .map_err(|error| format!("failed to create GStreamer playbin: {error}"))?;
+            let sink = gst::ElementFactory::make("glimagesink")
+                .build()
+                .or_else(|_| gst::ElementFactory::make("autovideosink").build())
+                .map_err(|error| format!("failed to create GStreamer video sink: {error}"))?;
+            let overlay = sink.clone().dynamic_cast::<gst_video::VideoOverlay>().ok();
+            playbin.set_property("video-sink", &sink);
+            playbin.set_property("uri", uri);
+            let bus = playbin.bus();
+            Ok(Self {
+                playbin: Some(playbin),
+                overlay,
+                bus,
+                creation_error: None,
+                window_handle_set: false,
+            })
+        }
+
+        fn failed(error: String) -> Self {
+            Self {
+                playbin: None,
+                overlay: None,
+                bus: None,
+                creation_error: Some(error),
+                window_handle_set: false,
+            }
+        }
+
+        fn present(&mut self, native_window_handle: usize, frame: &VideoSurfaceFrame) {
+            if let Some(overlay) = self.overlay.as_ref() {
+                unsafe {
+                    if !self.window_handle_set {
+                        overlay.set_window_handle(native_window_handle);
+                        self.window_handle_set = true;
+                    }
+                }
+                let rect = frame.rect;
+                let _ = overlay.set_render_rectangle(
+                    rect.origin.x.round() as i32,
+                    rect.origin.y.round() as i32,
+                    rect.size.width.max(1.0).round() as i32,
+                    rect.size.height.max(1.0).round() as i32,
+                );
+                overlay.expose();
+            }
+        }
+
+        fn hide(&mut self) {
+            if let Some(overlay) = self.overlay.as_ref() {
+                let _ = overlay.set_render_rectangle(0, 0, 1, 1);
+            }
+        }
+    }
+
+    impl Drop for PlayerEntry {
+        fn drop(&mut self) {
+            if let Some(playbin) = self.playbin.as_ref() {
+                let _ = playbin.set_state(gst::State::Null);
+            }
+        }
+    }
+
+    pub struct LinuxVideoPlayer {
+        registry: Arc<Mutex<HashMap<u64, PlayerEntry>>>,
+        surface_id: u64,
+        ready_sent: bool,
+        ended_sent: bool,
+        error_sent: bool,
+        pending_error: Option<String>,
+    }
+
+    impl Drop for LinuxVideoPlayer {
+        fn drop(&mut self) {
+            self.registry.lock().unwrap().remove(&self.surface_id);
+        }
+    }
+
+    impl LinuxVideoPlayer {
+        fn with_entry<R>(&self, f: impl FnOnce(&PlayerEntry) -> R) -> Option<R> {
+            self.registry.lock().unwrap().get(&self.surface_id).map(f)
+        }
+
+        fn with_entry_mut<R>(&self, f: impl FnOnce(&mut PlayerEntry) -> R) -> Option<R> {
+            self.registry
+                .lock()
+                .unwrap()
+                .get_mut(&self.surface_id)
+                .map(f)
+        }
+    }
+
+    impl VideoPlayer for LinuxVideoPlayer {
+        fn play(&mut self) {
+            self.with_entry(|entry| {
+                if let Some(playbin) = entry.playbin.as_ref() {
+                    let _ = playbin.set_state(gst::State::Playing);
+                }
+            });
+        }
+
+        fn pause(&mut self) {
+            self.with_entry(|entry| {
+                if let Some(playbin) = entry.playbin.as_ref() {
+                    let _ = playbin.set_state(gst::State::Paused);
+                }
+            });
+        }
+
+        fn stop(&mut self) {
+            self.with_entry(|entry| {
+                if let Some(playbin) = entry.playbin.as_ref() {
+                    let _ = playbin.set_state(gst::State::Ready);
+                }
+            });
+        }
+
+        fn position(&self) -> u64 {
+            self.with_entry(|entry| {
+                entry
+                    .playbin
+                    .as_ref()
+                    .and_then(|playbin| playbin.query_position::<gst::ClockTime>())
+                    .map(|time| time.mseconds())
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0)
+        }
+
+        fn duration(&self) -> Option<u64> {
+            self.with_entry(|entry| {
+                entry
+                    .playbin
+                    .as_ref()
+                    .and_then(|playbin| playbin.query_duration::<gst::ClockTime>())
+                    .map(|time| time.mseconds())
+            })
+            .flatten()
+        }
+
+        fn surface_id(&self) -> u64 {
+            self.surface_id
+        }
+
+        fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
+            if !self.error_sent {
+                if let Some(message) = self.pending_error.take().or_else(|| {
+                    self.with_entry_mut(|entry| entry.creation_error.take())
+                        .flatten()
+                }) {
+                    self.error_sent = true;
+                    events.push(VideoEvent::Error(message));
+                }
+            }
+            self.with_entry(|entry| {
+                if let Some(bus) = entry.bus.as_ref() {
+                    for message in bus.iter() {
+                        match message.view() {
+                            gst::MessageView::Eos(..) => {
+                                if !self.ended_sent {
+                                    events.push(VideoEvent::Ended);
+                                }
+                                self.ended_sent = true;
+                            }
+                            gst::MessageView::Error(error) => {
+                                if !self.error_sent {
+                                    self.error_sent = true;
+                                    events.push(VideoEvent::Error(format!(
+                                        "GStreamer video error: {}",
+                                        error.error()
+                                    )));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            });
+            if !self.ready_sent {
+                let duration = self.duration().unwrap_or(0);
+                self.ready_sent = true;
+                events.push(VideoEvent::Ready { duration });
+            }
+            events
+        }
+
+        fn seek_to(&mut self, position_ms: u64) {
+            self.with_entry(|entry| {
+                if let Some(playbin) = entry.playbin.as_ref() {
+                    let _ = playbin.seek_simple(
+                        gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT,
+                        gst::ClockTime::from_mseconds(position_ms),
+                    );
+                }
+            });
+        }
+
+        fn set_rate(&mut self, rate: f32) {
+            self.with_entry(|entry| {
+                if let Some(playbin) = entry.playbin.as_ref() {
+                    let position = playbin
+                        .query_position::<gst::ClockTime>()
+                        .unwrap_or(gst::ClockTime::ZERO);
+                    let _ = playbin.seek(
+                        rate.max(0.1) as f64,
+                        gst::SeekFlags::FLUSH,
+                        gst::SeekType::Set,
+                        position,
+                        gst::SeekType::None,
+                        gst::ClockTime::NONE,
+                    );
+                }
+            });
+        }
+
+        fn set_volume(&mut self, volume: f32) {
+            self.with_entry(|entry| {
+                if let Some(playbin) = entry.playbin.as_ref() {
+                    playbin.set_property("volume", volume.clamp(0.0, 1.0) as f64);
+                }
+            });
+        }
+
+        fn set_muted(&mut self, muted: bool) {
+            self.with_entry(|entry| {
+                if let Some(playbin) = entry.playbin.as_ref() {
+                    playbin.set_property("mute", muted);
+                }
+            });
+        }
+    }
+
+    fn init_gstreamer() -> Result<(), String> {
+        static INIT: OnceLock<Result<(), String>> = OnceLock::new();
+        INIT.get_or_init(|| gst::init().map_err(|error| error.to_string()))
+            .clone()
+    }
+
+    fn native_window_handle(window: &Window) -> Option<usize> {
+        let handle = window.window_handle().ok()?;
+        match handle.as_raw() {
+            RawWindowHandle::Xlib(handle) => Some(handle.window as usize),
+            RawWindowHandle::Xcb(handle) => Some(handle.window.get() as usize),
+            RawWindowHandle::Wayland(handle) => Some(handle.surface.as_ptr() as usize),
+            _ => None,
+        }
+    }
+
+    struct ResolvedSource {
+        requested: String,
+        uri: String,
+        diagnostic: Option<String>,
+    }
+
+    impl ResolvedSource {
+        fn error_message(&self) -> Option<String> {
+            self.diagnostic.as_ref().map(|diagnostic| {
+                format!(
+                    "{diagnostic} (requested='{}', resolved='{}')",
+                    self.requested, self.uri
+                )
+            })
+        }
+    }
+
+    fn resolve_source(source: &str) -> ResolvedSource {
+        let requested = source.to_string();
+        let trimmed = source.trim();
+        if trimmed.is_empty() {
+            return ResolvedSource {
+                requested,
+                uri: String::new(),
+                diagnostic: Some("video source path is empty".to_string()),
+            };
+        }
+        if trimmed.contains("://") {
+            return ResolvedSource {
+                requested,
+                uri: trimmed.to_string(),
+                diagnostic: None,
+            };
+        }
+        let candidate = if Path::new(trimmed).is_absolute() {
+            PathBuf::from(trimmed)
+        } else {
+            std::env::current_dir()
+                .map(|dir| dir.join(trimmed))
+                .unwrap_or_else(|_| PathBuf::from(trimmed))
+        };
+        let resolved = candidate.canonicalize().unwrap_or(candidate);
+        let diagnostic =
+            (!resolved.exists()).then(|| "video source path does not exist".to_string());
+        ResolvedSource {
+            requested,
+            uri: format!("file://{}", resolved.to_string_lossy()),
+            diagnostic,
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+mod android {
+    use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use fission_shell::VideoSurfaceFrame;
+    use jni::objects::{JClass, JObject, JString, JValue};
+    use jni::sys::jobject;
+    use jni::{JNIEnv, JavaVM};
+    use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    pub struct AndroidVideoBackend {
+        next_id: AtomicU64,
+        registry: Arc<Mutex<HashMap<u64, AndroidPlayerState>>>,
+    }
+
+    impl AndroidVideoBackend {
+        pub fn new() -> Self {
+            Self {
+                next_id: AtomicU64::new(1),
+                registry: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+    }
+
+    impl VideoBackend for AndroidVideoBackend {
+        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let pending_error = call_with_env(|env, activity_class| {
+                let source = env.new_string(source)?;
+                env.call_static_method(
+                    &activity_class,
+                    "fissionCreateVideo",
+                    "(JLjava/lang/String;)V",
+                    &[
+                        JValue::Long(id as i64),
+                        JValue::Object(&JObject::from(source)),
+                    ],
+                )?;
+                Ok(())
+            })
+            .err();
+            self.registry
+                .lock()
+                .unwrap()
+                .insert(id, AndroidPlayerState { pending_error });
+            Box::new(AndroidVideoPlayer {
+                registry: Arc::clone(&self.registry),
+                surface_id: id,
+                ready_sent: false,
+                ended_sent: false,
+                error_sent: false,
+            })
+        }
+
+        fn present_surfaces(&self, frames: &[VideoSurfaceFrame]) {
+            let mut seen = HashSet::new();
+            for frame in frames {
+                seen.insert(frame.surface_id);
+                let rect = frame.rect;
+                let _ = call_with_env(|env, activity_class| {
+                    env.call_static_method(
+                        &activity_class,
+                        "fissionUpdateVideoSurface",
+                        "(JIIIIZ)V",
+                        &[
+                            JValue::Long(frame.surface_id as i64),
+                            JValue::Int(rect.origin.x.round() as i32),
+                            JValue::Int(rect.origin.y.round() as i32),
+                            JValue::Int(rect.size.width.max(1.0).round() as i32),
+                            JValue::Int(rect.size.height.max(1.0).round() as i32),
+                            JValue::Bool(1),
+                        ],
+                    )?;
+                    Ok(())
+                });
+            }
+            let ids = self
+                .registry
+                .lock()
+                .unwrap()
+                .keys()
+                .copied()
+                .collect::<Vec<_>>();
+            for id in ids {
+                if !seen.contains(&id) {
+                    let _ = call_with_env(|env, activity_class| {
+                        env.call_static_method(
+                            &activity_class,
+                            "fissionSetVideoVisible",
+                            "(JZ)V",
+                            &[JValue::Long(id as i64), JValue::Bool(0)],
+                        )?;
+                        Ok(())
+                    });
+                }
+            }
+        }
+    }
+
+    struct AndroidPlayerState {
+        pending_error: Option<String>,
+    }
+
+    pub struct AndroidVideoPlayer {
+        registry: Arc<Mutex<HashMap<u64, AndroidPlayerState>>>,
+        surface_id: u64,
+        ready_sent: bool,
+        ended_sent: bool,
+        error_sent: bool,
+    }
+
+    impl Drop for AndroidVideoPlayer {
+        fn drop(&mut self) {
+            self.registry.lock().unwrap().remove(&self.surface_id);
+            let id = self.surface_id;
+            let _ = call_with_env(|env, activity_class| {
+                env.call_static_method(
+                    &activity_class,
+                    "fissionDestroyVideo",
+                    "(J)V",
+                    &[JValue::Long(id as i64)],
+                )?;
+                Ok(())
+            });
+        }
+    }
+
+    impl AndroidVideoPlayer {
+        fn call_void(&self, method: &str, signature: &str, args: &[JValue]) {
+            let _ = call_with_env(|env, activity_class| {
+                env.call_static_method(&activity_class, method, signature, args)?;
+                Ok(())
+            });
+        }
+
+        fn call_long(&self, method: &str) -> i64 {
+            call_with_env(|env, activity_class| {
+                Ok(env
+                    .call_static_method(
+                        &activity_class,
+                        method,
+                        "(J)J",
+                        &[JValue::Long(self.surface_id as i64)],
+                    )?
+                    .j()?)
+            })
+            .unwrap_or(0)
+        }
+
+        fn call_bool(&self, method: &str) -> bool {
+            call_with_env(|env, activity_class| {
+                Ok(env
+                    .call_static_method(
+                        &activity_class,
+                        method,
+                        "(J)Z",
+                        &[JValue::Long(self.surface_id as i64)],
+                    )?
+                    .z()?)
+            })
+            .unwrap_or(false)
+        }
+
+        fn call_string(&self, method: &str) -> Option<String> {
+            call_with_env(|env, activity_class| {
+                let value = env
+                    .call_static_method(
+                        &activity_class,
+                        method,
+                        "(J)Ljava/lang/String;",
+                        &[JValue::Long(self.surface_id as i64)],
+                    )?
+                    .l()?;
+                if value.is_null() {
+                    return Ok(None);
+                }
+                let value = JString::from(value);
+                let value: String = env.get_string(&value)?.into();
+                Ok(Some(value))
+            })
+            .ok()
+            .flatten()
+        }
+    }
+
+    impl VideoPlayer for AndroidVideoPlayer {
+        fn play(&mut self) {
+            self.call_void(
+                "fissionPlayVideo",
+                "(J)V",
+                &[JValue::Long(self.surface_id as i64)],
+            );
+        }
+
+        fn pause(&mut self) {
+            self.call_void(
+                "fissionPauseVideo",
+                "(J)V",
+                &[JValue::Long(self.surface_id as i64)],
+            );
+        }
+
+        fn stop(&mut self) {
+            self.call_void(
+                "fissionStopVideo",
+                "(J)V",
+                &[JValue::Long(self.surface_id as i64)],
+            );
+        }
+
+        fn position(&self) -> u64 {
+            self.call_long("fissionVideoPosition").max(0) as u64
+        }
+
+        fn duration(&self) -> Option<u64> {
+            let duration = self.call_long("fissionVideoDuration");
+            (duration >= 0).then_some(duration as u64)
+        }
+
+        fn surface_id(&self) -> u64 {
+            self.surface_id
+        }
+
+        fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
+            if !self.error_sent {
+                let pending_error = self
+                    .registry
+                    .lock()
+                    .unwrap()
+                    .get_mut(&self.surface_id)
+                    .and_then(|state| state.pending_error.take())
+                    .or_else(|| self.call_string("fissionVideoError"));
+                if let Some(error) = pending_error {
+                    self.error_sent = true;
+                    events.push(VideoEvent::Error(error));
+                }
+            }
+            if !self.ready_sent && self.call_bool("fissionVideoReady") {
+                self.ready_sent = true;
+                events.push(VideoEvent::Ready {
+                    duration: self.duration().unwrap_or(0),
+                });
+            }
+            if self.call_bool("fissionVideoEnded") && !self.ended_sent {
+                self.ended_sent = true;
+                events.push(VideoEvent::Ended);
+            }
+            if !self.call_bool("fissionVideoEnded") {
+                self.ended_sent = false;
+            }
+            events
+        }
+
+        fn seek_to(&mut self, position_ms: u64) {
+            self.call_void(
+                "fissionSeekVideo",
+                "(JJ)V",
+                &[
+                    JValue::Long(self.surface_id as i64),
+                    JValue::Long(position_ms as i64),
+                ],
+            );
+        }
+
+        fn set_rate(&mut self, rate: f32) {
+            self.call_void(
+                "fissionSetVideoRate",
+                "(JF)V",
+                &[JValue::Long(self.surface_id as i64), JValue::Float(rate)],
+            );
+        }
+
+        fn set_volume(&mut self, volume: f32) {
+            self.call_void(
+                "fissionSetVideoVolume",
+                "(JF)V",
+                &[
+                    JValue::Long(self.surface_id as i64),
+                    JValue::Float(volume.clamp(0.0, 1.0)),
+                ],
+            );
+        }
+
+        fn set_muted(&mut self, muted: bool) {
+            self.call_void(
+                "fissionSetVideoMuted",
+                "(JZ)V",
+                &[
+                    JValue::Long(self.surface_id as i64),
+                    JValue::Bool(if muted { 1 } else { 0 }),
+                ],
+            );
+        }
+    }
+
+    fn call_with_env<R>(
+        f: impl for<'local> FnOnce(&mut JNIEnv<'local>, JClass<'local>) -> jni::errors::Result<R>,
+    ) -> Result<R, String> {
+        let ctx = ndk_context::android_context();
+        let vm = unsafe { JavaVM::from_raw(ctx.vm().cast()) }
+            .map_err(|error| format!("failed to access Android JavaVM: {error}"))?;
+        let mut env = vm
+            .attach_current_thread()
+            .map_err(|error| format!("failed to attach Android JNI thread: {error}"))?;
+        let activity = unsafe { JObject::from_raw(ctx.context() as jobject) };
+        let activity_class = env
+            .get_object_class(&activity)
+            .map_err(|error| format!("failed to resolve Android Activity class: {error}"))?;
+        f(&mut env, activity_class)
+            .map_err(|error| format!("Android video JNI call failed: {error}"))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod web {
+    use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use fission_shell::VideoSurfaceFrame;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{Document, HtmlElement, HtmlVideoElement};
+
+    #[derive(Clone)]
+    struct DomVideo(HtmlVideoElement);
+
+    unsafe impl Send for DomVideo {}
+    unsafe impl Sync for DomVideo {}
+
+    impl DomVideo {
+        fn element(&self) -> &HtmlVideoElement {
+            &self.0
+        }
+    }
+
+    pub struct WebVideoBackend {
+        next_id: AtomicU64,
+        registry: Arc<Mutex<HashMap<u64, DomVideo>>>,
+    }
+
+    impl WebVideoBackend {
+        pub fn new() -> Self {
+            Self {
+                next_id: AtomicU64::new(1),
+                registry: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+    }
+
+    impl VideoBackend for WebVideoBackend {
+        fn create_player(&self, source: &str) -> Box<dyn VideoPlayer> {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let video = create_video_element(source);
+            self.registry.lock().unwrap().insert(id, video.clone());
+            Box::new(WebVideoPlayer {
+                registry: Arc::clone(&self.registry),
+                surface_id: id,
+                ready_sent: false,
+                ended_sent: false,
+                error_sent: false,
+                pending_error: None,
+            })
+        }
+
+        fn present_surfaces(&self, frames: &[VideoSurfaceFrame]) {
+            let mut seen = HashSet::new();
+            let registry = self.registry.lock().unwrap();
+            for frame in frames {
+                seen.insert(frame.surface_id);
+                if let Some(video) = registry.get(&frame.surface_id) {
+                    mount_and_position(video.element(), frame);
+                }
+            }
+            for (surface_id, video) in registry.iter() {
+                if !seen.contains(surface_id) {
+                    let _ = video.element().style().set_property("display", "none");
+                }
+            }
+        }
+    }
+
+    pub struct WebVideoPlayer {
+        registry: Arc<Mutex<HashMap<u64, DomVideo>>>,
+        surface_id: u64,
+        ready_sent: bool,
+        ended_sent: bool,
+        error_sent: bool,
+        pending_error: Option<String>,
+    }
+
+    impl Drop for WebVideoPlayer {
+        fn drop(&mut self) {
+            if let Some(video) = self.registry.lock().unwrap().remove(&self.surface_id) {
+                video.element().pause().ok();
+                video.element().remove();
+            }
+        }
+    }
+
+    impl WebVideoPlayer {
+        fn with_video<R>(&self, f: impl FnOnce(&HtmlVideoElement) -> R) -> Option<R> {
+            self.registry
+                .lock()
+                .unwrap()
+                .get(&self.surface_id)
+                .map(|video| f(video.element()))
+        }
+    }
+
+    impl VideoPlayer for WebVideoPlayer {
+        fn play(&mut self) {
+            self.with_video(|video| {
+                let promise = video.play().ok();
+                if let Some(promise) = promise {
+                    wasm_bindgen_futures::spawn_local(async move {
+                        let _ = JsFuture::from(promise).await;
+                    });
+                }
+            });
+        }
+
+        fn pause(&mut self) {
+            self.with_video(|video| {
+                video.pause().ok();
+            });
+        }
+
+        fn stop(&mut self) {
+            self.with_video(|video| {
+                video.pause().ok();
+                video.set_current_time(0.0);
+            });
+        }
+
+        fn position(&self) -> u64 {
+            self.with_video(|video| (video.current_time() * 1000.0).max(0.0) as u64)
+                .unwrap_or(0)
+        }
+
+        fn duration(&self) -> Option<u64> {
+            self.with_video(|video| {
+                let duration = video.duration();
+                duration.is_finite().then_some((duration * 1000.0) as u64)
+            })
+            .flatten()
+        }
+
+        fn surface_id(&self) -> u64 {
+            self.surface_id
+        }
+
+        fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
+            if !self.error_sent {
+                if let Some(message) = self.pending_error.take() {
+                    self.error_sent = true;
+                    events.push(VideoEvent::Error(message));
+                }
+            }
+            if !self.ready_sent {
+                if let Some(duration) = self.duration() {
+                    self.ready_sent = true;
+                    events.push(VideoEvent::Ready { duration });
+                }
+            }
+            let ended = self.with_video(|video| video.ended()).unwrap_or(false);
+            if ended && !self.ended_sent {
+                self.ended_sent = true;
+                events.push(VideoEvent::Ended);
+            }
+            if !ended {
+                self.ended_sent = false;
+            }
+            events
+        }
+
+        fn seek_to(&mut self, position_ms: u64) {
+            self.with_video(|video| video.set_current_time(position_ms as f64 / 1000.0));
+        }
+
+        fn set_rate(&mut self, rate: f32) {
+            self.with_video(|video| video.set_playback_rate(rate.max(0.1) as f64));
+        }
+
+        fn set_volume(&mut self, volume: f32) {
+            self.with_video(|video| video.set_volume(volume.clamp(0.0, 1.0) as f64));
+        }
+
+        fn set_muted(&mut self, muted: bool) {
+            self.with_video(|video| video.set_muted(muted));
+        }
+    }
+
+    fn create_video_element(source: &str) -> DomVideo {
+        let document = document();
+        let element = document
+            .create_element("video")
+            .expect("failed to create video element")
+            .dyn_into::<HtmlVideoElement>()
+            .expect("video element has wrong type");
+        element.set_src(source);
+        element.set_controls(true);
+        element.set_preload("auto");
+        let _ = element.set_attribute("playsinline", "");
+        let style = element.style();
+        let _ = style.set_property("position", "absolute");
+        let _ = style.set_property("display", "none");
+        let _ = style.set_property("z-index", "2147483646");
+        let _ = style.set_property("background", "black");
+        let _ = style.set_property("object-fit", "contain");
+        DomVideo(element)
+    }
+
+    fn mount_and_position(video: &HtmlVideoElement, frame: &VideoSurfaceFrame) {
+        if video.parent_element().is_none() {
+            document()
+                .body()
+                .expect("document body missing")
+                .append_child(video)
+                .expect("failed to mount video element");
+        }
+        let style = video.style();
+        let _ = style.set_property("display", "block");
+        let _ = style.set_property("left", &format!("{}px", frame.rect.origin.x));
+        let _ = style.set_property("top", &format!("{}px", frame.rect.origin.y));
+        let _ = style.set_property("width", &format!("{}px", frame.rect.size.width));
+        let _ = style.set_property("height", &format!("{}px", frame.rect.size.height));
+    }
+
+    fn document() -> Document {
+        web_sys::window()
+            .expect("window missing")
+            .document()
+            .expect("document missing")
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{create_video_backend, VideoEvent};
-    use fission_ir::WidgetId;
-    use fission_render::LayoutRect;
-    use fission_shell::VideoSurfaceFrame;
+    use super::create_video_backend;
 
     #[test]
-    fn video_backend_without_window_uses_safe_fallback() {
-        let backend = create_video_backend(None);
-        let mut player = backend.create_player("");
-
-        assert!(player.surface_id() > 0);
-
-        backend.present_surfaces(&[VideoSurfaceFrame {
-            widget_id: WidgetId::explicit("fallback-video"),
-            surface_id: player.surface_id(),
-            rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
-        }]);
-        backend.present_surfaces(&[]);
-
-        let events = player.poll_events();
-        assert!(
-            events
-                .iter()
-                .any(|event| matches!(event, VideoEvent::Error(_))),
-            "missing source should surface a recoverable error event"
-        );
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[should_panic(expected = "no state-only mock fallback exists")]
+    fn apple_video_backend_without_window_panics() {
+        let _ = create_video_backend(None);
     }
 }

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -92,12 +92,13 @@ mod mac {
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
+    use block::ConcreteBlock;
     use objc::rc::StrongPtr;
     use objc::{class, msg_send, sel, sel_impl};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use winit::window::Window;
 
@@ -218,6 +219,9 @@ mod mac {
                         .unwrap_or_else(|| Path::new(source)),
                 )
             };
+            let ended_flag = Arc::new(AtomicBool::new(false));
+            let observer =
+                unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
             Box::new(MacVideoPlayer {
                 registry: Arc::clone(&self.registry),
@@ -225,6 +229,9 @@ mod mac {
                 ready_sent: false,
                 error_sent: false,
                 pending_error,
+                ended_flag,
+                ended_sent: false,
+                observer: unsafe { RetainedId::new(observer) },
             })
         }
 
@@ -382,10 +389,18 @@ mod mac {
         ready_sent: bool,
         error_sent: bool,
         pending_error: Option<String>,
+        ended_flag: Arc<AtomicBool>,
+        ended_sent: bool,
+        observer: RetainedId,
     }
 
     impl Drop for MacVideoPlayer {
         fn drop(&mut self) {
+            // Remove the end-of-playback notification observer.
+            unsafe {
+                let center: id = msg_send![class!(NSNotificationCenter), defaultCenter];
+                let () = msg_send![center, removeObserver: self.observer.as_id()];
+            }
             // Pause/stop before releasing to avoid teardown race with layers.
             if let Some(player) = self.registry.get(self.player_id) {
                 unsafe {
@@ -445,10 +460,11 @@ mod mac {
         }
 
         fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
             if !self.error_sent {
                 if let Some(message) = self.pending_error.take() {
                     self.error_sent = true;
-                    return vec![VideoEvent::Error(message)];
+                    events.push(VideoEvent::Error(message));
                 }
             }
             if !self.ready_sent {
@@ -458,10 +474,17 @@ mod mac {
                     .get(self.player_id)
                     .and_then(|player| unsafe { item_duration_ms(player.as_id()) })
                     .unwrap_or(0);
-                vec![VideoEvent::Ready { duration }]
-            } else {
-                Vec::new()
+                events.push(VideoEvent::Ready { duration });
             }
+            let reached_end = self.ended_flag.swap(false, Ordering::Acquire);
+            if reached_end && !self.ended_sent {
+                self.ended_sent = true;
+                events.push(VideoEvent::Ended);
+            }
+            if !reached_end {
+                self.ended_sent = false;
+            }
+            events
         }
 
         fn seek_to(&mut self, position_ms: u64) {
@@ -610,6 +633,25 @@ mod mac {
         let () = msg_send![player, seekToTime: time toleranceBefore: zero_a toleranceAfter: zero_b];
     }
 
+    unsafe fn register_end_observer(player: id, flag: Arc<AtomicBool>) -> id {
+        let notification_name =
+            NSString::alloc(nil).init_str("AVPlayerItemDidPlayToEndTimeNotification");
+        let item: id = msg_send![player, currentItem];
+        let center: id = msg_send![class!(NSNotificationCenter), defaultCenter];
+        let block = ConcreteBlock::new(move |_notification: id| {
+            flag.store(true, Ordering::Release);
+        })
+        .copy();
+        let observer: id = msg_send![
+            center,
+            addObserverForName: notification_name
+            object: item
+            queue: nil
+            usingBlock: &*block
+        ];
+        observer
+    }
+
     fn cg_rect_from_layout(rect: LayoutRect, ctx: &LayerContext) -> CGRect {
         let width = rect.size.width as f64;
         let height = rect.size.height as f64;
@@ -668,6 +710,7 @@ mod ios {
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
+    use block::ConcreteBlock;
     use objc::rc::StrongPtr;
     use objc::runtime::Object;
     use objc::{class, msg_send, sel, sel_impl};
@@ -675,7 +718,7 @@ mod ios {
     use std::collections::{HashMap, HashSet};
     use std::ffi::CString;
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use winit::window::Window;
 
@@ -805,6 +848,9 @@ mod ios {
                         .unwrap_or_else(|| Path::new(source)),
                 )
             };
+            let ended_flag = Arc::new(AtomicBool::new(false));
+            let observer =
+                unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
             Box::new(IosVideoPlayer {
                 registry: Arc::clone(&self.registry),
@@ -815,6 +861,9 @@ mod ios {
                 audio: audio.clone(),
                 audio_session_configured,
                 audio_error: None,
+                ended_flag,
+                ended_sent: false,
+                observer: unsafe { RetainedId::retain(observer) },
             })
         }
 
@@ -953,10 +1002,18 @@ mod ios {
         audio: VideoAudioOptions,
         audio_session_configured: bool,
         audio_error: Option<String>,
+        ended_flag: Arc<AtomicBool>,
+        ended_sent: bool,
+        observer: RetainedId,
     }
 
     impl Drop for IosVideoPlayer {
         fn drop(&mut self) {
+            // Remove the end-of-playback notification observer.
+            unsafe {
+                let center: Id = msg_send![class!(NSNotificationCenter), defaultCenter];
+                let () = msg_send![center, removeObserver: self.observer.as_id()];
+            }
             if let Some(player) = self.registry.get(self.player_id) {
                 unsafe {
                     let () = msg_send![player.as_id(), pause];
@@ -1019,6 +1076,7 @@ mod ios {
         }
 
         fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
             if !self.error_sent {
                 if let Some(message) = self
                     .pending_error
@@ -1026,16 +1084,23 @@ mod ios {
                     .or_else(|| self.audio_error.take())
                 {
                     self.error_sent = true;
-                    return vec![VideoEvent::Error(message)];
+                    events.push(VideoEvent::Error(message));
                 }
             }
             if !self.ready_sent {
                 self.ready_sent = true;
                 let duration = self.duration().unwrap_or(0);
-                vec![VideoEvent::Ready { duration }]
-            } else {
-                Vec::new()
+                events.push(VideoEvent::Ready { duration });
             }
+            let reached_end = self.ended_flag.swap(false, Ordering::Acquire);
+            if reached_end && !self.ended_sent {
+                self.ended_sent = true;
+                events.push(VideoEvent::Ended);
+            }
+            if !reached_end {
+                self.ended_sent = false;
+            }
+            events
         }
 
         fn seek_to(&mut self, position_ms: u64) {
@@ -1284,6 +1349,24 @@ mod ios {
         let zero_a = CMTime::zero();
         let zero_b = CMTime::zero();
         let () = msg_send![player, seekToTime: time toleranceBefore: zero_a toleranceAfter: zero_b];
+    }
+
+    unsafe fn register_end_observer(player: Id, flag: Arc<AtomicBool>) -> Id {
+        let notification_name = ns_string("AVPlayerItemDidPlayToEndTimeNotification");
+        let item: Id = msg_send![player, currentItem];
+        let center: Id = msg_send![class!(NSNotificationCenter), defaultCenter];
+        let block = ConcreteBlock::new(move |_notification: Id| {
+            flag.store(true, Ordering::Release);
+        })
+        .copy();
+        let observer: Id = msg_send![
+            center,
+            addObserverForName: notification_name
+            object: item
+            queue: NIL
+            usingBlock: &*block
+        ];
+        observer
     }
 
     fn cg_rect_from_layout(rect: LayoutRect) -> CGRect {

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -88,11 +88,11 @@ mod mac {
 
     use core_graphics::geometry::{CGPoint, CGRect, CGSize};
 
+    use block::ConcreteBlock;
     use fission_core::ui::VideoAudioOptions;
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
-    use block::ConcreteBlock;
     use objc::rc::StrongPtr;
     use objc::{class, msg_send, sel, sel_impl};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -220,8 +220,7 @@ mod mac {
                 )
             };
             let ended_flag = Arc::new(AtomicBool::new(false));
-            let observer =
-                unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
+            let observer = unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
             Box::new(MacVideoPlayer {
                 registry: Arc::clone(&self.registry),
@@ -702,6 +701,7 @@ mod mac {
 #[allow(unexpected_cfgs)]
 mod ios {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use block::ConcreteBlock;
     use core_graphics::geometry::{CGPoint, CGRect, CGSize};
     use fission_core::ui::{
         IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,
@@ -710,7 +710,6 @@ mod ios {
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
-    use block::ConcreteBlock;
     use objc::rc::StrongPtr;
     use objc::runtime::Object;
     use objc::{class, msg_send, sel, sel_impl};
@@ -849,8 +848,7 @@ mod ios {
                 )
             };
             let ended_flag = Arc::new(AtomicBool::new(false));
-            let observer =
-                unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
+            let observer = unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
             Box::new(IosVideoPlayer {
                 registry: Arc::clone(&self.registry),

--- a/crates/shell/fission-shell/src/lib.rs
+++ b/crates/shell/fission-shell/src/lib.rs
@@ -1,6 +1,6 @@
+use fission_core::ui::VideoAudioOptions;
 use fission_ir::WidgetId;
 use fission_render::LayoutRect;
-use fission_core::ui::VideoAudioOptions;
 use serde::{Deserialize, Serialize};
 
 pub mod async_host;

--- a/crates/shell/fission-shell/src/lib.rs
+++ b/crates/shell/fission-shell/src/lib.rs
@@ -1,5 +1,6 @@
 use fission_ir::WidgetId;
 use fission_render::LayoutRect;
+use fission_core::ui::VideoAudioOptions;
 use serde::{Deserialize, Serialize};
 
 pub mod async_host;
@@ -20,7 +21,7 @@ pub struct VideoSurfaceFrame {
 }
 
 pub trait VideoBackend: Send + Sync {
-    fn create_player(&self, source: &str) -> Box<dyn VideoPlayer>;
+    fn create_player(&self, source: &str, audio: &VideoAudioOptions) -> Box<dyn VideoPlayer>;
     fn present_surfaces(&self, frames: &[VideoSurfaceFrame]);
 }
 

--- a/crates/shell/fission-shell/tests/shell_invariants.rs
+++ b/crates/shell/fission-shell/tests/shell_invariants.rs
@@ -44,7 +44,11 @@ impl VideoPlayer for DummyPlayer {
 }
 
 impl VideoBackend for DummyBackend {
-    fn create_player(&self, _source: &str) -> Box<dyn VideoPlayer> {
+    fn create_player(
+        &self,
+        _source: &str,
+        _audio: &fission_core::ui::VideoAudioOptions,
+    ) -> Box<dyn VideoPlayer> {
         Box::new(DummyPlayer::new())
     }
 
@@ -77,7 +81,8 @@ fn test_input_event_serialization() {
 #[test]
 fn test_video_backend_trait_object() -> Result<()> {
     let backend: Box<dyn VideoBackend> = Box::new(DummyBackend);
-    let mut player = backend.create_player("dummy.mp4");
+    let mut player =
+        backend.create_player("dummy.mp4", &fission_core::ui::VideoAudioOptions::default());
 
     player.play();
     player.pause();

--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -2237,7 +2237,298 @@ fn groovy_string_literal(value: &str) -> String {
 fn render_android_activity_java() -> &'static str {
     r#"package rs.fission.runtime;
 
-public final class FissionActivity extends android.app.NativeActivity {
+import android.app.NativeActivity;
+import android.media.MediaPlayer;
+import android.media.PlaybackParams;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.VideoView;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class FissionActivity extends NativeActivity {
+    private static volatile FissionActivity INSTANCE;
+    private static final Map<Long, FissionVideoSlot> VIDEOS = new HashMap<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        INSTANCE = this;
+    }
+
+    @Override
+    protected void onDestroy() {
+        runOnUiThread(() -> {
+            synchronized (VIDEOS) {
+                for (FissionVideoSlot slot : VIDEOS.values()) {
+                    slot.destroy();
+                }
+                VIDEOS.clear();
+            }
+        });
+        INSTANCE = null;
+        super.onDestroy();
+    }
+
+    public static void fissionCreateVideo(long id, String source) {
+        runOnUiThreadOrRecordError(id, () -> {
+            synchronized (VIDEOS) {
+                FissionVideoSlot previous = VIDEOS.remove(id);
+                if (previous != null) {
+                    previous.destroy();
+                }
+                FissionVideoSlot slot = new FissionVideoSlot(INSTANCE, source);
+                VIDEOS.put(id, slot);
+            }
+        });
+    }
+
+    public static void fissionUpdateVideoSurface(
+            long id,
+            int left,
+            int top,
+            int width,
+            int height,
+            boolean visible
+    ) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.update(left, top, width, height, visible);
+            }
+        });
+    }
+
+    public static void fissionSetVideoVisible(long id, boolean visible) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null && slot.view != null) {
+                slot.view.setVisibility(visible ? View.VISIBLE : View.GONE);
+            }
+        });
+    }
+
+    public static void fissionDestroyVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            synchronized (VIDEOS) {
+                FissionVideoSlot slot = VIDEOS.remove(id);
+                if (slot != null) {
+                    slot.destroy();
+                }
+            }
+        });
+    }
+
+    public static void fissionPlayVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.ended = false;
+                slot.view.start();
+            }
+        });
+    }
+
+    public static void fissionPauseVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.view.pause();
+            }
+        });
+    }
+
+    public static void fissionStopVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.view.pause();
+                slot.view.seekTo(0);
+                slot.ended = false;
+            }
+        });
+    }
+
+    public static void fissionSeekVideo(long id, long positionMs) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.view.seekTo((int)Math.max(0L, Math.min(positionMs, Integer.MAX_VALUE)));
+            }
+        });
+    }
+
+    public static void fissionSetVideoRate(long id, float rate) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.rate = Math.max(0.1f, rate);
+                slot.applyPlaybackParams();
+            }
+        });
+    }
+
+    public static void fissionSetVideoVolume(long id, float volume) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.volume = Math.max(0.0f, Math.min(volume, 1.0f));
+                slot.applyVolume();
+            }
+        });
+    }
+
+    public static void fissionSetVideoMuted(long id, boolean muted) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.muted = muted;
+                slot.applyVolume();
+            }
+        });
+    }
+
+    public static long fissionVideoPosition(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot == null || slot.view == null ? 0L : Math.max(0, slot.view.getCurrentPosition());
+    }
+
+    public static long fissionVideoDuration(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot == null || !slot.ready ? -1L : Math.max(0, slot.durationMs);
+    }
+
+    public static boolean fissionVideoReady(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot != null && slot.ready;
+    }
+
+    public static boolean fissionVideoEnded(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot != null && slot.ended;
+    }
+
+    public static String fissionVideoError(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot == null ? null : slot.error;
+    }
+
+    private static FissionVideoSlot slot(long id) {
+        synchronized (VIDEOS) {
+            return VIDEOS.get(id);
+        }
+    }
+
+    private static void runOnUiThreadOrRecordError(long id, Runnable action) {
+        FissionActivity activity = INSTANCE;
+        if (activity == null) {
+            recordError(id, "Fission Android video host is not attached to FissionActivity");
+            return;
+        }
+        activity.runOnUiThread(() -> {
+            try {
+                action.run();
+            } catch (Throwable error) {
+                recordError(id, "Android video host error: " + error);
+            }
+        });
+    }
+
+    private static void recordError(long id, String error) {
+        synchronized (VIDEOS) {
+            FissionVideoSlot slot = VIDEOS.get(id);
+            if (slot == null) {
+                slot = new FissionVideoSlot(error);
+                VIDEOS.put(id, slot);
+            } else {
+                slot.error = error;
+            }
+        }
+    }
+
+    private static final class FissionVideoSlot {
+        final VideoView view;
+        MediaPlayer mediaPlayer;
+        volatile boolean ready;
+        volatile boolean ended;
+        volatile int durationMs = -1;
+        volatile String error;
+        volatile float rate = 1.0f;
+        volatile float volume = 1.0f;
+        volatile boolean muted;
+
+        FissionVideoSlot(String error) {
+            this.view = null;
+            this.error = error;
+        }
+
+        FissionVideoSlot(FissionActivity activity, String source) {
+            this.view = new VideoView(activity);
+            this.view.setVisibility(View.GONE);
+            this.view.setZOrderOnTop(true);
+            this.view.setOnPreparedListener(player -> {
+                mediaPlayer = player;
+                ready = true;
+                ended = false;
+                durationMs = Math.max(0, view.getDuration());
+                applyVolume();
+                applyPlaybackParams();
+            });
+            this.view.setOnCompletionListener(player -> ended = true);
+            this.view.setOnErrorListener((player, what, extra) -> {
+                error = "Android MediaCodec playback error: what=" + what + ", extra=" + extra;
+                return true;
+            });
+            this.view.setVideoPath(source);
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(1, 1);
+            activity.addContentView(this.view, params);
+        }
+
+        void update(int left, int top, int width, int height, boolean visible) {
+            if (view == null) {
+                return;
+            }
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                    Math.max(1, width),
+                    Math.max(1, height)
+            );
+            view.setLayoutParams(params);
+            view.setX(left);
+            view.setY(top);
+            view.setVisibility(visible ? View.VISIBLE : View.GONE);
+        }
+
+        void applyPlaybackParams() {
+            if (mediaPlayer == null) {
+                return;
+            }
+            PlaybackParams params = mediaPlayer.getPlaybackParams();
+            params.setSpeed(rate);
+            mediaPlayer.setPlaybackParams(params);
+        }
+
+        void applyVolume() {
+            if (mediaPlayer == null) {
+                return;
+            }
+            float effective = muted ? 0.0f : volume;
+            mediaPlayer.setVolume(effective, effective);
+        }
+
+        void destroy() {
+            if (view == null) {
+                return;
+            }
+            view.stopPlayback();
+            ViewGroup parent = (ViewGroup)view.getParent();
+            if (parent != null) {
+                parent.removeView(view);
+            }
+        }
+    }
 }
 "#
 }

--- a/crates/tools/fission-test/tests/embeds.rs
+++ b/crates/tools/fission-test/tests/embeds.rs
@@ -32,6 +32,7 @@ fn video_embed_registers_runtime_state_and_draws_surface() {
         height: Some(180.0),
         autoplay: true,
         loop_playback: true,
+        ..Default::default()
     });
 
     harness.pump().expect("pump video embed");

--- a/documentation/content/reference/widgets/widget-pages/video.mdx
+++ b/documentation/content/reference/widgets/widget-pages/video.mdx
@@ -45,6 +45,7 @@ let player = Video {
     height: Some(360.0),
     autoplay: false,
     loop_playback: false,
+    audio: VideoAudioOptions::system_default(),
 }
 .into();
 
@@ -70,6 +71,48 @@ The useful part here is the separation of responsibilities.
 | `height` | `Option<f32>` | Requested layout height. | Defaults to `None`. |
 | `autoplay` | `bool` | Whether playback should begin automatically when possible. | Defaults to `false`. On initial registration, the runtime marks the video as playing when autoplay is requested. |
 | `loop_playback` | `bool` | Whether playback should restart after ending. | Defaults to `false`. |
+| `audio` | `VideoAudioOptions` | Platform-neutral audio-session policy and optional platform overrides. | Defaults to `VideoAudioOptions::system_default()`, so Fission does not force product-level audio behavior such as ignoring the iOS silent switch. |
+
+## Audio session policy
+
+Audio behavior is a product decision. Fission therefore does not hard-code a single global choice for every video-playing app.
+
+Use the default when the app should inherit the host platform's normal audio behavior:
+
+```rust
+Video {
+    source: "assets/inline-preview.mp4".into(),
+    audio: VideoAudioOptions::system_default(),
+    ..Default::default()
+}
+```
+
+Use foreground playback behavior when the video is the primary media experience:
+
+```rust
+Video {
+    source: "assets/lesson.mp4".into(),
+    audio: VideoAudioOptions::playback(),
+    ..Default::default()
+}
+```
+
+On iOS that maps to `AVAudioSessionCategoryPlayback` and activates the session on first play, which is the equivalent of configuring playback audio manually in the host shell. Apps that need a more precise iOS policy can use the platform escape hatch:
+
+```rust
+Video {
+    source: "assets/training.mp4".into(),
+    audio: VideoAudioOptions::playback()
+        .mix_with_others(true)
+        .ios(
+            IosVideoAudioOptions::mode(IosAudioSessionMode::MoviePlayback)
+                .with_option(IosAudioSessionCategoryOption::MixWithOthers),
+        ),
+    ..Default::default()
+}
+```
+
+If a platform cannot represent a requested option, the shell treats it as a backend limitation rather than changing the cross-platform widget contract.
 
 ## Runtime behavior
 
@@ -83,7 +126,7 @@ That is a good trade for this kind of surface. It means media playback still par
 
 What varies is the host API used by each target for this particular media surface.
 
-In the winit shell path, macOS and iOS use AVFoundation player layers, Windows uses Media Foundation, Linux uses GStreamer, Android uses the generated `FissionActivity` Java host bridge backed by Android media playback, and Web uses a browser `<video>` element positioned over the canvas. Static site and SSR output ordinary HTML video markup. Terminal does not support embedded video surfaces.
+In the winit shell path, macOS and iOS use AVFoundation player layers, Windows uses Media Foundation, Linux uses GStreamer, Android uses the generated `FissionActivity` Java host bridge backed by Android media playback, and Web uses a browser `<video>` element positioned over the canvas. Static site and SSR output ordinary HTML video markup. Terminal does not support embedded video surfaces. iOS audio-session policy is configured only when requested through `VideoAudioOptions`; the default does not force `AVAudioSessionCategoryPlayback`.
 
 The right way to read those differences is very narrow: codec support, local-file access, autoplay rules, z-ordering, and hardware decode behavior are backend-level concerns for this one host-backed media surface. They do not change the shared Fission widget, state, reducer, or layout model.
 
@@ -99,7 +142,7 @@ If video is only a nice-to-have on a screen, keep the surrounding experience res
 
 ## Production checklist
 
-For `Video`, review the fields that change behavior before treating the widget as finished: `id`, `source`, `width`, `height`, `autoplay`, `loop_playback`. The goal is to make the product rule visible in state and actions, not hidden inside ad-hoc construction code.
+For `Video`, review the fields that change behavior before treating the widget as finished: `id`, `source`, `width`, `height`, `autoplay`, `loop_playback`, and `audio`. The goal is to make the product rule visible in state and actions, not hidden inside ad-hoc construction code.
 
 - If this widget appears inside an interactive flow, keep the surrounding action binding in the parent component and test that the flow still has one clear reducer path.
 - Set `id` only when identity must be stable across filtering, reordering, diagnostics, or tests; otherwise let Fission derive identity from structure.

--- a/documentation/content/reference/widgets/widget-pages/video.mdx
+++ b/documentation/content/reference/widgets/widget-pages/video.mdx
@@ -79,13 +79,13 @@ Control actions such as play, pause, stop, seek, set rate, set volume, and set m
 
 That is a good trade for this kind of surface. It means media playback still participates in an explicit state model, even though the actual pixels come from a host-managed player backend.
 
-## Host backend differences today
+## Host backend differences
 
-What varies today is the backend implementation for this particular media surface.
+What varies is the host API used by each target for this particular media surface.
 
-In the checked-in winit shell path, macOS uses a real AVFoundation-backed player layer. Other current targets use the mock backend path that preserves the runtime contract and playback-state flow without providing the same native media implementation.
+In the winit shell path, macOS and iOS use AVFoundation player layers, Windows uses Media Foundation, Linux uses GStreamer, Android uses the generated `FissionActivity` Java host bridge backed by Android media playback, and Web uses a browser `<video>` element positioned over the canvas. Static site and SSR output ordinary HTML video markup. Terminal does not support embedded video surfaces.
 
-The right way to read that difference is very narrow: it tells you how far the current checked-in `Video` backend is implemented on each host. It does not say that Fission's overall macOS, Windows, Linux, Web, Android, iOS, Terminal, Static site, or SSR app model is not ready. It says that embedded video playback, like any specialized media surface, must be evaluated on the exact host backend you plan to ship.
+The right way to read those differences is very narrow: codec support, local-file access, autoplay rules, z-ordering, and hardware decode behavior are backend-level concerns for this one host-backed media surface. They do not change the shared Fission widget, state, reducer, or layout model.
 
 ## Specific guidance
 

--- a/examples/embed-video/src/lib.rs
+++ b/examples/embed-video/src/lib.rs
@@ -27,6 +27,7 @@ impl From<VideoEmbedApp> for Widget {
                     height: Some(270.0),
                     autoplay: true,
                     loop_playback: true,
+                    audio: VideoAudioOptions::playback(),
                 })
                 .width(480.0)
                 .height(270.0)

--- a/examples/mobile-smoke/platforms/android/AndroidManifest.xml
+++ b/examples/mobile-smoke/platforms/android/AndroidManifest.xml
@@ -11,11 +11,11 @@
     <application
         android:debuggable="true"
         android:extractNativeLibs="true"
-        android:hasCode="false"
+        android:hasCode="true"
         android:icon="@drawable/app_icon"
         android:label="Fission Mobile Smoke">
         <activity
-            android:name="android.app.NativeActivity"
+            android:name="rs.fission.runtime.FissionActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize|uiMode|density"
             android:exported="true"
             android:launchMode="singleTask"

--- a/examples/mobile-smoke/platforms/android/java/rs/fission/runtime/FissionActivity.java
+++ b/examples/mobile-smoke/platforms/android/java/rs/fission/runtime/FissionActivity.java
@@ -1,4 +1,295 @@
 package rs.fission.runtime;
 
-public final class FissionActivity extends android.app.NativeActivity {
+import android.app.NativeActivity;
+import android.media.MediaPlayer;
+import android.media.PlaybackParams;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.VideoView;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class FissionActivity extends NativeActivity {
+    private static volatile FissionActivity INSTANCE;
+    private static final Map<Long, FissionVideoSlot> VIDEOS = new HashMap<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        INSTANCE = this;
+    }
+
+    @Override
+    protected void onDestroy() {
+        runOnUiThread(() -> {
+            synchronized (VIDEOS) {
+                for (FissionVideoSlot slot : VIDEOS.values()) {
+                    slot.destroy();
+                }
+                VIDEOS.clear();
+            }
+        });
+        INSTANCE = null;
+        super.onDestroy();
+    }
+
+    public static void fissionCreateVideo(long id, String source) {
+        runOnUiThreadOrRecordError(id, () -> {
+            synchronized (VIDEOS) {
+                FissionVideoSlot previous = VIDEOS.remove(id);
+                if (previous != null) {
+                    previous.destroy();
+                }
+                FissionVideoSlot slot = new FissionVideoSlot(INSTANCE, source);
+                VIDEOS.put(id, slot);
+            }
+        });
+    }
+
+    public static void fissionUpdateVideoSurface(
+            long id,
+            int left,
+            int top,
+            int width,
+            int height,
+            boolean visible
+    ) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.update(left, top, width, height, visible);
+            }
+        });
+    }
+
+    public static void fissionSetVideoVisible(long id, boolean visible) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null && slot.view != null) {
+                slot.view.setVisibility(visible ? View.VISIBLE : View.GONE);
+            }
+        });
+    }
+
+    public static void fissionDestroyVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            synchronized (VIDEOS) {
+                FissionVideoSlot slot = VIDEOS.remove(id);
+                if (slot != null) {
+                    slot.destroy();
+                }
+            }
+        });
+    }
+
+    public static void fissionPlayVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.ended = false;
+                slot.view.start();
+            }
+        });
+    }
+
+    public static void fissionPauseVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.view.pause();
+            }
+        });
+    }
+
+    public static void fissionStopVideo(long id) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.view.pause();
+                slot.view.seekTo(0);
+                slot.ended = false;
+            }
+        });
+    }
+
+    public static void fissionSeekVideo(long id, long positionMs) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.view.seekTo((int)Math.max(0L, Math.min(positionMs, Integer.MAX_VALUE)));
+            }
+        });
+    }
+
+    public static void fissionSetVideoRate(long id, float rate) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.rate = Math.max(0.1f, rate);
+                slot.applyPlaybackParams();
+            }
+        });
+    }
+
+    public static void fissionSetVideoVolume(long id, float volume) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.volume = Math.max(0.0f, Math.min(volume, 1.0f));
+                slot.applyVolume();
+            }
+        });
+    }
+
+    public static void fissionSetVideoMuted(long id, boolean muted) {
+        runOnUiThreadOrRecordError(id, () -> {
+            FissionVideoSlot slot = slot(id);
+            if (slot != null) {
+                slot.muted = muted;
+                slot.applyVolume();
+            }
+        });
+    }
+
+    public static long fissionVideoPosition(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot == null || slot.view == null ? 0L : Math.max(0, slot.view.getCurrentPosition());
+    }
+
+    public static long fissionVideoDuration(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot == null || !slot.ready ? -1L : Math.max(0, slot.durationMs);
+    }
+
+    public static boolean fissionVideoReady(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot != null && slot.ready;
+    }
+
+    public static boolean fissionVideoEnded(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot != null && slot.ended;
+    }
+
+    public static String fissionVideoError(long id) {
+        FissionVideoSlot slot = slot(id);
+        return slot == null ? null : slot.error;
+    }
+
+    private static FissionVideoSlot slot(long id) {
+        synchronized (VIDEOS) {
+            return VIDEOS.get(id);
+        }
+    }
+
+    private static void runOnUiThreadOrRecordError(long id, Runnable action) {
+        FissionActivity activity = INSTANCE;
+        if (activity == null) {
+            recordError(id, "Fission Android video host is not attached to FissionActivity");
+            return;
+        }
+        activity.runOnUiThread(() -> {
+            try {
+                action.run();
+            } catch (Throwable error) {
+                recordError(id, "Android video host error: " + error);
+            }
+        });
+    }
+
+    private static void recordError(long id, String error) {
+        synchronized (VIDEOS) {
+            FissionVideoSlot slot = VIDEOS.get(id);
+            if (slot == null) {
+                slot = new FissionVideoSlot(error);
+                VIDEOS.put(id, slot);
+            } else {
+                slot.error = error;
+            }
+        }
+    }
+
+    private static final class FissionVideoSlot {
+        final VideoView view;
+        MediaPlayer mediaPlayer;
+        volatile boolean ready;
+        volatile boolean ended;
+        volatile int durationMs = -1;
+        volatile String error;
+        volatile float rate = 1.0f;
+        volatile float volume = 1.0f;
+        volatile boolean muted;
+
+        FissionVideoSlot(String error) {
+            this.view = null;
+            this.error = error;
+        }
+
+        FissionVideoSlot(FissionActivity activity, String source) {
+            this.view = new VideoView(activity);
+            this.view.setVisibility(View.GONE);
+            this.view.setZOrderOnTop(true);
+            this.view.setOnPreparedListener(player -> {
+                mediaPlayer = player;
+                ready = true;
+                ended = false;
+                durationMs = Math.max(0, view.getDuration());
+                applyVolume();
+                applyPlaybackParams();
+            });
+            this.view.setOnCompletionListener(player -> ended = true);
+            this.view.setOnErrorListener((player, what, extra) -> {
+                error = "Android MediaCodec playback error: what=" + what + ", extra=" + extra;
+                return true;
+            });
+            this.view.setVideoPath(source);
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(1, 1);
+            activity.addContentView(this.view, params);
+        }
+
+        void update(int left, int top, int width, int height, boolean visible) {
+            if (view == null) {
+                return;
+            }
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                    Math.max(1, width),
+                    Math.max(1, height)
+            );
+            view.setLayoutParams(params);
+            view.setX(left);
+            view.setY(top);
+            view.setVisibility(visible ? View.VISIBLE : View.GONE);
+        }
+
+        void applyPlaybackParams() {
+            if (mediaPlayer == null) {
+                return;
+            }
+            PlaybackParams params = mediaPlayer.getPlaybackParams();
+            params.setSpeed(rate);
+            mediaPlayer.setPlaybackParams(params);
+        }
+
+        void applyVolume() {
+            if (mediaPlayer == null) {
+                return;
+            }
+            float effective = muted ? 0.0f : volume;
+            mediaPlayer.setVolume(effective, effective);
+        }
+
+        void destroy() {
+            if (view == null) {
+                return;
+            }
+            view.stopPlayback();
+            ViewGroup parent = (ViewGroup)view.getParent();
+            if (parent != null) {
+                parent.removeView(view);
+            }
+        }
+    }
 }

--- a/examples/mobile-smoke/platforms/android/package-apk.sh
+++ b/examples/mobile-smoke/platforms/android/package-apk.sh
@@ -3,13 +3,10 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_DIR=$(cd -- "$SCRIPT_DIR/../.." && pwd)
-REPO_ROOT=$(cd -- "$PROJECT_DIR/../.." && pwd)
-ICON_SOURCE="${FISSION_APP_ICON:-$REPO_ROOT/docs/fission_logo.png}"
 TARGET="${ANDROID_TARGET_TRIPLE:-aarch64-linux-android}"
 PACKAGE_NAME="mobile-smoke"
 LIB_NAME="mobile_smoke"
 PROFILE="${ANDROID_PROFILE:-debug}"
-APP_ID="ai.worka.fission.mobile.smoke"
 ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
 ANDROID_MIN_API_LEVEL="${ANDROID_MIN_API_LEVEL:-${ANDROID_API_LEVEL:-24}}"
 
@@ -58,20 +55,6 @@ detect_latest_android_api() {
     | tail -1
 }
 
-detect_build_tools_dir() {
-  if [[ -n "${ANDROID_BUILD_TOOLS:-}" ]]; then
-    if [[ -d "$ANDROID_BUILD_TOOLS" ]]; then
-      printf '%s\n' "$ANDROID_BUILD_TOOLS"
-      return
-    fi
-    if [[ -d "$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS" ]]; then
-      printf '%s\n' "$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS"
-      return
-    fi
-  fi
-  find "$ANDROID_HOME/build-tools" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort -V | tail -1
-}
-
 ANDROID_TARGET_API_LEVEL="${ANDROID_TARGET_API_LEVEL:-$(detect_latest_android_api)}"
 if [[ -z "$ANDROID_TARGET_API_LEVEL" ]]; then
   printf 'No Android platform found under %s/platforms. Install one with sdkmanager "platforms;android-35" or newer.\n' "$ANDROID_HOME" >&2
@@ -87,31 +70,27 @@ CARGO_TARGET_AARCH64_LINUX_ANDROID_AR="${CARGO_TARGET_AARCH64_LINUX_ANDROID_AR:-
 export ANDROID_HOME ANDROID_NDK ANDROID_MIN_API_LEVEL ANDROID_TARGET_API_LEVEL ANDROID_TOOLCHAIN CC_aarch64_linux_android AR_aarch64_linux_android
 export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER CARGO_TARGET_AARCH64_LINUX_ANDROID_AR
 
-BUILD_TOOLS=$(detect_build_tools_dir)
-if [[ -z "$BUILD_TOOLS" || ! -d "$BUILD_TOOLS" ]]; then
-  printf 'Android build-tools not found. Install them with sdkmanager "build-tools;35.0.0" or set ANDROID_BUILD_TOOLS.\n' >&2
-  exit 1
-fi
-ANDROID_JAR="$ANDROID_HOME/platforms/android-$ANDROID_TARGET_API_LEVEL/android.jar"
-if [[ ! -f "$ANDROID_JAR" ]]; then
-  printf 'Android platform android-%s not found. Install it with sdkmanager "platforms;android-%s" or set ANDROID_TARGET_API_LEVEL.\n' "$ANDROID_TARGET_API_LEVEL" "$ANDROID_TARGET_API_LEVEL" >&2
-  exit 1
-fi
-AAPT="$BUILD_TOOLS/aapt"
-ZIPALIGN="$BUILD_TOOLS/zipalign"
-APKSIGNER="$BUILD_TOOLS/apksigner"
-for tool in "$AAPT" "$ZIPALIGN" "$APKSIGNER"; do
-  if [[ ! -x "$tool" ]]; then
-    printf 'Required Android build tool is missing or not executable: %s\n' "$tool" >&2
+if [[ -n "${FISSION_GRADLE:-}" ]]; then
+  read -r -a GRADLE_CMD <<< "$FISSION_GRADLE"
+elif [[ -x "$SCRIPT_DIR/gradlew" ]]; then
+  GRADLE_CMD=("$SCRIPT_DIR/gradlew")
+else
+  if ! command -v gradle >/dev/null 2>&1; then
+    printf 'Gradle is required for the generated Android project shell. Install Gradle or add a wrapper under %s.\n' "$SCRIPT_DIR" >&2
     exit 1
   fi
-done
+  GRADLE_CMD=(gradle)
+fi
 
 BUILD_ARGS=(build --manifest-path "$PROJECT_DIR/Cargo.toml" --lib --target "$TARGET" --package "$PACKAGE_NAME")
 ARTIFACT_DIR=debug
+GRADLE_VARIANT=Debug
+GRADLE_OUTPUT_DIR=debug
 if [[ "$PROFILE" == "release" ]]; then
   BUILD_ARGS+=(--release)
   ARTIFACT_DIR=release
+  GRADLE_VARIANT=Release
+  GRADLE_OUTPUT_DIR=release
 fi
 
 cargo "${BUILD_ARGS[@]}"
@@ -131,65 +110,28 @@ PY
 )
 
 SO_PATH="$TARGET_DIR/$TARGET/$ARTIFACT_DIR/lib$LIB_NAME.so"
-BUILD_DIR="$SCRIPT_DIR/build/$PROFILE"
-APK_ROOT="$BUILD_DIR/apk-root"
-UNALIGNED_APK="$BUILD_DIR/$PACKAGE_NAME-unaligned.apk"
-ALIGNED_APK="$BUILD_DIR/$PACKAGE_NAME-aligned.apk"
-SIGNED_APK="$BUILD_DIR/$PACKAGE_NAME.apk"
-KEYSTORE="${ANDROID_DEBUG_KEYSTORE:-$HOME/.android/debug.keystore}"
-
-rm -rf "$APK_ROOT"
-mkdir -p "$APK_ROOT/lib/arm64-v8a" "$APK_ROOT/res/drawable-nodpi" "$BUILD_DIR"
-cp "$SO_PATH" "$APK_ROOT/lib/arm64-v8a/lib$LIB_NAME.so"
-cp "$ICON_SOURCE" "$APK_ROOT/res/drawable-nodpi/app_icon.png"
+JNI_DIR="$SCRIPT_DIR/app/src/main/jniLibs/arm64-v8a"
+GENERATED_RES_DIR="$SCRIPT_DIR/app/src/main/res/drawable-nodpi"
+mkdir -p "$JNI_DIR" "$GENERATED_RES_DIR"
+cp "$SO_PATH" "$JNI_DIR/lib$LIB_NAME.so"
+shopt -s nullglob
+APP_ICONS=("$SCRIPT_DIR"/res/drawable-nodpi/app_icon.* "$SCRIPT_DIR"/res/drawable/app_icon.*)
+if (( ${#APP_ICONS[@]} == 0 )); then
+  cp "$PROJECT_DIR/assets/app-icon.png" "$GENERATED_RES_DIR/app_icon.png"
+fi
+shopt -u nullglob
 shopt -s nullglob
 SPLASH_IMAGES=("$SCRIPT_DIR"/res/drawable-nodpi/fission_splash_image.*)
 if (( ${#SPLASH_IMAGES[@]} == 0 )); then
-  cp "$ICON_SOURCE" "$APK_ROOT/res/drawable-nodpi/fission_splash_image.png"
+  cp "$PROJECT_DIR/assets/app-icon.png" "$GENERATED_RES_DIR/fission_splash_image.png"
 fi
 shopt -u nullglob
-if [[ -d "$SCRIPT_DIR/res" ]]; then
-  mkdir -p "$APK_ROOT/res"
-  cp -R "$SCRIPT_DIR/res/." "$APK_ROOT/res/"
+
+"${GRADLE_CMD[@]}" -p "$SCRIPT_DIR" ":app:assemble$GRADLE_VARIANT"
+
+APK="$SCRIPT_DIR/app/build/outputs/apk/$GRADLE_OUTPUT_DIR/app-$GRADLE_OUTPUT_DIR.apk"
+if [[ ! -f "$APK" ]]; then
+  printf 'Gradle did not produce the expected APK: %s\n' "$APK" >&2
+  exit 1
 fi
-
-BUILD_MANIFEST="$BUILD_DIR/AndroidManifest.xml"
-python3 - <<'PY' "$SCRIPT_DIR/AndroidManifest.xml" "$BUILD_MANIFEST" "$ANDROID_MIN_API_LEVEL" "$ANDROID_TARGET_API_LEVEL"
-import pathlib
-import re
-import sys
-
-source, dest, min_api, target_api = sys.argv[1:]
-manifest = open(source, encoding="utf-8").read()
-manifest = re.sub(r'android:minSdkVersion="\d+"', f'android:minSdkVersion="{min_api}"', manifest)
-manifest = re.sub(r'android:targetSdkVersion="\d+"', f'android:targetSdkVersion="{target_api}"', manifest)
-has_code = "true" if pathlib.Path(dest).with_name("apk-root").joinpath("classes.dex").exists() else "false"
-manifest = re.sub(r'android:hasCode="(?:true|false)"', f'android:hasCode="{has_code}"', manifest)
-open(dest, "w", encoding="utf-8").write(manifest)
-PY
-
-"$AAPT" package -f -F "$UNALIGNED_APK" -M "$BUILD_MANIFEST" -S "$APK_ROOT/res" -I "$ANDROID_JAR"
-(cd "$APK_ROOT" && zip -qr "$UNALIGNED_APK" lib)
-"$ZIPALIGN" -f 4 "$UNALIGNED_APK" "$ALIGNED_APK"
-
-if [[ ! -f "$KEYSTORE" ]]; then
-  mkdir -p "$(dirname "$KEYSTORE")"
-  keytool -genkeypair -v \
-    -keystore "$KEYSTORE" \
-    -storepass android \
-    -alias androiddebugkey \
-    -keypass android \
-    -dname "CN=Android Debug,O=Android,C=US" \
-    -keyalg RSA \
-    -keysize 2048 \
-    -validity 10000 >/dev/null 2>&1
-fi
-
-"$APKSIGNER" sign \
-  --ks "$KEYSTORE" \
-  --ks-pass pass:android \
-  --key-pass pass:android \
-  --out "$SIGNED_APK" \
-  "$ALIGNED_APK"
-
-printf '%s\n' "$SIGNED_APK"
+printf '%s\n' "$APK"

--- a/examples/mobile-smoke/platforms/android/run-emulator.sh
+++ b/examples/mobile-smoke/platforms/android/run-emulator.sh
@@ -91,5 +91,5 @@ APK=$("$SCRIPT_DIR/package-apk.sh")
 read -r -a ADB_INSTALL_FLAGS <<< "${ADB_INSTALL_FLAGS:---no-streaming -r}"
 "$ADB" install "${ADB_INSTALL_FLAGS[@]}" "$APK"
 "$ADB" forward "tcp:$HOST_PORT" "tcp:$DEVICE_PORT"
-"$ADB" shell am start -n ai.worka.fission.mobile.smoke/android.app.NativeActivity >/dev/null
+"$ADB" shell am start -n ai.worka.fission.mobile.smoke/rs.fission.runtime.FissionActivity >/dev/null
 printf 'APK=%s\n' "$APK"


### PR DESCRIPTION
## Summary

Closes #96.

This removes the no-op video backend path and wires real platform backends for the first-class targets:

- macOS/iOS: AVFoundation-backed native layers
- Windows: Media Foundation via `windows-rs`
- Linux: GStreamer video overlay via `gstreamer-rs`
- Android: generated `FissionActivity` Java bridge driven from Rust via `jni` + `ndk-context`
- Web: browser `<video>` overlay
- Static site / SSR: HTML `<video>` output
- unsupported targets: panic instead of silently using a mock

It also adds a platform-neutral `VideoAudioOptions` policy so iOS audio-session behavior is explicit app configuration rather than a framework-wide hard-coded default. The default remains `VideoAudioOptions::system_default()`. Apps that need silent-switch-ignoring foreground playback can opt in with `VideoAudioOptions::playback()`, and iOS-specific category/mode/options remain available through `IosVideoAudioOptions`.

## Notes

- Android app generation now emits a real `FissionActivity` subclass with video overlay methods, and `mobile-smoke` has been updated to use that activity.
- Static-site custom routes now preserve video registrations collected during widget conversion so `Video` lowers to real HTML `<video>`.
- iOS maps `VideoAudioOptions::playback()` to `AVAudioSessionCategoryPlayback` and activates on first play by default; the shell does not configure `AVAudioSession` for videos that use `system_default()`.
- Android CI pins Gradle 9.5.0 because AGP 8.13.2 currently fails against Gradle 9.6.x internal API removal.
- The winit runtime now consumes `VideoEvent::Ended` for `loop_playback`, so looped videos seek back to zero and resume when a backend reports completion.
- Coordinate/platform manual testing is still required on each OS before merge, especially Windows and Linux where local cross-compilation is blocked by host toolchain/system-library availability.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p fission-core`
- `cargo check -p fission-shell -p fission-shell-winit`
- `cargo check -p fission-shell-winit --target aarch64-linux-android`
- `cargo check -p fission-shell-winit --target aarch64-apple-ios-sim`
- `cargo check -p fission-shell-winit --target wasm32-unknown-unknown`
- `cargo check -p fission-command-core`
- `cargo test -p cargo-fission android --lib`
- `cargo test -p fission-shell-site custom_site_routes_render_video_as_html_video --lib`
- `cargo check -p mobile-smoke`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) examples/mobile-smoke/platforms/android/package-apk.sh`
- `cargo run -p cargo-fission --bin fission -- site check --project-dir documentation`

## Local limitations

- Full Windows target check is blocked on this machine by missing Windows C/MSVC toolchain pieces.
- Full Linux target check is blocked on this machine by missing GStreamer pkg-config/system libraries and Linux cross toolchain.
