### PR TITLE
fix(video): restart looped videos on VideoEvent::Ended (Stacked on #102)

### DIFF
--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -5734,8 +5734,18 @@ where
                                         }
                                     }
                                     VideoEvent::Ended => {
-                                        video_state.status = VideoStatus::Ended;
-                                        active_player.last_status = Some(VideoStatus::Ended);
+                                        if video_state.looped {
+                                            eprintln!("[loop-fix] restarting {:?}", widget_id);
+                                            player.seek_to(0);
+                                            video_state.status = VideoStatus::Playing;
+                                            // Setting last_status to None forces the
+                                            // sync-controls block above to re-issue
+                                            // player.play() on the next frame.
+                                            active_player.last_status = None;
+                                        } else {
+                                            video_state.status = VideoStatus::Ended;
+                                            active_player.last_status = Some(VideoStatus::Ended);
+                                        }
                                         request_redraw_logged(
                                             &window,
                                             elwt,

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -92,12 +92,13 @@ mod mac {
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
+    use block::ConcreteBlock;
     use objc::rc::StrongPtr;
     use objc::{class, msg_send, sel, sel_impl};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use winit::window::Window;
 
@@ -218,6 +219,9 @@ mod mac {
                         .unwrap_or_else(|| Path::new(source)),
                 )
             };
+            let ended_flag = Arc::new(AtomicBool::new(false));
+            let observer =
+                unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
             Box::new(MacVideoPlayer {
                 registry: Arc::clone(&self.registry),
@@ -225,6 +229,9 @@ mod mac {
                 ready_sent: false,
                 error_sent: false,
                 pending_error,
+                ended_flag,
+                ended_sent: false,
+                observer: unsafe { RetainedId::new(observer) },
             })
         }
 
@@ -382,10 +389,18 @@ mod mac {
         ready_sent: bool,
         error_sent: bool,
         pending_error: Option<String>,
+        ended_flag: Arc<AtomicBool>,
+        ended_sent: bool,
+        observer: RetainedId,
     }
 
     impl Drop for MacVideoPlayer {
         fn drop(&mut self) {
+            // Remove the end-of-playback notification observer.
+            unsafe {
+                let center: id = msg_send![class!(NSNotificationCenter), defaultCenter];
+                let () = msg_send![center, removeObserver: self.observer.as_id()];
+            }
             // Pause/stop before releasing to avoid teardown race with layers.
             if let Some(player) = self.registry.get(self.player_id) {
                 unsafe {
@@ -445,10 +460,11 @@ mod mac {
         }
 
         fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
             if !self.error_sent {
                 if let Some(message) = self.pending_error.take() {
                     self.error_sent = true;
-                    return vec![VideoEvent::Error(message)];
+                    events.push(VideoEvent::Error(message));
                 }
             }
             if !self.ready_sent {
@@ -458,10 +474,17 @@ mod mac {
                     .get(self.player_id)
                     .and_then(|player| unsafe { item_duration_ms(player.as_id()) })
                     .unwrap_or(0);
-                vec![VideoEvent::Ready { duration }]
-            } else {
-                Vec::new()
+                events.push(VideoEvent::Ready { duration });
             }
+            let reached_end = self.ended_flag.swap(false, Ordering::Acquire);
+            if reached_end && !self.ended_sent {
+                self.ended_sent = true;
+                events.push(VideoEvent::Ended);
+            }
+            if !reached_end {
+                self.ended_sent = false;
+            }
+            events
         }
 
         fn seek_to(&mut self, position_ms: u64) {
@@ -610,6 +633,25 @@ mod mac {
         let () = msg_send![player, seekToTime: time toleranceBefore: zero_a toleranceAfter: zero_b];
     }
 
+    unsafe fn register_end_observer(player: id, flag: Arc<AtomicBool>) -> id {
+        let notification_name =
+            NSString::alloc(nil).init_str("AVPlayerItemDidPlayToEndTimeNotification");
+        let item: id = msg_send![player, currentItem];
+        let center: id = msg_send![class!(NSNotificationCenter), defaultCenter];
+        let block = ConcreteBlock::new(move |_notification: id| {
+            flag.store(true, Ordering::Release);
+        })
+        .copy();
+        let observer: id = msg_send![
+            center,
+            addObserverForName: notification_name
+            object: item
+            queue: nil
+            usingBlock: &*block
+        ];
+        observer
+    }
+
     fn cg_rect_from_layout(rect: LayoutRect, ctx: &LayerContext) -> CGRect {
         let width = rect.size.width as f64;
         let height = rect.size.height as f64;
@@ -668,6 +710,7 @@ mod ios {
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::VideoSurfaceFrame;
+    use block::ConcreteBlock;
     use objc::rc::StrongPtr;
     use objc::runtime::Object;
     use objc::{class, msg_send, sel, sel_impl};
@@ -675,7 +718,7 @@ mod ios {
     use std::collections::{HashMap, HashSet};
     use std::ffi::CString;
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use winit::window::Window;
 
@@ -805,6 +848,9 @@ mod ios {
                         .unwrap_or_else(|| Path::new(source)),
                 )
             };
+            let ended_flag = Arc::new(AtomicBool::new(false));
+            let observer =
+                unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
             Box::new(IosVideoPlayer {
                 registry: Arc::clone(&self.registry),
@@ -815,6 +861,9 @@ mod ios {
                 audio: audio.clone(),
                 audio_session_configured,
                 audio_error: None,
+                ended_flag,
+                ended_sent: false,
+                observer: unsafe { RetainedId::retain(observer) },
             })
         }
 
@@ -953,10 +1002,18 @@ mod ios {
         audio: VideoAudioOptions,
         audio_session_configured: bool,
         audio_error: Option<String>,
+        ended_flag: Arc<AtomicBool>,
+        ended_sent: bool,
+        observer: RetainedId,
     }
 
     impl Drop for IosVideoPlayer {
         fn drop(&mut self) {
+            // Remove the end-of-playback notification observer.
+            unsafe {
+                let center: Id = msg_send![class!(NSNotificationCenter), defaultCenter];
+                let () = msg_send![center, removeObserver: self.observer.as_id()];
+            }
             if let Some(player) = self.registry.get(self.player_id) {
                 unsafe {
                     let () = msg_send![player.as_id(), pause];
@@ -1019,6 +1076,7 @@ mod ios {
         }
 
         fn poll_events(&mut self) -> Vec<VideoEvent> {
+            let mut events = Vec::new();
             if !self.error_sent {
                 if let Some(message) = self
                     .pending_error
@@ -1026,16 +1084,23 @@ mod ios {
                     .or_else(|| self.audio_error.take())
                 {
                     self.error_sent = true;
-                    return vec![VideoEvent::Error(message)];
+                    events.push(VideoEvent::Error(message));
                 }
             }
             if !self.ready_sent {
                 self.ready_sent = true;
                 let duration = self.duration().unwrap_or(0);
-                vec![VideoEvent::Ready { duration }]
-            } else {
-                Vec::new()
+                events.push(VideoEvent::Ready { duration });
             }
+            let reached_end = self.ended_flag.swap(false, Ordering::Acquire);
+            if reached_end && !self.ended_sent {
+                self.ended_sent = true;
+                events.push(VideoEvent::Ended);
+            }
+            if !reached_end {
+                self.ended_sent = false;
+            }
+            events
         }
 
         fn seek_to(&mut self, position_ms: u64) {
@@ -1284,6 +1349,24 @@ mod ios {
         let zero_a = CMTime::zero();
         let zero_b = CMTime::zero();
         let () = msg_send![player, seekToTime: time toleranceBefore: zero_a toleranceAfter: zero_b];
+    }
+
+    unsafe fn register_end_observer(player: Id, flag: Arc<AtomicBool>) -> Id {
+        let notification_name = ns_string("AVPlayerItemDidPlayToEndTimeNotification");
+        let item: Id = msg_send![player, currentItem];
+        let center: Id = msg_send![class!(NSNotificationCenter), defaultCenter];
+        let block = ConcreteBlock::new(move |_notification: Id| {
+            flag.store(true, Ordering::Release);
+        })
+        .copy();
+        let observer: Id = msg_send![
+            center,
+            addObserverForName: notification_name
+            object: item
+            queue: NIL
+            usingBlock: &*block
+        ];
+        observer
     }
 
     fn cg_rect_from_layout(rect: LayoutRect) -> CGRect {

--- a/crates/tools/fission-test/tests/embeds.rs
+++ b/crates/tools/fission-test/tests/embeds.rs
@@ -166,3 +166,108 @@ fn custom_embed_draws_surface() {
         other => panic!("expected custom surface, got {other:?}"),
     }
 }
+
+/// Verifies the loop-restart invariant: when a looped video ends, the
+/// handler should set status back to Playing (simulating a seek-to-0 +
+/// replay). This mirrors the logic in fission-shell-winit's
+/// VideoEvent::Ended handler.
+#[test]
+fn looped_video_restarts_on_ended_event() {
+    let widget_id = WidgetId::explicit("test.video.loop");
+    let mut harness = TestHarness::new(EmbedState).with_root_widget(Video {
+        id: Some(widget_id),
+        source: "fixtures/demo.mp4".into(),
+        width: Some(320.0),
+        height: Some(180.0),
+        autoplay: true,
+        loop_playback: true,
+        ..Default::default()
+    });
+
+    harness.pump().expect("pump looped video");
+
+    // Confirm initial state: looped is set, status is Playing (autoplay).
+    {
+        let video_state = harness
+            .runtime
+            .runtime_state
+            .video
+            .states
+            .get(&widget_id)
+            .expect("video state should be registered");
+        assert!(video_state.looped, "loop_playback should be copied to looped");
+        assert_eq!(
+            video_state.status,
+            fission_core::env::VideoStatus::Playing,
+            "autoplay video should start as Playing"
+        );
+    }
+
+    // Simulate what the shell's VideoEvent::Ended handler does when
+    // video_state.looped is true: reset status to Playing (the shell also
+    // calls player.seek_to(0), but we can't test that without a real
+    // player — the status transition is the key invariant).
+    {
+        let video_state = harness
+            .runtime
+            .runtime_state
+            .video
+            .states
+            .get_mut(&widget_id)
+            .expect("video state should still be registered");
+
+        // First, simulate the video reaching the end.
+        video_state.status = fission_core::env::VideoStatus::Ended;
+        assert_eq!(video_state.status, fission_core::env::VideoStatus::Ended);
+
+        // Now apply the loop-restart logic.
+        if video_state.looped {
+            video_state.status = fission_core::env::VideoStatus::Playing;
+        }
+        assert_eq!(
+            video_state.status,
+            fission_core::env::VideoStatus::Playing,
+            "looped video should restart to Playing after Ended"
+        );
+    }
+}
+
+/// Verifies that a non-looped video stays Ended when the video finishes.
+#[test]
+fn non_looped_video_stays_ended() {
+    let widget_id = WidgetId::explicit("test.video.noloop");
+    let mut harness = TestHarness::new(EmbedState).with_root_widget(Video {
+        id: Some(widget_id),
+        source: "fixtures/demo.mp4".into(),
+        width: Some(320.0),
+        height: Some(180.0),
+        autoplay: true,
+        loop_playback: false,
+        ..Default::default()
+    });
+
+    harness.pump().expect("pump non-looped video");
+
+    let video_state = harness
+        .runtime
+        .runtime_state
+        .video
+        .states
+        .get_mut(&widget_id)
+        .expect("video state should be registered");
+
+    assert!(!video_state.looped, "loop_playback should be false");
+
+    // Simulate video ending.
+    video_state.status = fission_core::env::VideoStatus::Ended;
+
+    // Apply the loop-restart logic — should NOT restart.
+    if video_state.looped {
+        video_state.status = fission_core::env::VideoStatus::Playing;
+    }
+    assert_eq!(
+        video_state.status,
+        fission_core::env::VideoStatus::Ended,
+        "non-looped video should stay Ended"
+    );
+}


### PR DESCRIPTION
This PR is stacked on top of PR #102 and targets `feature/native-video-backends` (the same target as #102).

## What Changed

- **Code-level:** The `VideoEvent::Ended` handler in `crates/shell/fission-shell-winit/src/lib.rs` now checks the `looped` flag on the video state. If `looped` is true, it calls `player.seek_to(0)` and transitions the state back to `Playing`, clearing `last_status` so the sync block will reissue `play()` on the next frame.
- **Compilation:** This has been verified to compile (`cargo check`) cleanly on both macOS (desktop) and iOS Simulator (`aarch64-apple-ios-sim`) targets.
- **Unit Tests:** Added two new unit tests (`looped_video_restarts_on_ended_event` and `non_looped_video_stays_ended`). Please note that these tests exercise the status-transition logic *in isolation* within `fission-test`. They do not call into the actual Winit shell handler in `lib.rs`.
- **Actual Behavior:** The loop-restart functionality was manually tested on-device/simulator by the PR author and observed to be working. (Note: This is manually verified, not independently machine-verified).

This PR gets the fix into `fission-ui/fission` for review. Merging this PR will update `feature/native-video-backends`, but moving that branch forward to `main` is handled separately by PR #100.
