### PR TITLE
Allow TextInput selection handles to be disabled

### DIFF
--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -162,7 +162,7 @@ impl Default for TextContextMenuConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TextSelectionControls {
-    /// Whether caret and selection-handle overlays are shown.
+    /// Whether touch-style caret and selection-handle overlays are shown.
     #[serde(default = "default_selection_controls_enabled")]
     pub enabled: bool,
     pub show_collapsed_handle: bool,

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -162,6 +162,9 @@ impl Default for TextContextMenuConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TextSelectionControls {
+    /// Whether caret and selection-handle overlays are shown.
+    #[serde(default = "default_selection_controls_enabled")]
+    pub enabled: bool,
     pub show_collapsed_handle: bool,
     pub handle_radius: f32,
     pub handle_fill: IrColor,
@@ -169,9 +172,14 @@ pub struct TextSelectionControls {
     pub handle_stroke_width: f32,
 }
 
+fn default_selection_controls_enabled() -> bool {
+    true
+}
+
 impl Default for TextSelectionControls {
     fn default() -> Self {
         Self {
+            enabled: true,
             show_collapsed_handle: true,
             handle_radius: 7.0,
             handle_fill: IrColor {
@@ -1638,33 +1646,35 @@ impl InternalLower for TextInput {
                 let affordances = &session_state.affordances;
                 let mut overlay_children = Vec::new();
 
-                if caret == anchor {
-                    if self.selection_controls.show_collapsed_handle {
-                        if let Some(point) = affordances.caret_handle {
+                if self.selection_controls.enabled {
+                    if caret == anchor {
+                        if self.selection_controls.show_collapsed_handle {
+                            if let Some(point) = affordances.caret_handle {
+                                overlay_children.push(self.build_selection_handle_overlay(
+                                    cx,
+                                    input_id,
+                                    TextSelectionHandleKind::Caret,
+                                    point,
+                                ));
+                            }
+                        }
+                    } else {
+                        if let Some(point) = affordances.selection_start_handle {
                             overlay_children.push(self.build_selection_handle_overlay(
                                 cx,
                                 input_id,
-                                TextSelectionHandleKind::Caret,
+                                TextSelectionHandleKind::Start,
                                 point,
                             ));
                         }
-                    }
-                } else {
-                    if let Some(point) = affordances.selection_start_handle {
-                        overlay_children.push(self.build_selection_handle_overlay(
-                            cx,
-                            input_id,
-                            TextSelectionHandleKind::Start,
-                            point,
-                        ));
-                    }
-                    if let Some(point) = affordances.selection_end_handle {
-                        overlay_children.push(self.build_selection_handle_overlay(
-                            cx,
-                            input_id,
-                            TextSelectionHandleKind::End,
-                            point,
-                        ));
+                        if let Some(point) = affordances.selection_end_handle {
+                            overlay_children.push(self.build_selection_handle_overlay(
+                                cx,
+                                input_id,
+                                TextSelectionHandleKind::End,
+                                point,
+                            ));
+                        }
                     }
                 }
 

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -3,7 +3,7 @@ use fission_core::internal::InternalLoweringCx;
 use fission_core::ui::widgets::text::{RichTextChild, RichTextSpan, TextScaler, WidgetSpan};
 use fission_core::ui::widgets::text_input::{
     DragStartBehavior, SpellCheckConfiguration, TextAlignVertical, TextContextMenuAction,
-    TextInputRuntimeConfig, TextMagnifierConfiguration, TextUndoController,
+    TextInputRuntimeConfig, TextMagnifierConfiguration, TextSelectionControls, TextUndoController,
 };
 use fission_core::ui::{Button, Container, RichText, RichTextRun, Spacer, Text, TextInput, Widget};
 use fission_core::{ActionEnvelope, ActionId};
@@ -1171,4 +1171,95 @@ fn focused_text_input_lowers_toolbar_handles_and_magnifier_overlays() {
     ));
 
     assert!(paint_ops(&ir).any(|op| matches!(op, PaintOp::DrawRichText { .. })));
+}
+
+#[test]
+fn disabled_text_selection_controls_omit_all_handle_overlays() {
+    let input_id = fission_ir::WidgetId::derived(89, &[0]);
+    let mut selected_runtime = RuntimeState::default();
+    selected_runtime.interaction.set_focused(Some(input_id));
+    let selected_state = selected_runtime.text_edit.get_mut_or_default(input_id);
+    selected_state.caret = 8;
+    selected_state.anchor = 2;
+    selected_state.affordances.selection_start_handle =
+        Some(fission_layout::LayoutPoint::new(18.0, 24.0));
+    selected_state.affordances.selection_end_handle =
+        Some(fission_layout::LayoutPoint::new(96.0, 24.0));
+    selected_state.affordances.toolbar_visible = true;
+    selected_state.affordances.toolbar_anchor = Some(fission_layout::LayoutPoint::new(40.0, 12.0));
+
+    let selected_ir = lower_node_with_runtime(
+        TextInput {
+            id: Some(input_id.into()),
+            value: "abcdefghij".into(),
+            selection_controls: TextSelectionControls {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into(),
+        selected_runtime,
+    );
+
+    assert!(!selected_ir
+        .nodes
+        .contains_key(&test_text_input_selection_handle_id(
+            input_id,
+            TextSelectionHandleKind::Start,
+        )));
+    assert!(!selected_ir
+        .nodes
+        .contains_key(&test_text_input_selection_handle_id(
+            input_id,
+            TextSelectionHandleKind::End,
+        )));
+    assert!(selected_ir
+        .nodes
+        .contains_key(&test_text_input_toolbar_button_id(
+            input_id,
+            TextContextMenuAction::Copy,
+        )));
+
+    let mut collapsed_runtime = RuntimeState::default();
+    collapsed_runtime.interaction.set_focused(Some(input_id));
+    let collapsed_state = collapsed_runtime.text_edit.get_mut_or_default(input_id);
+    collapsed_state.caret = 4;
+    collapsed_state.anchor = 4;
+    collapsed_state.affordances.caret_handle = Some(fission_layout::LayoutPoint::new(48.0, 24.0));
+    let collapsed_ir = lower_node_with_runtime(
+        TextInput {
+            id: Some(input_id.into()),
+            value: "abcdefghij".into(),
+            selection_controls: TextSelectionControls {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into(),
+        collapsed_runtime,
+    );
+
+    assert!(!collapsed_ir
+        .nodes
+        .contains_key(&test_text_input_selection_handle_id(
+            input_id,
+            TextSelectionHandleKind::Caret,
+        )));
+}
+
+#[test]
+fn text_selection_controls_deserialize_omitted_enabled_as_true() {
+    let mut serialized = serde_json::to_value(TextSelectionControls::default())
+        .expect("serialize selection controls");
+    serialized
+        .as_object_mut()
+        .expect("selection controls object")
+        .remove("enabled");
+
+    let controls: TextSelectionControls =
+        serde_json::from_value(serialized).expect("deserialize legacy selection controls");
+
+    assert!(controls.enabled);
 }

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -1086,9 +1086,14 @@ fn text_semantics_label_builder_sets_label() {
 
 #[test]
 fn focused_text_input_lowers_toolbar_handles_and_magnifier_overlays() {
+    assert!(TextSelectionControls::default().enabled);
+
     let input_id = fission_ir::WidgetId::derived(88, &[0]);
     let mut runtime = RuntimeState::default();
     runtime.interaction.set_focused(Some(input_id));
+    runtime
+        .text_edit
+        .sync_from_runtime(input_id, "abcdefghij", None, None);
     let state = runtime.text_edit.get_mut_or_default(input_id);
     state.caret = 8;
     state.anchor = 2;
@@ -1178,6 +1183,9 @@ fn disabled_text_selection_controls_omit_all_handle_overlays() {
     let input_id = fission_ir::WidgetId::derived(89, &[0]);
     let mut selected_runtime = RuntimeState::default();
     selected_runtime.interaction.set_focused(Some(input_id));
+    selected_runtime
+        .text_edit
+        .sync_from_runtime(input_id, "abcdefghij", None, None);
     let selected_state = selected_runtime.text_edit.get_mut_or_default(input_id);
     selected_state.caret = 8;
     selected_state.anchor = 2;
@@ -1187,6 +1195,10 @@ fn disabled_text_selection_controls_omit_all_handle_overlays() {
         Some(fission_layout::LayoutPoint::new(96.0, 24.0));
     selected_state.affordances.toolbar_visible = true;
     selected_state.affordances.toolbar_anchor = Some(fission_layout::LayoutPoint::new(40.0, 12.0));
+    selected_state.affordances.active_handle = Some(TextSelectionHandleKind::End);
+    selected_state.affordances.magnifier_visible = true;
+    selected_state.affordances.magnifier_anchor =
+        Some(fission_layout::LayoutPoint::new(96.0, 24.0));
 
     let selected_ir = lower_node_with_runtime(
         TextInput {
@@ -1196,33 +1208,66 @@ fn disabled_text_selection_controls_omit_all_handle_overlays() {
                 enabled: false,
                 ..Default::default()
             },
+            magnifier_configuration: TextMagnifierConfiguration {
+                diameter: 74.0,
+                ..Default::default()
+            },
             ..Default::default()
         }
         .into(),
         selected_runtime,
     );
 
-    assert!(!selected_ir
+    for kind in [
+        TextSelectionHandleKind::Caret,
+        TextSelectionHandleKind::Start,
+        TextSelectionHandleKind::End,
+    ] {
+        assert!(!selected_ir
+            .nodes
+            .contains_key(&test_text_input_selection_handle_id(input_id, kind)));
+    }
+    let semantics = selected_ir
         .nodes
-        .contains_key(&test_text_input_selection_handle_id(
-            input_id,
-            TextSelectionHandleKind::Start,
-        )));
-    assert!(!selected_ir
-        .nodes
-        .contains_key(&test_text_input_selection_handle_id(
-            input_id,
-            TextSelectionHandleKind::End,
-        )));
+        .values()
+        .find_map(|node| match &node.op {
+            Op::Semantics(semantics) if semantics.role == fission_ir::Role::TextInput => {
+                Some(semantics)
+            }
+            _ => None,
+        })
+        .expect("text input semantics");
+    assert_eq!(semantics.text_selection, Some((2, 8)));
+    let selection_highlight = paint_ops(&selected_ir).find_map(|op| match op {
+        PaintOp::DrawRichText { runs, .. } => runs
+            .iter()
+            .find(|run| run.text == "cdefgh" && run.style.background_color.is_some()),
+        _ => None,
+    });
+    assert!(selection_highlight.is_some());
     assert!(selected_ir
         .nodes
         .contains_key(&test_text_input_toolbar_button_id(
             input_id,
             TextContextMenuAction::Copy,
         )));
+    let magnifier_box = selected_ir.nodes.values().find(|node| {
+        matches!(
+            node.op,
+            Op::Layout(LayoutOp::Positioned {
+                width: Some(width),
+                height: Some(height),
+                ..
+            }) if (width - 74.0).abs() < 0.001 && (height - 74.0).abs() < 0.001
+        )
+    });
+    assert!(magnifier_box.is_some());
 
     let mut collapsed_runtime = RuntimeState::default();
     collapsed_runtime.interaction.set_focused(Some(input_id));
+    collapsed_runtime
+        .text_edit
+        .sync_from_runtime(input_id, "abcdefghij", None, None);
     let collapsed_state = collapsed_runtime.text_edit.get_mut_or_default(input_id);
     collapsed_state.caret = 4;
     collapsed_state.anchor = 4;
@@ -1241,12 +1286,24 @@ fn disabled_text_selection_controls_omit_all_handle_overlays() {
         collapsed_runtime,
     );
 
-    assert!(!collapsed_ir
-        .nodes
-        .contains_key(&test_text_input_selection_handle_id(
-            input_id,
-            TextSelectionHandleKind::Caret,
-        )));
+    for kind in [
+        TextSelectionHandleKind::Caret,
+        TextSelectionHandleKind::Start,
+        TextSelectionHandleKind::End,
+    ] {
+        assert!(!collapsed_ir
+            .nodes
+            .contains_key(&test_text_input_selection_handle_id(input_id, kind)));
+    }
+    assert!(paint_ops(&collapsed_ir).any(|op| {
+        matches!(
+            op,
+            PaintOp::DrawRichText {
+                caret_color: Some(_),
+                ..
+            }
+        )
+    }));
 }
 
 #[test]

--- a/documentation/content/reference/widgets/widget-pages/text-input.mdx
+++ b/documentation/content/reference/widgets/widget-pages/text-input.mdx
@@ -80,6 +80,7 @@ The empty string inside `SetEmail(String::new())` is only a placeholder so `ctx.
 | `styled_runs` | `Option<Vec<TextRun>>` | Pre-styled text runs for syntax-highlighted rendering. | When present, the concatenated runs must match `value` exactly. |
 | `locale` | `Option<String>` | Locale override for shaping and accessibility. | Defaults to `None`. |
 | `scroll_padding` | `Option<[f32; 4]>` | Extra space kept around the caret during auto-scroll. | Defaults to `None`. |
+| `selection_controls` | `TextSelectionControls` | Configures caret and selection-handle overlays. | Set `enabled` to `false` for mouse-first editors that should not show touch-style handles. Defaults to enabled. |
 
 ## How text, actions, and input method editor state work together
 
@@ -105,4 +106,3 @@ If a screen starts repeating the same `TextInput` setup, extract a named compone
 ## Related
 
 [`FormControl`](/reference/widgets/form-control), [`Editable`](/reference/widgets/editable), [`Combobox`](/reference/widgets/combobox), and [`Environment, input, and input method editor`](/reference/core/environment-input-and-ime).
-


### PR DESCRIPTION
## Summary

- add `TextSelectionControls::enabled` with a serde-compatible `true` default
- suppress only touch-style caret/start/end handle overlays when disabled
- preserve text selection, keyboard/pointer editing, context toolbar, magnifier, and ordinary caret paint
- document the desktop/editor configuration

## Validation

- default expanded selections still lower start/end handles
- disabled expanded and collapsed selections lower no handle nodes
- selection highlight and `Semantics::text_selection` remain present
- context toolbar and magnifier remain independent
- collapsed caret still paints
- legacy payloads without `enabled` deserialize to `true`
- `cargo fmt --all --check`
- `cargo test -p fission-core --test text_surface_api`

Closes #108.