### PR TITLE
Fix slider interaction and colour picker QA issues

### DIFF
--- a/crates/authoring/fission-widgets/src/colour_picker.rs
+++ b/crates/authoring/fission-widgets/src/colour_picker.rs
@@ -1,0 +1,1037 @@
+use crate::Wrap;
+use fission_core::ui::{
+    Button, ButtonVariant, Column, Container, Row, Slider, Text, TextInput, Widget,
+};
+use fission_core::ActionEnvelope;
+use fission_ir::op::{AlignItems, Color, Fill, FlexDirection, JustifyContent};
+use fission_ir::WidgetId;
+use std::sync::Arc;
+
+/// Built-in colour picker layouts inspired by common design-tool pickers.
+///
+/// Each variant is the same controlled widget rendered with a different density
+/// and control mix. Use [`ColourPicker::variant`] to switch between compact
+/// swatches, editor-style controls, social preset palettes, or individual hue
+/// and alpha controls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColourPickerVariant {
+    /// Chrome DevTools style: preview, saturation/value controls, hue, alpha and inputs.
+    Chrome,
+    /// Sketch style: editor controls with a denser preset strip.
+    Sketch,
+    /// Photoshop style: large preview plus detailed numeric fields.
+    Photoshop,
+    /// Compact style: only a tight palette grid.
+    Compact,
+    /// Circle style: round swatches for quick theme selection.
+    Circle,
+    /// GitHub style: small preset palette suitable for popovers and issue labels.
+    Github,
+    /// Twitter style: friendly social palette with a large preview.
+    Twitter,
+    /// Material style: Material Design colour families.
+    Material,
+    /// Slider style: preview plus hue, saturation, value and optional alpha sliders.
+    Slider,
+    /// Swatches style: large grouped colour families.
+    Swatches,
+    /// Block style: prominent preview block with editable hex and swatches.
+    Block,
+    /// Hue-only control.
+    Hue,
+    /// Alpha-only control.
+    Alpha,
+}
+
+impl Default for ColourPickerVariant {
+    fn default() -> Self {
+        Self::Chrome
+    }
+}
+
+/// HSV representation used by [`ColourPicker`] slider helpers.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ColourHsva {
+    /// Hue in degrees, clamped to `0..=360`.
+    pub hue: f32,
+    /// Saturation in `0..=1`.
+    pub saturation: f32,
+    /// Value/brightness in `0..=1`.
+    pub value: f32,
+    /// Alpha in `0..=1`.
+    pub alpha: f32,
+}
+
+impl ColourHsva {
+    /// Converts an IR colour into HSV plus alpha.
+    pub fn from_color(color: Color) -> Self {
+        let r = color.r as f32 / 255.0;
+        let g = color.g as f32 / 255.0;
+        let b = color.b as f32 / 255.0;
+        let max = r.max(g).max(b);
+        let min = r.min(g).min(b);
+        let delta = max - min;
+
+        let hue = if delta <= f32::EPSILON {
+            0.0
+        } else if (max - r).abs() <= f32::EPSILON {
+            60.0 * (((g - b) / delta) % 6.0)
+        } else if (max - g).abs() <= f32::EPSILON {
+            60.0 * (((b - r) / delta) + 2.0)
+        } else {
+            60.0 * (((r - g) / delta) + 4.0)
+        };
+
+        Self {
+            hue: if hue < 0.0 { hue + 360.0 } else { hue },
+            saturation: if max <= f32::EPSILON {
+                0.0
+            } else {
+                delta / max
+            },
+            value: max,
+            alpha: color.a as f32 / 255.0,
+        }
+    }
+
+    /// Converts HSV plus alpha into an IR colour.
+    pub fn to_color(self) -> Color {
+        let h = self.hue.rem_euclid(360.0);
+        let s = self.saturation.clamp(0.0, 1.0);
+        let v = self.value.clamp(0.0, 1.0);
+        let c = v * s;
+        let x = c * (1.0 - (((h / 60.0) % 2.0) - 1.0).abs());
+        let m = v - c;
+        let (r1, g1, b1) = match h {
+            h if h < 60.0 => (c, x, 0.0),
+            h if h < 120.0 => (x, c, 0.0),
+            h if h < 180.0 => (0.0, c, x),
+            h if h < 240.0 => (0.0, x, c),
+            h if h < 300.0 => (x, 0.0, c),
+            _ => (c, 0.0, x),
+        };
+
+        Color {
+            r: ((r1 + m) * 255.0).round().clamp(0.0, 255.0) as u8,
+            g: ((g1 + m) * 255.0).round().clamp(0.0, 255.0) as u8,
+            b: ((b1 + m) * 255.0).round().clamp(0.0, 255.0) as u8,
+            a: (self.alpha.clamp(0.0, 1.0) * 255.0)
+                .round()
+                .clamp(0.0, 255.0) as u8,
+        }
+    }
+}
+
+/// A customisable, controlled colour picker with Chrome, Sketch, Photoshop,
+/// Compact, Circle, GitHub, Twitter, Material, Slider, Swatches, Block, Hue and
+/// Alpha style layouts.
+///
+/// The widget is controlled: pass the current [`Color`] in [`ColourPicker::value`]
+/// and update it in reducers. Swatches dispatch full colour values through
+/// [`ColourPicker::on_change`]. Slider controls dispatch numeric channel updates
+/// through the matching `on_*_change` action.
+///
+/// ```rust,ignore
+/// ColourPicker {
+///     value: view.state().accent,
+///     variant: ColourPickerVariant::Chrome,
+///     on_change: Some(Arc::new(move |colour| set_accent(colour))),
+///     on_hue_change: Some(ctx.bind(SetAccentHue(0.0), reduce!(set_hue))),
+///     ..Default::default()
+/// }
+/// .into()
+/// ```
+#[derive(Clone)]
+pub struct ColourPicker {
+    /// Explicit widget identity.
+    pub id: Option<WidgetId>,
+    /// Stable identifier prefix exposed to accessibility and LiveTest selectors.
+    pub semantics_identifier: Option<String>,
+    /// Currently selected colour.
+    pub value: Color,
+    /// Visual picker layout.
+    pub variant: ColourPickerVariant,
+    /// Optional palette. When empty, the variant's built-in palette is used.
+    pub palette: Vec<Color>,
+    /// Recent or user-saved colours shown after the main palette.
+    pub recent: Vec<Color>,
+    /// Whether alpha controls and alpha text are visible.
+    pub show_alpha: bool,
+    /// Whether hex/rgb/hsv text fields are visible for variants that support them.
+    pub show_inputs: bool,
+    /// Preferred picker width in layout points.
+    pub width: Option<f32>,
+    /// Swatch size in layout points.
+    pub swatch_size: Option<f32>,
+    /// Number of columns used by dense swatch layouts.
+    pub columns: Option<usize>,
+    /// Factory for full colour changes, usually used by swatch selection.
+    pub on_change: Option<Arc<dyn Fn(Color) -> ActionEnvelope + Send + Sync>>,
+    /// Action receiving `f32` hue degrees from hue sliders.
+    pub on_hue_change: Option<ActionEnvelope>,
+    /// Action receiving `f32` saturation in `0..=1`.
+    pub on_saturation_change: Option<ActionEnvelope>,
+    /// Action receiving `f32` value/brightness in `0..=1`.
+    pub on_value_change: Option<ActionEnvelope>,
+    /// Action receiving `f32` alpha in `0..=1`.
+    pub on_alpha_change: Option<ActionEnvelope>,
+    /// Action receiving a `String` when the editable hex field changes.
+    pub on_hex_change: Option<ActionEnvelope>,
+}
+
+/// American spelling alias for codebases that prefer `ColorPicker`.
+pub type ColorPicker = ColourPicker;
+/// American spelling alias for codebases that prefer `ColorPickerVariant`.
+pub type ColorPickerVariant = ColourPickerVariant;
+
+impl Default for ColourPicker {
+    fn default() -> Self {
+        Self {
+            id: None,
+            semantics_identifier: None,
+            value: Color {
+                r: 59,
+                g: 130,
+                b: 246,
+                a: 255,
+            },
+            variant: ColourPickerVariant::Chrome,
+            palette: Vec::new(),
+            recent: Vec::new(),
+            show_alpha: true,
+            show_inputs: true,
+            width: None,
+            swatch_size: None,
+            columns: None,
+            on_change: None,
+            on_hue_change: None,
+            on_saturation_change: None,
+            on_value_change: None,
+            on_alpha_change: None,
+            on_hex_change: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for ColourPicker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ColourPicker")
+            .field("id", &self.id)
+            .field("value", &self.value)
+            .field("variant", &self.variant)
+            .field("show_alpha", &self.show_alpha)
+            .field("show_inputs", &self.show_inputs)
+            .finish()
+    }
+}
+
+impl ColourPicker {
+    /// Sets the stable selector prefix for the picker and its generated controls.
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
+}
+
+impl From<ColourPicker> for Widget {
+    fn from(component: ColourPicker) -> Self {
+        let (_, view) = fission_core::build::current::<()>();
+        let tokens = &view.env().theme.tokens;
+        let viewport = view.viewport_size();
+        let preferred_width = component.width.unwrap_or(match component.variant {
+            ColourPickerVariant::Photoshop => 420.0,
+            ColourPickerVariant::Compact | ColourPickerVariant::Github => 260.0,
+            ColourPickerVariant::Hue | ColourPickerVariant::Alpha => 280.0,
+            _ => 340.0,
+        });
+        let width = if viewport.width.is_finite() && viewport.width > 0.0 {
+            preferred_width.min((viewport.width - 48.0).max(220.0))
+        } else {
+            preferred_width
+        };
+        let content_width = (width - 24.0).max(180.0);
+        let palette = if component.palette.is_empty() {
+            default_palette(component.variant)
+        } else {
+            component.palette.clone()
+        };
+        let hsva = ColourHsva::from_color(component.value);
+
+        let body = match component.variant {
+            ColourPickerVariant::Chrome | ColourPickerVariant::Sketch => editor_picker(
+                &component,
+                &palette,
+                hsva,
+                content_width,
+                if component.variant == ColourPickerVariant::Sketch {
+                    "Sketch"
+                } else {
+                    "Chrome"
+                },
+            ),
+            ColourPickerVariant::Photoshop => {
+                photoshop_picker(&component, &palette, hsva, content_width)
+            }
+            ColourPickerVariant::Compact => swatch_grid(&component, &palette, 20.0, 10, true),
+            ColourPickerVariant::Circle => swatch_grid(&component, &palette, 30.0, 8, true),
+            ColourPickerVariant::Github => {
+                social_picker(&component, &palette, "GitHub labels", 26.0, 7)
+            }
+            ColourPickerVariant::Twitter => {
+                social_picker(&component, &palette, "Twitter accents", 34.0, 7)
+            }
+            ColourPickerVariant::Material => material_picker(&component, &palette, content_width),
+            ColourPickerVariant::Slider => slider_picker(&component, hsva, content_width, true),
+            ColourPickerVariant::Swatches => swatches_picker(&component, &palette),
+            ColourPickerVariant::Block => block_picker(&component, &palette, content_width),
+            ColourPickerVariant::Hue => channel_slider(
+                &component,
+                "Hue",
+                hsva.hue,
+                0.0,
+                360.0,
+                component.on_hue_change.clone(),
+                hue_fill(),
+                "hue",
+                content_width,
+            ),
+            ColourPickerVariant::Alpha => channel_slider(
+                &component,
+                "Alpha",
+                hsva.alpha,
+                0.0,
+                1.0,
+                component.on_alpha_change.clone(),
+                alpha_fill(component.value),
+                "alpha",
+                content_width,
+            ),
+        };
+
+        let mut root = Container::new(body)
+            .width(width)
+            .padding_all(12.0)
+            .bg(tokens.colors.surface_raised)
+            .border(tokens.colors.border, 1.0)
+            .border_radius(tokens.radii.large);
+        root.id = component.id;
+        root.into()
+    }
+}
+
+fn editor_picker(
+    picker: &ColourPicker,
+    palette: &[Color],
+    hsva: ColourHsva,
+    width: f32,
+    title: &str,
+) -> Widget {
+    Column {
+        gap: Some(10.0),
+        children: vec![
+            header(picker, title),
+            saturation_panel(picker, hsva, width),
+            slider_picker(picker, hsva, width, false),
+            inputs(picker, true),
+            swatch_grid(
+                picker,
+                palette,
+                picker.swatch_size.unwrap_or(22.0),
+                10,
+                false,
+            ),
+            recent_row(picker),
+        ],
+        ..Default::default()
+    }
+    .into()
+}
+
+fn photoshop_picker(
+    picker: &ColourPicker,
+    palette: &[Color],
+    hsva: ColourHsva,
+    width: f32,
+) -> Widget {
+    Row {
+        gap: Some(12.0),
+        align_items: AlignItems::Start,
+        children: vec![
+            Container::new(Column {
+                gap: Some(10.0),
+                children: vec![
+                    saturation_panel(picker, hsva, 240.0),
+                    channel_slider(
+                        picker,
+                        "Hue",
+                        hsva.hue,
+                        0.0,
+                        360.0,
+                        picker.on_hue_change.clone(),
+                        hue_fill(),
+                        "hue",
+                        (width - 116.0).max(220.0),
+                    ),
+                    channel_slider(
+                        picker,
+                        "Saturation",
+                        hsva.saturation,
+                        0.0,
+                        1.0,
+                        picker.on_saturation_change.clone(),
+                        saturation_fill(hsva),
+                        "saturation",
+                        (width - 116.0).max(220.0),
+                    ),
+                    channel_slider(
+                        picker,
+                        "Value",
+                        hsva.value,
+                        0.0,
+                        1.0,
+                        picker.on_value_change.clone(),
+                        value_fill(hsva),
+                        "value",
+                        (width - 116.0).max(220.0),
+                    ),
+                    swatch_grid(picker, palette, 20.0, 8, false),
+                ],
+                ..Default::default()
+            })
+            .width((width - 116.0).max(220.0))
+            .into(),
+            Container::new(Column {
+                gap: Some(8.0),
+                children: vec![preview(picker, 76.0), inputs(picker, true)],
+                ..Default::default()
+            })
+            .width(92.0)
+            .into(),
+        ],
+        ..Default::default()
+    }
+    .into()
+}
+
+fn slider_picker(
+    picker: &ColourPicker,
+    hsva: ColourHsva,
+    width: f32,
+    include_preview: bool,
+) -> Widget {
+    let mut children = Vec::new();
+    if include_preview {
+        children.push(
+            Row {
+                gap: Some(12.0),
+                align_items: AlignItems::Center,
+                children: vec![preview(picker, 44.0), inputs(picker, false)],
+                ..Default::default()
+            }
+            .into(),
+        );
+    }
+    children.extend([
+        channel_slider(
+            picker,
+            "Hue",
+            hsva.hue,
+            0.0,
+            360.0,
+            picker.on_hue_change.clone(),
+            hue_fill(),
+            "hue",
+            width,
+        ),
+        channel_slider(
+            picker,
+            "Saturation",
+            hsva.saturation,
+            0.0,
+            1.0,
+            picker.on_saturation_change.clone(),
+            saturation_fill(hsva),
+            "saturation",
+            width,
+        ),
+        channel_slider(
+            picker,
+            "Value",
+            hsva.value,
+            0.0,
+            1.0,
+            picker.on_value_change.clone(),
+            value_fill(hsva),
+            "value",
+            width,
+        ),
+    ]);
+    if picker.show_alpha {
+        children.push(channel_slider(
+            picker,
+            "Alpha",
+            hsva.alpha,
+            0.0,
+            1.0,
+            picker.on_alpha_change.clone(),
+            alpha_fill(picker.value),
+            "alpha",
+            width,
+        ));
+    }
+
+    Column {
+        gap: Some(8.0),
+        children,
+        ..Default::default()
+    }
+    .into()
+}
+
+fn material_picker(picker: &ColourPicker, palette: &[Color], width: f32) -> Widget {
+    Column {
+        gap: Some(10.0),
+        children: vec![
+            header(picker, "Material"),
+            Row {
+                gap: Some(12.0),
+                children: vec![preview(picker, 48.0), inputs(picker, false)],
+                ..Default::default()
+            }
+            .into(),
+            swatch_grid(
+                picker,
+                palette,
+                34.0,
+                ((width / 42.0) as usize).max(5),
+                true,
+            ),
+        ],
+        ..Default::default()
+    }
+    .into()
+}
+
+fn social_picker(
+    picker: &ColourPicker,
+    palette: &[Color],
+    title: &str,
+    size: f32,
+    columns: usize,
+) -> Widget {
+    Column {
+        gap: Some(10.0),
+        children: vec![
+            header(picker, title),
+            Row {
+                gap: Some(10.0),
+                children: vec![
+                    preview(picker, 38.0),
+                    Text::new(hex_string(picker.value)).into(),
+                ],
+                ..Default::default()
+            }
+            .into(),
+            swatch_grid(picker, palette, size, columns, true),
+        ],
+        ..Default::default()
+    }
+    .into()
+}
+
+fn swatches_picker(picker: &ColourPicker, palette: &[Color]) -> Widget {
+    let groups = palette.chunks(7).map(|group| {
+        Row {
+            gap: Some(6.0),
+            children: group
+                .iter()
+                .map(|color| swatch(picker, *color, 28.0, 8.0))
+                .collect(),
+            ..Default::default()
+        }
+        .into()
+    });
+
+    Column {
+        gap: Some(8.0),
+        children: std::iter::once(header(picker, "Swatches"))
+            .chain(groups)
+            .collect(),
+        ..Default::default()
+    }
+    .into()
+}
+
+fn block_picker(picker: &ColourPicker, palette: &[Color], width: f32) -> Widget {
+    Column {
+        gap: Some(10.0),
+        children: vec![
+            Container::new(Text::new(hex_string(picker.value)).color(contrast_color(picker.value)))
+                .height(92.0)
+                .padding_all(14.0)
+                .bg(picker.value)
+                .border_radius(10.0)
+                .into(),
+            inputs(picker, false),
+            swatch_grid(
+                picker,
+                palette,
+                28.0,
+                ((width / 36.0) as usize).max(6),
+                true,
+            ),
+        ],
+        ..Default::default()
+    }
+    .into()
+}
+
+fn header(picker: &ColourPicker, title: &str) -> Widget {
+    Row {
+        gap: Some(10.0),
+        align_items: AlignItems::Center,
+        children: vec![preview(picker, 28.0), Text::new(title).size(14.0).into()],
+        ..Default::default()
+    }
+    .into()
+}
+
+fn saturation_panel(_picker: &ColourPicker, hsva: ColourHsva, width: f32) -> Widget {
+    let base = ColourHsva {
+        saturation: 1.0,
+        value: 1.0,
+        ..hsva
+    }
+    .to_color();
+    Container::new(Text::new(""))
+        .width(width)
+        .height(138.0)
+        .bg_fill(Fill::LinearGradient {
+            start: (0.0, 0.0),
+            end: (1.0, 0.0),
+            stops: vec![(0.0, Color::WHITE), (1.0, base)],
+        })
+        .border(
+            Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 35,
+            },
+            1.0,
+        )
+        .border_radius(10.0)
+        .into()
+}
+
+fn channel_slider(
+    picker: &ColourPicker,
+    label: &str,
+    value: f32,
+    min: f32,
+    max: f32,
+    action: Option<ActionEnvelope>,
+    fill: Fill,
+    semantic_suffix: &str,
+    width: f32,
+) -> Widget {
+    let identifier = picker
+        .semantics_identifier
+        .as_ref()
+        .map(|prefix| format!("{prefix}.{semantic_suffix}"));
+    Container::new(Column {
+        gap: Some(4.0),
+        children: vec![
+            Row {
+                justify_content: JustifyContent::SpaceBetween,
+                children: vec![
+                    Text::new(label).size(12.0).into(),
+                    Text::new(format_channel_value(label, value))
+                        .size(12.0)
+                        .into(),
+                ],
+                ..Default::default()
+            }
+            .into(),
+            Container::new(Slider {
+                semantics_identifier: identifier,
+                value,
+                min,
+                max,
+                track_height: Some(18.0),
+                thumb_size: Some(16.0),
+                track_fill: Some(Fill::Solid(Color {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                    a: 0,
+                })),
+                on_change: action,
+                ..Default::default()
+            })
+            .width(width)
+            .height(18.0)
+            .bg_fill(fill)
+            .border_radius(8.0)
+            .into(),
+        ],
+        ..Default::default()
+    })
+    .width(width)
+    .into()
+}
+
+fn inputs(picker: &ColourPicker, expanded: bool) -> Widget {
+    if !picker.show_inputs {
+        return Container::new(Text::new(hex_string(picker.value))).into();
+    }
+
+    let hex = hex_string(picker.value);
+    let mut children = vec![
+        TextInput {
+            semantics_identifier: picker
+                .semantics_identifier
+                .as_ref()
+                .map(|prefix| format!("{prefix}.hex")),
+            value: hex,
+            width: Some(if expanded { 112.0 } else { 96.0 }),
+            on_change: picker.on_hex_change.clone(),
+            ..Default::default()
+        }
+        .into(),
+        Text::new(format!(
+            "rgb({}, {}, {})",
+            picker.value.r, picker.value.g, picker.value.b
+        ))
+        .size(12.0)
+        .into(),
+    ];
+    if expanded {
+        let hsva = ColourHsva::from_color(picker.value);
+        children.push(
+            Text::new(format!(
+                "hsv({:.0}, {:.0}%, {:.0}%)",
+                hsva.hue,
+                hsva.saturation * 100.0,
+                hsva.value * 100.0
+            ))
+            .size(12.0)
+            .into(),
+        );
+    }
+    if picker.show_alpha {
+        children.push(
+            Text::new(format!("alpha {:.0}%", picker.value.a as f32 / 2.55))
+                .size(12.0)
+                .into(),
+        );
+    }
+
+    Wrap {
+        direction: FlexDirection::Row,
+        spacing: Some(6.0),
+        children,
+    }
+    .into()
+}
+
+fn preview(picker: &ColourPicker, size: f32) -> Widget {
+    Container::new(Text::new(""))
+        .size(size, size)
+        .bg(picker.value)
+        .border(
+            Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 45,
+            },
+            1.0,
+        )
+        .border_radius((size / 5.0).clamp(6.0, 14.0))
+        .into()
+}
+
+fn recent_row(picker: &ColourPicker) -> Widget {
+    if picker.recent.is_empty() {
+        return Container::new(Text::new("")).height(0.0).into();
+    }
+
+    Row {
+        gap: Some(6.0),
+        children: std::iter::once(Text::new("Recent").size(12.0).into())
+            .chain(
+                picker
+                    .recent
+                    .iter()
+                    .map(|color| swatch(picker, *color, 18.0, 5.0)),
+            )
+            .collect(),
+        ..Default::default()
+    }
+    .into()
+}
+
+fn swatch_grid(
+    picker: &ColourPicker,
+    palette: &[Color],
+    default_size: f32,
+    default_columns: usize,
+    selected_label: bool,
+) -> Widget {
+    let size = picker.swatch_size.unwrap_or(default_size);
+    let columns = picker.columns.unwrap_or(default_columns).max(1);
+    let children = palette
+        .iter()
+        .map(|color| swatch(picker, *color, size, size / 2.8))
+        .collect::<Vec<_>>();
+    let grid = Wrap {
+        direction: FlexDirection::Row,
+        spacing: Some(6.0),
+        children,
+    };
+    if selected_label {
+        Column {
+            gap: Some(8.0),
+            children: vec![
+                Text::new(format!("Selected {}", hex_string(picker.value)))
+                    .size(12.0)
+                    .into(),
+                Container::new(grid)
+                    .width((size + 6.0) * columns as f32)
+                    .into(),
+            ],
+            ..Default::default()
+        }
+        .into()
+    } else {
+        Container::new(grid)
+            .width((size + 6.0) * columns as f32)
+            .into()
+    }
+}
+
+fn swatch(picker: &ColourPicker, color: Color, size: f32, radius: f32) -> Widget {
+    let selected = same_rgb_alpha(picker.value, color);
+    let action = picker.on_change.as_ref().map(|callback| callback(color));
+    let id = picker.semantics_identifier.as_ref().map(|prefix| {
+        format!(
+            "{prefix}.swatch.{}",
+            hex_string(color).trim_start_matches('#')
+        )
+    });
+    Button {
+        child: None,
+        on_press: action,
+        width: Some(size),
+        height: Some(size),
+        padding: Some([0.0; 4]),
+        variant: ButtonVariant::Ghost,
+        background_fill: Some(Fill::Solid(color)),
+        semantics: None,
+        ..Default::default()
+    }
+    .semantics_identifier(id.unwrap_or_else(|| format!("colour.swatch.{}", hex_string(color))))
+    .background_fill(Fill::Solid(color))
+    .into_with_border(
+        if selected {
+            Color::BLACK
+        } else {
+            Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 45,
+            }
+        },
+        radius,
+    )
+}
+
+trait SwatchBorder {
+    fn into_with_border(self, border: Color, radius: f32) -> Widget;
+}
+
+impl SwatchBorder for Button {
+    fn into_with_border(self, border: Color, radius: f32) -> Widget {
+        let width = self.width.unwrap_or(24.0);
+        let height = self.height.unwrap_or(24.0);
+        Container::new(self)
+            .size(width, height)
+            .border(border, 2.0)
+            .border_radius(radius)
+            .into()
+    }
+}
+
+fn hue_fill() -> Fill {
+    Fill::LinearGradient {
+        start: (0.0, 0.0),
+        end: (1.0, 0.0),
+        stops: vec![
+            (0.0, rgb(255, 0, 0)),
+            (0.17, rgb(255, 255, 0)),
+            (0.33, rgb(0, 255, 0)),
+            (0.50, rgb(0, 255, 255)),
+            (0.67, rgb(0, 0, 255)),
+            (0.83, rgb(255, 0, 255)),
+            (1.0, rgb(255, 0, 0)),
+        ],
+    }
+}
+
+fn saturation_fill(hsva: ColourHsva) -> Fill {
+    Fill::LinearGradient {
+        start: (0.0, 0.0),
+        end: (1.0, 0.0),
+        stops: vec![
+            (
+                0.0,
+                ColourHsva {
+                    saturation: 0.0,
+                    ..hsva
+                }
+                .to_color(),
+            ),
+            (
+                1.0,
+                ColourHsva {
+                    saturation: 1.0,
+                    ..hsva
+                }
+                .to_color(),
+            ),
+        ],
+    }
+}
+
+fn value_fill(hsva: ColourHsva) -> Fill {
+    Fill::LinearGradient {
+        start: (0.0, 0.0),
+        end: (1.0, 0.0),
+        stops: vec![
+            (0.0, Color::BLACK),
+            (1.0, ColourHsva { value: 1.0, ..hsva }.to_color()),
+        ],
+    }
+}
+
+fn alpha_fill(color: Color) -> Fill {
+    Fill::LinearGradient {
+        start: (0.0, 0.0),
+        end: (1.0, 0.0),
+        stops: vec![(0.0, color.with_alpha(0)), (1.0, color.with_alpha(255))],
+    }
+}
+
+fn default_palette(variant: ColourPickerVariant) -> Vec<Color> {
+    match variant {
+        ColourPickerVariant::Material => material_palette(),
+        ColourPickerVariant::Github => github_palette(),
+        ColourPickerVariant::Twitter => twitter_palette(),
+        ColourPickerVariant::Circle => circle_palette(),
+        _ => standard_palette(),
+    }
+}
+
+fn standard_palette() -> Vec<Color> {
+    [
+        "#D0021B", "#F5A623", "#F8E71C", "#8B572A", "#7ED321", "#417505", "#BD10E0", "#9013FE",
+        "#4A90E2", "#50E3C2", "#B8E986", "#000000", "#4A4A4A", "#9B9B9B", "#FFFFFF",
+    ]
+    .iter()
+    .filter_map(|value| parse_hex_color(value))
+    .collect()
+}
+
+fn material_palette() -> Vec<Color> {
+    [
+        "#F44336", "#E91E63", "#9C27B0", "#673AB7", "#3F51B5", "#2196F3", "#03A9F4", "#00BCD4",
+        "#009688", "#4CAF50", "#8BC34A", "#CDDC39", "#FFEB3B", "#FFC107", "#FF9800", "#FF5722",
+        "#795548", "#607D8B",
+    ]
+    .iter()
+    .filter_map(|value| parse_hex_color(value))
+    .collect()
+}
+
+fn github_palette() -> Vec<Color> {
+    [
+        "#B60205", "#D93F0B", "#FBCA04", "#0E8A16", "#006B75", "#1D76DB", "#0052CC", "#5319E7",
+        "#E99695", "#F9D0C4", "#FEF2C0", "#C2E0C6", "#BFDADC", "#BFD4F2", "#D4C5F9",
+    ]
+    .iter()
+    .filter_map(|value| parse_hex_color(value))
+    .collect()
+}
+
+fn twitter_palette() -> Vec<Color> {
+    [
+        "#1DA1F2", "#14171A", "#657786", "#AAB8C2", "#E1E8ED", "#F5F8FA", "#17BF63", "#F45D22",
+        "#E0245E", "#794BC4", "#FFAD1F", "#2EC4B6",
+    ]
+    .iter()
+    .filter_map(|value| parse_hex_color(value))
+    .collect()
+}
+
+fn circle_palette() -> Vec<Color> {
+    [
+        "#F44336", "#FF9800", "#FFEB3B", "#4CAF50", "#00BCD4", "#2196F3", "#3F51B5", "#9C27B0",
+        "#E91E63", "#795548", "#607D8B", "#000000",
+    ]
+    .iter()
+    .filter_map(|value| parse_hex_color(value))
+    .collect()
+}
+
+fn parse_hex_color(value: &str) -> Option<Color> {
+    let hex = value.strip_prefix('#').unwrap_or(value);
+    if hex.len() != 6 && hex.len() != 8 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    let a = if hex.len() == 8 {
+        u8::from_str_radix(&hex[6..8], 16).ok()?
+    } else {
+        255
+    };
+    Some(Color { r, g, b, a })
+}
+
+fn hex_string(color: Color) -> String {
+    if color.a == 255 {
+        format!("#{:02X}{:02X}{:02X}", color.r, color.g, color.b)
+    } else {
+        format!(
+            "#{:02X}{:02X}{:02X}{:02X}",
+            color.r, color.g, color.b, color.a
+        )
+    }
+}
+
+fn rgb(r: u8, g: u8, b: u8) -> Color {
+    Color { r, g, b, a: 255 }
+}
+
+fn same_rgb_alpha(a: Color, b: Color) -> bool {
+    a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a
+}
+
+fn contrast_color(color: Color) -> Color {
+    let luma = (0.299 * color.r as f32 + 0.587 * color.g as f32 + 0.114 * color.b as f32) / 255.0;
+    if luma > 0.58 {
+        Color::BLACK
+    } else {
+        Color::WHITE
+    }
+}
+
+fn format_channel_value(label: &str, value: f32) -> String {
+    match label {
+        "Hue" => format!("{value:.0} deg"),
+        _ => format!("{:.0}%", value * 100.0),
+    }
+}

--- a/crates/authoring/fission-widgets/src/colour_picker.rs
+++ b/crates/authoring/fission-widgets/src/colour_picker.rs
@@ -4,7 +4,7 @@ use fission_core::ui::{
 };
 use fission_core::ActionEnvelope;
 use fission_ir::op::{AlignItems, Color, Fill, FlexDirection, JustifyContent};
-use fission_ir::WidgetId;
+use fission_ir::{Role, Semantics, WidgetId};
 use std::sync::Arc;
 
 /// Built-in colour picker layouts inspired by common design-tool pickers.
@@ -814,12 +814,20 @@ fn swatch_grid(
 fn swatch(picker: &ColourPicker, color: Color, size: f32, radius: f32) -> Widget {
     let selected = same_rgb_alpha(picker.value, color);
     let action = picker.on_change.as_ref().map(|callback| callback(color));
-    let id = picker.semantics_identifier.as_ref().map(|prefix| {
-        format!(
-            "{prefix}.swatch.{}",
-            hex_string(color).trim_start_matches('#')
-        )
-    });
+    let hex = hex_string(color);
+    let id = picker
+        .semantics_identifier
+        .as_ref()
+        .map(|prefix| format!("{prefix}.swatch.{}", hex.trim_start_matches('#')))
+        .unwrap_or_else(|| format!("colour.swatch.{}", hex.trim_start_matches('#')));
+    let semantics = Semantics {
+        role: Role::Button,
+        label: Some(format!("Select {hex}")),
+        identifier: Some(id),
+        checked: Some(selected),
+        focusable: true,
+        ..Default::default()
+    };
     Button {
         child: None,
         on_press: action,
@@ -828,10 +836,9 @@ fn swatch(picker: &ColourPicker, color: Color, size: f32, radius: f32) -> Widget
         padding: Some([0.0; 4]),
         variant: ButtonVariant::Ghost,
         background_fill: Some(Fill::Solid(color)),
-        semantics: None,
+        semantics: Some(semantics),
         ..Default::default()
     }
-    .semantics_identifier(id.unwrap_or_else(|| format!("colour.swatch.{}", hex_string(color))))
     .background_fill(Fill::Solid(color))
     .into_with_border(
         if selected {

--- a/crates/authoring/fission-widgets/src/lib.rs
+++ b/crates/authoring/fission-widgets/src/lib.rs
@@ -128,6 +128,11 @@ pub use time_picker::TimePicker;
 pub mod date_range_picker;
 pub use date_range_picker::DateRangePicker;
 
+pub mod colour_picker;
+pub use colour_picker::{
+    ColorPicker, ColorPickerVariant, ColourHsva, ColourPicker, ColourPickerVariant,
+};
+
 pub mod combobox;
 pub use combobox::Combobox;
 

--- a/crates/authoring/fission-widgets/src/router.rs
+++ b/crates/authoring/fission-widgets/src/router.rs
@@ -1,5 +1,7 @@
 use fission_core::build::{self, BuildCtxHandle, ViewHandle};
+use fission_core::ui::Composite;
 use fission_core::{GlobalState, Widget};
+use fission_ir::WidgetId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -25,12 +27,18 @@ impl<S: GlobalState> From<Router<S>> for Widget {
 
         for route in &this.routes {
             if let Some(params) = match_route(&route.path, &this.current_path) {
-                return (route.builder)(ctx, view, &params);
+                return route_scoped_widget(
+                    &format!("{}=>{}", route.path, this.current_path),
+                    (route.builder)(ctx, view, &params),
+                );
             }
         }
 
         if let Some(not_found) = &this.not_found {
-            return not_found(ctx, view, &HashMap::new());
+            return route_scoped_widget(
+                &format!("not_found=>{}", this.current_path),
+                not_found(ctx, view, &HashMap::new()),
+            );
         }
 
         fission_core::ui::Text::new(format!("404: {}", this.current_path)).into()
@@ -79,6 +87,17 @@ impl<S: GlobalState> Router<S> {
         self.not_found = Some(Arc::new(move |_ctx, _view, _| builder().into()));
         self
     }
+}
+
+fn route_scoped_widget(route_key: &str, child: Widget) -> Widget {
+    Composite {
+        id: Some(WidgetId::explicit(&format!(
+            "fission.router.route:{route_key}"
+        ))),
+        child,
+        ..Default::default()
+    }
+    .into()
 }
 
 // Simple route matcher: "/users/:id" matches "/users/123" -> {"id": "123"}

--- a/crates/authoring/fission-widgets/src/tabs.rs
+++ b/crates/authoring/fission-widgets/src/tabs.rs
@@ -5,7 +5,7 @@ use crate::motion_support::{
 use crate::stack::{HStack, VStack};
 use fission_core::motion::{follow_x_and_width, Motion, MotionTrack, Presence};
 use fission_core::ui::{
-    Button, ButtonVariant, ComponentSize, ComponentState, Container, Text, Widget,
+    Button, ButtonVariant, ComponentSize, ComponentState, Composite, Container, Text, Widget,
 };
 use fission_core::{ActionEnvelope, WidgetId, WidgetIdExt};
 use serde::{Deserialize, Serialize};
@@ -318,6 +318,15 @@ impl From<Tabs> for Widget {
         } else {
             fission_core::ui::widgets::spacer::Spacer::default().into()
         };
+        active_content = Composite {
+            id: Some(WidgetId::derived(
+                slot_id(base_id, SLOT_CONTENT).as_u128(),
+                &[this.active_index as u32, 0],
+            )),
+            child: active_content,
+            ..Default::default()
+        }
+        .into();
         if let Some(plan) = &motion_plan {
             active_content = Presence {
                 id: WidgetId::derived(

--- a/crates/authoring/fission-widgets/tests/router_test.rs
+++ b/crates/authoring/fission-widgets/tests/router_test.rs
@@ -1,6 +1,7 @@
 use fission_core::internal::BuildCtx;
-use fission_core::ui::Text;
+use fission_core::ui::{Scroll, Text};
 use fission_core::{build, GlobalState, View};
+use fission_ir::{LayoutOp, Op, WidgetId};
 use fission_widgets::router::{Route, Router};
 use std::sync::Arc;
 
@@ -64,6 +65,17 @@ fn test_router_params() {
     assert_widget_draws_text(&node, "User 123");
 }
 
+#[test]
+fn router_scopes_route_content_by_matched_path() {
+    let first = route_scroll_id("/page/one");
+    let second = route_scroll_id("/page/two");
+
+    assert_ne!(
+        first, second,
+        "route-local scroll state must not carry between different matched paths"
+    );
+}
+
 fn assert_widget_draws_text(widget: &fission_core::Widget, expected: &str) {
     let ir = fission_core::internal::lower_widget_to_ir(widget);
     assert!(
@@ -74,4 +86,44 @@ fn assert_widget_draws_text(widget: &fission_core::Widget, expected: &str) {
         )),
         "expected lowered widget tree to draw `{expected}`"
     );
+}
+
+fn route_scroll_id(path: &str) -> WidgetId {
+    let mut runtime = fission_core::Runtime::default();
+    runtime.add_app_state(Box::new(State)).unwrap();
+
+    let mut ctx = BuildCtx::<State>::new();
+    let env = fission_core::Env::default();
+    let view = View::new(
+        runtime.get_app_state::<State>().unwrap(),
+        &runtime.runtime_state,
+        &env,
+        None,
+    );
+
+    let router = Router::<State> {
+        current_path: path.into(),
+        routes: vec![Route {
+            path: "/page/:slug".into(),
+            builder: Arc::new(|_, _, params| {
+                Scroll {
+                    child: Some(Text::new(format!("Page {}", params["slug"])).into()),
+                    ..Default::default()
+                }
+                .into()
+            }),
+        }],
+        not_found: None,
+    };
+
+    let node = build::enter(&mut ctx, &view, || router.into());
+    let ir = fission_core::internal::lower_widget_to_ir(&node);
+
+    ir.nodes
+        .iter()
+        .find_map(|(id, node)| match node.op {
+            Op::Layout(LayoutOp::Scroll { .. }) => Some(*id),
+            _ => None,
+        })
+        .expect("route should lower a scroll node")
 }

--- a/crates/authoring/fission-widgets/tests/tabs_test.rs
+++ b/crates/authoring/fission-widgets/tests/tabs_test.rs
@@ -1,0 +1,63 @@
+use fission_core::internal::BuildCtx;
+use fission_core::ui::{Scroll, Text, Widget};
+use fission_core::{build, GlobalState, View};
+use fission_ir::{LayoutOp, Op, WidgetId};
+use fission_widgets::{TabItem, Tabs};
+
+#[derive(Default, Clone, Debug)]
+struct State;
+impl GlobalState for State {}
+
+#[test]
+fn tabs_scope_active_content_by_selected_tab() {
+    let first = active_tab_scroll_id(0);
+    let second = active_tab_scroll_id(1);
+
+    assert_ne!(
+        first, second,
+        "tab-local scroll state must not carry between different active tabs"
+    );
+}
+
+fn active_tab_scroll_id(active_index: usize) -> WidgetId {
+    let mut runtime = fission_core::Runtime::default();
+    runtime.add_app_state(Box::new(State)).unwrap();
+
+    let mut ctx = BuildCtx::<State>::new();
+    let env = fission_core::Env::default();
+    let view = View::new(
+        runtime.get_app_state::<State>().unwrap(),
+        &runtime.runtime_state,
+        &env,
+        None,
+    );
+
+    let tabs = Tabs {
+        active_index,
+        items: vec![tab("One"), tab("Two")],
+        ..Default::default()
+    };
+
+    let node: Widget = build::enter(&mut ctx, &view, || tabs.into());
+    let ir = fission_core::internal::lower_widget_to_ir(&node);
+
+    ir.nodes
+        .iter()
+        .find_map(|(id, node)| match node.op {
+            Op::Layout(LayoutOp::Scroll { .. }) => Some(*id),
+            _ => None,
+        })
+        .expect("active tab should lower a scroll node")
+}
+
+fn tab(title: &str) -> TabItem {
+    TabItem {
+        title: title.into(),
+        content: Scroll {
+            child: Some(Text::new(format!("{title} content")).into()),
+            ..Default::default()
+        }
+        .into(),
+        on_press: None,
+    }
+}

--- a/crates/core/fission-core/src/env.rs
+++ b/crates/core/fission-core/src/env.rs
@@ -209,6 +209,10 @@ impl ScrollStateMap {
     pub fn set_offset(&mut self, id: WidgetId, offset: f32) {
         self.offsets.insert(id, offset);
     }
+
+    pub fn retain_active(&mut self, active: &std::collections::HashSet<WidgetId>) {
+        self.offsets.retain(|id, _| active.contains(id));
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/core/fission-core/src/input/slider.rs
+++ b/crates/core/fission-core/src/input/slider.rs
@@ -71,7 +71,7 @@ impl SliderController {
                         let new_val = min + t * (max - min);
 
                         if let Some(entry) = sem.actions.entries.first() {
-                            let payload = serde_json::to_vec(&new_val).unwrap();
+                            let payload = slider_payload(entry.payload_data.as_deref(), new_val);
                             let envelope = ActionEnvelope {
                                 id: ActionId::from_u128(entry.action_id),
                                 payload,
@@ -87,5 +87,86 @@ impl SliderController {
                 }
             }
         }
+    }
+}
+
+fn slider_payload(template: Option<&[u8]>, new_value: f32) -> Vec<u8> {
+    let Some(template) = template else {
+        return serde_json::to_vec(&new_value).expect("slider value serialization failed");
+    };
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(template) else {
+        return serde_json::to_vec(&new_value).expect("slider value serialization failed");
+    };
+    let Some(number) = serde_json::Number::from_f64(new_value as f64) else {
+        return serde_json::to_vec(&new_value).expect("slider value serialization failed");
+    };
+
+    if replace_numeric_payload(&mut value, number) {
+        serde_json::to_vec(&value).expect("slider action serialization failed")
+    } else {
+        serde_json::to_vec(&new_value).expect("slider value serialization failed")
+    }
+}
+
+fn replace_numeric_payload(value: &mut serde_json::Value, number: serde_json::Number) -> bool {
+    match value {
+        serde_json::Value::Number(slot) => {
+            *slot = number;
+            true
+        }
+        serde_json::Value::Array(items) if items.len() == 1 && items[0].is_number() => {
+            items[0] = serde_json::Value::Number(number);
+            true
+        }
+        serde_json::Value::Object(fields) => {
+            if let Some(slot) = fields.get_mut("value").filter(|slot| slot.is_number()) {
+                *slot = serde_json::Value::Number(number);
+                return true;
+            }
+            let mut numeric_keys = fields
+                .iter()
+                .filter_map(|(key, field)| field.is_number().then_some(key.clone()))
+                .collect::<Vec<_>>();
+            if numeric_keys.len() == 1 {
+                let key = numeric_keys.pop().expect("one numeric key");
+                if let Some(slot) = fields.get_mut(&key) {
+                    *slot = serde_json::Value::Number(number);
+                    return true;
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::slider_payload;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(transparent)]
+    struct TransparentSliderValue(f32);
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct NamedSliderValue {
+        value: f32,
+    }
+
+    #[test]
+    fn slider_payload_preserves_transparent_action_shape() {
+        let payload = slider_payload(Some(b"0.0"), 75.0);
+        let action: TransparentSliderValue = serde_json::from_slice(&payload).unwrap();
+
+        assert_eq!(action, TransparentSliderValue(75.0));
+    }
+
+    #[test]
+    fn slider_payload_preserves_named_value_action_shape() {
+        let payload = slider_payload(Some(br#"{"value":0.0}"#), 25.0);
+        let action: NamedSliderValue = serde_json::from_slice(&payload).unwrap();
+
+        assert_eq!(action, NamedSliderValue { value: 25.0 });
     }
 }

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -1447,7 +1447,12 @@ impl Runtime {
                         while let Some(node_id) = current_id {
                             if let Some(node) = ir.nodes.get(&node_id) {
                                 if let Op::Semantics(semantics) = &node.op {
-                                    if let Some(action_entry) = semantics.actions.entries.first() {
+                                    if let Some(action_entry) =
+                                        semantics.actions.entries.iter().find(|entry| {
+                                            entry.trigger
+                                                == fission_ir::semantics::ActionTrigger::Default
+                                        })
+                                    {
                                         if let Some(payload) = &action_entry.payload_data {
                                             let envelope = ActionEnvelope {
                                                 id: ActionId::from_u128(action_entry.action_id),
@@ -1591,7 +1596,11 @@ impl Runtime {
                             if let Op::Semantics(semantics) = &node.op {
                                 if semantics.role == fission_ir::semantics::Role::TextInput {
                                     // No action
-                                } else if let Some(action_entry) = semantics.actions.entries.first()
+                                } else if let Some(action_entry) =
+                                    semantics.actions.entries.iter().find(|entry| {
+                                        entry.trigger
+                                            == fission_ir::semantics::ActionTrigger::Default
+                                    })
                                 {
                                     if let Some(payload) = &action_entry.payload_data {
                                         let envelope = ActionEnvelope {

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -1009,6 +1009,26 @@ impl Runtime {
     /// schedule another frame.
     pub fn post_layout_hook(&mut self, ir: &CoreIR, layout: &LayoutSnapshot) -> bool {
         let needs_follow_up_frame = self.apply_pending_scroll_into_view(ir, layout);
+        let active_scroll_nodes: HashSet<WidgetId> = ir
+            .nodes
+            .iter()
+            .filter_map(|(id, node)| match node.op {
+                Op::Layout(LayoutOp::Scroll { .. }) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        self.runtime_state
+            .scroll
+            .retain_active(&active_scroll_nodes);
+        if self
+            .runtime_state
+            .gesture
+            .scrollbar_drag
+            .is_some_and(|drag| !active_scroll_nodes.contains(&drag.node_id))
+        {
+            self.runtime_state.gesture.scrollbar_drag = None;
+        }
+
         let mut current_heroes = HashMap::new();
 
         for (id, node) in &ir.nodes {

--- a/crates/core/fission-core/src/ui/widgets/slider.rs
+++ b/crates/core/fission-core/src/ui/widgets/slider.rs
@@ -42,6 +42,18 @@ pub struct Slider {
     pub min: f32,
     /// Maximum value (default: 1.0).
     pub max: f32,
+    /// Visual track height in layout points. Defaults to `4.0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub track_height: Option<f32>,
+    /// Visual thumb diameter in layout points. Defaults to `16.0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumb_size: Option<f32>,
+    /// Optional track fill. Defaults to the active theme border colour.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub track_fill: Option<Fill>,
+    /// Optional thumb fill. Defaults to the active theme primary colour.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumb_fill: Option<Fill>,
     /// Action dispatched when the user drags the thumb.
     pub on_change: Option<ActionEnvelope>,
 }
@@ -62,6 +74,10 @@ impl Default for Slider {
             value: 0.0,
             min: 0.0,
             max: 1.0,
+            track_height: None,
+            thumb_size: None,
+            track_fill: None,
+            thumb_fill: None,
             on_change: None,
         }
     }
@@ -73,42 +89,23 @@ impl InternalLower for Slider {
         cx.push_scope(id);
 
         let tokens = &cx.env.theme.tokens;
-        let thumb_size = 16.0;
-        let track_height = 4.0;
+        let thumb_size = self.thumb_size.unwrap_or(16.0).max(1.0);
+        let track_height = self.track_height.unwrap_or(4.0).max(1.0);
+        let control_height = thumb_size.max(track_height);
 
         let range = (self.max - self.min).max(0.0001);
         let pct = ((self.value - self.min) / range).clamp(0.0, 1.0) * 100.0;
 
-        // Visual Structure:
-        // Grid [Percent(pct), Fixed(thumb), Auto]
-        // Row 1: Height(max(track, thumb))
-
-        // Track Background: DrawRect on the main container (centered vertically?)
-        // Actually, we want the track to be vertically centered.
-        // And Thumb centered.
-
-        // Let's make the root a Grid.
-        // It has a background PaintOp for the Track line?
-        // If we paint on Root, it fills the whole area.
-        // We want track to be thin.
-        // So we need a child for Track?
-        // But Track must span the whole width.
-        // Use ZStack.
-        // Layer 1: Track (Centered vertically).
-        // Layer 2: Thumb Grid.
-
         let layout_id = cx.next_node_id();
 
         let track_layer = {
-            // Center the thin track in the thumb-height z-stack without
-            // materialising detached helper nodes in the IR.
-            let p_y = (thumb_size - track_height) / 2.0;
+            let p_y = (control_height - track_height) / 2.0;
 
             let mut track_container = InternalIrBuilder::new(
                 cx.next_node_id(),
                 Op::Layout(LayoutOp::Box {
                     width: None,
-                    height: None,
+                    height: Some(control_height),
                     min_width: None,
                     max_width: None,
                     min_height: None,
@@ -123,7 +120,11 @@ impl InternalLower for Slider {
             let inner_paint = InternalIrBuilder::new(
                 cx.next_node_id(),
                 Op::Paint(PaintOp::DrawRect {
-                    fill: Some(Fill::Solid(tokens.colors.border)),
+                    fill: Some(
+                        self.track_fill
+                            .clone()
+                            .unwrap_or(Fill::Solid(tokens.colors.border)),
+                    ),
                     stroke: None,
                     corner_radius: track_height / 2.0,
                     shadow: None,
@@ -131,20 +132,8 @@ impl InternalLower for Slider {
             )
             .build(cx);
 
-            // We need inner box to have height `track_height`.
-            // The padding pushes the content in.
-            // The inner box fills the remaining height.
-            // If container height is `thumb_size`, and padding is `(thumb-track)/2`, remaining is `track`.
-            // But container height is `Auto` (driven by ZStack constraint?).
-            // ZStack constraints are "largest child".
-            // If Thumb layer is `thumb_size` height, Root is `thumb_size`.
-            // Track container fills Root.
-
-            // So yes, Padding approach works if Root height is constrained by Thumb.
-
-            // But `inner_paint` needs a layout node to fill?
             let mut inner_box =
-                InternalIrBuilder::new(cx.next_node_id(), Op::Layout(LayoutOp::AbsoluteFill)); // Fill the padded area
+                InternalIrBuilder::new(cx.next_node_id(), Op::Layout(LayoutOp::AbsoluteFill));
             inner_box.add_child(inner_paint);
             let inner_id = inner_box.build(cx);
 
@@ -157,7 +146,11 @@ impl InternalLower for Slider {
             let thumb_paint = InternalIrBuilder::new(
                 cx.next_node_id(),
                 Op::Paint(PaintOp::DrawRect {
-                    fill: Some(Fill::Solid(tokens.colors.primary)),
+                    fill: Some(
+                        self.thumb_fill
+                            .clone()
+                            .unwrap_or(Fill::Solid(tokens.colors.primary)),
+                    ),
                     stroke: None,
                     corner_radius: thumb_size / 2.0,
                     shadow: Some(fission_ir::op::BoxShadow {
@@ -190,7 +183,36 @@ impl InternalLower for Slider {
                 }),
             );
             thumb_box.add_child(thumb_paint);
-            let thumb_id = thumb_box.build(cx);
+            let thumb_box_id = thumb_box.build(cx);
+
+            // Grid placement positions the thumb's left edge at the value
+            // percentage. Translate the visual thumb so its centre sits on the
+            // track point the user clicked or dragged to.
+            let mut transformed_thumb = InternalIrBuilder::new(
+                cx.next_node_id(),
+                Op::Layout(LayoutOp::Transform {
+                    transform: [
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0,
+                        -thumb_size / 2.0,
+                        (control_height - thumb_size) / 2.0,
+                        0.0,
+                        1.0,
+                    ],
+                }),
+            );
+            transformed_thumb.add_child(thumb_box_id);
+            let transformed_thumb_id = transformed_thumb.build(cx);
 
             let mut grid = InternalIrBuilder::new(
                 cx.next_node_id(),
@@ -200,7 +222,7 @@ impl InternalLower for Slider {
                         GridTrack::Points(thumb_size),
                         GridTrack::Fr(1.0),
                     ],
-                    rows: vec![GridTrack::Points(thumb_size)],
+                    rows: vec![GridTrack::Points(control_height)],
                     column_gap: None,
                     row_gap: None,
                     padding: [0.0; 4],
@@ -217,7 +239,7 @@ impl InternalLower for Slider {
                     col_end: fission_ir::op::GridPlacement::Auto,
                 }),
             );
-            item.add_child(thumb_id);
+            item.add_child(transformed_thumb_id);
             let item_id = item.build(cx);
 
             grid.add_child(item_id);

--- a/crates/core/fission-core/tests/scroll_state.rs
+++ b/crates/core/fission-core/tests/scroll_state.rs
@@ -1,0 +1,18 @@
+use std::collections::HashSet;
+
+use fission_core::ScrollStateMap;
+use fission_ir::WidgetId;
+
+#[test]
+fn scroll_state_discards_unmounted_scroll_nodes() {
+    let active = WidgetId::explicit("active-scroll");
+    let inactive = WidgetId::explicit("inactive-scroll");
+    let mut scroll = ScrollStateMap::default();
+    scroll.set_offset(active, 40.0);
+    scroll.set_offset(inactive, 120.0);
+
+    scroll.retain_active(&HashSet::from([active]));
+
+    assert_eq!(scroll.get_offset(active), 40.0);
+    assert_eq!(scroll.get_offset(inactive), 0.0);
+}

--- a/crates/core/fission-core/tests/slider_input.rs
+++ b/crates/core/fission-core/tests/slider_input.rs
@@ -1,0 +1,102 @@
+use fission_core::event::{InputEvent, PointerButton, PointerEvent};
+use fission_core::{ActionEnvelope, ActionId, GlobalState, Runtime};
+use fission_ir::semantics::ActionTrigger;
+use fission_ir::WidgetId;
+use fission_ir::{ActionEntry, ActionSet, CompositeStyle, CoreIR, CoreNode, Op, Role, Semantics};
+use fission_layout::{LayoutNodeGeometry, LayoutPoint, LayoutRect, LayoutSize, LayoutSnapshot};
+
+#[derive(Default, Debug, Clone)]
+struct SliderState {
+    changes: usize,
+    value: f32,
+}
+
+impl GlobalState for SliderState {}
+
+#[test]
+fn slider_pointer_up_does_not_replay_template_change_payload() -> anyhow::Result<()> {
+    let action_id = ActionId::from_name("fission_core_test::SliderChanged");
+    let slider_id = WidgetId::explicit("slider");
+    let (ir, layout) = slider_tree(slider_id, action_id);
+    let mut runtime = Runtime::default();
+    runtime.add_app_state(Box::new(SliderState::default()))?;
+    runtime.register_reducer::<SliderState>(action_id, record_slider_change)?;
+
+    let point = LayoutPoint::new(150.0, 20.0);
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Down {
+            point,
+            button: PointerButton::Primary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Up {
+            point,
+            button: PointerButton::Primary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+
+    let state = runtime
+        .get_app_state::<SliderState>()
+        .expect("slider state");
+    assert_eq!(state.changes, 1);
+    assert_eq!(state.value, 25.0);
+    Ok(())
+}
+
+fn record_slider_change(
+    state: &mut SliderState,
+    action: &ActionEnvelope,
+    _target: WidgetId,
+) -> anyhow::Result<()> {
+    state.changes += 1;
+    state.value = serde_json::from_slice(&action.payload)?;
+    Ok(())
+}
+
+fn slider_tree(slider_id: WidgetId, action_id: ActionId) -> (CoreIR, LayoutSnapshot) {
+    let mut ir = CoreIR::default();
+    ir.root = Some(slider_id);
+    ir.nodes.insert(
+        slider_id,
+        CoreNode {
+            id: slider_id,
+            op: Op::Semantics(Semantics {
+                role: Role::Slider,
+                focusable: true,
+                draggable: true,
+                min_value: Some(0.0),
+                max_value: Some(100.0),
+                current_value: Some(0.0),
+                actions: ActionSet {
+                    entries: vec![ActionEntry {
+                        trigger: ActionTrigger::Change,
+                        action_id: action_id.as_u128(),
+                        payload_data: Some(serde_json::to_vec(&0.0).unwrap()),
+                    }],
+                },
+                ..Default::default()
+            }),
+            composite: CompositeStyle::default(),
+            children: Vec::new(),
+            parent: None,
+            hash: 0,
+        },
+    );
+
+    let mut layout = LayoutSnapshot::new(LayoutSize::new(300.0, 100.0));
+    layout.nodes.insert(
+        slider_id,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(100.0, 10.0, 200.0, 20.0),
+            content_size: LayoutSize::new(200.0, 20.0),
+        },
+    );
+    (ir, layout)
+}

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -7,10 +7,11 @@ use fission::prelude::fission_action;
 use fission::prelude::DesktopApp;
 use fission::widgets::{
     Accordion, AccordionItem, Alert, AlertKind, Avatar, Badge, Breadcrumb, BreadcrumbItem, Card,
-    CircularProgress, Code, Divider, Drawer, DrawerSide, EmptyState, HStack, Kbd, Link, MenuButton,
-    MenuItem, Modal, ModalAction, NumberInput, Pagination, ProgressBar, SegmentedControl, Select,
-    SelectItem, Skeleton, SkeletonMotion, Spacer, Spinner, SpinnerMotion, Stat, Stepper, TabItem,
-    Tabs, Tag, Timeline, TimelineItem, Toast, ToastKind, Tooltip, TreeItem, TreeView, VStack,
+    CircularProgress, Code, ColourHsva, ColourPicker, ColourPickerVariant, Divider, Drawer,
+    DrawerSide, EmptyState, HStack, Kbd, Link, MenuButton, MenuItem, Modal, ModalAction,
+    NumberInput, Pagination, ProgressBar, SegmentedControl, Select, SelectItem, Skeleton,
+    SkeletonMotion, Spacer, Spinner, SpinnerMotion, Stat, Stepper, TabItem, Tabs, Tag, Timeline,
+    TimelineItem, Toast, ToastKind, Tooltip, TreeItem, TreeView, VStack, Wrap,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -23,6 +24,8 @@ struct GalleryState {
     slider_val: f32,
     range_start: f32,
     range_end: f32,
+    colour_value: IrColor,
+    colour_variant: usize,
     checked: bool,
     switch_on: bool,
     text_value: String,
@@ -50,6 +53,13 @@ impl Default for GalleryState {
             slider_val: 50.0,
             range_start: 0.0,
             range_end: 0.0,
+            colour_value: IrColor {
+                r: 59,
+                g: 130,
+                b: 246,
+                a: 255,
+            },
+            colour_variant: 0,
             checked: true,
             switch_on: true,
             text_value: String::new(),
@@ -78,6 +88,34 @@ impl GlobalState for GalleryState {}
 #[fission_action(no_eq)]
 #[serde(transparent)]
 struct SetSlider(f32);
+
+#[fission_action(no_eq)]
+#[serde(transparent)]
+struct SetGalleryColour(IrColor);
+
+#[fission_action(no_eq)]
+#[serde(transparent)]
+struct SetGalleryColourHue(f32);
+
+#[fission_action(no_eq)]
+#[serde(transparent)]
+struct SetGalleryColourSaturation(f32);
+
+#[fission_action(no_eq)]
+#[serde(transparent)]
+struct SetGalleryColourValue(f32);
+
+#[fission_action(no_eq)]
+#[serde(transparent)]
+struct SetGalleryColourAlpha(f32);
+
+#[fission_action]
+#[serde(transparent)]
+struct SetGalleryColourHex(String);
+
+#[fission_action]
+#[serde(transparent)]
+struct SetColourVariant(usize);
 
 #[fission_action]
 struct ToggleChecked;
@@ -178,6 +216,85 @@ impl BuildInline for Divider {
             .flex_grow(1.0)
             .into()
     }
+}
+
+fn colour_variants() -> &'static [(&'static str, ColourPickerVariant)] {
+    &[
+        ("Chrome", ColourPickerVariant::Chrome),
+        ("Sketch", ColourPickerVariant::Sketch),
+        ("Photoshop", ColourPickerVariant::Photoshop),
+        ("Compact", ColourPickerVariant::Compact),
+        ("Circle", ColourPickerVariant::Circle),
+        ("GitHub", ColourPickerVariant::Github),
+        ("Twitter", ColourPickerVariant::Twitter),
+        ("Material", ColourPickerVariant::Material),
+        ("Slider", ColourPickerVariant::Slider),
+        ("Swatches", ColourPickerVariant::Swatches),
+        ("Block", ColourPickerVariant::Block),
+        ("Hue", ColourPickerVariant::Hue),
+        ("Alpha", ColourPickerVariant::Alpha),
+    ]
+}
+
+fn colour_variant_chip_width(label: &str) -> f32 {
+    match label {
+        "Photoshop" => 112.0,
+        "Swatches" => 104.0,
+        "Material" | "Compact" => 96.0,
+        "GitHub" | "Twitter" | "Chrome" | "Sketch" => 86.0,
+        _ => 74.0,
+    }
+}
+
+fn parse_gallery_hex(value: &str) -> Option<IrColor> {
+    let hex = value.trim().strip_prefix('#').unwrap_or(value.trim());
+    if hex.len() != 6 && hex.len() != 8 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    let a = if hex.len() == 8 {
+        u8::from_str_radix(&hex[6..8], 16).ok()?
+    } else {
+        255
+    };
+    Some(IrColor { r, g, b, a })
+}
+
+fn gallery_hex_string(colour: IrColor) -> String {
+    if colour.a == 255 {
+        format!("#{:02X}{:02X}{:02X}", colour.r, colour.g, colour.b)
+    } else {
+        format!(
+            "#{:02X}{:02X}{:02X}{:02X}",
+            colour.r, colour.g, colour.b, colour.a
+        )
+    }
+}
+
+fn set_colour_hue(state: &mut GalleryState, hue: f32) {
+    let mut hsva = ColourHsva::from_color(state.colour_value);
+    hsva.hue = hue;
+    state.colour_value = hsva.to_color();
+}
+
+fn set_colour_saturation(state: &mut GalleryState, saturation: f32) {
+    let mut hsva = ColourHsva::from_color(state.colour_value);
+    hsva.saturation = saturation;
+    state.colour_value = hsva.to_color();
+}
+
+fn set_colour_value(state: &mut GalleryState, value: f32) {
+    let mut hsva = ColourHsva::from_color(state.colour_value);
+    hsva.value = value;
+    state.colour_value = hsva.to_color();
+}
+
+fn set_colour_alpha(state: &mut GalleryState, alpha: f32) {
+    let mut hsva = ColourHsva::from_color(state.colour_value);
+    hsva.alpha = alpha;
+    state.colour_value = hsva.to_color();
 }
 
 // --- App Widget ---
@@ -355,6 +472,156 @@ impl From<GalleryApp> for Widget {
                     on_decrement: Some(ctx.bind(
                         DecrementNumber,
                         reduce_with!((|s: &mut GalleryState, _, _| s.number_val -= 1.0)),
+                    )),
+                    ..Default::default()
+                }
+                .into(),
+            ],
+        );
+
+        // -- Colour Picker --
+        let colour_variants = colour_variants();
+        let active_colour_variant = colour_variants
+            .get(s.colour_variant)
+            .map(|(_, variant)| *variant)
+            .unwrap_or(ColourPickerVariant::Chrome);
+        let colour_change = Arc::new({
+            let env = ctx.bind(
+                SetGalleryColour(s.colour_value),
+                reduce_with!((|s: &mut GalleryState, a: SetGalleryColour, _| s.colour_value = a.0)),
+            );
+            move |colour: IrColor| ActionEnvelope {
+                id: env.id,
+                payload: serde_json::to_vec(&colour).unwrap(),
+            }
+        });
+        let colour_section = section(
+            "Colour Picker",
+            vec![
+                Text::new(
+                    "Built-in picker variants covering Chrome, Sketch, Photoshop, Compact, Circle, GitHub, Twitter, Material, Slider, Swatches, Block, Hue and Alpha layouts.",
+                )
+                .color(tokens.colors.text_secondary)
+                .into(),
+                HStack {
+                    spacing: Some(10.0),
+                    children: vec![
+                        Container::new(Text::new(""))
+                            .size(28.0, 28.0)
+                            .bg(s.colour_value)
+                            .border(tokens.colors.border, 1.0)
+                            .border_radius(tokens.radii.small)
+                            .into(),
+                        Text::new(format!("Current {}", gallery_hex_string(s.colour_value)))
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                    ],
+                    ..Default::default()
+                }
+                .into(),
+                Wrap {
+                    direction: FlexDirection::Row,
+                    spacing: Some(6.0),
+                    children: colour_variants
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, (label, _))| {
+                            Button {
+                                variant: if idx == s.colour_variant {
+                                    ButtonVariant::Filled
+                                } else {
+                                    ButtonVariant::Outline
+                                },
+                                child: Some(Text::new(*label).into()),
+                                on_press: Some(ctx.bind(
+                                    SetColourVariant(idx),
+                                    reduce_with!(
+                                        (|s: &mut GalleryState, a: SetColourVariant, _| {
+                                            s.colour_variant = a.0
+                                        })
+                                    ),
+                                )),
+                                width: Some(colour_variant_chip_width(label)),
+                                height: Some(34.0),
+                                padding: Some([10.0, 10.0, 6.0, 6.0]),
+                                ..Default::default()
+                            }
+                            .semantics_identifier(format!("gallery.colour.variant.{label}"))
+                            .into()
+                        })
+                        .collect(),
+                }
+                .into(),
+                ColourPicker {
+                    id: Some(WidgetId::explicit("gallery_colour_picker")),
+                    semantics_identifier: Some("gallery.colour".into()),
+                    value: s.colour_value,
+                    variant: active_colour_variant,
+                    show_alpha: true,
+                    show_inputs: true,
+                    width: Some(control_width.min(420.0).max(260.0)),
+                    recent: vec![
+                        IrColor {
+                            r: 16,
+                            g: 185,
+                            b: 129,
+                            a: 255,
+                        },
+                        IrColor {
+                            r: 244,
+                            g: 63,
+                            b: 94,
+                            a: 255,
+                        },
+                        IrColor {
+                            r: 245,
+                            g: 158,
+                            b: 11,
+                            a: 255,
+                        },
+                    ],
+                    on_change: Some(colour_change),
+                    on_hue_change: Some(ctx.bind(
+                        SetGalleryColourHue(0.0),
+                        reduce_with!(
+                            (|s: &mut GalleryState, a: SetGalleryColourHue, _| {
+                                set_colour_hue(s, a.0)
+                            })
+                        ),
+                    )),
+                    on_saturation_change: Some(ctx.bind(
+                        SetGalleryColourSaturation(0.0),
+                        reduce_with!(
+                            (|s: &mut GalleryState, a: SetGalleryColourSaturation, _| {
+                                set_colour_saturation(s, a.0)
+                            })
+                        ),
+                    )),
+                    on_value_change: Some(ctx.bind(
+                        SetGalleryColourValue(0.0),
+                        reduce_with!(
+                            (|s: &mut GalleryState, a: SetGalleryColourValue, _| {
+                                set_colour_value(s, a.0)
+                            })
+                        ),
+                    )),
+                    on_alpha_change: Some(ctx.bind(
+                        SetGalleryColourAlpha(1.0),
+                        reduce_with!(
+                            (|s: &mut GalleryState, a: SetGalleryColourAlpha, _| {
+                                set_colour_alpha(s, a.0)
+                            })
+                        ),
+                    )),
+                    on_hex_change: Some(ctx.bind(
+                        SetGalleryColourHex(String::new()),
+                        reduce_with!(
+                            (|s: &mut GalleryState, a: SetGalleryColourHex, _| {
+                                if let Some(colour) = parse_gallery_hex(&a.0) {
+                                    s.colour_value = colour;
+                                }
+                            })
+                        ),
                     )),
                     ..Default::default()
                 }
@@ -904,6 +1171,7 @@ impl From<GalleryApp> for Widget {
                     .into(),
                 display_section,
                 input_section,
+                colour_section,
                 feedback_section,
                 nav_section,
                 data_section,


### PR DESCRIPTION
## Summary

- Fix slider thumb positioning so the visual centre sits on the clicked/dragged track position.
- Preserve slider action payload shapes while injecting the new numeric value.
- Prevent generic pointer/keyboard activation from replaying non-default semantic actions such as slider `Change` templates.
- Prune unmounted scroll state and scope Router/Tabs content so page or tab changes do not inherit stale scroll offsets.
- Add the built-in `ColourPicker` widget and widget-gallery examples for Chrome, Sketch, Photoshop, Compact, Circle, GitHub, Twitter, Material, Slider, Swatches, Block, Hue and Alpha variants.

## Manual QA

- Ran `widget-gallery` with LiveTest control on port `9987`.
- Verified colour picker slider visual alignment from screenshot: `.artifacts/screenshots/slider-qa/hue-slider-centered-fixed-final.png`.
- Verified selector-driven slider clicks using visible bounds:
  - `gallery.colour.hue` 25% -> `89.84`, 75% -> `270.16`
  - `gallery.colour.saturation` 25% -> `0.25`, 75% -> `0.75`
  - `gallery.colour.value` 25% -> `0.25`, 75% -> `0.75`

## Validation

- `cargo fmt --all`
- `cargo check -p fission-core -p fission-widgets -p widget-gallery`
- `cargo test -p fission-core --test slider_input --test scroll_state`
- `cargo test -p fission-core input::slider::tests --lib`
- `cargo test -p fission-widgets --test router_test --test tabs_test`
- `git diff --check`
