### PR TITLE
Gate native video dependencies and type Video sources

### DIFF
--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -37,6 +37,11 @@ three-d = [
     "fission-shell-mobile?/three-d",
     "fission-shell-web?/three-d",
 ]
+video = [
+    "fission-shell-desktop?/video",
+    "fission-shell-mobile?/video",
+    "fission-shell-web?/video",
+]
 web = ["dep:fission-shell-web"]
 
 [dependencies]

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -70,7 +70,9 @@ pub mod three_d {
 
 /// Derive and attribute macros — `#[fission_action]`, `#[fission_reducer]`, and friends.
 pub mod macros {
-    pub use fission_core::{reduce, reduce_with, widgets, with_reducer};
+    pub use fission_core::{
+        reduce, reduce_with, video_asset, video_file, video_network, widgets, with_reducer,
+    };
     pub use fission_macros::*;
 }
 
@@ -163,7 +165,7 @@ pub use fission_core::ui::{
     IosAudioSessionMode, IosVideoAudioOptions, LayoutBuilder, LazyColumn, Overlay, Positioned,
     Provider, Radio, RichText, RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer,
     Switch, Text, TextContent, TextFontStyle, TextInput, TextRunStyle, Video, VideoAudioActivation,
-    VideoAudioOptions, VideoAudioPolicy, Widget, WidgetIdExt, ZStack,
+    VideoAudioOptions, VideoAudioPolicy, VideoSource, Widget, WidgetIdExt, ZStack,
 };
 
 // Core action/state types
@@ -365,6 +367,7 @@ pub use fission_shell_web::{
 };
 
 // Macros
+pub use fission_core::{video_asset, video_file, video_network};
 pub use fission_macros::{
     fission_action, fission_component, fission_reducer, Action as ActionDerive, FissionGlobalState,
     FissionStateView,
@@ -384,8 +387,8 @@ pub mod prelude {
         IosAudioSessionCategoryOption, IosAudioSessionMode, IosVideoAudioOptions, LayoutBuilder,
         LazyColumn, Overlay, Positioned, Radio, RichText, RichTextRun, Row, SafeArea, Scroll,
         SemanticsRegion, Slider, Spacer, Switch, Text, TextContent, TextFontStyle, TextInput,
-        TextRunStyle, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, Widget,
-        WidgetIdExt, ZStack,
+        TextRunStyle, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy,
+        VideoSource, Widget, WidgetIdExt, ZStack,
     };
     pub use fission_widgets::*;
 
@@ -394,7 +397,9 @@ pub mod prelude {
     pub use fission_core::event::{InputEvent, KeyCode, KeyEvent, PointerButton, PointerEvent};
     pub use fission_core::op::{Color, Fill, PaintOp};
     pub use fission_core::Bytes;
-    pub use fission_core::{reduce, reduce_with, widgets, with_reducer};
+    pub use fission_core::{
+        reduce, reduce_with, video_asset, video_file, video_network, widgets, with_reducer,
+    };
     pub use fission_core::{
         Action, ActionEnvelope, ActionId, ActionScopeId, AuthenticateBiometricCapability,
         BiometricAuthenticateRequest, BiometricAuthenticateResult, BiometricAvailability,

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -344,11 +344,15 @@ pub mod public {
     pub use crate::time::{Clock, CurrentTime};
     pub use crate::ui::{
         provider, ActionScope, BadgeTone, Button, ButtonHierarchy, ButtonMotion, CardPattern,
-        Column, ComponentSize, ComponentState, CustomWidget, Provider, Row, Text, Widget,
-        WidgetIdExt,
+        Column, ComponentSize, ComponentState, CustomWidget, IosAudioSessionCategory,
+        IosAudioSessionCategoryOption, IosAudioSessionMode, IosVideoAudioOptions, Provider, Row,
+        Text, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource,
+        Widget, WidgetIdExt,
     };
     pub use crate::view::{ComputedView, FissionViewField, Selector, ValueView, View};
-    pub use crate::{reduce, reduce_with, widgets, with_reducer};
+    pub use crate::{
+        reduce, reduce_with, video_asset, video_file, video_network, widgets, with_reducer,
+    };
     pub use fission_ir::op;
     pub use fission_ir::{EmbedKind, FocusPolicy, Op, Role, Semantics, WidgetId};
     pub use fission_layout::{
@@ -511,7 +515,10 @@ pub use registry::{
 pub use time::{Clock, CurrentTime};
 pub use ui::{
     provider, ActionScope, BadgeTone, Button, ButtonHierarchy, ButtonMotion, CardPattern, Column,
-    ComponentSize, ComponentState, CustomWidget, Provider, Row, Text, Widget, WidgetIdExt,
+    ComponentSize, ComponentState, CustomWidget, IosAudioSessionCategory,
+    IosAudioSessionCategoryOption, IosAudioSessionMode, IosVideoAudioOptions, Provider, Row, Text,
+    Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource, Widget,
+    WidgetIdExt,
 };
 pub use view::{ComputedView, FissionViewField, Selector, ValueView, View};
 
@@ -555,6 +562,44 @@ macro_rules! widgets {
             widgets
         }
     };
+}
+
+/// Creates a [`Video`](crate::ui::Video) from an app asset literal and fails
+/// compilation when the asset does not exist under `CARGO_MANIFEST_DIR`.
+///
+/// Use [`Video::asset`](crate::ui::Video::asset) when the path is computed at
+/// runtime and cannot be checked by the compiler.
+#[macro_export]
+macro_rules! video_asset {
+    ($path:literal $(,)?) => {{
+        const _: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
+        $crate::ui::Video::asset($path)
+    }};
+}
+
+/// Creates a [`Video`](crate::ui::Video) from a compile-time local file path
+/// and fails compilation when that path cannot be resolved by `include_bytes!`.
+///
+/// Relative paths are resolved the same way as `include_bytes!`: relative to the
+/// source file that invokes this macro.
+#[macro_export]
+macro_rules! video_file {
+    ($path:expr $(,)?) => {{
+        const _: &[u8] = include_bytes!($path);
+        $crate::ui::Video::file($path)
+    }};
+}
+
+/// Creates a [`Video`](crate::ui::Video) from a network URL literal.
+///
+/// Network playback support is shell-specific; use this helper for literal URLs
+/// and [`Video::network`](crate::ui::Video::network) when the URL is computed at
+/// runtime.
+#[macro_export]
+macro_rules! video_network {
+    ($url:literal $(,)?) => {{
+        $crate::ui::Video::network($url)
+    }};
 }
 
 /// Binds an action to a reducer in one expression.

--- a/crates/core/fission-core/src/ui/mod.rs
+++ b/crates/core/fission-core/src/ui/mod.rs
@@ -16,5 +16,5 @@ pub use widgets::{
     IosVideoAudioOptions, LayoutBuilder, LazyColumn, Overlay, Positioned, Provider, Radio,
     RichText, RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text,
     TextContent, TextFontStyle, TextInput, TextInputChangePayload, TextRunStyle, Video,
-    VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, ZStack,
+    VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource, ZStack,
 };

--- a/crates/core/fission-core/src/ui/node.rs
+++ b/crates/core/fission-core/src/ui/node.rs
@@ -580,10 +580,10 @@ impl From<Video> for Widget {
     fn from(w: Video) -> Self {
         let node_id = crate::build::current_widget_id()
             .or(w.id)
-            .unwrap_or_else(|| fission_ir::WidgetId::explicit(&w.source));
+            .unwrap_or_else(|| fission_ir::WidgetId::explicit(&w.source.key()));
         crate::build::try_register_video(crate::registry::VideoRegistration {
             node_id,
-            source: w.source.clone(),
+            source: w.source.as_str().to_string(),
             autoplay: w.autoplay,
             loop_playback: w.loop_playback,
             audio: w.audio.clone(),

--- a/crates/core/fission-core/src/ui/widgets/mod.rs
+++ b/crates/core/fission-core/src/ui/widgets/mod.rs
@@ -61,6 +61,7 @@ pub use transform::Transform;
 pub use video::{
     IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,
     IosVideoAudioOptions, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy,
+    VideoSource,
 };
 
 pub mod gesture_detector;

--- a/crates/core/fission-core/src/ui/widgets/video.rs
+++ b/crates/core/fission-core/src/ui/widgets/video.rs
@@ -5,6 +5,7 @@ use fission_ir::{
     WidgetId,
 };
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// A platform-native video player widget.
 ///
@@ -16,23 +17,20 @@ use serde::{Deserialize, Serialize};
 /// # Example
 ///
 /// ```rust,ignore
-/// Video {
-///     source: "https://example.com/clip.mp4".into(),
-///     width: Some(640.0),
-///     height: Some(360.0),
-///     autoplay: true,
-///     loop_playback: false,
-///     audio: VideoAudioOptions::playback(),
-///     ..Default::default()
-/// }
-/// .into();
+/// Video::network("https://example.com/clip.mp4")
+///     .size(640.0, 360.0)
+///     .autoplay(true)
+///     .loop_playback(false)
+///     .audio(VideoAudioOptions::playback())
+///     .into();
 /// ```
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Video {
     /// Stable widget identity (auto-derived from `source` if `None`).
     pub id: Option<WidgetId>,
-    /// URL or asset path to the video file.
-    pub source: String,
+    /// Typed video source consumed by the active shell.
+    pub source: VideoSource,
     /// Fixed width in layout points.
     pub width: Option<f32>,
     /// Fixed height in layout points.
@@ -51,7 +49,158 @@ pub struct Video {
     pub audio: VideoAudioOptions,
 }
 
-impl Video {}
+impl Default for Video {
+    fn default() -> Self {
+        Self {
+            id: None,
+            source: VideoSource::default(),
+            width: None,
+            height: None,
+            autoplay: false,
+            loop_playback: false,
+            audio: VideoAudioOptions::default(),
+        }
+    }
+}
+
+/// Source of media for a [`Video`] widget.
+///
+/// The source is platform-neutral. Shells translate it into the native media
+/// API they own: static and SSR targets emit HTML `<video>` sources, web uses
+/// `HtmlVideoElement`, and native shells use their platform video backends.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VideoSource {
+    /// App-bundled asset path, relative to the app/project asset root.
+    Asset { path: String },
+    /// Local filesystem path.
+    File { path: String },
+    /// Network URL. Backend support depends on the active shell and platform.
+    Network { url: String },
+}
+
+impl Default for VideoSource {
+    fn default() -> Self {
+        Self::Asset {
+            path: String::new(),
+        }
+    }
+}
+
+impl VideoSource {
+    /// Returns the shell-facing source string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Asset { path } | Self::File { path } => path,
+            Self::Network { url } => url,
+        }
+    }
+
+    /// Returns a stable source key for fallback IDs and runtime comparisons.
+    pub fn key(&self) -> String {
+        match self {
+            Self::Asset { path } => format!("asset:{path}"),
+            Self::File { path } => format!("file:{path}"),
+            Self::Network { url } => format!("network:{url}"),
+        }
+    }
+}
+
+impl From<&str> for VideoSource {
+    fn from(source: &str) -> Self {
+        infer_video_source(source)
+    }
+}
+
+impl From<String> for VideoSource {
+    fn from(source: String) -> Self {
+        infer_video_source(&source)
+    }
+}
+
+fn infer_video_source(source: &str) -> VideoSource {
+    if source.contains("://") {
+        VideoSource::Network {
+            url: source.to_string(),
+        }
+    } else if Path::new(source).is_absolute() {
+        VideoSource::File {
+            path: source.to_string(),
+        }
+    } else {
+        VideoSource::Asset {
+            path: source.to_string(),
+        }
+    }
+}
+
+impl Video {
+    /// Creates a video from an app-bundled asset path.
+    pub fn asset(path: impl Into<String>) -> Self {
+        Self::from_source(VideoSource::Asset { path: path.into() })
+    }
+
+    /// Creates a video from a local filesystem path.
+    pub fn file(path: impl Into<String>) -> Self {
+        Self::from_source(VideoSource::File { path: path.into() })
+    }
+
+    /// Creates a video from a network URL.
+    pub fn network(url: impl Into<String>) -> Self {
+        Self::from_source(VideoSource::Network { url: url.into() })
+    }
+
+    /// Creates a video from a typed source.
+    pub fn from_source(source: impl Into<VideoSource>) -> Self {
+        Self {
+            source: source.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Sets an explicit widget identity.
+    pub fn id(mut self, id: WidgetId) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets a fixed width in layout points.
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    /// Sets a fixed height in layout points.
+    pub fn height(mut self, height: f32) -> Self {
+        self.height = Some(height);
+        self
+    }
+
+    /// Sets a fixed width and height in layout points.
+    pub fn size(mut self, width: f32, height: f32) -> Self {
+        self.width = Some(width);
+        self.height = Some(height);
+        self
+    }
+
+    /// Sets whether playback starts automatically.
+    pub fn autoplay(mut self, autoplay: bool) -> Self {
+        self.autoplay = autoplay;
+        self
+    }
+
+    /// Sets whether playback loops after reaching the end.
+    pub fn loop_playback(mut self, loop_playback: bool) -> Self {
+        self.loop_playback = loop_playback;
+        self
+    }
+
+    /// Sets platform-neutral audio behavior.
+    pub fn audio(mut self, audio: VideoAudioOptions) -> Self {
+        self.audio = audio;
+        self
+    }
+}
 
 /// Audio-session behavior requested by a [`Video`] widget.
 ///
@@ -250,7 +399,9 @@ pub enum IosAudioSessionCategoryOption {
 
 impl InternalLower for Video {
     fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {
-        let widget_id = self.id.unwrap_or_else(|| WidgetId::explicit(&self.source));
+        let widget_id = self
+            .id
+            .unwrap_or_else(|| WidgetId::explicit(&self.source.key()));
         let layout_id = cx.widget_node_id(widget_id);
 
         let embed_id = InternalIrBuilder::new(

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 default = []
 tray = ["fission-shell-winit/tray"]
 three-d = ["fission-shell-winit/three-d"]
+video = ["fission-shell-winit/video"]
 
 [dependencies]
 fission-shell = { path = "../fission-shell", version = "0.7.0" }

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [features]
 default = []
 three-d = ["fission-shell-winit/three-d"]
+video = ["fission-shell-winit/video"]
 
 [dependencies]
 fission-shell = { path = "../fission-shell", version = "0.7.0" }

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1710,16 +1710,12 @@ mod tests {
     impl From<VideoPage> for Widget {
         fn from(_component: VideoPage) -> Self {
             let (_ctx, _view) = fission_core::build::current::<TestState>();
-            Video {
-                id: Some(WidgetId::explicit("site-video")),
-                source: "https://example.com/demo.mp4".to_string(),
-                width: Some(320.0),
-                height: Some(180.0),
-                autoplay: true,
-                loop_playback: true,
-                ..Default::default()
-            }
-            .into()
+            Video::network("https://example.com/demo.mp4")
+                .id(WidgetId::explicit("site-video"))
+                .size(320.0, 180.0)
+                .autoplay(true)
+                .loop_playback(true)
+                .into()
         }
     }
 

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [features]
 default = []
 three-d = ["fission-shell-winit/three-d"]
+video = ["fission-shell-winit/video"]
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 default = []
 tray = ["dep:tray-icon"]
 three-d = ["dep:fission-3d"]
+video = ["dep:gstreamer", "dep:gstreamer-video"]
 
 [dependencies]
 fission-shell = { path = "../fission-shell", version = "0.7.0" }
@@ -64,8 +65,8 @@ winit = { package = "fission-winit", version = "0.30.13-fission.1", features = [
 windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Media_MediaFoundation", "Win32_System_Com", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-gstreamer = "0.25"
-gstreamer-video = "0.25"
+gstreamer = { version = "0.25", optional = true }
+gstreamer-video = { version = "0.25", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios", target_os = "macos"))'.dependencies]
 rxing = { version = "0.9", default-features = false, features = ["image", "image_formats", "decoders", "encoding_rs", "full_barcode_format_support", "multi_barcode_readers"] }

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -8,7 +8,7 @@ use winit::window::Window;
 pub use android::AndroidVideoBackend;
 #[cfg(target_os = "ios")]
 pub use ios::IosVideoBackend;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "video"))]
 pub use linux::LinuxVideoBackend;
 #[cfg(target_os = "macos")]
 pub use mac::MacVideoBackend;
@@ -47,14 +47,22 @@ pub fn create_video_backend(window: Option<&Window>) -> Arc<dyn VideoBackend> {
     #[cfg(target_os = "windows")]
     panic!("Fission Video for Windows requires a Win32 window handle");
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "video"))]
     if let Some(window) = window {
         if let Some(backend) = LinuxVideoBackend::try_new(window) {
             return Arc::new(backend);
         }
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "video"))]
     panic!("Fission Video for Linux requires an X11 or Wayland window handle");
+
+    #[cfg(all(target_os = "linux", not(feature = "video")))]
+    {
+        let _ = window;
+        return Arc::new(unsupported::UnsupportedVideoBackend::new(
+            "Fission native Video on Linux requires the `video` feature and GStreamer development packages. Enable `fission = { version = \"...\", features = [\"desktop\", \"video\"] }`; on Debian/Ubuntu install `sudo apt install libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev`. Static site, SSR, and Web video do not require this native backend.",
+        ));
+    }
 
     #[cfg(target_os = "android")]
     {
@@ -71,11 +79,77 @@ pub fn create_video_backend(window: Option<&Window>) -> Arc<dyn VideoBackend> {
         target_os = "macos",
         target_os = "ios",
         target_os = "windows",
-        target_os = "linux",
+        all(target_os = "linux", feature = "video"),
         target_os = "android",
         target_arch = "wasm32"
     )))]
     panic!("Fission Video is unsupported on this platform");
+}
+
+#[cfg(all(target_os = "linux", not(feature = "video")))]
+mod unsupported {
+    use super::{VideoBackend, VideoEvent, VideoPlayer};
+    use fission_core::ui::VideoAudioOptions;
+    use fission_shell::VideoSurfaceFrame;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    pub struct UnsupportedVideoBackend {
+        message: &'static str,
+        next_id: AtomicU64,
+    }
+
+    impl UnsupportedVideoBackend {
+        pub fn new(message: &'static str) -> Self {
+            Self {
+                message,
+                next_id: AtomicU64::new(1),
+            }
+        }
+    }
+
+    impl VideoBackend for UnsupportedVideoBackend {
+        fn create_player(&self, _source: &str, _audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
+            Box::new(UnsupportedVideoPlayer {
+                surface_id: self.next_id.fetch_add(1, Ordering::Relaxed),
+                message: self.message,
+                error_sent: false,
+            })
+        }
+
+        fn present_surfaces(&self, _frames: &[VideoSurfaceFrame]) {}
+    }
+
+    struct UnsupportedVideoPlayer {
+        surface_id: u64,
+        message: &'static str,
+        error_sent: bool,
+    }
+
+    impl VideoPlayer for UnsupportedVideoPlayer {
+        fn play(&mut self) {}
+        fn pause(&mut self) {}
+        fn stop(&mut self) {}
+        fn position(&self) -> u64 {
+            0
+        }
+        fn duration(&self) -> Option<u64> {
+            None
+        }
+        fn surface_id(&self) -> u64 {
+            self.surface_id
+        }
+        fn poll_events(&mut self) -> Vec<VideoEvent> {
+            if self.error_sent {
+                return Vec::new();
+            }
+            self.error_sent = true;
+            vec![VideoEvent::Error(self.message.to_string())]
+        }
+        fn seek_to(&mut self, _position_ms: u64) {}
+        fn set_rate(&mut self, _rate: f32) {}
+        fn set_volume(&mut self, _volume: f32) {}
+        fn set_muted(&mut self, _muted: bool) {}
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -211,14 +285,7 @@ mod mac {
         fn create_player(&self, source: &str, _audio: &VideoAudioOptions) -> Box<dyn VideoPlayer> {
             let resolved_source = resolve_video_source(source);
             let pending_error = resolved_source.error_message();
-            let player = unsafe {
-                create_av_player(
-                    resolved_source
-                        .resolved_path
-                        .as_deref()
-                        .unwrap_or_else(|| Path::new(source)),
-                )
-            };
+            let player = unsafe { create_av_player(&resolved_source, source) };
             let ended_flag = Arc::new(AtomicBool::new(false));
             let observer = unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
@@ -519,11 +586,27 @@ mod mac {
         }
     }
 
-    unsafe fn create_av_player(source_path: &Path) -> StrongPtr {
-        let url = file_url_from_path(source_path);
+    unsafe fn create_av_player(source: &ResolvedVideoSource, fallback: &str) -> StrongPtr {
+        let url = if let Some(url) = source.remote_url.as_deref() {
+            url_from_string(url)
+        } else {
+            file_url_from_path(
+                source
+                    .resolved_path
+                    .as_deref()
+                    .unwrap_or_else(|| Path::new(fallback)),
+            )
+        };
         let player: id = msg_send![class!(AVPlayer), playerWithURL: url];
         // playerWithURL returns an autoreleased object; retain to own it.
         StrongPtr::retain(player)
+    }
+
+    fn url_from_string(url: &str) -> id {
+        unsafe {
+            let ns_string = NSString::alloc(nil).init_str(url);
+            msg_send![class!(NSURL), URLWithString: ns_string]
+        }
     }
 
     fn file_url_from_path(path: &Path) -> id {
@@ -536,6 +619,7 @@ mod mac {
     struct ResolvedVideoSource {
         requested: String,
         resolved_path: Option<PathBuf>,
+        remote_url: Option<String>,
         diagnostic: Option<String>,
     }
 
@@ -562,6 +646,7 @@ mod mac {
             return ResolvedVideoSource {
                 requested,
                 resolved_path: None,
+                remote_url: None,
                 diagnostic: Some("video source path is empty".to_string()),
             };
         }
@@ -569,10 +654,8 @@ mod mac {
             return ResolvedVideoSource {
                 requested,
                 resolved_path: None,
-                diagnostic: Some(
-                    "video backend only supports local filesystem paths for media sources"
-                        .to_string(),
-                ),
+                remote_url: Some(trimmed.to_string()),
+                diagnostic: None,
             };
         }
 
@@ -585,6 +668,7 @@ mod mac {
                     return ResolvedVideoSource {
                         requested,
                         resolved_path: None,
+                        remote_url: None,
                         diagnostic: Some(format!(
                             "failed to resolve relative video source against current directory: {error}"
                         )),
@@ -607,6 +691,7 @@ mod mac {
         ResolvedVideoSource {
             requested,
             resolved_path: Some(resolved_path),
+            remote_url: None,
             diagnostic,
         }
     }
@@ -839,14 +924,7 @@ mod ios {
                     Err(error) => pending_error = pending_error.or(Some(error)),
                 }
             }
-            let player = unsafe {
-                create_av_player(
-                    resolved_source
-                        .resolved_path
-                        .as_deref()
-                        .unwrap_or_else(|| Path::new(source)),
-                )
-            };
+            let player = unsafe { create_av_player(&resolved_source, source) };
             let ended_flag = Arc::new(AtomicBool::new(false));
             let observer = unsafe { register_end_observer(*player, Arc::clone(&ended_flag)) };
             let player_id = self.registry.register(player);
@@ -1132,10 +1210,26 @@ mod ios {
         }
     }
 
-    unsafe fn create_av_player(source_path: &Path) -> StrongPtr {
-        let url = file_url_from_path(source_path);
+    unsafe fn create_av_player(source: &ResolvedVideoSource, fallback: &str) -> StrongPtr {
+        let url = if let Some(url) = source.remote_url.as_deref() {
+            url_from_string(url)
+        } else {
+            file_url_from_path(
+                source
+                    .resolved_path
+                    .as_deref()
+                    .unwrap_or_else(|| Path::new(fallback)),
+            )
+        };
         let player: Id = msg_send![class!(AVPlayer), playerWithURL: url];
         StrongPtr::retain(player)
+    }
+
+    fn url_from_string(url: &str) -> Id {
+        unsafe {
+            let ns_url = ns_string(url);
+            msg_send![class!(NSURL), URLWithString: ns_url]
+        }
     }
 
     fn file_url_from_path(path: &Path) -> Id {
@@ -1256,6 +1350,7 @@ mod ios {
     struct ResolvedVideoSource {
         requested: String,
         resolved_path: Option<PathBuf>,
+        remote_url: Option<String>,
         diagnostic: Option<String>,
     }
 
@@ -1282,6 +1377,7 @@ mod ios {
             return ResolvedVideoSource {
                 requested,
                 resolved_path: None,
+                remote_url: None,
                 diagnostic: Some("video source path is empty".to_string()),
             };
         }
@@ -1289,10 +1385,8 @@ mod ios {
             return ResolvedVideoSource {
                 requested,
                 resolved_path: None,
-                diagnostic: Some(
-                    "native Apple video backend only supports local filesystem paths for media sources"
-                        .to_string(),
-                ),
+                remote_url: Some(trimmed.to_string()),
+                diagnostic: None,
             };
         }
         let candidate = if Path::new(trimmed).is_absolute() {
@@ -1304,6 +1398,7 @@ mod ios {
                     return ResolvedVideoSource {
                         requested,
                         resolved_path: None,
+                        remote_url: None,
                         diagnostic: Some(format!(
                             "failed to resolve relative video source against current directory: {error}"
                         )),
@@ -1324,6 +1419,7 @@ mod ios {
         ResolvedVideoSource {
             requested,
             resolved_path: Some(resolved_path),
+            remote_url: None,
             diagnostic,
         }
     }
@@ -1849,7 +1945,7 @@ mod windows {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "video"))]
 mod linux {
     use super::{VideoBackend, VideoEvent, VideoPlayer};
     use fission_core::ui::VideoAudioOptions;

--- a/crates/tools/fission-test/tests/embeds.rs
+++ b/crates/tools/fission-test/tests/embeds.rs
@@ -25,15 +25,13 @@ fn display_surfaces(harness: &TestHarness<EmbedState>) -> Vec<DisplayOp> {
 #[test]
 fn video_embed_registers_runtime_state_and_draws_surface() {
     let widget_id = WidgetId::explicit("test.video");
-    let mut harness = TestHarness::new(EmbedState).with_root_widget(Video {
-        id: Some(widget_id),
-        source: "fixtures/demo.mp4".into(),
-        width: Some(320.0),
-        height: Some(180.0),
-        autoplay: true,
-        loop_playback: true,
-        ..Default::default()
-    });
+    let mut harness = TestHarness::new(EmbedState).with_root_widget(
+        Video::asset("fixtures/demo.mp4")
+            .id(widget_id)
+            .size(320.0, 180.0)
+            .autoplay(true)
+            .loop_playback(true),
+    );
 
     harness.pump().expect("pump video embed");
 

--- a/documentation/content/reference/widgets/widget-pages/video.mdx
+++ b/documentation/content/reference/widgets/widget-pages/video.mdx
@@ -38,15 +38,10 @@ use fission::WidgetId;
 let video_id = WidgetId::explicit("welcome_video");
 let controls = ctx.video_controls(video_id);
 
-let player = Video {
-    id: Some(video_id),
-    source: "assets/welcome.mp4".into(),
-    width: Some(640.0),
-    height: Some(360.0),
-    autoplay: false,
-    loop_playback: false,
-    audio: VideoAudioOptions::system_default(),
-}
+let player = video_asset!("assets/welcome.mp4")
+    .id(video_id)
+    .size(640.0, 360.0)
+    .audio(VideoAudioOptions::system_default())
 .into();
 
 let play_button = Button {
@@ -66,7 +61,7 @@ The useful part here is the separation of responsibilities.
 | Field | Type | Meaning | Notes and default behavior |
 | --- | --- | --- | --- |
 | `id` | `Option<WidgetId>` | Stable identity for this video surface and its control actions. | Defaults to an id derived from `source`. Provide an explicit id when you need predictable controls or multiple instances of the same source. |
-| `source` | `String` | Video media source path or web address string. | Required. The backend ultimately decides how that source is resolved. The checked-in winit video backend currently expects local filesystem media paths. |
+| `source` | `VideoSource` | Typed video media source: asset, file, or network URL. | Set this through `Video::asset`, `Video::file`, `Video::network`, `Video::from_source`, or the checked literal helpers. Direct `Video { ... }` construction is intentionally not part of the app-facing API. |
 | `width` | `Option<f32>` | Requested layout width. | Defaults to `None`. |
 | `height` | `Option<f32>` | Requested layout height. | Defaults to `None`. |
 | `autoplay` | `bool` | Whether playback should begin automatically when possible. | Defaults to `false`. On initial registration, the runtime marks the video as playing when autoplay is requested. |
@@ -80,36 +75,28 @@ Audio behavior is a product decision. Fission therefore does not hard-code a sin
 Use the default when the app should inherit the host platform's normal audio behavior:
 
 ```rust
-Video {
-    source: "assets/inline-preview.mp4".into(),
-    audio: VideoAudioOptions::system_default(),
-    ..Default::default()
-}
+Video::asset("assets/inline-preview.mp4")
+    .audio(VideoAudioOptions::system_default())
 ```
 
 Use foreground playback behavior when the video is the primary media experience:
 
 ```rust
-Video {
-    source: "assets/lesson.mp4".into(),
-    audio: VideoAudioOptions::playback(),
-    ..Default::default()
-}
+Video::asset("assets/lesson.mp4").audio(VideoAudioOptions::playback())
 ```
 
 On iOS that maps to `AVAudioSessionCategoryPlayback` and activates the session on first play, which is the equivalent of configuring playback audio manually in the host shell. Apps that need a more precise iOS policy can use the platform escape hatch:
 
 ```rust
-Video {
-    source: "assets/training.mp4".into(),
-    audio: VideoAudioOptions::playback()
+Video::asset("assets/training.mp4")
+    .audio(
+        VideoAudioOptions::playback()
         .mix_with_others(true)
         .ios(
             IosVideoAudioOptions::mode(IosAudioSessionMode::MoviePlayback)
                 .with_option(IosAudioSessionCategoryOption::MixWithOthers),
         ),
-    ..Default::default()
-}
+    )
 ```
 
 If a platform cannot represent a requested option, the shell treats it as a backend limitation rather than changing the cross-platform widget contract.
@@ -128,11 +115,25 @@ What varies is the host API used by each target for this particular media surfac
 
 In the winit shell path, macOS and iOS use AVFoundation player layers, Windows uses Media Foundation, Linux uses GStreamer, Android uses the generated `FissionActivity` Java host bridge backed by Android media playback, and Web uses a browser `<video>` element positioned over the canvas. Static site and SSR output ordinary HTML video markup. Terminal does not support embedded video surfaces. iOS audio-session policy is configured only when requested through `VideoAudioOptions`; the default does not force `AVAudioSessionCategoryPlayback`.
 
+Native Linux video is behind the `video` Cargo feature so ordinary desktop apps do not need GStreamer development packages unless they use embedded video:
+
+```toml
+fission = { version = "0.7", default-features = false, features = ["desktop", "video"] }
+```
+
+On Debian or Ubuntu, enabling that feature requires:
+
+```bash
+sudo apt install libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+```
+
 The right way to read those differences is very narrow: codec support, local-file access, autoplay rules, z-ordering, and hardware decode behavior are backend-level concerns for this one host-backed media surface. They do not change the shared Fission widget, state, reducer, or layout model.
 
 ## Specific guidance
 
 Give production-critical videos explicit ids and build controls around `ctx.video_controls(...)`. That keeps your commands stable even if the surrounding layout changes.
+
+For compile-time checked literal sources, use `video_asset!("relative/path.mp4")` for app assets or `video_file!(...)` for local file literals. These helpers only fail when the literal path cannot be resolved at compile time. Runtime strings should use `Video::asset`, `Video::file`, or `Video::network` and will be validated by the active shell backend at runtime.
 
 Treat playback user interface as ordinary app user interface. Buttons, labels, progress displays, and surrounding layout still belong to your widget tree and app state, even though the media surface itself is host-managed.
 

--- a/examples/embed-video/Cargo.toml
+++ b/examples/embed-video/Cargo.toml
@@ -8,7 +8,7 @@ name = "embed_video"
 
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../crates/authoring/fission", default-features = false, features = ["desktop"] }
+fission = { path = "../../crates/authoring/fission", default-features = false, features = ["desktop", "video"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/examples/embed-video/src/lib.rs
+++ b/examples/embed-video/src/lib.rs
@@ -20,15 +20,14 @@ impl From<VideoEmbedApp> for Widget {
                     .size(14.0)
                     .color(tokens.text_secondary)
                     .into(),
-                Container::new(Video {
-                    id: Some(WidgetId::explicit("embed-video.demo")),
-                    source: concat!(env!("CARGO_MANIFEST_DIR"), "/assets/demo.mp4").into(),
-                    width: Some(480.0),
-                    height: Some(270.0),
-                    autoplay: true,
-                    loop_playback: true,
-                    audio: VideoAudioOptions::playback(),
-                })
+                Container::new(
+                    video_file!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/demo.mp4"))
+                        .id(WidgetId::explicit("embed-video.demo"))
+                        .size(480.0, 270.0)
+                        .autoplay(true)
+                        .loop_playback(true)
+                        .audio(VideoAudioOptions::playback()),
+                )
                 .width(480.0)
                 .height(270.0)
                 .border(tokens.border, 1.0)

--- a/examples/inbox/Cargo.toml
+++ b/examples/inbox/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.7.0"
 edition = "2021"
 
 [dependencies]
-fission = { path = "../../crates/authoring/fission", default-features = false, features = ["desktop"] }
+fission = { path = "../../crates/authoring/fission", default-features = false, features = ["desktop", "video"] }
 fission-ir = { path = "../../crates/core/fission-ir" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"

--- a/examples/inbox/src/components/email_detail.rs
+++ b/examples/inbox/src/components/email_detail.rs
@@ -335,13 +335,7 @@ impl From<EmailDetail> for Widget {
                         .into(),
                         AspectRatio {
                             ratio: 16.0 / 9.0,
-                            child: Video {
-                                source: "docs/video1.mp4".into(),
-                                autoplay: false,
-                                loop_playback: false,
-                                ..Default::default()
-                            }
-                            .into(),
+                            child: Video::asset("docs/video1.mp4").into(),
                         }
                         .into(),
                     ],


### PR DESCRIPTION
## Summary

This is a follow-up to the native video backend work. It keeps `Video` as a first-class cross-target widget while avoiding unconditional native Linux video dependencies for apps that do not use embedded video.

- Make `Video` app construction go through typed source constructors instead of external struct literals:
  - `Video::asset(...)`
  - `Video::file(...)`
  - `Video::network(...)`
  - `Video::from_source(VideoSource::...)`
- Add checked literal helpers:
  - `video_asset!("assets/demo.mp4")` checks under `CARGO_MANIFEST_DIR` at compile time.
  - `video_file!(...)` checks the literal path with `include_bytes!` at compile time.
  - `video_network!("https://...")` provides the matching literal helper for URL sources.
- Add a public `VideoSource` type so asset, file, and network sources are explicit in app code and docs.
- Gate Linux native video dependencies behind a `video` feature:
  - `fission = { default-features = false, features = ["desktop", "video"] }`
  - propagated through `fission`, desktop/mobile/web shell crates, and `fission-shell-winit`.
- Keep static site, SSR, and Web video independent from the native Linux GStreamer backend.
- Update video examples, inbox, embed tests, static-site tests, and the Video reference page for the new API.

## Behavior

Direct external `Video { ... }` construction is intentionally no longer the app-facing API. The struct is now `#[non_exhaustive]`, so app code uses the constructors above while Fission keeps room to evolve source metadata without another source-breaking literal field shape.

This does **not** block string literals. Runtime string values still work through `Video::asset`, `Video::file`, and `Video::network`. Compile-time existence checks apply only when the app opts into the literal helper macros, because variables cannot be resolved by Rust at compile time.

On Linux native shells, omitting the `video` feature no longer pulls in GStreamer development dependencies. If a native Linux app mounts a `Video` without enabling the feature, the shell reports a clear unsupported-backend diagnostic explaining the feature and Debian/Ubuntu packages to install.

## Notes

- macOS and iOS URL handling now passes network sources to `AVPlayer` as `NSURL URLWithString`, so `Video::network(...)` is not rejected by the Apple backend.
- The lower runtime `VideoRegistration` still stores the shell-facing string source so existing runtime state and test APIs stay narrow.
- Exact compile-time detection of “Video was used but native Linux video feature is missing” is not enforced in core because the same `Video` widget is valid for Static site, SSR, and Web targets without the native GStreamer backend. The hard compile-time check is therefore scoped to literal file/asset existence via the macros.

## Validation

Run from a clean worktree based on `origin/main`:

- `cargo check -p fission-core`
- `cargo check -p fission-shell-winit --no-default-features`
- `cargo check -p fission --features desktop`
- `cargo check -p fission --features "desktop video"`
- `cargo check -p embed-video`
- `cargo check -p inbox`
- `cargo test -p fission-test --test embeds`
- `cargo test -p fission-shell-site --no-run`
- `git diff --check`
