### PR TITLE
fix(ios): configure AVAudioSession for video playback

### DIFF
--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -728,6 +728,7 @@ mod ios {
     impl IosVideoBackend {
         pub fn try_new(window: &Window) -> Option<Self> {
             let ui_view = ui_view_from_window(window)?;
+            unsafe { configure_audio_session() };
             Some(Self {
                 view: unsafe { RetainedId::retain(ui_view) },
                 layers: Mutex::new(HashMap::new()),
@@ -1048,6 +1049,23 @@ mod ios {
         let sanitized = value.replace('\0', "");
         let cstr = CString::new(sanitized).unwrap();
         unsafe { msg_send![class!(NSString), stringWithUTF8String: cstr.as_ptr()] }
+    }
+
+    /// Configures the shared AVAudioSession so video audio plays even with
+    /// the silent switch engaged, matching standard short-form-video-app
+    /// behavior (TikTok, Reels, Shorts) rather than iOS's default
+    /// `.soloAmbient` session, which would otherwise silence playback on
+    /// mute and refuse to play under another app's active audio session.
+    ///
+    /// Category choice is a product decision as much as a technical one —
+    /// if silent-switch-respecting, mixable playback is preferred instead,
+    /// swap "AVAudioSessionCategoryPlayback" for
+    /// "AVAudioSessionCategoryAmbient".
+    unsafe fn configure_audio_session() {
+        let session: Id = msg_send![class!(AVAudioSession), sharedInstance];
+        let category = ns_string("AVAudioSessionCategoryPlayback");
+        let _: i8 = msg_send![session, setCategory: category error: NIL];
+        let _: i8 = msg_send![session, setActive: YES error: NIL];
     }
 
     struct ResolvedVideoSource {


### PR DESCRIPTION
## Add AVAudioSession configuration to iOS video backend

### What

Adds a one-time `AVAudioSession` configuration call (`configure_audio_session()`) to `IosVideoBackend::try_new`, setting the audio session category to `.playback` so that video audio plays even when the iOS silent switch is engaged.

### Why

Without explicit audio session configuration, iOS defaults to the `.soloAmbient` category, which:
- **Silences audio when the ring/silent switch is toggled** — unexpected for video playback
- **Won't play if another app already has an active playback session**

This doesn't match user expectations for video-playing apps. Standard short-form-video apps (TikTok, Reels, Shorts) all use `.playback` to avoid this.

### The change

A single `configure_audio_session()` function is added to the `ios` module, called once from `IosVideoBackend::try_new()` (session-wide, not per-player). It:
1. Gets the shared `AVAudioSession` instance
2. Sets the category to `AVAudioSessionCategoryPlayback`
3. Activates the session

No new framework links are needed — `AVAudioSession` is part of the `AVFoundation` framework already linked in this module.

### Category choice — inviting input

The `.playback` category is a **product decision** as much as a technical one. If silent-switch-respecting, mixable playback is preferred instead, swapping `"AVAudioSessionCategoryPlayback"` for `"AVAudioSessionCategoryAmbient"` is a one-line change. Flagging this explicitly for @zcourts and maintainers to weigh in on, rather than presenting `.playback` as the only correct choice.

### What was and wasn't verified

- ✅ `cargo check -p fission-shell-winit --target aarch64-apple-ios-sim` — compile-verified for iOS simulator target
- ❌ **Not** tested on a real device or simulator with actual audio playback — no physical iOS device available in this environment. The `AVAudioSession` API surface is well-established and the `msg_send!` pattern matches the module's existing conventions exactly, but audio behavior under the silent switch has not been confirmed end-to-end.

### Relationship to #100

This is a small, additive fix on top of the existing work in PR #100 (`feature/native-video-backends`), not an alternative implementation. It closes the one remaining gap (no audio session configuration) that was identified during review of #100.

Refs: #96, #100