### PR TITLE
Keep oversized nearest scroll targets anchored at their leading edge

### DIFF
--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -803,7 +803,9 @@ impl Runtime {
             }
             ScrollAlignment::End => reveal_end - viewport_size,
             ScrollAlignment::Nearest => {
-                if reveal_start < viewport_start {
+                if reveal_end - reveal_start > viewport_size {
+                    reveal_start
+                } else if reveal_start < viewport_start {
                     reveal_start
                 } else if reveal_end > viewport_end {
                     reveal_end - viewport_size

--- a/crates/core/fission-core/tests/scroll_into_view.rs
+++ b/crates/core/fission-core/tests/scroll_into_view.rs
@@ -183,6 +183,26 @@ fn nearest_alignment_keeps_already_visible_target_stationary() {
 }
 
 #[test]
+fn nearest_alignment_uses_leading_edge_for_target_larger_than_viewport() {
+    let (ir, mut layout, scroll, target) = vertical_scroll_tree();
+    layout.nodes.get_mut(&target).unwrap().rect = LayoutRect::new(0.0, 40.0, 100.0, 180.0);
+    let mut runtime = Runtime::default();
+
+    runtime.queue_scroll_into_view(ScrollIntoViewRequest {
+        container: Some(scroll),
+        target,
+        axis: ScrollAxis::Vertical,
+        alignment: ScrollAlignment::Nearest,
+        padding: [0.0; 4],
+        behavior: ScrollBehavior::Instant,
+        if_needed: true,
+    });
+
+    assert!(runtime.post_layout_hook(&ir, &layout));
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 40.0);
+}
+
+#[test]
 fn missing_target_is_retried_once_after_next_layout() {
     let (mut ir, mut layout, scroll, target) = vertical_scroll_tree();
     ir.nodes.remove(&target);


### PR DESCRIPTION
## Summary

- align oversized targets to their leading edge for `ScrollAlignment::Nearest`
- preserve explicit Start, Center, End, and Fraction alignment behavior
- add a core runtime regression for selector-style `if_needed` scrolling

When a target is larger than its viewport, trailing-edge alignment cannot make the whole target visible and instead hides the useful leading edge. This keeps selector-driven focus and activation anchored at the start of large controls.

Closes #112.

## Validation

`cargo test -p fission-core --test scroll_into_view -- --nocapture`