### PR TITLE
Fix controlled TextInput rendering after external updates

### DIFF
--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -1254,44 +1254,61 @@ impl InternalLower for TextInput {
 
         // 2. Text Preparation
         let session = cx.runtime_state.text_edit.get(input_id);
-        let session_display = if is_focused {
-            session
-                .filter(|state| {
-                    state.pending_model_sync
-                        || state.preedit.is_some()
-                        || (self.restoration_id.is_some() && self.value.is_empty())
-                        || state.committed_text() == self.value
-                })
-                .map(|state| state.display_text())
+        let retained_session = if is_focused {
+            session.filter(|state| {
+                state.pending_model_sync
+                    || state.preedit.is_some()
+                    || (self.restoration_id.is_some() && self.value.is_empty())
+                    || state.committed_text() == self.value
+            })
         } else {
             None
         };
+        let session_display = retained_session.map(|state| state.display_text());
+        let model_selection = session
+            .map(|state| {
+                (
+                    clamp_text_offset(&self.value, state.caret),
+                    clamp_text_offset(&self.value, state.anchor),
+                )
+            })
+            .unwrap_or((self.value.len(), self.value.len()));
+        let semantic_value = retained_session
+            .map(|state| state.committed_text())
+            .unwrap_or_else(|| self.value.clone());
 
-        let (display_text, preedit_range, preedit_cursor_range, caret, anchor) = if self
-            .obscure_text
-        {
-            let mut combined = self.value.clone();
-            if let Some((display, _)) = &session_display {
-                combined = display.clone();
-            }
-            let (caret, anchor) = session.map(|st| (st.caret, st.anchor)).unwrap_or((0, 0));
-            let masked = Self::mask_text(&combined, self.obscuring_character);
-            let mapped_caret = Self::masked_byte_offset(&combined, &masked, caret);
-            let mapped_anchor = Self::masked_byte_offset(&combined, &masked, anchor);
-            (masked, None, None, mapped_caret, mapped_anchor)
-        } else {
-            match session_display {
-                Some((combined, preedit_range)) => {
-                    let (caret, anchor) = session.map(|st| (st.caret, st.anchor)).unwrap_or((0, 0));
-                    let cursor_range = session.and_then(|st| st.display_preedit_cursor_range());
-                    (combined, preedit_range, cursor_range, caret, anchor)
+        let (display_text, preedit_range, preedit_cursor_range, caret, anchor) =
+            if self.obscure_text {
+                let mut combined = self.value.clone();
+                if let Some((display, _)) = &session_display {
+                    combined = display.clone();
                 }
-                None => {
-                    let (caret, anchor) = session.map(|st| (st.caret, st.anchor)).unwrap_or((0, 0));
-                    (self.value.clone(), None, None, caret, anchor)
+                let (caret, anchor) = retained_session
+                    .map(|state| (state.caret, state.anchor))
+                    .unwrap_or(model_selection);
+                let masked = Self::mask_text(&combined, self.obscuring_character);
+                let mapped_caret = Self::masked_byte_offset(&combined, &masked, caret);
+                let mapped_anchor = Self::masked_byte_offset(&combined, &masked, anchor);
+                (masked, None, None, mapped_caret, mapped_anchor)
+            } else {
+                match session_display {
+                    Some((combined, preedit_range)) => {
+                        let (caret, anchor) = retained_session
+                            .map(|state| (state.caret, state.anchor))
+                            .unwrap_or(model_selection);
+                        let cursor_range =
+                            retained_session.and_then(|state| state.display_preedit_cursor_range());
+                        (combined, preedit_range, cursor_range, caret, anchor)
+                    }
+                    None => (
+                        self.value.clone(),
+                        None,
+                        None,
+                        model_selection.0,
+                        model_selection.1,
+                    ),
                 }
-            }
-        };
+            };
 
         // Construct Runs
         let mut runs = Vec::new();
@@ -1841,7 +1858,7 @@ impl InternalLower for TextInput {
             role: Role::TextInput,
             label: resolved_label.clone().or(resolved_placeholder.clone()),
             identifier: self.semantics_identifier.clone(),
-            value: Some(self.value.clone()),
+            value: Some(semantic_value),
             actions: Default::default(),
             action_scope_id: None,
             focusable: self.enabled,
@@ -1947,6 +1964,14 @@ impl InternalLower for TextInput {
         );
         semantics_id
     }
+}
+
+fn clamp_text_offset(value: &str, mut offset: usize) -> usize {
+    offset = offset.min(value.len());
+    while offset > 0 && !value.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
 }
 
 fn split_runs_for_range(

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -1255,7 +1255,14 @@ impl InternalLower for TextInput {
         // 2. Text Preparation
         let session = cx.runtime_state.text_edit.get(input_id);
         let session_display = if is_focused {
-            session.map(|st| st.display_text())
+            session
+                .filter(|state| {
+                    state.pending_model_sync
+                        || state.preedit.is_some()
+                        || (self.restoration_id.is_some() && self.value.is_empty())
+                        || state.committed_text() == self.value
+                })
+                .map(|state| state.display_text())
         } else {
             None
         };

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -1085,6 +1085,73 @@ fn text_semantics_label_builder_sets_label() {
 }
 
 #[test]
+fn focused_text_input_renders_new_controlled_value_after_runtime_buffer_was_empty() {
+    let input_id = fission_ir::WidgetId::derived(87, &[0]);
+    let mut runtime = RuntimeState::default();
+    runtime.interaction.set_focused(Some(input_id));
+    runtime
+        .text_edit
+        .sync_from_runtime(input_id, "", None, None);
+
+    let ir = lower_node_with_runtime(
+        TextInput {
+            id: Some(input_id.into()),
+            value: "Restored by the model".into(),
+            placeholder: Some("Placeholder".into()),
+            ..Default::default()
+        }
+        .into(),
+        runtime,
+    );
+
+    let rendered = paint_ops(&ir)
+        .find_map(|op| match op {
+            PaintOp::DrawRichText { runs, .. } => {
+                Some(runs.iter().map(|run| run.text.as_str()).collect::<String>())
+            }
+            _ => None,
+        })
+        .expect("text input rich text paint op");
+
+    assert_eq!(rendered, "Restored by the model");
+}
+
+#[test]
+fn focused_text_input_keeps_pending_local_value_until_model_catches_up() {
+    let input_id = fission_ir::WidgetId::derived(87, &[1]);
+    let mut runtime = RuntimeState::default();
+    runtime.interaction.set_focused(Some(input_id));
+    runtime
+        .text_edit
+        .sync_from_runtime(input_id, "Old", None, None);
+    runtime
+        .text_edit
+        .get_mut_or_default(input_id)
+        .apply_edit(0..3, "Local edit", 10, 10);
+
+    let ir = lower_node_with_runtime(
+        TextInput {
+            id: Some(input_id.into()),
+            value: "Old".into(),
+            ..Default::default()
+        }
+        .into(),
+        runtime,
+    );
+
+    let rendered = paint_ops(&ir)
+        .find_map(|op| match op {
+            PaintOp::DrawRichText { runs, .. } => {
+                Some(runs.iter().map(|run| run.text.as_str()).collect::<String>())
+            }
+            _ => None,
+        })
+        .expect("text input rich text paint op");
+
+    assert_eq!(rendered, "Local edit");
+}
+
+#[test]
 fn focused_text_input_lowers_toolbar_handles_and_magnifier_overlays() {
     let input_id = fission_ir::WidgetId::derived(88, &[0]);
     let mut runtime = RuntimeState::default();

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -1114,6 +1114,68 @@ fn focused_text_input_renders_new_controlled_value_after_runtime_buffer_was_empt
         .expect("text input rich text paint op");
 
     assert_eq!(rendered, "Restored by the model");
+
+    let semantics = ir
+        .nodes
+        .values()
+        .find_map(|node| match &node.op {
+            Op::Semantics(semantics) if semantics.role == fission_ir::Role::TextInput => {
+                Some(semantics)
+            }
+            _ => None,
+        })
+        .expect("text input semantics");
+    assert_eq!(semantics.value.as_deref(), Some("Restored by the model"));
+    assert_eq!(semantics.text_selection, Some((0, 0)));
+}
+
+#[test]
+fn focused_text_input_clamps_stale_selection_to_new_controlled_value() {
+    let input_id = fission_ir::WidgetId::derived(87, &[2]);
+    let mut runtime = RuntimeState::default();
+    runtime.interaction.set_focused(Some(input_id));
+    runtime
+        .text_edit
+        .sync_from_runtime(input_id, "A much longer retained value", None, None);
+    let stale_state = runtime.text_edit.get_mut_or_default(input_id);
+    stale_state.caret = usize::MAX;
+    stale_state.anchor = 1;
+
+    let ir = lower_node_with_runtime(
+        TextInput {
+            id: Some(input_id.into()),
+            value: "é".into(),
+            ..Default::default()
+        }
+        .into(),
+        runtime,
+    );
+
+    let rendered = paint_ops(&ir)
+        .find_map(|op| match op {
+            PaintOp::DrawRichText { runs, .. } => {
+                Some(runs.iter().map(|run| run.text.as_str()).collect::<String>())
+            }
+            _ => None,
+        })
+        .expect("text input rich text paint op");
+    assert_eq!(rendered, "é");
+
+    let semantics = ir
+        .nodes
+        .values()
+        .find_map(|node| match &node.op {
+            Op::Semantics(semantics) if semantics.role == fission_ir::Role::TextInput => {
+                Some(semantics)
+            }
+            _ => None,
+        })
+        .expect("text input semantics");
+    assert_eq!(semantics.value.as_deref(), Some("é"));
+    assert_eq!(semantics.text_selection, Some((0, "é".len())));
+    let (anchor, caret) = semantics.text_selection.expect("text selection");
+    assert!("é".is_char_boundary(anchor));
+    assert!("é".is_char_boundary(caret));
 }
 
 #[test]
@@ -1149,6 +1211,19 @@ fn focused_text_input_keeps_pending_local_value_until_model_catches_up() {
         .expect("text input rich text paint op");
 
     assert_eq!(rendered, "Local edit");
+
+    let semantics = ir
+        .nodes
+        .values()
+        .find_map(|node| match &node.op {
+            Op::Semantics(semantics) if semantics.role == fission_ir::Role::TextInput => {
+                Some(semantics)
+            }
+            _ => None,
+        })
+        .expect("text input semantics");
+    assert_eq!(semantics.value.as_deref(), Some("Local edit"));
+    assert_eq!(semantics.text_selection, Some((10, 10)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reject stale retained edit state after settled controlled-value updates
- derive paint text, IME state, selection, and semantic value from one accepted logical source
- clamp rejected stale caret/anchor offsets to UTF-8 boundaries in the controlled value
- preserve pending local edits and restoration state until the model catches up

## Problem

A focused controlled input could paint an old retained buffer after an external model update. Rejecting only that display buffer was incomplete because selection offsets could still come from unrelated retained text.

## Validation

- external value restoration paints and exposes the model value
- stale oversized selections clamp to a shorter multibyte model value on valid character boundaries
- pending local edits remain painted and semantically authoritative
- restoration behavior remains covered
- `cargo fmt --all --check`
- `cargo test -p fission-core --test text_surface_api`
- `cargo test -p fission-core --test input_controller_tests test_restoration_id_restores_local_edit_state`

Closes #110.