### PR TITLE
Add drag-and-drop runtime, widgets, and gallery demo

### DIFF
--- a/crates/authoring/fission-widgets/src/draggable.rs
+++ b/crates/authoring/fission-widgets/src/draggable.rs
@@ -1,19 +1,71 @@
-use fission_core::ui::widgets::GestureDetector;
-use fission_core::{ActionEnvelope, Widget};
+use fission_core::ui::widgets::{GestureDetector, Positioned};
+use fission_core::{ActionEnvelope, DragSessionPayload, PortalLayer, Widget, WidgetId};
 
+/// How the drag preview should be positioned while the pointer moves.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DragPreviewOptions {
+    /// Horizontal offset from the pointer position.
+    pub offset_x: f32,
+    /// Vertical offset from the pointer position.
+    pub offset_y: f32,
+    /// Optional grid size used to snap the preview while dragging.
+    pub snap_grid: Option<f32>,
+}
+
+impl Default for DragPreviewOptions {
+    fn default() -> Self {
+        Self {
+            offset_x: 12.0,
+            offset_y: 12.0,
+            snap_grid: None,
+        }
+    }
+}
+
+/// Wraps a child so it can start an internal drag with an explicit payload.
+///
+/// Use `preview` to provide the drag avatar rendered under the pointer while
+/// dragging. For preview rendering, supply either `id` or
+/// `semantics_identifier` so the runtime drag session can match this source
+/// across rebuilds.
 #[derive(Clone, Debug)]
 pub struct Draggable {
+    /// Stable identity for the drag source.
+    pub id: Option<WidgetId>,
+    /// Stable semantic/test identifier exposed to accessibility and LiveTest.
+    pub semantics_identifier: Option<String>,
+    /// Opaque bytes delivered to a target through `ctx.input.as_internal_drop()`.
     pub payload: Vec<u8>,
+    /// Visible widget the user starts dragging.
     pub child: Widget,
+    /// Optional avatar rendered near the pointer while this source is dragged.
+    pub preview: Option<Widget>,
+    /// Positioning and optional snapping behavior for `preview`.
+    pub preview_options: DragPreviewOptions,
+    /// Action dispatched when the pointer movement becomes a drag.
     pub on_drag_start: Option<ActionEnvelope>,
+    /// Action dispatched when the drag gesture ends.
     pub on_drag_end: Option<ActionEnvelope>,
+}
+
+impl Draggable {
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
 }
 
 impl From<Draggable> for Widget {
     fn from(component: Draggable) -> Self {
         let this = &component;
 
+        if let Some(preview) = this.preview.clone() {
+            maybe_register_drag_preview(this, preview);
+        }
+
         GestureDetector {
+            id: this.id,
+            semantics_identifier: this.semantics_identifier.clone(),
             child: this.child.clone(),
             drag_payload: Some(this.payload.clone()),
             on_drag_start: this.on_drag_start.clone(),
@@ -24,21 +76,105 @@ impl From<Draggable> for Widget {
     }
 }
 
+fn maybe_register_drag_preview(source: &Draggable, preview: Widget) {
+    let Some(runtime) = fission_core::build::try_current_runtime_state() else {
+        return;
+    };
+    let Some(session) = runtime.gesture.drag_session.as_ref() else {
+        return;
+    };
+    if !matches!(session.payload, DragSessionPayload::Internal(_)) {
+        return;
+    }
+
+    let source_matches = source.id.is_some_and(|id| Some(id) == session.source_node)
+        || source
+            .semantics_identifier
+            .as_ref()
+            .is_some_and(|id| Some(id) == session.source_identifier.as_ref());
+    if !source_matches {
+        return;
+    }
+
+    let (ctx, _) = fission_core::build::current::<()>();
+    let options = &source.preview_options;
+    let mut x = session.point.x + options.offset_x;
+    let mut y = session.point.y + options.offset_y;
+    if let Some(grid) = options.snap_grid.filter(|grid| *grid > 0.0) {
+        x = (x / grid).round() * grid;
+        y = (y / grid).round() * grid;
+    }
+
+    ctx.register_portal_with_layer(
+        PortalLayer::Toast,
+        Some(WidgetId::explicit("fission.drag.preview")),
+        Positioned {
+            left: Some(x),
+            top: Some(y),
+            child: Some(preview),
+            ..Default::default()
+        }
+        .into(),
+    );
+}
+
 #[derive(Clone, Debug)]
 pub struct DragTarget {
+    /// Stable identity for the drop target.
+    pub id: Option<WidgetId>,
+    /// Stable semantic/test identifier exposed to accessibility and LiveTest.
+    pub semantics_identifier: Option<String>,
+    /// Action dispatched when an internal or external drag is dropped here.
     pub on_drop: Option<ActionEnvelope>,
+    /// Visible target in its idle state.
     pub child: Widget,
+    /// Optional visible target while this target is the hovered drop target.
+    pub hover_child: Option<Widget>,
+}
+
+impl DragTarget {
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
 }
 
 impl From<DragTarget> for Widget {
     fn from(component: DragTarget) -> Self {
         let this = &component;
+        let child = if target_is_hovered(this.id, this.semantics_identifier.as_deref()) {
+            this.hover_child
+                .clone()
+                .unwrap_or_else(|| this.child.clone())
+        } else {
+            this.child.clone()
+        };
 
         GestureDetector {
-            child: this.child.clone(),
+            id: this.id,
+            semantics_identifier: this.semantics_identifier.clone(),
+            child,
             on_drop: this.on_drop.clone(),
             ..Default::default()
         }
         .into()
     }
+}
+
+pub(crate) fn target_is_hovered(id: Option<WidgetId>, identifier: Option<&str>) -> bool {
+    let Some(runtime) = fission_core::build::try_current_runtime_state() else {
+        return false;
+    };
+    let Some(session) = runtime.gesture.drag_session.as_ref() else {
+        return false;
+    };
+    id.is_some_and(|id| Some(id) == session.target_node)
+        || identifier
+            .is_some_and(|identifier| session.target_identifier.as_deref() == Some(identifier))
+}
+
+pub(crate) fn drag_is_active() -> bool {
+    fission_core::build::try_current_runtime_state()
+        .and_then(|runtime| runtime.gesture.drag_session.as_ref())
+        .is_some()
 }

--- a/crates/authoring/fission-widgets/src/dropzone.rs
+++ b/crates/authoring/fission-widgets/src/dropzone.rs
@@ -1,22 +1,62 @@
+use crate::draggable::{drag_is_active, target_is_hovered};
 use fission_core::ui::widgets::GestureDetector;
 use fission_core::ui::Widget;
-use fission_core::ActionEnvelope;
+use fission_core::{ActionEnvelope, WidgetId};
 use serde::{Deserialize, Serialize};
 
+/// A drag-and-drop surface that can render different child widgets for idle,
+/// active-drag, and hovered-target states.
+///
+/// `Dropzone` accepts both internal drags from [`crate::Draggable`] and
+/// external file drops delivered by desktop shells. Reducers can distinguish
+/// payloads with `ctx.input.as_internal_drop()` and `ctx.input.as_drop_paths()`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Dropzone {
+    /// Stable identity for the drop surface.
+    pub id: Option<WidgetId>,
+    /// Stable semantic/test identifier exposed to accessibility and LiveTest.
+    pub semantics_identifier: Option<String>,
+    /// Visible content shown when no drag is active or no alternate child is
+    /// applicable.
     pub child: Widget,
+    /// Optional child shown when any drag is active in the window.
+    pub active_child: Option<Widget>,
+    /// Optional child shown when this dropzone is the current hovered target.
+    pub hover_child: Option<Widget>,
+    /// Action dispatched when an internal or external drag is dropped here.
     pub on_drop: Option<ActionEnvelope>,
+    /// Action dispatched when a drag enters this dropzone's hit area.
     pub on_drag_enter: Option<ActionEnvelope>,
+    /// Action dispatched when a drag leaves this dropzone's hit area.
     pub on_drag_leave: Option<ActionEnvelope>,
+}
+
+impl Dropzone {
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.semantics_identifier = Some(identifier.into());
+        self
+    }
 }
 
 impl From<Dropzone> for Widget {
     fn from(component: Dropzone) -> Self {
         let this = &component;
+        let child = if target_is_hovered(this.id, this.semantics_identifier.as_deref()) {
+            this.hover_child
+                .clone()
+                .unwrap_or_else(|| this.child.clone())
+        } else if drag_is_active() {
+            this.active_child
+                .clone()
+                .unwrap_or_else(|| this.child.clone())
+        } else {
+            this.child.clone()
+        };
 
         GestureDetector {
-            child: this.child.clone(),
+            id: this.id,
+            semantics_identifier: this.semantics_identifier.clone(),
+            child,
             on_drop: this.on_drop.clone(),
             on_drag_enter: this.on_drag_enter.clone(),
             on_drag_leave: this.on_drag_leave.clone(),

--- a/crates/authoring/fission-widgets/src/lib.rs
+++ b/crates/authoring/fission-widgets/src/lib.rs
@@ -160,7 +160,7 @@ pub mod terminal;
 pub use terminal::{TerminalLaunchConfig, TerminalSession, TerminalView};
 
 pub mod draggable;
-pub use draggable::{DragTarget, Draggable};
+pub use draggable::{DragPreviewOptions, DragTarget, Draggable};
 
 pub mod empty_state;
 pub use empty_state::EmptyState;

--- a/crates/authoring/fission-widgets/tests/draggable_test.rs
+++ b/crates/authoring/fission-widgets/tests/draggable_test.rs
@@ -49,6 +49,8 @@ fn test_internal_drag_drop_flow() {
         children: vec![
             build::enter(&mut build_ctx, &view, || {
                 Draggable {
+                    id: None,
+                    semantics_identifier: None,
                     payload: "hello".as_bytes().to_vec(),
                     on_drag_start: None,
                     on_drag_end: None,
@@ -60,11 +62,15 @@ fn test_internal_drag_drop_flow() {
                         ..Default::default()
                     }
                     .into(),
+                    preview: None,
+                    preview_options: Default::default(),
                 }
                 .into()
             }),
             build::enter(&mut build_ctx, &view, || {
                 DragTarget {
+                    id: None,
+                    semantics_identifier: None,
                     on_drop: Some(ActionEnvelope {
                         id: OnDrop::static_id(),
                         payload: OnDrop.encode(),
@@ -74,6 +80,7 @@ fn test_internal_drag_drop_flow() {
                         .height(100.0)
                         .bg(fission_core::op::Color::RED)
                         .into(),
+                    hover_child: None,
                 }
                 .into()
             }),

--- a/crates/authoring/fission-widgets/tests/dropzone_test.rs
+++ b/crates/authoring/fission-widgets/tests/dropzone_test.rs
@@ -17,7 +17,11 @@ fn test_dropzone_structure() {
     let mut ctx = BuildCtx::<TestState>::new();
 
     let dropzone = Dropzone {
+        id: None,
+        semantics_identifier: None,
         child: Spacer::default().into(),
+        active_child: None,
+        hover_child: None,
         on_drop: None,
         on_drag_enter: None,
         on_drag_leave: None,

--- a/crates/core/fission-core/src/effect.rs
+++ b/crates/core/fission-core/src/effect.rs
@@ -272,9 +272,23 @@ pub enum ActionInput {
         delta_y: f32,
     },
     /// External file drop (e.g. from the OS file manager).
-    Drop { paths: Vec<String>, x: f32, y: f32 },
+    Drop {
+        paths: Vec<String>,
+        x: f32,
+        y: f32,
+        /// Modifier bitmask active during the drop (Shift=1, Alt=2,
+        /// Ctrl=4, Super=8).
+        modifiers: u8,
+    },
     /// Internal drag-and-drop with an opaque byte payload.
-    InternalDrop { payload: Vec<u8>, x: f32, y: f32 },
+    InternalDrop {
+        payload: Vec<u8>,
+        x: f32,
+        y: f32,
+        /// Modifier bitmask active during the drop (Shift=1, Alt=2,
+        /// Ctrl=4, Super=8).
+        modifiers: u8,
+    },
     /// The action was dispatched from a subtree with a raw action scope.
     ScopedRaw {
         scope_id: u128,
@@ -347,6 +361,18 @@ impl ActionInput {
     pub fn as_internal_drop(&self) -> Option<&[u8]> {
         match self.unscoped() {
             ActionInput::InternalDrop { payload, .. } => Some(payload),
+            _ => None,
+        }
+    }
+
+    /// Modifier bitmask active during a drop action.
+    ///
+    /// This lets app reducers choose copy/move/link semantics without binding
+    /// that product rule into the drag runtime itself.
+    pub fn as_drop_modifiers(&self) -> Option<u8> {
+        match self.unscoped() {
+            ActionInput::Drop { modifiers, .. } => Some(*modifiers),
+            ActionInput::InternalDrop { modifiers, .. } => Some(*modifiers),
             _ => None,
         }
     }

--- a/crates/core/fission-core/src/env.rs
+++ b/crates/core/fission-core/src/env.rs
@@ -196,6 +196,45 @@ pub struct GestureState {
     pub dragging_payload: Option<Vec<u8>>,
     pub pressed_button: Option<crate::event::PointerButton>,
     pub scrollbar_drag: Option<crate::scrollbar::ScrollbarDragState>,
+    /// Runtime drag state used by widgets to render previews and hovered
+    /// drop-target feedback during the current frame.
+    pub drag_session: Option<DragSessionState>,
+}
+
+/// Payload currently carried by a drag session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DragSessionPayload {
+    /// Opaque bytes from an in-app drag source.
+    Internal(Vec<u8>),
+    /// Files supplied by the host platform during an external drag.
+    ExternalFiles(Vec<String>),
+}
+
+impl DragSessionPayload {
+    /// Human-readable payload family used by demos and diagnostics.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Internal(_) => "internal",
+            Self::ExternalFiles(_) => "files",
+        }
+    }
+}
+
+/// Runtime-only state for a drag gesture currently in progress.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DragSessionState {
+    /// Semantics node that started the drag, when this is an internal drag.
+    pub source_node: Option<WidgetId>,
+    /// Stable source identifier, if supplied by the drag source widget.
+    pub source_identifier: Option<String>,
+    /// Payload carried by the drag.
+    pub payload: DragSessionPayload,
+    /// Pointer position in layout coordinates.
+    pub point: LayoutPoint,
+    /// Target currently under the pointer that advertises a drop action.
+    pub target_node: Option<WidgetId>,
+    /// Stable target identifier, if supplied by the drop target widget.
+    pub target_identifier: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/core/fission-core/src/event.rs
+++ b/crates/core/fission-core/src/event.rs
@@ -162,6 +162,31 @@ pub enum GestureEvent {
     LongPress { point: LayoutPoint },
 }
 
+/// File drag-and-drop events delivered by desktop shells.
+///
+/// These events model OS-level drags such as files dragged from Finder,
+/// Explorer, or a Linux file manager into a Fission window. Internal widget
+/// drags use normal pointer events plus the widget drag payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ExternalDragEvent {
+    /// One or more external files are hovering over the window.
+    Hover {
+        point: LayoutPoint,
+        paths: Vec<String>,
+        /// Modifier bitmask (Shift=1, Alt=2, Ctrl=4, Super=8).
+        modifiers: u8,
+    },
+    /// The external drag left the window or was cancelled by the platform.
+    Cancel,
+    /// One or more external files were dropped at the current pointer point.
+    Drop {
+        point: LayoutPoint,
+        paths: Vec<String>,
+        /// Modifier bitmask (Shift=1, Alt=2, Ctrl=4, Super=8).
+        modifiers: u8,
+    },
+}
+
 /// The top-level input event type consumed by
 /// [`Runtime::handle_input`](crate::Runtime::handle_input).
 ///
@@ -176,6 +201,8 @@ pub enum InputEvent {
     Ime(ImeEvent),
     /// High-level gesture events.
     Gesture(GestureEvent),
+    /// Desktop shell drag-and-drop events from outside the app.
+    ExternalDrag(ExternalDragEvent),
     /// Application lifecycle transitions.
     Lifecycle(LifecycleEvent),
 }

--- a/crates/core/fission-core/src/input/gesture.rs
+++ b/crates/core/fission-core/src/input/gesture.rs
@@ -1,10 +1,10 @@
 use super::{ControllerContext, InputController};
-use crate::event::{InputEvent, PointerEvent};
+use crate::event::{ExternalDragEvent, InputEvent, PointerEvent};
 use crate::scrollbar::{
     scrollbar_drag_offset, scrollbar_drag_offset_with_grab, scrollbar_geometry_for_node,
     scrollbar_hit_test, scrollbar_point_for_node, ScrollbarDragState, ScrollbarHitKind,
 };
-use crate::{ActionEnvelope, ActionId, ActionInput};
+use crate::{ActionEnvelope, ActionId, ActionInput, DragSessionPayload, DragSessionState};
 use fission_ir::op::RichTextAnnotation;
 use fission_ir::{semantics::ActionTrigger, Op, WidgetId};
 use fission_layout::LayoutPoint;
@@ -90,6 +90,20 @@ impl InputController for GestureController {
 
                             if !ctx.gesture.is_panning && dist_sq > threshold {
                                 ctx.gesture.is_panning = true;
+                                if let Some(payload) = ctx.gesture.dragging_payload.clone() {
+                                    let target = ctx.gesture.target_node;
+                                    let source_identifier =
+                                        target.and_then(|id| self.semantic_identifier(ctx, id));
+                                    ctx.gesture.drag_session = Some(DragSessionState {
+                                        source_node: target,
+                                        source_identifier,
+                                        payload: DragSessionPayload::Internal(payload),
+                                        point: *point,
+                                        target_node: None,
+                                        target_identifier: None,
+                                    });
+                                    self.update_drag_target(ctx, *point);
+                                }
                                 // Dispatch DragStart now
                                 if let Some(target) = ctx.gesture.target_node {
                                     self.dispatch_trigger(
@@ -103,6 +117,11 @@ impl InputController for GestureController {
                             }
 
                             if ctx.gesture.is_panning {
+                                if let Some(session) = ctx.gesture.drag_session.as_mut() {
+                                    session.point = *point;
+                                }
+                                self.update_drag_target(ctx, *point);
+
                                 let last = ctx.gesture.last_point.unwrap_or(start);
                                 let delta = LayoutPoint {
                                     x: point.x - last.x,
@@ -134,7 +153,9 @@ impl InputController for GestureController {
                             }
                         }
                     }
-                    PointerEvent::Up { point, .. } => {
+                    PointerEvent::Up {
+                        point, modifiers, ..
+                    } => {
                         let scrollbar_drag = ctx.gesture.scrollbar_drag.take();
                         let mut handled = false;
                         let was_secondary = matches!(
@@ -147,8 +168,9 @@ impl InputController for GestureController {
                                 if let Some(up_hit) = crate::hit_test::hit_test_with_scroll(
                                     ctx.ir, ctx.layout, ctx.scroll, *point,
                                 ) {
-                                    let _ =
-                                        self.dispatch_internal_drop(ctx, up_hit, payload, *point);
+                                    let _ = self.dispatch_internal_drop(
+                                        ctx, up_hit, payload, *point, *modifiers,
+                                    );
                                 }
                             }
 
@@ -261,6 +283,8 @@ impl InputController for GestureController {
                         ctx.gesture.start_point = None;
                         ctx.gesture.is_panning = false;
                         ctx.gesture.dragging_payload = None;
+                        self.clear_drag_target(ctx, *point);
+                        ctx.gesture.drag_session = None;
                         ctx.gesture.pressed_button = None;
                         if scrollbar_drag.is_some() {
                             ctx.gesture.target_node = None;
@@ -271,6 +295,79 @@ impl InputController for GestureController {
                     _ => {}
                 }
             }
+            InputEvent::ExternalDrag(event) => match event {
+                ExternalDragEvent::Hover { point, paths, .. } => {
+                    ctx.gesture.drag_session = Some(DragSessionState {
+                        source_node: None,
+                        source_identifier: None,
+                        payload: DragSessionPayload::ExternalFiles(paths.clone()),
+                        point: *point,
+                        target_node: ctx
+                            .gesture
+                            .drag_session
+                            .as_ref()
+                            .and_then(|s| s.target_node),
+                        target_identifier: ctx
+                            .gesture
+                            .drag_session
+                            .as_ref()
+                            .and_then(|s| s.target_identifier.clone()),
+                    });
+                    self.update_drag_target(ctx, *point);
+                    return true;
+                }
+                ExternalDragEvent::Cancel => {
+                    let point = ctx
+                        .gesture
+                        .drag_session
+                        .as_ref()
+                        .map(|session| session.point)
+                        .unwrap_or(LayoutPoint::ZERO);
+                    self.clear_drag_target(ctx, point);
+                    ctx.gesture.drag_session = None;
+                    return true;
+                }
+                ExternalDragEvent::Drop {
+                    point,
+                    paths,
+                    modifiers,
+                } => {
+                    ctx.gesture.drag_session = Some(DragSessionState {
+                        source_node: None,
+                        source_identifier: None,
+                        payload: DragSessionPayload::ExternalFiles(paths.clone()),
+                        point: *point,
+                        target_node: ctx
+                            .gesture
+                            .drag_session
+                            .as_ref()
+                            .and_then(|s| s.target_node),
+                        target_identifier: ctx
+                            .gesture
+                            .drag_session
+                            .as_ref()
+                            .and_then(|s| s.target_identifier.clone()),
+                    });
+                    self.update_drag_target(ctx, *point);
+                    if let Some(target) = ctx
+                        .gesture
+                        .drag_session
+                        .as_ref()
+                        .and_then(|s| s.target_node)
+                    {
+                        let _ = self.dispatch_external_drop(
+                            ctx,
+                            target,
+                            paths.clone(),
+                            *point,
+                            *modifiers,
+                        );
+                    }
+                    self.clear_drag_target(ctx, *point);
+                    ctx.gesture.drag_session = None;
+                    return true;
+                }
+            },
             _ => {}
         }
         false
@@ -380,12 +477,95 @@ impl GestureController {
         None
     }
 
+    fn semantic_identifier(&self, ctx: &ControllerContext, start_node: WidgetId) -> Option<String> {
+        let mut current_id = Some(start_node);
+        while let Some(node_id) = current_id {
+            if let Some(node) = ctx.ir.nodes.get(&node_id) {
+                if let Op::Semantics(sem) = &node.op {
+                    if let Some(identifier) = &sem.identifier {
+                        return Some(identifier.clone());
+                    }
+                }
+                current_id = node.parent;
+            } else {
+                break;
+            }
+        }
+        None
+    }
+
+    fn find_drop_target(&self, ctx: &ControllerContext, start_node: WidgetId) -> Option<WidgetId> {
+        let mut current_id = Some(start_node);
+        while let Some(node_id) = current_id {
+            if let Some(node) = ctx.ir.nodes.get(&node_id) {
+                if let Op::Semantics(sem) = &node.op {
+                    if sem
+                        .actions
+                        .entries
+                        .iter()
+                        .any(|entry| entry.trigger == ActionTrigger::Drop)
+                    {
+                        return Some(node_id);
+                    }
+                }
+                current_id = node.parent;
+            } else {
+                break;
+            }
+        }
+        None
+    }
+
+    fn update_drag_target(&self, ctx: &mut ControllerContext, point: LayoutPoint) {
+        let next_target =
+            crate::hit_test::hit_test_with_scroll(ctx.ir, ctx.layout, ctx.scroll, point)
+                .and_then(|hit| self.find_drop_target(ctx, hit));
+
+        let previous_target = ctx
+            .gesture
+            .drag_session
+            .as_ref()
+            .and_then(|s| s.target_node);
+        if previous_target == next_target {
+            return;
+        }
+
+        if let Some(previous) = previous_target {
+            self.dispatch_trigger(ctx, previous, ActionTrigger::DragLeave, point, None);
+        }
+        if let Some(next) = next_target {
+            self.dispatch_trigger(ctx, next, ActionTrigger::DragEnter, point, None);
+        }
+
+        let next_identifier = next_target.and_then(|id| self.semantic_identifier(ctx, id));
+        if let Some(session) = ctx.gesture.drag_session.as_mut() {
+            session.target_node = next_target;
+            session.target_identifier = next_identifier;
+        }
+    }
+
+    fn clear_drag_target(&self, ctx: &mut ControllerContext, point: LayoutPoint) {
+        if let Some(previous) = ctx
+            .gesture
+            .drag_session
+            .as_ref()
+            .and_then(|s| s.target_node)
+        {
+            self.dispatch_trigger(ctx, previous, ActionTrigger::DragLeave, point, None);
+        }
+        if let Some(session) = ctx.gesture.drag_session.as_mut() {
+            session.target_node = None;
+            session.target_identifier = None;
+        }
+    }
+
     fn dispatch_internal_drop(
         &self,
         ctx: &mut ControllerContext,
         target_node: WidgetId,
         payload: Vec<u8>,
         point: LayoutPoint,
+        modifiers: u8,
     ) -> bool {
         let mut current_id = Some(target_node);
         while let Some(node_id) = current_id {
@@ -405,6 +585,50 @@ impl GestureController {
                                     payload: payload.clone(),
                                     x: point.x,
                                     y: point.y,
+                                    modifiers,
+                                },
+                            );
+
+                            ctx.dispatched_actions.push((node_id, envelope, input));
+                            return true;
+                        }
+                    }
+                }
+                current_id = node.parent;
+            } else {
+                break;
+            }
+        }
+        false
+    }
+
+    fn dispatch_external_drop(
+        &self,
+        ctx: &mut ControllerContext,
+        target_node: WidgetId,
+        paths: Vec<String>,
+        point: LayoutPoint,
+        modifiers: u8,
+    ) -> bool {
+        let mut current_id = Some(target_node);
+        while let Some(node_id) = current_id {
+            if let Some(node) = ctx.ir.nodes.get(&node_id) {
+                if let Op::Semantics(sem) = &node.op {
+                    for entry in &sem.actions.entries {
+                        if entry.trigger == ActionTrigger::Drop {
+                            let envelope = ActionEnvelope {
+                                id: ActionId::from_u128(entry.action_id),
+                                payload: entry.payload_data.clone().unwrap_or_default(),
+                            };
+
+                            let input = crate::input::scoped_action_input(
+                                ctx.ir,
+                                node_id,
+                                ActionInput::Drop {
+                                    paths: paths.clone(),
+                                    x: point.x,
+                                    y: point.y,
+                                    modifiers,
                                 },
                             );
 

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -220,8 +220,8 @@ pub mod public {
         ScrollBehavior, ScrollIntoViewRequest,
     };
     pub use crate::env::{
-        Clipboard, Env, ImeHandler, InteractionStateMap, RuntimeState, ScrollStateMap, WindowEnv,
-        WindowTitle,
+        Clipboard, DragSessionPayload, DragSessionState, Env, ImeHandler, InteractionStateMap,
+        RuntimeState, ScrollStateMap, WindowEnv, WindowTitle,
     };
     pub use crate::runtime::Runtime;
     pub use crate::state::{LocalStateKey, LocalStateStore, StateField};
@@ -229,7 +229,8 @@ pub mod public {
 
     pub use crate::build::{BuildCtxHandle, ViewHandle};
     pub use crate::event::{
-        InputEvent, KeyCode, KeyEvent, LifecycleEvent, PointerButton, PointerEvent,
+        ExternalDragEvent, InputEvent, KeyCode, KeyEvent, LifecycleEvent, PointerButton,
+        PointerEvent,
     };
     pub use crate::motion::*;
     pub use crate::platform::{
@@ -391,15 +392,17 @@ pub use effect::{
     ScrollBehavior, ScrollIntoViewRequest,
 };
 pub use env::{
-    Clipboard, Env, ImeHandler, InteractionStateMap, RouteLocation, RuntimeState, ScrollStateMap,
-    WindowEnv, WindowTitle,
+    Clipboard, DragSessionPayload, DragSessionState, Env, ImeHandler, InteractionStateMap,
+    RouteLocation, RuntimeState, ScrollStateMap, WindowEnv, WindowTitle,
 };
 pub use motion::*;
 pub use runtime::Runtime;
 pub use state::{LocalStateKey, LocalStateStore, StateField};
 
 pub use build::{BuildCtxHandle, ViewHandle};
-pub use event::{InputEvent, KeyCode, KeyEvent, LifecycleEvent, PointerButton, PointerEvent};
+pub use event::{
+    ExternalDragEvent, InputEvent, KeyCode, KeyEvent, LifecycleEvent, PointerButton, PointerEvent,
+};
 pub use fission_ir::op;
 pub use fission_ir::{EmbedKind, FocusPolicy, Op, Role, Semantics, WidgetId};
 pub use fission_layout::{

--- a/crates/core/fission-core/tests/drag_drop.rs
+++ b/crates/core/fission-core/tests/drag_drop.rs
@@ -1,0 +1,260 @@
+use anyhow::Result;
+use fission_core::event::{ExternalDragEvent, InputEvent, PointerButton, PointerEvent};
+use fission_core::{
+    Action, ActionId, ActionInput, ActionRegistry, GlobalState, ReducerContext, Runtime, WidgetId,
+};
+use fission_ir::op::LayoutOp;
+use fission_ir::semantics::{ActionTrigger, Role};
+use fission_ir::{ActionEntry, ActionSet, CoreIR, Op, Semantics};
+use fission_layout::{LayoutNodeGeometry, LayoutPoint, LayoutRect, LayoutSize, LayoutSnapshot};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default)]
+struct DragState {
+    events: Vec<String>,
+}
+
+impl GlobalState for DragState {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct RecordDrag {
+    event: String,
+}
+
+impl Action for RecordDrag {
+    fn static_id() -> ActionId {
+        ActionId::from_name("tests::drag_drop::RecordDrag")
+    }
+}
+
+fn record_drag(state: &mut DragState, action: RecordDrag, ctx: &mut ReducerContext<DragState>) {
+    let detail = match ctx.input.unscoped() {
+        ActionInput::InternalDrop { payload, .. } => {
+            format!("internal:{}", String::from_utf8_lossy(payload))
+        }
+        ActionInput::Drop { paths, .. } => format!("files:{}", paths.join(",")),
+        ActionInput::Pointer { .. } => "pointer".into(),
+        other => format!("{other:?}"),
+    };
+    state.events.push(format!("{}:{detail}", action.event));
+}
+
+fn action(event: &str) -> ActionEntry {
+    let action = RecordDrag {
+        event: event.into(),
+    };
+    ActionEntry {
+        trigger: match event {
+            "drop" => ActionTrigger::Drop,
+            "enter" => ActionTrigger::DragEnter,
+            "leave" => ActionTrigger::DragLeave,
+            "start" => ActionTrigger::DragStart,
+            "end" => ActionTrigger::DragEnd,
+            _ => ActionTrigger::Default,
+        },
+        action_id: RecordDrag::static_id().as_u128(),
+        payload_data: Some(action.encode()),
+    }
+}
+
+fn semantics(role: Role, entries: Vec<ActionEntry>) -> Op {
+    Op::Semantics(Semantics {
+        role,
+        actions: ActionSet { entries },
+        ..Default::default()
+    })
+}
+
+fn drag_tree() -> (CoreIR, LayoutSnapshot, WidgetId, WidgetId, WidgetId) {
+    let root = WidgetId::explicit("drag.root");
+    let source = WidgetId::explicit("drag.source");
+    let target = WidgetId::explicit("drag.target");
+
+    let mut ir = CoreIR::default();
+    let mut source_sem = Semantics {
+        role: Role::Button,
+        identifier: Some("demo.drag.source".into()),
+        drag_payload: Some(b"card-1".to_vec()),
+        actions: ActionSet {
+            entries: vec![action("start"), action("end")],
+        },
+        ..Default::default()
+    };
+    source_sem.draggable = true;
+
+    let target_sem = match semantics(
+        Role::Generic,
+        vec![action("enter"), action("leave"), action("drop")],
+    ) {
+        Op::Semantics(mut sem) => {
+            sem.identifier = Some("demo.drop.target".into());
+            Op::Semantics(sem)
+        }
+        op => op,
+    };
+
+    ir.add_node(source, Op::Semantics(source_sem), Vec::new());
+    ir.add_node(target, target_sem, Vec::new());
+    ir.add_node(root, Op::Layout(LayoutOp::ZStack), vec![source, target]);
+    ir.set_root(root);
+
+    let mut layout = LayoutSnapshot::new(LayoutSize::new(260.0, 120.0));
+    layout.nodes.insert(
+        root,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(0.0, 0.0, 260.0, 120.0),
+            content_size: LayoutSize::new(260.0, 120.0),
+        },
+    );
+    layout.nodes.insert(
+        source,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(10.0, 10.0, 70.0, 50.0),
+            content_size: LayoutSize::new(70.0, 50.0),
+        },
+    );
+    layout.nodes.insert(
+        target,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(130.0, 10.0, 90.0, 70.0),
+            content_size: LayoutSize::new(90.0, 70.0),
+        },
+    );
+
+    (ir, layout, root, source, target)
+}
+
+fn runtime() -> Result<Runtime> {
+    let mut runtime = Runtime::default();
+    runtime.add_app_state(Box::new(DragState::default()))?;
+    let mut registry = ActionRegistry::<DragState>::new();
+    registry
+        .register(record_drag as fn(&mut DragState, RecordDrag, &mut ReducerContext<DragState>));
+    runtime.absorb_registry(registry);
+    Ok(runtime)
+}
+
+fn state(runtime: &Runtime) -> &DragState {
+    runtime.get_app_state::<DragState>().expect("drag state")
+}
+
+#[test]
+fn internal_drag_dispatches_drop_payload_and_drag_boundaries() -> Result<()> {
+    let (ir, layout, _, _, _) = drag_tree();
+    let mut runtime = runtime()?;
+    let source_point = LayoutPoint::new(20.0, 20.0);
+    let target_point = LayoutPoint::new(150.0, 30.0);
+
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Down {
+            point: source_point,
+            button: PointerButton::Primary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Move {
+            point: target_point,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Up {
+            point: target_point,
+            button: PointerButton::Primary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+
+    assert_eq!(
+        state(&runtime).events,
+        vec![
+            "enter:pointer",
+            "start:pointer",
+            "drop:internal:card-1",
+            "end:pointer",
+            "leave:pointer",
+        ]
+    );
+    assert!(runtime.runtime_state.gesture.drag_session.is_none());
+    Ok(())
+}
+
+#[test]
+fn drag_leave_fires_when_internal_drag_moves_off_target() -> Result<()> {
+    let (ir, layout, _, _, _) = drag_tree();
+    let mut runtime = runtime()?;
+
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Down {
+            point: LayoutPoint::new(20.0, 20.0),
+            button: PointerButton::Primary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Move {
+            point: LayoutPoint::new(150.0, 30.0),
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Move {
+            point: LayoutPoint::new(245.0, 100.0),
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+
+    assert!(state(&runtime).events.contains(&"enter:pointer".into()));
+    assert!(state(&runtime).events.contains(&"leave:pointer".into()));
+    Ok(())
+}
+
+#[test]
+fn external_file_drop_dispatches_paths_to_hovered_drop_target() -> Result<()> {
+    let (ir, layout, _, _, _) = drag_tree();
+    let mut runtime = runtime()?;
+    let point = LayoutPoint::new(150.0, 30.0);
+
+    runtime.handle_input(
+        InputEvent::ExternalDrag(ExternalDragEvent::Hover {
+            point,
+            paths: vec!["/tmp/report.pdf".into()],
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::ExternalDrag(ExternalDragEvent::Drop {
+            point,
+            paths: vec!["/tmp/report.pdf".into(), "/tmp/photo.png".into()],
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+
+    assert_eq!(
+        state(&runtime).events,
+        vec![
+            "enter:pointer",
+            "drop:files:/tmp/report.pdf,/tmp/photo.png",
+            "leave:pointer",
+        ]
+    );
+    assert!(runtime.runtime_state.gesture.drag_session.is_none());
+    Ok(())
+}

--- a/crates/shell/fission-shell-terminal/src/test_control.rs
+++ b/crates/shell/fission-shell-terminal/src/test_control.rs
@@ -206,6 +206,11 @@ where
                 self.pump()?;
                 Ok(TestResponse::Ok {})
             }
+            TestCommand::ExternalFileHover { .. }
+            | TestCommand::ExternalFileDrop { .. }
+            | TestCommand::ExternalFileCancel {} => Ok(TestResponse::Error {
+                message: "external file drag-and-drop is not supported by the terminal backend".into(),
+            }),
             TestCommand::ResolveSelector { .. }
             | TestCommand::TapSelector { .. }
             | TestCommand::ActivateSelector { .. }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -38,10 +38,10 @@ use fission_core::internal::InternalLoweringCx;
 use fission_core::ui::VideoAudioOptions;
 use fission_core::{
     Action, ActionEnvelope, ActionId, ActionRegistry, DeepLink, DeepLinkConfig, DeepLinkReceived,
-    Env, GlobalState, InputEvent, KeyCode, KeyEvent as FissionKeyEvent, NotificationResponse,
-    NotificationResponseReceived, OpenUrlRequest, PointerButton, PointerEvent, Runtime,
-    ScrollAlignment, ScrollAxis, ScrollBehavior, ScrollIntoViewRequest, ServiceBindings, View,
-    Widget, WidgetIdExt, OPEN_URL,
+    Env, ExternalDragEvent, GlobalState, InputEvent, KeyCode, KeyEvent as FissionKeyEvent,
+    NotificationResponse, NotificationResponseReceived, OpenUrlRequest, PointerButton,
+    PointerEvent, Runtime, ScrollAlignment, ScrollAxis, ScrollBehavior, ScrollIntoViewRequest,
+    ServiceBindings, View, Widget, WidgetIdExt, OPEN_URL,
 };
 use fission_core::{ActionInput, CapabilityInvocationPayload, Effect};
 use fission_diagnostics::prelude as diag;
@@ -2380,6 +2380,62 @@ fn handle_cursor_moved(
             redraw_pending,
             frame_trace,
             "pointer_move",
+        );
+    }
+}
+
+/// Handle OS drag-and-drop events such as files dragged from Finder/Explorer.
+fn handle_external_drag(
+    event: ExternalDragEvent,
+    runtime: &mut Runtime,
+    pipeline: &Pipeline,
+    effect_result_tx: &mpsc::Sender<EffectResult>,
+    event_proxy: &EventLoopProxy<TestEvent>,
+    async_registry: &AsyncRegistry,
+    active_services: &mut HashMap<ServiceKey, ActiveServiceHandle>,
+    service_bindings: &mut HashMap<ServiceBindingKey, ServiceBindings>,
+    next_service_instance_id: &mut u64,
+    window: &Window,
+    elwt: &EventLoopWindowTarget,
+    last_redraw_at: &mut Instant,
+    min_frame: Duration,
+    redraw_pending: &mut bool,
+    frame_trace: &mut FrameTraceState,
+    invalidations: &mut InvalidationSet,
+) {
+    if let (Some(ir), Some(layout)) = (&pipeline.prev_ir, &pipeline.last_snapshot) {
+        if let Err(e) = runtime.handle_input(InputEvent::ExternalDrag(event), ir, layout) {
+            eprintln!("External drag handling error: {:?}", e);
+        }
+        invalidations.mark_build();
+        if process_pending_effects(
+            runtime,
+            effect_result_tx,
+            event_proxy,
+            async_registry,
+            active_services,
+            service_bindings,
+            next_service_instance_id,
+        ) {
+            invalidations.mark_build();
+            request_redraw_logged(
+                window,
+                elwt,
+                last_redraw_at,
+                min_frame,
+                redraw_pending,
+                frame_trace,
+                "external_drag:effects",
+            );
+        }
+        request_redraw_logged(
+            window,
+            elwt,
+            last_redraw_at,
+            min_frame,
+            redraw_pending,
+            frame_trace,
+            "external_drag",
         );
     }
 }
@@ -4976,6 +5032,83 @@ where
                             &mut invalidations,
                         );
                     }
+                    TestEvent::ExternalFileHover { x, y, paths } => {
+                        let Some(window) = platform_window.active_window() else {
+                            return;
+                        };
+                        handle_external_drag(
+                            ExternalDragEvent::Hover {
+                                point: LayoutPoint { x, y },
+                                paths,
+                                modifiers: 0,
+                            },
+                            &mut runtime,
+                            &pipeline,
+                            &effect_result_tx,
+                            &event_proxy,
+                            &async_registry,
+                            &mut active_services,
+                            &mut service_bindings,
+                            &mut next_service_instance_id,
+                            window,
+                            elwt,
+                            &mut last_redraw_at,
+                            min_frame,
+                            &mut redraw_pending,
+                            &mut frame_trace,
+                            &mut invalidations,
+                        );
+                    }
+                    TestEvent::ExternalFileDrop { x, y, paths } => {
+                        let Some(window) = platform_window.active_window() else {
+                            return;
+                        };
+                        handle_external_drag(
+                            ExternalDragEvent::Drop {
+                                point: LayoutPoint { x, y },
+                                paths,
+                                modifiers: 0,
+                            },
+                            &mut runtime,
+                            &pipeline,
+                            &effect_result_tx,
+                            &event_proxy,
+                            &async_registry,
+                            &mut active_services,
+                            &mut service_bindings,
+                            &mut next_service_instance_id,
+                            window,
+                            elwt,
+                            &mut last_redraw_at,
+                            min_frame,
+                            &mut redraw_pending,
+                            &mut frame_trace,
+                            &mut invalidations,
+                        );
+                    }
+                    TestEvent::ExternalFileCancel => {
+                        let Some(window) = platform_window.active_window() else {
+                            return;
+                        };
+                        handle_external_drag(
+                            ExternalDragEvent::Cancel,
+                            &mut runtime,
+                            &pipeline,
+                            &effect_result_tx,
+                            &event_proxy,
+                            &async_registry,
+                            &mut active_services,
+                            &mut service_bindings,
+                            &mut next_service_instance_id,
+                            window,
+                            elwt,
+                            &mut last_redraw_at,
+                            min_frame,
+                            &mut redraw_pending,
+                            &mut frame_trace,
+                            &mut invalidations,
+                        );
+                    }
                     TestEvent::Resize { width, height } => {
                         let Some(window) = platform_window.active_window() else {
                             return;
@@ -7525,6 +7658,82 @@ where
                                 &mut invalidations,
                             );
                             last_cursor_position = None;
+                        }
+                        WindowEvent::HoveredFile(path) => {
+                            if let Some(position) = last_cursor_position {
+                                let point =
+                                    window_physical_position_to_layout_point(window, position);
+                                handle_external_drag(
+                                    ExternalDragEvent::Hover {
+                                        point,
+                                        paths: vec![path.to_string_lossy().into_owned()],
+                                        modifiers: current_mods,
+                                    },
+                                    &mut runtime,
+                                    &pipeline,
+                                    &effect_result_tx,
+                                    &event_proxy,
+                                    &async_registry,
+                                    &mut active_services,
+                                    &mut service_bindings,
+                                    &mut next_service_instance_id,
+                                    &window,
+                                    elwt,
+                                    &mut last_redraw_at,
+                                    min_frame,
+                                    &mut redraw_pending,
+                                    &mut frame_trace,
+                                    &mut invalidations,
+                                );
+                            }
+                        }
+                        WindowEvent::HoveredFileCancelled => {
+                            handle_external_drag(
+                                ExternalDragEvent::Cancel,
+                                &mut runtime,
+                                &pipeline,
+                                &effect_result_tx,
+                                &event_proxy,
+                                &async_registry,
+                                &mut active_services,
+                                &mut service_bindings,
+                                &mut next_service_instance_id,
+                                &window,
+                                elwt,
+                                &mut last_redraw_at,
+                                min_frame,
+                                &mut redraw_pending,
+                                &mut frame_trace,
+                                &mut invalidations,
+                            );
+                        }
+                        WindowEvent::DroppedFile(path) => {
+                            if let Some(position) = last_cursor_position {
+                                let point =
+                                    window_physical_position_to_layout_point(window, position);
+                                handle_external_drag(
+                                    ExternalDragEvent::Drop {
+                                        point,
+                                        paths: vec![path.to_string_lossy().into_owned()],
+                                        modifiers: current_mods,
+                                    },
+                                    &mut runtime,
+                                    &pipeline,
+                                    &effect_result_tx,
+                                    &event_proxy,
+                                    &async_registry,
+                                    &mut active_services,
+                                    &mut service_bindings,
+                                    &mut next_service_instance_id,
+                                    &window,
+                                    elwt,
+                                    &mut last_redraw_at,
+                                    min_frame,
+                                    &mut redraw_pending,
+                                    &mut frame_trace,
+                                    &mut invalidations,
+                                );
+                            }
                         }
                         WindowEvent::MouseInput { state, button, .. } => {
                             #[cfg(target_arch = "wasm32")]

--- a/crates/shell/fission-shell-winit/src/test_control.rs
+++ b/crates/shell/fission-shell-winit/src/test_control.rs
@@ -242,6 +242,18 @@ fn dispatch_command(cmd: TestCommand, injector: &EventInjector) -> TestResponse 
             inject_event(injector, TestEvent::Scroll { x, y, dx, dy });
             TestResponse::Ok {}
         }
+        TestCommand::ExternalFileHover { x, y, paths } => {
+            inject_event(injector, TestEvent::ExternalFileHover { x, y, paths });
+            TestResponse::Ok {}
+        }
+        TestCommand::ExternalFileDrop { x, y, paths } => {
+            inject_event(injector, TestEvent::ExternalFileDrop { x, y, paths });
+            TestResponse::Ok {}
+        }
+        TestCommand::ExternalFileCancel {} => {
+            inject_event(injector, TestEvent::ExternalFileCancel);
+            TestResponse::Ok {}
+        }
         TestCommand::TypeText { text } => {
             inject_event(injector, TestEvent::TextInput { text });
             TestResponse::Ok {}

--- a/crates/tools/fission-test-driver/src/lib.rs
+++ b/crates/tools/fission-test-driver/src/lib.rs
@@ -115,6 +115,17 @@ pub enum TestCommand {
         dx: f32,
         dy: f32,
     },
+    ExternalFileHover {
+        x: f32,
+        y: f32,
+        paths: Vec<String>,
+    },
+    ExternalFileDrop {
+        x: f32,
+        y: f32,
+        paths: Vec<String>,
+    },
+    ExternalFileCancel {},
     TypeText {
         text: String,
     },
@@ -209,6 +220,17 @@ pub enum TestEvent {
         dx: f32,
         dy: f32,
     },
+    ExternalFileHover {
+        x: f32,
+        y: f32,
+        paths: Vec<String>,
+    },
+    ExternalFileDrop {
+        x: f32,
+        y: f32,
+        paths: Vec<String>,
+    },
+    ExternalFileCancel,
     Resize {
         width: u32,
         height: u32,
@@ -770,6 +792,32 @@ impl LiveTestClient {
             end_y,
             steps,
         })?;
+        self.pump()?;
+        Ok(())
+    }
+
+    pub fn external_file_hover(&self, x: f32, y: f32, paths: impl Into<Vec<String>>) -> Result<()> {
+        self.send(TestCommand::ExternalFileHover {
+            x,
+            y,
+            paths: paths.into(),
+        })?;
+        self.pump()?;
+        Ok(())
+    }
+
+    pub fn external_file_drop(&self, x: f32, y: f32, paths: impl Into<Vec<String>>) -> Result<()> {
+        self.send(TestCommand::ExternalFileDrop {
+            x,
+            y,
+            paths: paths.into(),
+        })?;
+        self.pump()?;
+        Ok(())
+    }
+
+    pub fn external_file_cancel(&self) -> Result<()> {
+        self.send(TestCommand::ExternalFileCancel {})?;
         self.pump()?;
         Ok(())
     }

--- a/documentation/content/reference/widgets/widget-pages/drag-target.mdx
+++ b/documentation/content/reference/widgets/widget-pages/drag-target.mdx
@@ -15,15 +15,18 @@ It wraps a child and dispatches one action when something is dropped on it. Use 
 use fission::prelude::*;
 
 let widget: Widget = DragTarget {
-child: Text::new("Drop here to move").into(),
-on_drop: Some(ctx.bind(
-    MoveCardHere,
-    reduce_with!((|state: &mut BoardState, _action: MoveCardHere, ctx| {
-        if let Some(bytes) = ctx.input.as_internal_drop() {
-            state.pending_drop_card_id = Some(String::from_utf8(bytes.to_vec()).unwrap());
-        }
-    })),
-)),
+    id: Some(WidgetId::explicit("move_card_target")),
+    semantics_identifier: Some("board.move_card_target".into()),
+    child: Text::new("Drop here to move").into(),
+    hover_child: Some(Text::new("Release to move here").into()),
+    on_drop: Some(ctx.bind(
+        MoveCardHere,
+        reduce_with!((|state: &mut BoardState, _action: MoveCardHere, ctx| {
+            if let Some(bytes) = ctx.input.as_internal_drop() {
+                state.pending_drop_card_id = Some(String::from_utf8(bytes.to_vec()).unwrap());
+            }
+        })),
+    )),
 }
 .into();
 ```
@@ -34,7 +37,10 @@ The dropped payload travels through `ctx.input`, not through the action type its
 
 | Field | Type | Meaning | Notes / default behavior |
 | --- | --- | --- | --- |
+| `id` | `Option<WidgetId>` | Stable identity for the drop target. | Use explicit IDs for repeated or dynamic targets. |
+| `semantics_identifier` | `Option<String>` | Stable semantic/test identifier. | Lets tests target this drop surface without coordinates. |
 | `child` | `Widget` | The visible drop target surface. | Required. |
+| `hover_child` | `Option<Widget>` | Alternate surface while this target is hovered by a drag. | Defaults to `None`, so `child` remains visible. |
 | `on_drop` | `Option<ActionEnvelope>` | Action dispatched when the runtime delivers a drop to this target. | Defaults to `None`. Read payloads from `ReducerContext::input`. |
 
 ## How drop data reaches your reducer
@@ -59,4 +65,3 @@ If a screen starts repeating the same `DragTarget` setup, extract a named compon
 ## Related
 
 [`Draggable`](/reference/widgets/draggable), [`Dropzone`](/reference/widgets/dropzone), [`GestureDetector`](/reference/widgets/gesture-detector), and [`Overlay`](/reference/widgets/overlay).
-

--- a/documentation/content/reference/widgets/widget-pages/draggable.mdx
+++ b/documentation/content/reference/widgets/widget-pages/draggable.mdx
@@ -15,15 +15,26 @@ It takes a visible child and a payload of bytes. When the user begins dragging, 
 use fission::prelude::*;
 
 let widget: Widget = Draggable {
+    id: Some(WidgetId::explicit("release_checklist_drag")),
+    semantics_identifier: Some("cards.release_checklist.drag".into()),
     payload: view.state().card_id.as_bytes().to_vec(),
-    on_drag_start: Some(start_drag_action),
-    on_drag_end: Some(end_drag_action),
     child: Button {
         child: Some(Text::new("Release checklist").into()),
         on_press: Some(open_card_action),
         ..Default::default()
     }
     .into(),
+    preview: Some(Tag {
+        label: "Release checklist".into(),
+        on_close: None,
+    }
+    .into()),
+    preview_options: DragPreviewOptions {
+        snap_grid: Some(24.0),
+        ..Default::default()
+    },
+    on_drag_start: Some(start_drag_action),
+    on_drag_end: Some(end_drag_action),
 }
 .into();
 ```
@@ -34,8 +45,12 @@ The payload carries just enough information for the eventual drop target to know
 
 | Field | Type | Meaning | Notes / default behavior |
 | --- | --- | --- | --- |
+| `id` | `Option<WidgetId>` | Stable identity for the drag source. | Use explicit IDs for reordered, filtered, or generated rows. |
+| `semantics_identifier` | `Option<String>` | Stable semantic/test identifier. | Lets tests and accessibility tooling identify the drag source. |
 | `payload` | `Vec<u8>` | Bytes attached to the drag. | Required. The reducer on the drop target decodes them from `ctx.input.as_internal_drop()`. |
 | `child` | `Widget` | Visible content that the user drags. | Required. |
+| `preview` | `Option<Widget>` | Optional drag avatar rendered near the pointer. | Defaults to `None`; provide `id` or `semantics_identifier` so the runtime can match the source during rebuilds. |
+| `preview_options` | `DragPreviewOptions` | Pointer offset and optional preview snapping. | Defaults to a small pointer offset and no snapping. |
 | `on_drag_start` | `Option<ActionEnvelope>` | Action fired when dragging begins. | Defaults to `None`. Useful for visual state such as highlighting the source item. |
 | `on_drag_end` | `Option<ActionEnvelope>` | Action fired when dragging ends. | Defaults to `None`, regardless of whether a target accepted the drop. |
 

--- a/documentation/content/reference/widgets/widget-pages/dropzone.mdx
+++ b/documentation/content/reference/widgets/widget-pages/dropzone.mdx
@@ -15,17 +15,21 @@ Use it when a part of the screen should visibly respond as something is dragged 
 use fission::prelude::*;
 
 let widget: Widget = Dropzone {
-child: upload_panel_node,
-on_drag_enter: Some(with_reducer!(ctx, SetHoveringUpload(true), on_set_hovering_upload)),
-on_drag_leave: Some(with_reducer!(ctx, SetHoveringUpload(false), on_set_hovering_upload)),
-on_drop: Some(ctx.bind(
-    FilesDropped,
-    reduce_with!((|state: &mut ComposerState, _action: FilesDropped, ctx| {
-        if let Some(paths) = ctx.input.as_drop_paths() {
-            state.attachments.extend(paths.iter().cloned());
-        }
-    })),
-)),
+    id: Some(WidgetId::explicit("composer_upload_dropzone")),
+    semantics_identifier: Some("composer.attachments.dropzone".into()),
+    child: upload_panel_node,
+    active_child: Some(upload_panel_active_node),
+    hover_child: Some(upload_panel_hover_node),
+    on_drag_enter: Some(with_reducer!(ctx, SetHoveringUpload(true), on_set_hovering_upload)),
+    on_drag_leave: Some(with_reducer!(ctx, SetHoveringUpload(false), on_set_hovering_upload)),
+    on_drop: Some(ctx.bind(
+        FilesDropped,
+        reduce_with!((|state: &mut ComposerState, _action: FilesDropped, ctx| {
+            if let Some(paths) = ctx.input.as_drop_paths() {
+                state.attachments.extend(paths.iter().cloned());
+            }
+        })),
+    )),
 }
 .into();
 ```
@@ -36,7 +40,11 @@ Here the hover state lives in `GlobalState`, so the next build can re-render the
 
 | Field | Type | Meaning | Notes / default behavior |
 | --- | --- | --- | --- |
+| `id` | `Option<WidgetId>` | Stable identity for the drop surface. | Use explicit IDs for repeated or dynamic dropzones. |
+| `semantics_identifier` | `Option<String>` | Stable semantic/test identifier. | Lets tests target this surface without coordinates. |
 | `child` | `Widget` | Visible content wrapped by the drop surface. | Required. |
+| `active_child` | `Option<Widget>` | Alternate child shown while any drag is active in the window. | Defaults to `None`, so `child` remains visible. |
+| `hover_child` | `Option<Widget>` | Alternate child shown while this dropzone is the hovered target. | Defaults to `None`, so `child` remains visible. |
 | `on_drop` | `Option<ActionEnvelope>` | Action dispatched when something is dropped on the surface. | Read external paths with `ctx.input.as_drop_paths()` or internal bytes with `ctx.input.as_internal_drop()`. |
 | `on_drag_enter` | `Option<ActionEnvelope>` | Action dispatched when a drag enters the bounds. | Useful for setting hover state in `GlobalState`. |
 | `on_drag_leave` | `Option<ActionEnvelope>` | Action dispatched when a drag leaves the bounds. | Useful for clearing hover state. |
@@ -63,4 +71,3 @@ If a screen starts repeating the same `Dropzone` setup, extract a named componen
 ## Related
 
 [`Draggable`](/reference/widgets/draggable), [`DragTarget`](/reference/widgets/drag-target), [`FormControl`](/reference/widgets/form-control), and [`GestureDetector`](/reference/widgets/gesture-detector).
-

--- a/examples/inbox/src/features/compose.rs
+++ b/examples/inbox/src/features/compose.rs
@@ -308,7 +308,11 @@ impl From<ComposeModal> for Widget {
                 id: None,
                 is_barrier: true,
                 children: vec![Dropzone {
+                    id: None,
+                    semantics_identifier: None,
                     child: content,
+                    active_child: None,
+                    hover_child: None,
                     on_drop: Some(ctx.bind(
                         FileSelected,
                         reduce_with!(

--- a/examples/inbox/src/features/settings.rs
+++ b/examples/inbox/src/features/settings.rs
@@ -338,6 +338,8 @@ impl From<SettingsModal> for Widget {
             .iter()
             .map(|label| {
                 Draggable {
+                    id: None,
+                    semantics_identifier: None,
                     payload: label.as_bytes().to_vec(),
                     on_drag_start: Some(ActionEnvelope {
                         id: drag_active_id,
@@ -352,12 +354,16 @@ impl From<SettingsModal> for Widget {
                         on_close: None,
                     }
                     .into(),
+                    preview: None,
+                    preview_options: Default::default(),
                 }
                 .into()
             })
             .collect::<Vec<_>>();
 
         let drop_target = DragTarget {
+            id: None,
+            semantics_identifier: None,
             on_drop: Some(ActionEnvelope {
                 id: label_drop_id,
                 payload: serde_json::to_vec(&LabelDropped("Pinned".into())).unwrap(),
@@ -374,6 +380,7 @@ impl From<SettingsModal> for Widget {
             .border(tokens.colors.border, 1.0)
             .border_radius(8.0)
             .into(),
+            hover_child: None,
         }
         .into();
 

--- a/examples/widget-gallery/src/drag_drop.rs
+++ b/examples/widget-gallery/src/drag_drop.rs
@@ -1,0 +1,451 @@
+use fission::core::op::Color as IrColor;
+use fission::core::ui::{Button, ButtonVariant, Container, Text, Widget};
+use fission::core::{reduce_with, ReducerContext, WidgetId};
+use fission::prelude::fission_action;
+use fission::widgets::{DragPreviewOptions, DragTarget, Draggable, Dropzone, HStack, Tag, VStack};
+
+use crate::GalleryState;
+
+#[derive(Clone)]
+pub(crate) struct DragDropSection;
+
+#[derive(Clone)]
+struct TaskCard {
+    label: String,
+    snap_to_grid: bool,
+}
+
+#[derive(Clone)]
+struct LaneDropzone {
+    id: &'static str,
+    title: &'static str,
+    items: Vec<String>,
+}
+
+#[derive(Clone)]
+struct ExternalFileDropTarget;
+
+#[derive(Clone)]
+struct DragLog;
+
+#[fission_action]
+struct ToggleSnapPreview;
+
+#[fission_action]
+struct DragStarted(String);
+
+#[fission_action]
+struct DragEnded(String);
+
+#[fission_action]
+struct DropOnLane(String);
+
+#[fission_action]
+struct DragEntered(String);
+
+#[fission_action]
+struct DragLeft(String);
+
+#[fission_action]
+struct ExternalFilesDropped;
+
+fn toggle_snap_preview(
+    state: &mut GalleryState,
+    _: ToggleSnapPreview,
+    _: &mut ReducerContext<GalleryState>,
+) {
+    state.drag_snap_preview = !state.drag_snap_preview;
+}
+
+fn drag_started(
+    state: &mut GalleryState,
+    action: DragStarted,
+    _: &mut ReducerContext<GalleryState>,
+) {
+    push_drag_log(state, format!("Started dragging {}", action.0));
+}
+
+fn drag_ended(state: &mut GalleryState, action: DragEnded, _: &mut ReducerContext<GalleryState>) {
+    push_drag_log(state, format!("Ended dragging {}", action.0));
+    state.drag_hover_zone = None;
+}
+
+fn drag_entered(
+    state: &mut GalleryState,
+    action: DragEntered,
+    _: &mut ReducerContext<GalleryState>,
+) {
+    state.drag_hover_zone = Some(action.0.clone());
+    push_drag_log(state, format!("Hovering over {}", action.0));
+}
+
+fn drag_left(state: &mut GalleryState, action: DragLeft, _: &mut ReducerContext<GalleryState>) {
+    if state.drag_hover_zone.as_deref() == Some(action.0.as_str()) {
+        state.drag_hover_zone = None;
+    }
+    push_drag_log(state, format!("Left {}", action.0));
+}
+
+fn drop_on_lane(
+    state: &mut GalleryState,
+    action: DropOnLane,
+    ctx: &mut ReducerContext<GalleryState>,
+) {
+    let Some(payload) = ctx.input.as_internal_drop() else {
+        return;
+    };
+    let label = String::from_utf8_lossy(payload).into_owned();
+    remove_task(state, &label);
+    match action.0.as_str() {
+        "Backlog" => state.drag_backlog.push(label.clone()),
+        "Done" => state.drag_done.push(label.clone()),
+        _ => state.drag_backlog.push(label.clone()),
+    }
+    state.drag_hover_zone = None;
+    push_drag_log(state, format!("Dropped {label} on {}", action.0));
+}
+
+fn external_files_dropped(
+    state: &mut GalleryState,
+    _: ExternalFilesDropped,
+    ctx: &mut ReducerContext<GalleryState>,
+) {
+    let Some(paths) = ctx.input.as_drop_paths() else {
+        return;
+    };
+    for path in paths {
+        state.drag_external_files.push(path.clone());
+    }
+    push_drag_log(state, format!("Accepted {} external file(s)", paths.len()));
+}
+
+fn remove_task(state: &mut GalleryState, label: &str) {
+    state.drag_backlog.retain(|item| item != label);
+    state.drag_done.retain(|item| item != label);
+}
+
+fn push_drag_log(state: &mut GalleryState, message: String) {
+    if state.drag_log.first() == Some(&message) {
+        return;
+    }
+    state.drag_log.insert(0, message);
+    state.drag_log.truncate(6);
+}
+
+impl From<DragDropSection> for Widget {
+    fn from(_: DragDropSection) -> Self {
+        let (ctx, view) = fission::build::current::<GalleryState>();
+        let state = view.state();
+        let tokens = &view.env().theme.tokens;
+
+        VStack {
+            spacing: Some(12.0),
+            children: vec![
+                Text::new("Drag and Drop").size(20.0).into(),
+                Text::new(
+                    "Drag task cards between lanes, hover over targets to see accepted-state feedback, or drop external files onto the import target.",
+                )
+                .color(tokens.colors.text_secondary)
+                .into(),
+                HStack {
+                    spacing: Some(10.0),
+                    children: vec![
+                        Button {
+                            variant: if state.drag_snap_preview {
+                                ButtonVariant::Filled
+                            } else {
+                                ButtonVariant::Outline
+                            },
+                            child: Some(Text::new(if state.drag_snap_preview {
+                                "Snap preview: on"
+                            } else {
+                                "Snap preview: off"
+                            })
+                            .into()),
+                            on_press: Some(ctx.bind(
+                                ToggleSnapPreview,
+                                reduce_with!(toggle_snap_preview),
+                            )),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("gallery.drag.snap_preview")
+                        .into(),
+                        Text::new("The preview avatar follows the pointer; snapping shows grid-constrained drag UX.")
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                    ],
+                }
+                .into(),
+                HStack {
+                    spacing: Some(16.0),
+                    children: vec![
+                        LaneDropzone {
+                            id: "Backlog",
+                            title: "Backlog",
+                            items: state.drag_backlog.clone(),
+                        }
+                        .into(),
+                        LaneDropzone {
+                            id: "Done",
+                            title: "Done",
+                            items: state.drag_done.clone(),
+                        }
+                        .into(),
+                        VStack {
+                            spacing: Some(10.0),
+                            children: vec![ExternalFileDropTarget.into(), DragLog.into()],
+                        }
+                        .into(),
+                    ],
+                }
+                .into(),
+            ],
+        }
+        .into()
+    }
+}
+
+impl From<TaskCard> for Widget {
+    fn from(card: TaskCard) -> Self {
+        let (ctx, view) = fission::build::current::<GalleryState>();
+        let tokens = &view.env().theme.tokens;
+        let preview_options = DragPreviewOptions {
+            snap_grid: card.snap_to_grid.then_some(24.0),
+            ..Default::default()
+        };
+
+        Draggable {
+            id: Some(WidgetId::explicit(&format!(
+                "gallery.drag.card.{}",
+                card.label
+            ))),
+            semantics_identifier: Some(format!("gallery.drag.card.{}", card.label)),
+            payload: card.label.as_bytes().to_vec(),
+            child: Container::new(HStack {
+                spacing: Some(8.0),
+                children: vec![
+                    Text::new("::").color(tokens.colors.text_secondary).into(),
+                    Text::new(card.label.clone()).into(),
+                ],
+            })
+            .padding_all(10.0)
+            .border(tokens.colors.border, 1.0)
+            .border_radius(10.0)
+            .bg(tokens.colors.surface)
+            .into(),
+            preview: Some(
+                Container::new(HStack {
+                    spacing: Some(6.0),
+                    children: vec![
+                        Text::new("move")
+                            .size(11.0)
+                            .color(tokens.colors.primary)
+                            .into(),
+                        Text::new(card.label.clone()).into(),
+                    ],
+                })
+                .padding_all(10.0)
+                .border(tokens.colors.primary, 1.0)
+                .border_radius(12.0)
+                .bg(tokens.colors.surface.with_alpha(235))
+                .into(),
+            ),
+            preview_options,
+            on_drag_start: Some(
+                ctx.bind(DragStarted(card.label.clone()), reduce_with!(drag_started)),
+            ),
+            on_drag_end: Some(ctx.bind(DragEnded(card.label), reduce_with!(drag_ended))),
+        }
+        .into()
+    }
+}
+
+impl From<LaneDropzone> for Widget {
+    fn from(lane: LaneDropzone) -> Self {
+        let (ctx, view) = fission::build::current::<GalleryState>();
+        let state = view.state();
+        let tokens = &view.env().theme.tokens;
+        let title = lane.title;
+        let is_hovered = state.drag_hover_zone.as_deref() == Some(title);
+        let mut children: Vec<Widget> = vec![
+            HStack {
+                spacing: Some(8.0),
+                children: vec![
+                    Text::new(title).size(16.0).into(),
+                    Tag {
+                        label: format!("{}", lane.items.len()),
+                        on_close: None,
+                    }
+                    .into(),
+                ],
+            }
+            .into(),
+            Text::new(if is_hovered {
+                "Release to drop here"
+            } else {
+                "Drag cards into this lane"
+            })
+            .size(12.0)
+            .color(tokens.colors.text_secondary)
+            .into(),
+        ];
+        for item in lane.items {
+            children.push(
+                TaskCard {
+                    label: item,
+                    snap_to_grid: state.drag_snap_preview,
+                }
+                .into(),
+            );
+        }
+
+        let idle = Container::new(VStack {
+            spacing: Some(8.0),
+            children: children.clone(),
+        })
+        .width(210.0)
+        .min_height(190.0)
+        .padding_all(12.0)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(14.0)
+        .bg(tokens.colors.background.with_alpha(35))
+        .into();
+
+        let active = Container::new(VStack {
+            spacing: Some(8.0),
+            children: children.clone(),
+        })
+        .width(210.0)
+        .min_height(190.0)
+        .padding_all(12.0)
+        .border(tokens.colors.primary.with_alpha(150), 1.0)
+        .border_radius(14.0)
+        .bg(tokens.colors.primary.with_alpha(18))
+        .into();
+
+        let hover = Container::new(VStack {
+            spacing: Some(8.0),
+            children,
+        })
+        .width(210.0)
+        .min_height(190.0)
+        .padding_all(12.0)
+        .border(tokens.colors.primary, 2.0)
+        .border_radius(14.0)
+        .bg(tokens.colors.primary.with_alpha(36))
+        .into();
+
+        Dropzone {
+            id: Some(WidgetId::explicit(&format!(
+                "gallery.drag.zone.{}",
+                lane.id
+            ))),
+            semantics_identifier: Some(format!("gallery.drag.zone.{}", lane.id)),
+            child: idle,
+            active_child: Some(active),
+            hover_child: Some(hover),
+            on_drop: Some(ctx.bind(DropOnLane(title.into()), reduce_with!(drop_on_lane))),
+            on_drag_enter: Some(ctx.bind(DragEntered(title.into()), reduce_with!(drag_entered))),
+            on_drag_leave: Some(ctx.bind(DragLeft(title.into()), reduce_with!(drag_left))),
+        }
+        .into()
+    }
+}
+
+impl From<ExternalFileDropTarget> for Widget {
+    fn from(_: ExternalFileDropTarget) -> Self {
+        let (ctx, view) = fission::build::current::<GalleryState>();
+        let state = view.state();
+        let tokens = &view.env().theme.tokens;
+        let mut file_widgets = vec![Text::new("External files").size(16.0).into()];
+        if state.drag_external_files.is_empty() {
+            file_widgets.push(
+                Text::new("Drop files from Finder, Explorer, or the test driver here.")
+                    .size(12.0)
+                    .color(tokens.colors.text_secondary)
+                    .into(),
+            );
+        } else {
+            for file in state.drag_external_files.iter().take(4) {
+                file_widgets.push(Text::new(file.clone()).size(12.0).into());
+            }
+        }
+
+        DragTarget {
+            id: Some(WidgetId::explicit("gallery.drag.external_files")),
+            semantics_identifier: Some("gallery.drag.external_files".into()),
+            on_drop: Some(ctx.bind(ExternalFilesDropped, reduce_with!(external_files_dropped))),
+            child: Container::new(VStack {
+                spacing: Some(6.0),
+                children: file_widgets.clone(),
+            })
+            .width(230.0)
+            .min_height(86.0)
+            .padding_all(12.0)
+            .border(tokens.colors.border, 1.0)
+            .border_radius(14.0)
+            .bg(tokens.colors.background.with_alpha(28))
+            .into(),
+            hover_child: Some(
+                Container::new(VStack {
+                    spacing: Some(6.0),
+                    children: file_widgets,
+                })
+                .width(230.0)
+                .min_height(86.0)
+                .padding_all(12.0)
+                .border(tokens.colors.primary, 2.0)
+                .border_radius(14.0)
+                .bg(tokens.colors.primary.with_alpha(32))
+                .into(),
+            ),
+        }
+        .into()
+    }
+}
+
+impl From<DragLog> for Widget {
+    fn from(_: DragLog) -> Self {
+        let (_, view) = fission::build::current::<GalleryState>();
+        let state = view.state();
+        let tokens = &view.env().theme.tokens;
+        let rows: Vec<Widget> = if state.drag_log.is_empty() {
+            vec![Text::new("Drag log is empty.")
+                .size(12.0)
+                .color(tokens.colors.text_secondary)
+                .into()]
+        } else {
+            state
+                .drag_log
+                .iter()
+                .map(|entry| Text::new(entry.clone()).size(12.0).into())
+                .collect()
+        };
+
+        Container::new(VStack {
+            spacing: Some(5.0),
+            children: vec![
+                Text::new("Interaction log").size(16.0).into(),
+                VStack {
+                    spacing: Some(4.0),
+                    children: rows,
+                }
+                .into(),
+            ],
+        })
+        .width(230.0)
+        .min_height(116.0)
+        .padding_all(12.0)
+        .border(
+            IrColor {
+                r: 190,
+                g: 190,
+                b: 190,
+                a: 140,
+            },
+            1.0,
+        )
+        .border_radius(14.0)
+        .into()
+    }
+}

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -1,3 +1,6 @@
+mod drag_drop;
+
+use drag_drop::DragDropSection;
 use fission::core::op::Color as IrColor;
 use fission::core::ui::{
     Button, ButtonVariant, Checkbox, Container, ContextMenu, ContextMenuEntry, ContextMenuItem,
@@ -45,6 +48,12 @@ struct GalleryState {
     tree_expanded: HashSet<String>,
     tree_selected: Option<String>,
     show_toast: bool,
+    drag_backlog: Vec<String>,
+    drag_done: Vec<String>,
+    drag_hover_zone: Option<String>,
+    drag_log: Vec<String>,
+    drag_snap_preview: bool,
+    drag_external_files: Vec<String>,
 }
 
 impl Default for GalleryState {
@@ -79,6 +88,16 @@ impl Default for GalleryState {
             tree_expanded,
             tree_selected: None,
             show_toast: false,
+            drag_backlog: vec![
+                "Inbox triage".into(),
+                "Invoice import".into(),
+                "Follow-up".into(),
+            ],
+            drag_done: vec!["Release notes".into()],
+            drag_hover_zone: None,
+            drag_log: Vec::new(),
+            drag_snap_preview: false,
+            drag_external_files: Vec::new(),
         }
     }
 }
@@ -1226,6 +1245,7 @@ impl From<GalleryApp> for Widget {
                 feedback_section,
                 nav_section,
                 data_section,
+                DragDropSection.into(),
                 overlay_section,
                 Spacer {
                     height: Some(40.0),


### PR DESCRIPTION
## Summary

- Adds runtime drag-session state for internal drags, hovered drop target tracking, and drag enter/leave dispatch.
- Adds platform-independent external file drag events and wires winit `HoveredFile`, `HoveredFileCancelled`, and `DroppedFile` into the runtime.
- Extends `Draggable`, `DragTarget`, and `Dropzone` with stable IDs, semantic identifiers, drag previews, hover/active visuals, and preview snap options.
- Adds LiveTest/test-driver commands for external file hover/drop/cancel and a widget-gallery drag-and-drop workbench section.

## Details

- Internal drops continue to deliver opaque bytes through `ctx.input.as_internal_drop()`.
- External drops deliver paths through `ctx.input.as_drop_paths()`.
- Both internal and external drop inputs now carry the active modifier bitmask via `ctx.input.as_drop_modifiers()`, so app reducers can implement copy/move/link policy without hard-coding it into the runtime.
- Drag previews are opt-in and rendered as a portal while the matching drag source is active.
- Dropzone alternate children are declarative: idle, any-drag-active, and hovered-target states.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p fission-core -p fission-widgets -p fission-test-driver -p fission-shell-winit -p widget-gallery`
- `cargo test -p fission-core --test drag_drop`
- `cargo test -p fission-widgets --no-run`
- Manual widget-gallery LiveTest run with `/cmd` drag and external file-drop commands; screenshots saved locally at:
  - `/tmp/fission-drag-drop-qa/drag-drop-section.png`
  - `/tmp/fission-drag-drop-qa/drag-after-internal-drop.png`
  - `/tmp/fission-drag-drop-qa/drag-after-external-drop.png`

## Notes

- The OS file-drop bridge is implemented for the winit shell. Other shells can now map their host drag events to `InputEvent::ExternalDrag` without changing widget APIs.
- Native cursor negotiation and platform-level accepted-operation feedback are not implemented in this PR; reducers receive modifiers so product-level copy/move policy can be implemented now.
