### PR TITLE
Fix Linux video terminal event state borrows

### DIFF
--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -2090,19 +2090,21 @@ mod linux {
                     events.push(VideoEvent::Error(message));
                 }
             }
+            let mut ended_sent = self.ended_sent;
+            let mut error_sent = self.error_sent;
             self.with_entry(|entry| {
                 if let Some(bus) = entry.bus.as_ref() {
                     for message in bus.iter() {
                         match message.view() {
                             gst::MessageView::Eos(..) => {
-                                if !self.ended_sent {
+                                if !ended_sent {
                                     events.push(VideoEvent::Ended);
                                 }
-                                self.ended_sent = true;
+                                ended_sent = true;
                             }
                             gst::MessageView::Error(error) => {
-                                if !self.error_sent {
-                                    self.error_sent = true;
+                                if !error_sent {
+                                    error_sent = true;
                                     events.push(VideoEvent::Error(format!(
                                         "GStreamer video error: {}",
                                         error.error()
@@ -2114,6 +2116,8 @@ mod linux {
                     }
                 }
             });
+            self.ended_sent = ended_sent;
+            self.error_sent = error_sent;
             if !self.ready_sent {
                 let duration = self.duration().unwrap_or(0);
                 self.ready_sent = true;


### PR DESCRIPTION
## Summary

- process Linux GStreamer EOS and error messages through local copies of the one-shot delivery flags
- persist the resulting terminal-event state after the registry entry borrow ends
- preserve event ordering and duplicate suppression while removing conflicting borrows of `self`

## Rationale

`LinuxVideoPlayer::poll_events` called `self.with_entry(...)`, which immutably borrowed `self` for the closure, then mutated `self.ended_sent` and `self.error_sent` inside that closure. Rust rejects those overlapping borrows with `E0500`, preventing `fission-shell-winit` from compiling on Linux.

The registry entry remains read-only. Only the two player-local delivery flags are staged locally and written back after bus polling.

## Verification

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p fission-shell-winit --lib` (98 passed)