### PR TITLE
Capture and restore focus across barrier lifecycles

### DIFF
--- a/crates/authoring/fission-widgets/src/drawer.rs
+++ b/crates/authoring/fission-widgets/src/drawer.rs
@@ -1,6 +1,6 @@
 use crate::motion_support::{
     dedupe, exit_for, fade_in, push_enter_with_exit, slide_x_in, slide_y_in, slot_id,
-    SLOT_BACKDROP, SLOT_PANEL,
+    SLOT_BACKDROP, SLOT_FOCUS_SCOPE, SLOT_PANEL,
 };
 use fission_core::motion::{MotionTrack, Presence};
 use fission_core::op::{BoxShadow, Color};
@@ -343,7 +343,7 @@ impl From<Drawer> for Widget {
             bottom: Some(0.0),
             child: Some(
                 fission_core::ui::widgets::FocusScope {
-                    id: None,
+                    id: Some(slot_id(this.id, SLOT_FOCUS_SCOPE)),
                     is_barrier: true,
                     children: vec![root],
                 }

--- a/crates/authoring/fission-widgets/src/modal.rs
+++ b/crates/authoring/fission-widgets/src/modal.rs
@@ -1,6 +1,6 @@
 use crate::motion_support::{
     dedupe, exit_for, fade_in, push_enter_with_exit, scale_in, slide_x_in, slide_y_in, slot_id,
-    SLOT_BACKDROP, SLOT_SURFACE,
+    SLOT_BACKDROP, SLOT_FOCUS_SCOPE, SLOT_SURFACE,
 };
 use crate::stack::{HStack, VStack};
 use crate::Icon;
@@ -448,7 +448,7 @@ impl From<Modal> for Widget {
             bottom: Some(0.0),
             child: Some(
                 fission_core::ui::widgets::FocusScope {
-                    id: None,
+                    id: Some(slot_id(this.id, SLOT_FOCUS_SCOPE)),
                     is_barrier: true,
                     children: vec![root],
                 }

--- a/crates/authoring/fission-widgets/src/motion_support.rs
+++ b/crates/authoring/fission-widgets/src/motion_support.rs
@@ -7,6 +7,7 @@ use fission_core::WidgetId;
 pub(crate) const SLOT_BACKDROP: u32 = 0xBACC_DA7A;
 pub(crate) const SLOT_SURFACE: u32 = 0x5AFA_CE;
 pub(crate) const SLOT_PANEL: u32 = 0xCAFE_2A1;
+pub(crate) const SLOT_FOCUS_SCOPE: u32 = 0xF0C0_5C0E;
 pub(crate) const SLOT_INDICATOR: u32 = 0x1D1_CA70;
 pub(crate) const SLOT_CONTENT: u32 = 0xC017_E17;
 

--- a/crates/core/fission-core/src/hit_test.rs
+++ b/crates/core/fission-core/src/hit_test.rs
@@ -178,32 +178,14 @@ pub fn find_next_focus_node(
     current: Option<WidgetId>,
     reverse: bool,
 ) -> Option<WidgetId> {
-    // Identify current scope if focused node is provided
-    let (current_scope_id, current_is_barrier) = if let Some(id) = current {
-        let scope = find_parent_scope(id, ir);
-        let mut is_barrier = false;
-        if let Some(sid) = scope {
-            if let Some(node) = ir.nodes.get(&sid) {
-                if let Op::Semantics(s) = &node.op {
-                    is_barrier = s.is_focus_barrier;
-                }
-            }
+    let nodes_in_scope = if let Some(barrier_id) = topmost_focus_barrier(ir) {
+        focusable_nodes_in_scope(ir, barrier_id)
+    } else if let Some(scope_id) = current.and_then(|id| find_containing_focus_scope(id, ir)) {
+        if is_focus_barrier(ir, scope_id) {
+            focusable_nodes_in_scope(ir, scope_id)
+        } else {
+            get_all_focusable_nodes(ir)
         }
-        (scope, is_barrier)
-    } else {
-        (None, false)
-    };
-
-    let nodes_in_scope = if current_is_barrier {
-        let scope_id = current_scope_id.unwrap();
-        let mut list = Vec::new();
-        // Start recursion on CHILDREN of the barrier root to avoid skipping it
-        if let Some(node) = ir.nodes.get(&scope_id) {
-            for child in &node.children {
-                collect_focusable_nodes(*child, ir, &mut list, true, 0);
-            }
-        }
-        sort_focusable_nodes(ir, list)
     } else {
         get_all_focusable_nodes(ir)
     };
@@ -248,6 +230,61 @@ pub fn get_all_focusable_nodes(ir: &CoreIR) -> Vec<WidgetId> {
         collect_focusable_nodes(root, ir, &mut list, false, 0);
     }
     sort_focusable_nodes(ir, list)
+}
+
+/// Returns focus barriers in tree order. The last barrier is the topmost active
+/// barrier because overlays lower after their underlying content.
+pub fn focus_barriers_in_tree_order(ir: &CoreIR) -> Vec<WidgetId> {
+    let mut barriers = Vec::new();
+    if let Some(root) = ir.root {
+        collect_focus_barriers(root, ir, &mut barriers);
+    }
+    barriers
+}
+
+/// Returns the topmost active focus barrier in the current semantic tree.
+pub fn topmost_focus_barrier(ir: &CoreIR) -> Option<WidgetId> {
+    focus_barriers_in_tree_order(ir).last().copied()
+}
+
+/// Returns enabled focusable nodes inside `scope_id` in traversal order.
+pub fn focusable_nodes_in_scope(ir: &CoreIR, scope_id: WidgetId) -> Vec<WidgetId> {
+    let mut list = Vec::new();
+    if let Some(scope) = ir.nodes.get(&scope_id) {
+        let mut order = 0;
+        for child in &scope.children {
+            collect_focusable_nodes(*child, ir, &mut list, false, order);
+            order = list.last().map(|(_, index)| *index + 1).unwrap_or(order);
+        }
+    }
+    sort_focusable_nodes(ir, list)
+}
+
+/// Returns the preferred entry target for a focus scope.
+pub fn preferred_focus_node_in_scope(ir: &CoreIR, scope_id: WidgetId) -> Option<WidgetId> {
+    let nodes = focusable_nodes_in_scope(ir, scope_id);
+    nodes
+        .iter()
+        .copied()
+        .find(|id| semantics(ir, *id).is_some_and(|value| value.autofocus))
+        .or_else(|| nodes.first().copied())
+}
+
+/// Returns whether `node_id` is an enabled focus target.
+pub fn is_enabled_focus_node(ir: &CoreIR, node_id: WidgetId) -> bool {
+    semantics(ir, node_id).is_some_and(|value| value.focusable && !value.disabled)
+}
+
+/// Returns whether `node_id` is `ancestor_id` or belongs to its subtree.
+pub fn is_descendant_or_self(ir: &CoreIR, node_id: WidgetId, ancestor_id: WidgetId) -> bool {
+    let mut current = Some(node_id);
+    while let Some(id) = current {
+        if id == ancestor_id {
+            return true;
+        }
+        current = ir.nodes.get(&id).and_then(|node| node.parent);
+    }
+    false
 }
 
 fn sort_focusable_nodes(ir: &CoreIR, mut list: Vec<(WidgetId, usize)>) -> Vec<WidgetId> {
@@ -320,8 +357,20 @@ fn collect_focusable_nodes(
     }
 }
 
-fn find_parent_scope(node_id: WidgetId, ir: &CoreIR) -> Option<WidgetId> {
-    let mut curr = ir.nodes.get(&node_id)?.parent;
+fn collect_focus_barriers(node_id: WidgetId, ir: &CoreIR, barriers: &mut Vec<WidgetId>) {
+    let Some(node) = ir.nodes.get(&node_id) else {
+        return;
+    };
+    if matches!(&node.op, Op::Semantics(value) if value.is_focus_scope && value.is_focus_barrier) {
+        barriers.push(node_id);
+    }
+    for child in &node.children {
+        collect_focus_barriers(*child, ir, barriers);
+    }
+}
+
+fn find_containing_focus_scope(node_id: WidgetId, ir: &CoreIR) -> Option<WidgetId> {
+    let mut curr = Some(node_id);
     while let Some(pid) = curr {
         if let Some(node) = ir.nodes.get(&pid) {
             if let Op::Semantics(s) = &node.op {
@@ -335,6 +384,17 @@ fn find_parent_scope(node_id: WidgetId, ir: &CoreIR) -> Option<WidgetId> {
         }
     }
     None
+}
+
+fn is_focus_barrier(ir: &CoreIR, node_id: WidgetId) -> bool {
+    semantics(ir, node_id).is_some_and(|value| value.is_focus_barrier)
+}
+
+fn semantics(ir: &CoreIR, node_id: WidgetId) -> Option<&fission_ir::Semantics> {
+    match &ir.nodes.get(&node_id)?.op {
+        Op::Semantics(value) => Some(value),
+        _ => None,
+    }
 }
 
 pub fn find_neighbor_focus_node(

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -58,6 +58,12 @@ struct PendingScrollIntoView {
     retries_remaining: u8,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FocusBarrierFrame {
+    id: WidgetId,
+    restore_target: Option<WidgetId>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ScrollIntoViewOutcome {
     Applied { changed: bool },
@@ -118,6 +124,8 @@ pub struct Runtime {
     pub pending_effects: Vec<EffectEnvelope>,
     /// Post-layout scroll requests that need computed geometry before applying.
     pending_scroll_into_view: Vec<PendingScrollIntoView>,
+    /// Active focus barriers and the targets restored as each barrier closes.
+    focus_barriers: Vec<FocusBarrierFrame>,
     /// Monotonically increasing counter for deterministic request id generation.
     pub next_req_id: u64,
     /// Declarative runtime resources that currently exist.
@@ -138,6 +146,7 @@ impl Default for Runtime {
             ime_handler: None,
             pending_effects: Vec::new(),
             pending_scroll_into_view: Vec::new(),
+            focus_barriers: Vec::new(),
             next_req_id: 0,
             active_resources: HashMap::new(),
             next_resource_generation: 1,
@@ -171,6 +180,118 @@ impl Runtime {
     pub fn with_ime_handler(mut self, handler: Arc<dyn ImeHandler>) -> Self {
         self.ime_handler = Some(handler);
         self
+    }
+
+    /// Reconciles keyboard focus with the focus barriers in a newly lowered IR.
+    ///
+    /// New barriers capture focus, nested barriers retain a restoration chain,
+    /// and closing barriers restores the most recent valid target.
+    pub fn reconcile_focus(&mut self, ir: &CoreIR) -> Result<bool> {
+        use crate::hit_test::{
+            focus_barriers_in_tree_order, get_all_focusable_nodes, is_descendant_or_self,
+            is_enabled_focus_node, preferred_focus_node_in_scope,
+        };
+
+        let active_barriers = focus_barriers_in_tree_order(ir);
+        let common_prefix = self
+            .focus_barriers
+            .iter()
+            .map(|frame| frame.id)
+            .zip(active_barriers.iter().copied())
+            .take_while(|(tracked, active)| tracked == active)
+            .count();
+        let popped_any = self.focus_barriers.len() > common_prefix;
+        let mut restore_target = None;
+        while self.focus_barriers.len() > common_prefix {
+            restore_target = self
+                .focus_barriers
+                .pop()
+                .and_then(|frame| frame.restore_target);
+        }
+
+        for (index, barrier_id) in active_barriers
+            .iter()
+            .copied()
+            .enumerate()
+            .skip(common_prefix)
+        {
+            let restore = if index == 0 {
+                restore_target
+                    .filter(|id| is_enabled_focus_node(ir, *id))
+                    .or_else(|| {
+                        self.runtime_state
+                            .interaction
+                            .focused
+                            .filter(|id| is_enabled_focus_node(ir, *id))
+                    })
+            } else {
+                let parent_barrier_id = active_barriers[index - 1];
+                self.runtime_state
+                    .interaction
+                    .focused
+                    .filter(|id| {
+                        is_enabled_focus_node(ir, *id)
+                            && is_descendant_or_self(ir, *id, parent_barrier_id)
+                            && !is_descendant_or_self(ir, *id, barrier_id)
+                    })
+                    .or_else(|| preferred_focus_node_in_scope(ir, parent_barrier_id))
+            };
+            self.focus_barriers.push(FocusBarrierFrame {
+                id: barrier_id,
+                restore_target: restore,
+            });
+        }
+
+        let current = self.runtime_state.interaction.focused;
+        let next = if let Some(barrier_id) = active_barriers.last().copied() {
+            current
+                .filter(|id| {
+                    is_enabled_focus_node(ir, *id) && is_descendant_or_self(ir, *id, barrier_id)
+                })
+                .or_else(|| {
+                    restore_target.filter(|id| {
+                        is_enabled_focus_node(ir, *id) && is_descendant_or_self(ir, *id, barrier_id)
+                    })
+                })
+                .or_else(|| preferred_focus_node_in_scope(ir, barrier_id))
+        } else if popped_any {
+            restore_target
+                .filter(|id| is_enabled_focus_node(ir, *id))
+                .or_else(|| {
+                    let nodes = get_all_focusable_nodes(ir);
+                    nodes
+                        .iter()
+                        .copied()
+                        .find(|id| {
+                            matches!(
+                                ir.nodes.get(id).map(|node| &node.op),
+                                Some(Op::Semantics(semantics)) if semantics.autofocus
+                            )
+                        })
+                        .or_else(|| nodes.first().copied())
+                })
+        } else {
+            current.filter(|id| is_enabled_focus_node(ir, *id))
+        };
+
+        if current == next {
+            return Ok(false);
+        }
+
+        self.clear_text_pending_on_blur(current, next);
+        self.dispatch_custom_blur_actions(ir, current)?;
+        self.runtime_state.interaction.set_focused(next);
+        if let Some(ime_handler) = &self.ime_handler {
+            let accepts_text = next.is_some_and(|id| {
+                matches!(
+                    ir.nodes.get(&id).map(|node| &node.op),
+                    Some(Op::Semantics(semantics))
+                        if semantics.role == fission_ir::semantics::Role::TextInput
+                )
+            });
+            ime_handler.set_ime_allowed(accepts_text);
+        }
+        Ok(true)
     }
 
     pub fn caret_from_point_in_text(
@@ -913,6 +1034,8 @@ impl Runtime {
         use crate::input::{ControllerContext, InputController};
         use crate::scrollbar::scrollbar_hit_test;
         use crate::ui::custom_render::downcast_render_object;
+
+        self.reconcile_focus(ir)?;
 
         if self.runtime_state.interaction.focused.is_none() {
             if let Some(autofocus_id) = Self::find_autofocus_node(ir) {

--- a/crates/core/fission-core/src/tests/focus_scope_test.rs
+++ b/crates/core/fission-core/src/tests/focus_scope_test.rs
@@ -4,7 +4,40 @@ use crate::internal::InternalLower;
 use crate::lowering::InternalLoweringCx;
 use crate::ui::widgets::button::Button;
 use crate::ui::widgets::focus_scope::FocusScope;
+use crate::ui::Widget;
+use crate::Runtime;
 use fission_ir::{CoreIR, Op, WidgetId};
+
+fn test_action() -> crate::ActionEnvelope {
+    crate::ActionEnvelope {
+        id: crate::ActionId::from_u128(1),
+        payload: Vec::new(),
+    }
+}
+
+fn focus_button(id: &str, autofocus: bool) -> Widget {
+    Button {
+        id: Some(WidgetId::explicit(id)),
+        on_press: Some(test_action()),
+        semantics: Some(fission_ir::Semantics {
+            role: fission_ir::Role::Button,
+            focusable: true,
+            autofocus,
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+    .into()
+}
+
+fn lower(root: Widget) -> CoreIR {
+    let env = Env::default();
+    let runtime_state = RuntimeState::default();
+    let mut cx = InternalLoweringCx::new(&env, &runtime_state, None, None);
+    let root_id = root.lower(&mut cx);
+    cx.ir.root = Some(root_id);
+    cx.ir
+}
 
 #[test]
 fn test_focus_scope_traversal() {
@@ -116,4 +149,249 @@ fn test_focus_scope_traversal() {
         Some(b2_id),
         "Tab from B3 should cycle to B2 due to barrier"
     );
+}
+
+#[test]
+fn active_barrier_captures_focus_and_restores_the_background_target() {
+    let background_id = WidgetId::explicit("background");
+    let modal_primary_id = WidgetId::explicit("modal-primary");
+    let modal_secondary_id = WidgetId::explicit("modal-secondary");
+    let scope_id = WidgetId::explicit("modal-scope");
+
+    let background_ir = lower(
+        crate::ui::widgets::column::Column {
+            children: vec![focus_button("background", false)],
+            ..Default::default()
+        }
+        .into(),
+    );
+    let modal_ir = lower(
+        crate::ui::widgets::column::Column {
+            children: vec![
+                focus_button("background", false),
+                FocusScope {
+                    id: Some(scope_id),
+                    is_barrier: true,
+                    children: vec![
+                        focus_button("modal-secondary", false),
+                        focus_button("modal-primary", true),
+                    ],
+                }
+                .into(),
+            ],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let mut runtime = Runtime::default();
+    runtime
+        .runtime_state
+        .interaction
+        .set_focused(Some(background_id));
+
+    assert!(runtime.reconcile_focus(&modal_ir).unwrap());
+    assert_eq!(
+        runtime.runtime_state.interaction.focused,
+        Some(modal_primary_id)
+    );
+    assert_eq!(
+        find_next_focus_node(&modal_ir, Some(background_id), false),
+        Some(modal_secondary_id),
+        "a background focus target must not bypass the active barrier"
+    );
+
+    assert!(runtime.reconcile_focus(&background_ir).unwrap());
+    assert_eq!(
+        runtime.runtime_state.interaction.focused,
+        Some(background_id)
+    );
+}
+
+#[test]
+fn nested_barriers_restore_outer_focus_before_background_focus() {
+    let background_id = WidgetId::explicit("background");
+    let outer_id = WidgetId::explicit("outer-action");
+    let inner_id = WidgetId::explicit("inner-action");
+
+    let background = || {
+        lower(
+            crate::ui::widgets::column::Column {
+                children: vec![focus_button("background", false)],
+                ..Default::default()
+            }
+            .into(),
+        )
+    };
+    let outer = || {
+        lower(
+            crate::ui::widgets::column::Column {
+                children: vec![
+                    focus_button("background", false),
+                    FocusScope {
+                        id: Some(WidgetId::explicit("outer-scope")),
+                        is_barrier: true,
+                        children: vec![focus_button("outer-action", false)],
+                    }
+                    .into(),
+                ],
+                ..Default::default()
+            }
+            .into(),
+        )
+    };
+    let nested = lower(
+        crate::ui::widgets::column::Column {
+            children: vec![
+                focus_button("background", false),
+                FocusScope {
+                    id: Some(WidgetId::explicit("outer-scope")),
+                    is_barrier: true,
+                    children: vec![
+                        focus_button("outer-action", false),
+                        FocusScope {
+                            id: Some(WidgetId::explicit("inner-scope")),
+                            is_barrier: true,
+                            children: vec![focus_button("inner-action", false)],
+                        }
+                        .into(),
+                    ],
+                }
+                .into(),
+            ],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let mut runtime = Runtime::default();
+    runtime
+        .runtime_state
+        .interaction
+        .set_focused(Some(background_id));
+    assert!(runtime.reconcile_focus(&nested).unwrap());
+    assert_eq!(runtime.runtime_state.interaction.focused, Some(inner_id));
+
+    assert!(runtime.reconcile_focus(&outer()).unwrap());
+    assert_eq!(runtime.runtime_state.interaction.focused, Some(outer_id));
+
+    assert!(runtime.reconcile_focus(&background()).unwrap());
+    assert_eq!(
+        runtime.runtime_state.interaction.focused,
+        Some(background_id)
+    );
+}
+
+#[test]
+fn nested_barrier_restores_the_current_outer_focus_target() {
+    let background_id = WidgetId::explicit("background");
+    let outer_primary_id = WidgetId::explicit("outer-primary");
+    let outer_secondary_id = WidgetId::explicit("outer-secondary");
+    let inner_id = WidgetId::explicit("inner-action");
+
+    let outer = || {
+        lower(
+            crate::ui::widgets::column::Column {
+                children: vec![
+                    focus_button("background", false),
+                    FocusScope {
+                        id: Some(WidgetId::explicit("outer-scope")),
+                        is_barrier: true,
+                        children: vec![
+                            focus_button("outer-primary", true),
+                            focus_button("outer-secondary", false),
+                        ],
+                    }
+                    .into(),
+                ],
+                ..Default::default()
+            }
+            .into(),
+        )
+    };
+    let nested = lower(
+        crate::ui::widgets::column::Column {
+            children: vec![
+                focus_button("background", false),
+                FocusScope {
+                    id: Some(WidgetId::explicit("outer-scope")),
+                    is_barrier: true,
+                    children: vec![
+                        focus_button("outer-primary", true),
+                        focus_button("outer-secondary", false),
+                        FocusScope {
+                            id: Some(WidgetId::explicit("inner-scope")),
+                            is_barrier: true,
+                            children: vec![focus_button("inner-action", false)],
+                        }
+                        .into(),
+                    ],
+                }
+                .into(),
+            ],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let mut runtime = Runtime::default();
+    runtime
+        .runtime_state
+        .interaction
+        .set_focused(Some(background_id));
+    assert!(runtime.reconcile_focus(&outer()).unwrap());
+    assert_eq!(
+        runtime.runtime_state.interaction.focused,
+        Some(outer_primary_id)
+    );
+
+    runtime
+        .runtime_state
+        .interaction
+        .set_focused(Some(outer_secondary_id));
+    assert!(runtime.reconcile_focus(&nested).unwrap());
+    assert_eq!(runtime.runtime_state.interaction.focused, Some(inner_id));
+
+    assert!(runtime.reconcile_focus(&outer()).unwrap());
+    assert_eq!(
+        runtime.runtime_state.interaction.focused,
+        Some(outer_secondary_id)
+    );
+}
+
+#[test]
+fn closing_barrier_uses_a_valid_fallback_when_restore_target_was_removed() {
+    let removed_id = WidgetId::explicit("removed-background");
+    let fallback_id = WidgetId::explicit("fallback-background");
+    let modal_ir = lower(
+        crate::ui::widgets::column::Column {
+            children: vec![
+                focus_button("removed-background", false),
+                FocusScope {
+                    id: Some(WidgetId::explicit("modal-scope")),
+                    is_barrier: true,
+                    children: vec![focus_button("modal-action", false)],
+                }
+                .into(),
+            ],
+            ..Default::default()
+        }
+        .into(),
+    );
+    let closed_ir = lower(
+        crate::ui::widgets::column::Column {
+            children: vec![focus_button("fallback-background", false)],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let mut runtime = Runtime::default();
+    runtime
+        .runtime_state
+        .interaction
+        .set_focused(Some(removed_id));
+    assert!(runtime.reconcile_focus(&modal_ir).unwrap());
+    assert!(runtime.reconcile_focus(&closed_ir).unwrap());
+    assert_eq!(runtime.runtime_state.interaction.focused, Some(fallback_id));
 }

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -1366,28 +1366,39 @@ impl InternalLower for TextInput {
         } else if let Some(styled) = &self.styled_runs {
             // Preserve syntax colouring while letting the widget-level typography
             // define the default family/weight/spacing.
-            runs = styled
+            let styled_text = styled
                 .iter()
-                .cloned()
-                .map(|mut run| {
-                    if run.style.font_family.is_none() {
-                        run.style.font_family = base_text_style.font_family.clone();
-                    }
-                    if run.style.font_weight == 400 {
-                        run.style.font_weight = base_text_style.font_weight;
-                    }
-                    if run.style.font_style == fission_ir::op::FontStyle::Normal {
-                        run.style.font_style = base_text_style.font_style;
-                    }
-                    if run.style.line_height.is_none() {
-                        run.style.line_height = base_text_style.line_height;
-                    }
-                    if run.style.letter_spacing == 0.0 {
-                        run.style.letter_spacing = base_text_style.letter_spacing;
-                    }
-                    run
-                })
-                .collect();
+                .map(|run| run.text.as_str())
+                .collect::<String>();
+            if styled_text == display_text {
+                runs = styled
+                    .iter()
+                    .cloned()
+                    .map(|mut run| {
+                        if run.style.font_family.is_none() {
+                            run.style.font_family = base_text_style.font_family.clone();
+                        }
+                        if run.style.font_weight == 400 {
+                            run.style.font_weight = base_text_style.font_weight;
+                        }
+                        if run.style.font_style == fission_ir::op::FontStyle::Normal {
+                            run.style.font_style = base_text_style.font_style;
+                        }
+                        if run.style.line_height.is_none() {
+                            run.style.line_height = base_text_style.line_height;
+                        }
+                        if run.style.letter_spacing == 0.0 {
+                            run.style.letter_spacing = base_text_style.letter_spacing;
+                        }
+                        run
+                    })
+                    .collect();
+            } else {
+                runs.push(fission_ir::op::TextRun {
+                    text: display_text.clone(),
+                    style: base_text_style.clone(),
+                });
+            }
         } else {
             runs.push(fission_ir::op::TextRun {
                 text: display_text.clone(),

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -1241,7 +1241,8 @@ fn focused_text_input_accepts_transformed_model_value_after_pending_local_edit()
         "First itemSecond item".len(),
     );
 
-    let accepted_model_value = "First item\nSecond item";
+    let accepted_model_value = "First item
+Second item";
     let ir = lower_node_with_runtime(
         TextInput {
             id: Some(input_id.into()),
@@ -1278,6 +1279,76 @@ fn focused_text_input_accepts_transformed_model_value_after_pending_local_edit()
         semantics.text_selection,
         Some((accepted_model_value.len(), accepted_model_value.len()))
     );
+}
+
+#[test]
+fn focused_text_input_ignores_stale_styled_runs_for_pending_local_value() {
+    let input_id = fission_ir::WidgetId::derived(87, &[3]);
+    let mut runtime = RuntimeState::default();
+    runtime.interaction.set_focused(Some(input_id));
+    runtime
+        .text_edit
+        .sync_from_runtime(input_id, "Old", None, None);
+    runtime
+        .text_edit
+        .get_mut_or_default(input_id)
+        .apply_edit(0..3, "Local edit", 10, 10);
+
+    let stale_styled_runs = vec![fission_ir::op::TextRun {
+        text: "Old".into(),
+        style: fission_ir::op::TextStyle {
+            font_size: 14.0,
+            color: Color {
+                r: 200,
+                g: 0,
+                b: 0,
+                a: 255,
+            },
+            underline: false,
+            font_family: None,
+            locale: None,
+            font_weight: 400,
+            font_style: fission_ir::op::FontStyle::Normal,
+            line_height: None,
+            letter_spacing: 0.0,
+            background_color: None,
+        },
+    }];
+
+    let ir = lower_node_with_runtime(
+        TextInput {
+            id: Some(input_id.into()),
+            value: "Old".into(),
+            styled_runs: Some(stale_styled_runs),
+            ..Default::default()
+        }
+        .into(),
+        runtime,
+    );
+
+    let rendered = paint_ops(&ir)
+        .find_map(|op| match op {
+            PaintOp::DrawRichText { runs, .. } => {
+                Some(runs.iter().map(|run| run.text.as_str()).collect::<String>())
+            }
+            _ => None,
+        })
+        .expect("text input rich text paint op");
+
+    assert_eq!(rendered, "Local edit");
+
+    let semantics = ir
+        .nodes
+        .values()
+        .find_map(|node| match &node.op {
+            Op::Semantics(semantics) if semantics.role == fission_ir::Role::TextInput => {
+                Some(semantics)
+            }
+            _ => None,
+        })
+        .expect("text input semantics");
+    assert_eq!(semantics.value.as_deref(), Some("Local edit"));
+    assert_eq!(semantics.text_selection, Some((10, 10)));
 }
 
 #[test]

--- a/crates/shell/fission-shell-terminal/src/app.rs
+++ b/crates/shell/fission-shell-terminal/src/app.rs
@@ -191,17 +191,21 @@ where
         }
 
         let node_tree = self.build_widget_tree(viewport)?;
-        let mut cx = InternalLoweringCx::new(
-            &self.env,
-            &self.runtime.runtime_state,
-            Some(&self.measurer),
-            self.last_snapshot.as_ref(),
-        );
-        let root_id = fission_core::internal::lower_widget(&node_tree, &mut cx);
-        cx.ir.root = Some(root_id);
-        verify_terminal_ir(&cx.ir).context("terminal shell support check failed")?;
+        let (ir, root_id) = {
+            let mut cx = InternalLoweringCx::new(
+                &self.env,
+                &self.runtime.runtime_state,
+                Some(&self.measurer),
+                self.last_snapshot.as_ref(),
+            );
+            let root_id = fission_core::internal::lower_widget(&node_tree, &mut cx);
+            cx.ir.root = Some(root_id);
+            (cx.ir, root_id)
+        };
+        verify_terminal_ir(&ir).context("terminal shell support check failed")?;
+        self.runtime.reconcile_focus(&ir)?;
 
-        let layout_input_nodes = build_layout_tree(&cx.ir, &self.env);
+        let layout_input_nodes = build_layout_tree(&ir, &self.env);
         self.layout_engine.update(&layout_input_nodes);
         self.layout_engine
             .verify_post_update(&layout_input_nodes, root_id)?;
@@ -213,13 +217,13 @@ where
 
         let renderer = TerminalRenderer::from_theme(&self.env.theme);
         let frame = renderer.render(
-            &cx.ir,
+            &ir,
             &snapshot,
             &self.runtime.runtime_state.scroll,
             width,
             height,
         )?;
-        self.last_ir = Some(cx.ir);
+        self.last_ir = Some(ir);
         self.last_snapshot = Some(snapshot);
         Ok(frame)
     }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -6709,19 +6709,30 @@ where
                                 }
                                 .into();
 
-                                let mut lower_cx = InternalLoweringCx::new(
-                                    &env,
-                                    &runtime.runtime_state,
-                                    runtime.measurer.as_ref(),
-                                    pipeline.last_snapshot.as_ref(),
-                                );
-                                let root_id = fission_core::internal::lower_widget(
-                                    &final_root,
-                                    &mut lower_cx,
-                                );
-                                lower_cx.ir.root = Some(root_id);
+                                let ir = {
+                                    let mut lower_cx = InternalLoweringCx::new(
+                                        &env,
+                                        &runtime.runtime_state,
+                                        runtime.measurer.as_ref(),
+                                        pipeline.last_snapshot.as_ref(),
+                                    );
+                                    let root_id = fission_core::internal::lower_widget(
+                                        &final_root,
+                                        &mut lower_cx,
+                                    );
+                                    lower_cx.ir.root = Some(root_id);
+                                    lower_cx.ir
+                                };
 
-                                let pipeline_invalidations = pipeline.replace_ir(lower_cx.ir, &env);
+                                match runtime.reconcile_focus(&ir) {
+                                    Ok(true) => invalidations.mark_build(),
+                                    Ok(false) => {}
+                                    Err(err) => {
+                                        eprintln!("Runtime focus reconciliation error: {err:?}");
+                                    }
+                                }
+
+                                let pipeline_invalidations = pipeline.replace_ir(ir, &env);
                                 invalidations.merge(pipeline_invalidations);
                                 last_built_viewport = Some(build_viewport);
                             }

--- a/crates/tools/fission-test/src/lib.rs
+++ b/crates/tools/fission-test/src/lib.rs
@@ -379,17 +379,21 @@ impl<S: GlobalState> TestHarness<S> {
             if trace {
                 eprintln!("[test-trace] lower start");
             }
-            let mut cx = InternalLoweringCx::new(
-                &self.env,
-                &self.runtime.runtime_state,
-                Some(&self.measurer),
-                self.last_snapshot.as_ref(),
-            );
-            let root_id = fission_core::internal::lower_widget(&node_tree, &mut cx);
-            cx.ir.root = Some(root_id);
+            let (ir, root_id) = {
+                let mut cx = InternalLoweringCx::new(
+                    &self.env,
+                    &self.runtime.runtime_state,
+                    Some(&self.measurer),
+                    self.last_snapshot.as_ref(),
+                );
+                let root_id = fission_core::internal::lower_widget(&node_tree, &mut cx);
+                cx.ir.root = Some(root_id);
+                (cx.ir, root_id)
+            };
+            self.runtime.reconcile_focus(&ir)?;
 
-            let layout_input_nodes = build_layout_tree(&cx.ir, &self.env);
-            self.last_ir = Some(cx.ir);
+            let layout_input_nodes = build_layout_tree(&ir, &self.env);
+            self.last_ir = Some(ir);
             if trace {
                 eprintln!("[test-trace] lower done nodes={}", layout_input_nodes.len());
             }

--- a/crates/tools/fission-test/tests/text_input_large_scroll.rs
+++ b/crates/tools/fission-test/tests/text_input_large_scroll.rs
@@ -1,0 +1,212 @@
+use anyhow::Result;
+use fission_core::event::{ImeEvent, InputEvent};
+use fission_core::op::{Color, FlexDirection};
+use fission_core::ui::{Column, Container, Positioned, Scroll, Spacer, TextInput, Widget, ZStack};
+use fission_core::GlobalState;
+use fission_ir::semantics::Role;
+use fission_ir::{Op, PaintOp, WidgetId};
+use fission_test::{TestDriver, TestHarness};
+
+#[derive(Debug, Default, Clone)]
+struct State {
+    text: String,
+}
+
+impl GlobalState for State {}
+
+#[fission_macros::fission_action]
+struct UpdateText(String);
+
+fn update_text(state: &mut State, action: UpdateText) {
+    state.text = action.0;
+}
+
+#[derive(Clone)]
+struct LargeScrollEditor;
+
+impl From<LargeScrollEditor> for Widget {
+    fn from(_component: LargeScrollEditor) -> Self {
+        let (ctx, view) = fission_core::build::current::<State>();
+        let paper = Color {
+            r: 255,
+            g: 255,
+            b: 255,
+            a: 255,
+        };
+        let ink = Color {
+            r: 15,
+            g: 23,
+            b: 42,
+            a: 255,
+        };
+        let border = Color {
+            r: 226,
+            g: 232,
+            b: 240,
+            a: 255,
+        };
+        let text_input = TextInput {
+            id: Some(WidgetId::explicit("large.editor.body")),
+            value: view.state().text.clone(),
+            on_change: Some(ctx.bind(
+                UpdateText(String::new()),
+                update_text as fn(&mut State, UpdateText),
+            )),
+            width: Some(672.0),
+            height: Some(912.0),
+            multiline: true,
+            borderless: true,
+            capture_tab: false,
+            auto_indent: true,
+            font_size: Some(14.5),
+            line_height: Some(22.0),
+            text_color: Some(ink),
+            padding: Some([0.0, 0.0, 0.0, 0.0]),
+            expands: true,
+            scroll_padding: Some([16.0, 16.0, 48.0, 48.0]),
+            selection_controls: fission_core::ui::widgets::text_input::TextSelectionControls {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .semantics_identifier("large.editor.body");
+
+        let page: Widget = Container::new(ZStack {
+            children: vec![
+                Spacer {
+                    width: Some(816.0),
+                    height: Some(1056.0),
+                    ..Default::default()
+                }
+                .into(),
+                Positioned {
+                    left: Some(72.0),
+                    top: Some(72.0),
+                    width: Some(672.0),
+                    height: Some(912.0),
+                    child: Some(text_input.into()),
+                    ..Default::default()
+                }
+                .into(),
+            ],
+            ..Default::default()
+        })
+        .width(816.0)
+        .height(1056.0)
+        .bg(paper)
+        .border(border, 1.0)
+        .into();
+
+        Container::new(Scroll {
+            id: Some(WidgetId::explicit("large.editor.scroll")),
+            child: Some(
+                Container::new(Column {
+                    children: vec![page],
+                    ..Default::default()
+                })
+                .width(816.0)
+                .height(1056.0)
+                .into(),
+            ),
+            direction: FlexDirection::Column,
+            width: Some(752.0),
+            height: Some(400.0),
+            show_scrollbar: true,
+            ..Default::default()
+        })
+        .width(752.0)
+        .height(400.0)
+        .bg(Color {
+            r: 248,
+            g: 250,
+            b: 252,
+            a: 255,
+        })
+        .into()
+    }
+}
+
+#[test]
+fn large_multiline_text_input_paints_committed_text_inside_scrolled_page() -> Result<()> {
+    let marker = "Fission large editor marker\nSaved through IME\n";
+    let mut driver =
+        TestDriver::new(TestHarness::new(State::default()).with_root_widget(LargeScrollEditor));
+    driver.harness.env.viewport_size = fission_layout::LayoutSize::new(800.0, 600.0);
+    driver.pump()?;
+
+    let scroll_id = WidgetId::explicit("large.editor.scroll");
+    driver
+        .harness
+        .runtime
+        .runtime_state
+        .scroll
+        .set_offset(scroll_id, 72.0);
+    driver.pump()?;
+
+    let input = driver
+        .find_role(Role::TextInput)
+        .into_iter()
+        .find(|record| record.node_id == WidgetId::explicit("large.editor.body"))
+        .expect("large editor TextInput semantics");
+    driver
+        .harness
+        .runtime
+        .runtime_state
+        .interaction
+        .set_focused(Some(input.node_id));
+    driver
+        .harness
+        .send_event(InputEvent::Ime(ImeEvent::Commit {
+            text: marker.to_string(),
+        }))?;
+    driver.pump()?;
+
+    let ir = driver.harness.last_ir.as_ref().expect("IR");
+    let semantics = ir
+        .nodes
+        .get(&input.node_id)
+        .and_then(|node| match &node.op {
+            Op::Semantics(semantics) => Some(semantics),
+            _ => None,
+        })
+        .expect("TextInput semantics after commit");
+    assert_eq!(semantics.value.as_deref(), Some(marker));
+
+    let display_text = driver
+        .harness
+        .get_last_display_list()
+        .expect("display list")
+        .ops
+        .iter()
+        .filter_map(|op| match op {
+            fission_render::DisplayOp::DrawText { text, .. } => Some(text.clone()),
+            fission_render::DisplayOp::DrawRichText { runs, .. } => {
+                Some(runs.iter().map(|run| run.text.as_str()).collect::<String>())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        display_text.iter().any(|text| text.contains(marker)),
+        "display list did not contain committed TextInput text; visible text={display_text:?}"
+    );
+
+    let paint_text = ir
+        .nodes
+        .values()
+        .filter_map(|node| match &node.op {
+            Op::Paint(PaintOp::DrawRichText { runs, .. }) => {
+                Some(runs.iter().map(|run| run.text.as_str()).collect::<String>())
+            }
+            Op::Paint(PaintOp::DrawText { text, .. }) => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        paint_text.iter().any(|text| text.contains(marker)),
+        "IR paint nodes did not contain committed TextInput text; paint text={paint_text:?}"
+    );
+
+    Ok(())
+}

--- a/crates/tools/fission-test/tests/text_input_modal_focus.rs
+++ b/crates/tools/fission-test/tests/text_input_modal_focus.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use fission_core::event::{PointerButton, PointerEvent};
-use fission_core::ui::{TextInput, Widget};
+use fission_core::ui::{Button, TextInput, Widget};
 use fission_core::{with_reducer, GlobalState, WidgetId};
 use fission_test::TestHarness;
 use fission_widgets::Modal;
@@ -91,6 +91,97 @@ fn clicking_text_input_inside_modal_sets_focus() -> Result<()> {
         h.runtime.runtime_state.interaction.focused,
         Some(subject_id),
         "expected subject TextInput to become focused on click"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn modal_captures_focus_on_open_and_restores_it_on_close() -> Result<()> {
+    let opener_id = WidgetId::explicit("modal_opener");
+    let modal_input_id = WidgetId::explicit("modal_input");
+
+    #[derive(Clone)]
+    struct Root;
+
+    impl From<Root> for Widget {
+        fn from(_component: Root) -> Self {
+            let (ctx, view) = fission_core::build::current::<State>();
+            let dismiss_action = with_reducer!(ctx, Dismiss, dismiss);
+            fission_core::ui::ZStack {
+                children: vec![
+                    Button {
+                        id: Some(WidgetId::explicit("modal_opener")),
+                        on_press: Some(dismiss_action.clone()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    Modal {
+                        id: WidgetId::explicit("focus_modal"),
+                        title: "Focus lifecycle".into(),
+                        content: TextInput {
+                            id: Some(WidgetId::explicit("modal_input")),
+                            value: "Modal text".into(),
+                            autofocus: true,
+                            ..Default::default()
+                        }
+                        .into(),
+                        is_open: view.state().modal_open,
+                        on_dismiss: Some(dismiss_action),
+                        actions: vec![],
+                        width: Some(420.0),
+                        motion: None,
+                    }
+                    .into(),
+                ],
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
+    let mut harness = TestHarness::new(State { modal_open: false }).with_root_widget(Root);
+    harness.pump()?;
+    harness
+        .runtime
+        .runtime_state
+        .interaction
+        .set_focused(Some(opener_id));
+
+    harness
+        .runtime
+        .get_app_state_mut::<State>()
+        .expect("modal state")
+        .modal_open = true;
+    harness.pump()?;
+    assert_eq!(
+        harness.runtime.runtime_state.interaction.focused,
+        Some(modal_input_id),
+        "the modal autofocus target must capture focus on the opening frame"
+    );
+
+    harness.send_event(fission_core::InputEvent::Keyboard(
+        fission_core::KeyEvent::Down {
+            key_code: fission_core::KeyCode::Tab,
+            modifiers: 0,
+        },
+    ))?;
+    assert_ne!(
+        harness.runtime.runtime_state.interaction.focused,
+        Some(opener_id),
+        "Tab must remain inside the active modal barrier"
+    );
+
+    harness
+        .runtime
+        .get_app_state_mut::<State>()
+        .expect("modal state")
+        .modal_open = false;
+    harness.pump()?;
+    assert_eq!(
+        harness.runtime.runtime_state.interaction.focused,
+        Some(opener_id),
+        "closing the modal must restore its opener"
     );
 
     Ok(())


### PR DESCRIPTION
Closes #114

## Summary
- reconcile active focus barriers after lowering so newly opened barriers capture focus without waiting for an input event
- preserve restoration targets across nested barriers, including the current focused target inside the parent barrier
- constrain Tab traversal to the topmost active barrier even when the previous focused node belonged to background content
- give Modal and Drawer stable focus-scope slot IDs so barriers can be tracked across frames
- run reconciliation from the Winit shell, terminal shell, and fission-test harness before layout

## Tests
- `cargo test -p fission-core focus_scope -- --nocapture`
- `cargo test -p fission-test --test text_input_modal_focus -- --nocapture`
- `cargo test -p fission-widgets -- --nocapture`
- `cargo check -p fission-shell-terminal -p fission-shell-winit`

Note: the shell check still reports the existing Linux video backend unreachable-code warning.