### PR TITLE
Expose semantic identifiers on interactive widgets

### DIFF
--- a/crates/authoring/fission-widgets/tests/widget_invariants.rs
+++ b/crates/authoring/fission-widgets/tests/widget_invariants.rs
@@ -128,7 +128,8 @@ fn test_button_widget_lower_with_child_and_semantics() {
             scroll_padding: None,
         }),
         ..Default::default()
-    };
+    }
+    .semantics_identifier("actions.primary");
 
     let env = Env::default();
     let runtime_state = RuntimeState::default();
@@ -144,6 +145,8 @@ fn test_button_widget_lower_with_child_and_semantics() {
     assert!(matches!(semantics_node.op, Op::Semantics(_)));
 
     if let Op::Semantics(s_op) = &semantics_node.op {
+        assert_eq!(s_op.identifier.as_deref(), Some("actions.primary"));
+        assert_eq!(s_op.label.as_deref(), Some("My Button"));
         assert_eq!(s_op.actions.entries.len(), 1);
         assert_eq!(
             s_op.actions.entries[0].action_id,

--- a/crates/authoring/fission-widgets/tests/widget_tests.rs
+++ b/crates/authoring/fission-widgets/tests/widget_tests.rs
@@ -1,7 +1,7 @@
 use fission_core::internal::{InternalLower, InternalLoweringCx};
 use fission_core::ui::GestureDetector;
-use fission_core::{Env, RuntimeState};
-use fission_ir::{Op, Role};
+use fission_core::{ActionEnvelope, ActionId, Env, RuntimeState};
+use fission_ir::{semantics::ActionTrigger, Op, Role};
 use fission_widgets::{Checkbox, Radio, Slider, Spacer, Switch};
 
 #[test]
@@ -58,8 +58,15 @@ fn test_checkbox_lowering() {
 
 #[test]
 fn test_radio_lowering_preserves_semantics_identifier() {
+    let action_id = ActionId::from_name("fission_widgets_test::SelectPrimaryChoice");
+    let expected_action_id = action_id.as_u128();
     let radio = Radio {
         checked: true,
+        label: Some("Primary".into()),
+        on_select: Some(ActionEnvelope {
+            id: action_id,
+            payload: vec![1],
+        }),
         ..Default::default()
     }
     .semantics_identifier("choices.primary");
@@ -71,10 +78,14 @@ fn test_radio_lowering_preserves_semantics_identifier() {
 
     let node = cx.ir.nodes.get(&id).unwrap();
     if let Op::Semantics(s) = &node.op {
-        assert_eq!(s.role, Role::Checkbox);
+        assert_eq!(s.role, Role::Radio);
         assert_eq!(s.identifier.as_deref(), Some("choices.primary"));
         assert_eq!(s.checked, Some(true));
+        assert_eq!(s.label.as_deref(), Some("Primary"));
         assert!(s.focusable);
+        assert!(s.actions.entries.iter().any(|entry| {
+            entry.trigger == ActionTrigger::Default && entry.action_id == expected_action_id
+        }));
     } else {
         panic!("Radio should lower to Semantics root");
     }

--- a/crates/authoring/fission-widgets/tests/widget_tests.rs
+++ b/crates/authoring/fission-widgets/tests/widget_tests.rs
@@ -1,7 +1,8 @@
 use fission_core::internal::{InternalLower, InternalLoweringCx};
+use fission_core::ui::GestureDetector;
 use fission_core::{Env, RuntimeState};
 use fission_ir::{Op, Role};
-use fission_widgets::{Checkbox, Slider};
+use fission_widgets::{Checkbox, Radio, Slider, Spacer, Switch};
 
 #[test]
 fn test_slider_lowering() {
@@ -10,7 +11,8 @@ fn test_slider_lowering() {
         min: 0.0,
         max: 1.0,
         ..Default::default()
-    };
+    }
+    .semantics_identifier("settings.volume");
 
     let env = Env::default();
     let runtime = RuntimeState::default();
@@ -21,6 +23,7 @@ fn test_slider_lowering() {
     // Slider.lower wraps in Semantics
     if let Op::Semantics(s) = &node.op {
         assert_eq!(s.role, Role::Slider);
+        assert_eq!(s.identifier.as_deref(), Some("settings.volume"));
         assert_eq!(s.current_value, Some(0.5));
         assert_eq!(s.min_value, Some(0.0));
         assert_eq!(s.max_value, Some(1.0));
@@ -35,7 +38,8 @@ fn test_checkbox_lowering() {
     let cb = Checkbox {
         checked: true,
         ..Default::default()
-    };
+    }
+    .semantics_identifier("settings.enabled");
 
     let env = Env::default();
     let runtime = RuntimeState::default();
@@ -45,9 +49,82 @@ fn test_checkbox_lowering() {
     let node = cx.ir.nodes.get(&id).unwrap();
     if let Op::Semantics(s) = &node.op {
         assert_eq!(s.role, Role::Checkbox);
+        assert_eq!(s.identifier.as_deref(), Some("settings.enabled"));
         assert_eq!(s.checked, Some(true));
     } else {
         panic!("Checkbox should lower to Semantics root");
+    }
+}
+
+#[test]
+fn test_radio_lowering_preserves_semantics_identifier() {
+    let radio = Radio {
+        checked: true,
+        ..Default::default()
+    }
+    .semantics_identifier("choices.primary");
+
+    let env = Env::default();
+    let runtime = RuntimeState::default();
+    let mut cx = InternalLoweringCx::new(&env, &runtime, None, None);
+    let id = radio.lower(&mut cx);
+
+    let node = cx.ir.nodes.get(&id).unwrap();
+    if let Op::Semantics(s) = &node.op {
+        assert_eq!(s.role, Role::Checkbox);
+        assert_eq!(s.identifier.as_deref(), Some("choices.primary"));
+        assert_eq!(s.checked, Some(true));
+        assert!(s.focusable);
+    } else {
+        panic!("Radio should lower to Semantics root");
+    }
+}
+
+#[test]
+fn test_switch_lowering_preserves_semantics_identifier() {
+    let switch = Switch {
+        checked: true,
+        ..Default::default()
+    }
+    .semantics_identifier("settings.dark_mode");
+
+    let env = Env::default();
+    let runtime = RuntimeState::default();
+    let mut cx = InternalLoweringCx::new(&env, &runtime, None, None);
+    let id = switch.lower(&mut cx);
+
+    let node = cx.ir.nodes.get(&id).unwrap();
+    if let Op::Semantics(s) = &node.op {
+        assert_eq!(s.role, Role::Switch);
+        assert_eq!(s.identifier.as_deref(), Some("settings.dark_mode"));
+        assert_eq!(s.checked, Some(true));
+        assert!(s.focusable);
+    } else {
+        panic!("Switch should lower to Semantics root");
+    }
+}
+
+#[test]
+fn test_gesture_detector_lowering_preserves_semantics_identifier() {
+    let detector = GestureDetector {
+        drag_payload: Some(vec![1, 2, 3]),
+        child: Spacer::default().into(),
+        ..Default::default()
+    }
+    .semantics_identifier("canvas.drag_handle");
+
+    let env = Env::default();
+    let runtime = RuntimeState::default();
+    let mut cx = InternalLoweringCx::new(&env, &runtime, None, None);
+    let id = detector.lower(&mut cx);
+
+    let node = cx.ir.nodes.get(&id).unwrap();
+    if let Op::Semantics(s) = &node.op {
+        assert_eq!(s.identifier.as_deref(), Some("canvas.drag_handle"));
+        assert!(s.draggable);
+        assert_eq!(s.drag_payload.as_deref(), Some([1, 2, 3].as_slice()));
+    } else {
+        panic!("GestureDetector should lower to Semantics root");
     }
 }
 

--- a/crates/core/fission-core/src/ui/widgets/button.rs
+++ b/crates/core/fission-core/src/ui/widgets/button.rs
@@ -287,6 +287,15 @@ pub struct Button {
 }
 
 impl Button {
+    /// Sets the stable identifier exposed on the button's semantics node.
+    ///
+    /// This preserves any custom semantics already configured on the button.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        let semantics = self.semantics.get_or_insert_with(default_button_semantics);
+        semantics.identifier = Some(identifier.into());
+        self
+    }
+
     pub fn background_fill(mut self, fill: Fill) -> Self {
         self.background_fill = Some(fill);
         self

--- a/crates/core/fission-core/src/ui/widgets/checkbox.rs
+++ b/crates/core/fission-core/src/ui/widgets/checkbox.rs
@@ -28,6 +28,9 @@ use serde::{Deserialize, Serialize};
 pub struct Checkbox {
     /// Explicit node identity.
     pub id: Option<WidgetId>,
+    /// Stable identifier exposed on the checkbox's interactive semantics node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantics_identifier: Option<String>,
     /// Current checked state.
     pub checked: bool,
     /// Action dispatched when the checkbox is tapped.
@@ -36,7 +39,13 @@ pub struct Checkbox {
     pub label: Option<String>,
 }
 
-impl Checkbox {}
+impl Checkbox {
+    /// Sets the stable identifier exposed to accessibility and test tooling.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
+}
 
 impl InternalLower for Checkbox {
     fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {
@@ -198,7 +207,7 @@ impl InternalLower for Checkbox {
         let mut semantics = fission_ir::Semantics {
             role: fission_ir::Role::Checkbox,
             label: self.label.clone(),
-            identifier: None,
+            identifier: self.semantics_identifier.clone(),
             value: Some(if self.checked {
                 "true".into()
             } else {

--- a/crates/core/fission-core/src/ui/widgets/gesture_detector.rs
+++ b/crates/core/fission-core/src/ui/widgets/gesture_detector.rs
@@ -37,6 +37,9 @@ use serde::{Deserialize, Serialize};
 pub struct GestureDetector {
     /// Explicit node identity.
     pub id: Option<WidgetId>,
+    /// Stable identifier exposed on the detector's interactive semantics node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantics_identifier: Option<String>,
     /// The child widget that receives gesture detection.
     pub child: Widget,
     /// Action dispatched on a single tap (pointer up after pointer down).
@@ -72,6 +75,7 @@ impl Default for GestureDetector {
     fn default() -> Self {
         Self {
             id: None,
+            semantics_identifier: None,
             child: crate::ui::widgets::spacer::Spacer::default().into(),
             on_tap: None,
             on_double_tap: None,
@@ -97,6 +101,12 @@ impl GestureDetector {
             ..Default::default()
         }
     }
+
+    /// Sets the stable identifier exposed to accessibility and test tooling.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
 }
 
 impl InternalLower for GestureDetector {
@@ -110,7 +120,7 @@ impl InternalLower for GestureDetector {
         let mut semantics = Semantics {
             role: Role::Generic,
             label: None,
-            identifier: None,
+            identifier: self.semantics_identifier.clone(),
             value: None,
             actions: Default::default(),
             action_scope_id: None,

--- a/crates/core/fission-core/src/ui/widgets/radio.rs
+++ b/crates/core/fission-core/src/ui/widgets/radio.rs
@@ -233,7 +233,7 @@ impl InternalLower for Radio {
         cx.pop_scope();
 
         let mut semantics = fission_ir::Semantics {
-            role: fission_ir::Role::Checkbox, // Reuse Checkbox for Radio behavior?
+            role: fission_ir::Role::Radio,
             label: self.label.clone(),
             identifier: self.semantics_identifier.clone(),
             value: Some(if self.checked {

--- a/crates/core/fission-core/src/ui/widgets/radio.rs
+++ b/crates/core/fission-core/src/ui/widgets/radio.rs
@@ -33,6 +33,9 @@ use serde::{Deserialize, Serialize};
 pub struct Radio {
     /// Explicit node identity.
     pub id: Option<WidgetId>,
+    /// Stable identifier exposed on the radio's interactive semantics node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantics_identifier: Option<String>,
     /// Whether this radio button is currently selected.
     pub checked: bool,
     /// Action dispatched when this radio button is tapped.
@@ -41,7 +44,13 @@ pub struct Radio {
     pub label: Option<String>,
 }
 
-impl Radio {}
+impl Radio {
+    /// Sets the stable identifier exposed to accessibility and test tooling.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
+}
 
 impl InternalLower for Radio {
     fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {
@@ -226,7 +235,7 @@ impl InternalLower for Radio {
         let mut semantics = fission_ir::Semantics {
             role: fission_ir::Role::Checkbox, // Reuse Checkbox for Radio behavior?
             label: self.label.clone(),
-            identifier: None,
+            identifier: self.semantics_identifier.clone(),
             value: Some(if self.checked {
                 "true".into()
             } else {

--- a/crates/core/fission-core/src/ui/widgets/slider.rs
+++ b/crates/core/fission-core/src/ui/widgets/slider.rs
@@ -33,6 +33,9 @@ use serde::{Deserialize, Serialize};
 pub struct Slider {
     /// Explicit node identity.
     pub id: Option<WidgetId>,
+    /// Stable identifier exposed on the slider's interactive semantics node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantics_identifier: Option<String>,
     /// Current value (clamped to `[min, max]`).
     pub value: f32,
     /// Minimum value (default: 0.0).
@@ -43,12 +46,19 @@ pub struct Slider {
     pub on_change: Option<ActionEnvelope>,
 }
 
-impl Slider {}
+impl Slider {
+    /// Sets the stable identifier exposed to accessibility and test tooling.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
+}
 
 impl Default for Slider {
     fn default() -> Self {
         Self {
             id: None,
+            semantics_identifier: None,
             value: 0.0,
             min: 0.0,
             max: 1.0,
@@ -229,7 +239,7 @@ impl InternalLower for Slider {
         let mut semantics = fission_ir::Semantics {
             role: fission_ir::Role::Slider,
             label: None,
-            identifier: None,
+            identifier: self.semantics_identifier.clone(),
             value: Some(format!("{:.2}", self.value)),
             actions: Default::default(),
             action_scope_id: None,

--- a/crates/core/fission-core/src/ui/widgets/switch.rs
+++ b/crates/core/fission-core/src/ui/widgets/switch.rs
@@ -26,13 +26,22 @@ use serde::{Deserialize, Serialize};
 pub struct Switch {
     /// Explicit node identity.
     pub id: Option<WidgetId>,
+    /// Stable identifier exposed on the switch's interactive semantics node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantics_identifier: Option<String>,
     /// Current on/off state.
     pub checked: bool,
     /// Action dispatched when the switch is tapped.
     pub on_toggle: Option<ActionEnvelope>,
 }
 
-impl Switch {}
+impl Switch {
+    /// Sets the stable identifier exposed to accessibility and test tooling.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
+}
 
 impl InternalLower for Switch {
     fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {
@@ -147,7 +156,7 @@ impl InternalLower for Switch {
         let mut semantics = fission_ir::Semantics {
             role: fission_ir::Role::Switch,
             label: None,
-            identifier: None,
+            identifier: self.semantics_identifier.clone(),
             value: Some(if self.checked {
                 "true".into()
             } else {

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -284,6 +284,9 @@ pub(crate) fn text_input_toolbar_button_id(
 pub struct TextInput {
     /// Explicit node identity (used for focus tracking and scroll state).
     pub id: Option<WidgetId>,
+    /// Stable identifier exposed on the input's interactive semantics node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantics_identifier: Option<String>,
     /// The current text value (controlled by the application).
     pub value: String,
     /// Optional label shown above the field.
@@ -468,6 +471,12 @@ pub struct TextInput {
 }
 
 impl TextInput {
+    /// Sets the stable identifier exposed to accessibility and test tooling.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
+
     pub fn value(mut self, v: impl Into<String>) -> Self {
         self.value = v.into();
         self
@@ -786,6 +795,7 @@ impl Default for TextInput {
     fn default() -> Self {
         Self {
             id: None,
+            semantics_identifier: None,
             value: String::new(),
             label: None,
             placeholder: None,
@@ -1823,7 +1833,7 @@ impl InternalLower for TextInput {
         let mut semantics = Semantics {
             role: Role::TextInput,
             label: resolved_label.clone().or(resolved_placeholder.clone()),
-            identifier: None,
+            identifier: self.semantics_identifier.clone(),
             value: Some(self.value.clone()),
             actions: Default::default(),
             action_scope_id: None,

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -367,6 +367,7 @@ fn text_input_lowers_cursor_and_semantics_overrides() {
             scroll_padding: Some([12.0, 13.0, 14.0, 15.0]),
             ..Default::default()
         }
+        .semantics_identifier("profile.email")
         .into(),
     );
 
@@ -382,6 +383,7 @@ fn text_input_lowers_cursor_and_semantics_overrides() {
         .expect("text input semantics");
 
     assert_eq!(semantics.label.as_deref(), Some("Email"));
+    assert_eq!(semantics.identifier.as_deref(), Some("profile.email"));
     assert!(semantics.read_only);
     assert!(semantics.disabled);
     assert!(!semantics.focusable);

--- a/crates/core/fission-ir/src/semantics.rs
+++ b/crates/core/fission-ir/src/semantics.rs
@@ -26,6 +26,8 @@ pub enum Role {
     Image,
     /// A toggle that is either checked or unchecked.
     Checkbox,
+    /// A one-of-many selectable option in a radio group.
+    Radio,
     /// A toggle switch (on/off).
     Switch,
     /// A modal or non-modal dialog overlay.
@@ -332,8 +334,8 @@ pub struct Semantics {
     /// Editable text selection as byte offsets `(anchor, focus)`.
     #[serde(default)]
     pub text_selection: Option<(usize, usize)>,
-    /// For checkboxes and switches: `Some(true)` = checked, `Some(false)` = unchecked,
-    /// `None` = not a toggle.
+    /// For checkboxes, radios, and switches: `Some(true)` = checked or selected,
+    /// `Some(false)` = unchecked or unselected, and `None` = no checked state.
     pub checked: Option<bool>,
     /// Whether the node is disabled (grayed out, non-interactive).
     pub disabled: bool,

--- a/crates/core/fission-semantics/tests/semantics_invariants.rs
+++ b/crates/core/fission-semantics/tests/semantics_invariants.rs
@@ -6,6 +6,7 @@ fn test_role_variants() {
         Role::Button,
         Role::Text,
         Role::Image,
+        Role::Radio,
         Role::Slider,
         Role::List,
         Role::ListItem,

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -1540,7 +1540,12 @@ impl HtmlRenderer<'_> {
             Role::ListItem => "li",
             Role::Dialog => "section",
             Role::Text | Role::Generic => "div",
-            Role::TextInput | Role::Checkbox | Role::Switch | Role::Slider | Role::Input => {
+            Role::TextInput
+            | Role::Checkbox
+            | Role::Radio
+            | Role::Switch
+            | Role::Slider
+            | Role::Input => {
                 unreachable!("interactive controls are rendered before generic semantics")
             }
         };
@@ -1611,6 +1616,17 @@ impl HtmlRenderer<'_> {
                 }
                 Ok(format!(
                     "<label class=\"fission-site-node fission-site-control\" data-fission-node=\"{}\"><input class=\"fission-site-checkbox\" type=\"checkbox\"{attrs}><span class=\"fission-site-control-label\">{}</span>{children}</label>",
+                    node.id,
+                    escape_text(label_text)
+                ))
+            }
+            Role::Radio => {
+                if semantics.checked.unwrap_or(false) {
+                    attrs.push_str(" checked");
+                }
+
+                Ok(format!(
+                    "<label class=\"fission-site-node fission-site-control\" data-fission-node=\"{}\"><input class=\"fission-site-radio\" type=\"radio\"{attrs}><span class=\"fission-site-control-label\">{}</span>{children}</label>",
                     node.id,
                     escape_text(label_text)
                 ))
@@ -2698,7 +2714,7 @@ fn justify_content_css(justify: JustifyContent) -> &'static str {
 fn is_native_control_role(role: Role) -> bool {
     matches!(
         role,
-        Role::TextInput | Role::Checkbox | Role::Switch | Role::Slider | Role::Input
+        Role::TextInput | Role::Checkbox | Role::Radio | Role::Switch | Role::Slider | Role::Input
     )
 }
 
@@ -2998,6 +3014,35 @@ mod tests {
         assert!(rendered.html.contains("loop"));
         assert!(rendered.html.contains("<input"));
         assert!(rendered.html.contains("value=\"fission\""));
+    }
+
+    #[test]
+    fn radio_semantics_render_as_checked_native_radio_input() {
+        let radio = WidgetId::explicit("shipping-express");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            radio,
+            Op::Semantics(Semantics {
+                role: Role::Radio,
+                label: Some("Express shipping".into()),
+                identifier: Some("shipping.express".into()),
+                checked: Some(true),
+                focusable: true,
+                ..Default::default()
+            }),
+            Vec::new(),
+        );
+        ir.set_root(radio);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered.html.contains("class=\"fission-site-radio\""));
+        assert!(rendered.html.contains("type=\"radio\""));
+        assert!(rendered.html.contains(" checked"));
+        assert!(rendered
+            .html
+            .contains("data-fission-semantics=\"shipping.express\""));
+        assert!(!rendered.html.contains("type=\"checkbox\""));
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/accessibility.rs
+++ b/crates/shell/fission-shell-winit/src/accessibility.rs
@@ -593,6 +593,7 @@ mod imp {
             },
             Role::Image => AccessRole::Image,
             Role::Checkbox => AccessRole::CheckBox,
+            Role::Radio => AccessRole::RadioButton,
             Role::Switch => AccessRole::Switch,
             Role::Dialog => AccessRole::Dialog,
             Role::Slider => AccessRole::Slider,
@@ -1146,6 +1147,17 @@ mod imp {
             assert_eq!(node.label(), Some("Save"));
             assert!(node.supports_action(Action::Click));
             assert_eq!(node.bounds(), Some(Rect::new(20.0, 10.0, 180.0, 70.0)));
+        }
+
+        #[test]
+        fn maps_radio_semantics_to_accesskit_radio_button() {
+            let semantics = Semantics {
+                role: Role::Radio,
+                checked: Some(true),
+                ..Semantics::default()
+            };
+
+            assert_eq!(access_role_for(&semantics), AccessRole::RadioButton);
         }
     }
 }

--- a/documentation/content/reference/widgets/widget-pages/radio.mdx
+++ b/documentation/content/reference/widgets/widget-pages/radio.mdx
@@ -48,7 +48,7 @@ Every radio in the group emits a concrete selection action. The reducer stores t
 
 The important product rule is not inside the widget. It is in the reducer: only one item in the group should end up selected after an action. That is why radios pair naturally with an enum or selected index in app state.
 
-One implementation detail is worth knowing: the checked-in visual widget behaves like a radio, but its lowered semantics currently reuse the checkbox role internally. The interaction model still works, but if assistive-technology role precision matters on your target, validate it carefully.
+`Radio` exposes `Role::Radio`, uses `checked` for its selected state, and dispatches `on_select` through its default semantic action.
 
 ## Specific advice
 
@@ -68,4 +68,3 @@ If a screen starts repeating the same `Radio` setup, extract a named component a
 ## Related
 
 [`Checkbox`](/reference/widgets/checkbox), [`Switch`](/reference/widgets/switch), [`SegmentedControl`](/reference/widgets/segmented-control), and [`Select`](/reference/widgets/select).
-


### PR DESCRIPTION
## Summary

- add `semantics_identifier` fields and builders to `TextInput`, `Slider`, `Checkbox`, `Radio`, `Switch`, and `GestureDetector`
- add `Button::semantics_identifier(...)` while preserving any existing custom semantics
- propagate identifiers onto each widget-owned interactive semantics node
- add `Role::Radio` as a first-class public IR role and lower `Radio` to it
- map radio semantics to AccessKit `RadioButton` and native static/SSR `<input type="radio">` output
- cover the affected controls, role mappings, and native radio rendering with regression tests

## Rationale

Wrapping an interactive widget in `SemanticsRegion` puts the stable identifier on a separate node. The inner node still owns the role, focusability, actions, text selection, checked state, value range, and drag metadata, so semantic commands can resolve the wrapper and then reject it as the wrong control type.

This change follows the existing `Text` and `RichText` widget convention. It sets identifiers directly on the synthesized control semantics and otherwise preserves their state and actions.

Radio is represented independently from checkbox and switch end to end. It retains checked state for selection, dispatches `on_select` through its default action, renders as a native radio control, and maps to the platform radio-button accessibility role. Toggle selectors remain restricted to `Checkbox | Switch`; radio selection continues through tap/default action.

Optional identifier fields use Serde defaults and are omitted when unset, preserving existing serialized forms. `Role::Radio` is a public IR enum expansion with the existing derives unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p fission-core --test text_surface_api` (22 passed)
- `cargo test -p fission-widgets` (all tests passed)
- `cargo test -p fission-semantics` (all tests passed)
- `cargo test -p fission-shell-site radio_semantics_render_as_checked_native_radio_input -- --nocapture` (passed)
- focused lowering suites verify identifiers for all seven controls and radio role, checked state, label, focusability, and default action

The focused `fission-shell-winit` AccessKit mapping test is present, but local execution is blocked before tests run by existing `E0500` borrow-check errors in `fission-shell-winit/src/video_backend.rs:2093`. That file is unchanged from the PR base.

The combined core/widgets package run also reaches four existing failures in `input_controller_tests`: `test_text_input_copy_paste`, `test_undo_controller_capacity_limits_history_depth`, `test_word_navigation`, and `test_word_navigation_skips_non_word_segments`. All four were reproduced unchanged in a clean worktree at the PR base commit `87a94ad0`.

Strict Clippy on Rust 1.96 is currently blocked by existing warnings on the base branch in core and workspace dependencies.

Fixes #105