### PR TITLE
Add selectable text and widget-backed context menus

### DIFF
--- a/crates/authoring/fission-widgets/src/hero.rs
+++ b/crates/authoring/fission-widgets/src/hero.rs
@@ -61,6 +61,8 @@ impl InternalLowerer for HeroLowerer {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: None,
             disabled: false,
             read_only: false,

--- a/crates/authoring/fission-widgets/tests/widget_invariants.rs
+++ b/crates/authoring/fission-widgets/tests/widget_invariants.rs
@@ -96,6 +96,8 @@ fn test_button_widget_lower_with_child_and_semantics() {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: None,
             disabled: false,
             read_only: false,

--- a/crates/core/fission-core/src/env.rs
+++ b/crates/core/fission-core/src/env.rs
@@ -173,6 +173,8 @@ pub struct RuntimeState {
     pub motion: MotionStateMap,
     pub interaction: InteractionStateMap,
     pub text_edit: TextEditStateMap,
+    pub selectable_text: SelectableTextStateMap,
+    pub context_menu: ContextMenuState,
     pub clipboard: String,
     pub caret_visible: HashMap<WidgetId, bool>,
     pub gesture: GestureState,
@@ -208,6 +210,62 @@ impl ScrollStateMap {
 
     pub fn set_offset(&mut self, id: WidgetId, offset: f32) {
         self.offsets.insert(id, offset);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ContextMenuState {
+    pub owner: Option<WidgetId>,
+    pub anchor: Option<LayoutPoint>,
+}
+
+impl ContextMenuState {
+    pub fn open(&mut self, owner: WidgetId, anchor: LayoutPoint) {
+        self.owner = Some(owner);
+        self.anchor = Some(anchor);
+    }
+
+    pub fn close(&mut self) {
+        self.owner = None;
+        self.anchor = None;
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SelectableTextStateMap {
+    pub states: HashMap<WidgetId, SelectableTextState>,
+}
+
+impl SelectableTextStateMap {
+    pub fn get(&self, id: WidgetId) -> Option<&SelectableTextState> {
+        self.states.get(&id)
+    }
+
+    pub fn get_mut_or_default(&mut self, id: WidgetId) -> &mut SelectableTextState {
+        self.states.entry(id).or_default()
+    }
+
+    pub fn selection_range(&self, id: WidgetId) -> Option<(usize, usize)> {
+        self.states
+            .get(&id)
+            .and_then(SelectableTextState::selection_range)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SelectableTextState {
+    pub anchor: usize,
+    pub caret: usize,
+    pub selecting: bool,
+}
+
+impl SelectableTextState {
+    pub fn selection_range(&self) -> Option<(usize, usize)> {
+        if self.anchor == self.caret {
+            None
+        } else {
+            Some((self.anchor, self.caret))
+        }
     }
 }
 

--- a/crates/core/fission-core/src/input/gesture.rs
+++ b/crates/core/fission-core/src/input/gesture.rs
@@ -172,21 +172,30 @@ impl InputController for GestureController {
                                         || self.is_descendant(ctx, up_hit, target)
                                         || self.is_descendant(ctx, target, up_hit)
                                     {
-                                        let rich_text_path = self.path_for_node(ctx, up_hit);
-                                        if let Some((annotation_node_id, annotation)) =
-                                            crate::input::hover::resolve_rich_text_annotation_at_point(
-                                                ctx,
-                                                &rich_text_path,
-                                                *point,
-                                            )
+                                        if let Some(menu_owner) =
+                                            self.find_context_menu_owner(ctx, up_hit)
                                         {
-                                            handled = self.dispatch_annotation_trigger(
-                                                ctx,
-                                                annotation_node_id,
-                                                &annotation,
-                                                ActionTrigger::SecondaryClick,
-                                                *point,
-                                            );
+                                            ctx.context_menu.open(menu_owner, *point);
+                                            handled = true;
+                                        }
+
+                                        let rich_text_path = self.path_for_node(ctx, up_hit);
+                                        if !handled {
+                                            if let Some((annotation_node_id, annotation)) =
+                                                crate::input::hover::resolve_rich_text_annotation_at_point(
+                                                    ctx,
+                                                    &rich_text_path,
+                                                    *point,
+                                                )
+                                            {
+                                                handled = self.dispatch_annotation_trigger(
+                                                    ctx,
+                                                    annotation_node_id,
+                                                    &annotation,
+                                                    ActionTrigger::SecondaryClick,
+                                                    *point,
+                                                );
+                                            }
                                         }
 
                                         if !handled
@@ -246,6 +255,9 @@ impl InputController for GestureController {
                             }
                         }
 
+                        if !was_secondary {
+                            ctx.context_menu.close();
+                        }
                         ctx.gesture.start_point = None;
                         ctx.gesture.is_panning = false;
                         ctx.gesture.dragging_payload = None;
@@ -289,6 +301,26 @@ impl GestureController {
             }
         }
         false
+    }
+
+    fn find_context_menu_owner(
+        &self,
+        ctx: &ControllerContext,
+        start_node: WidgetId,
+    ) -> Option<WidgetId> {
+        let mut current_id = Some(start_node);
+        while let Some(node_id) = current_id {
+            let Some(node) = ctx.ir.nodes.get(&node_id) else {
+                break;
+            };
+            if let Op::Semantics(semantics) = &node.op {
+                if semantics.context_menu && !semantics.disabled {
+                    return Some(node_id);
+                }
+            }
+            current_id = node.parent;
+        }
+        None
     }
 
     fn dispatch_annotation_trigger(

--- a/crates/core/fission-core/src/input/mod.rs
+++ b/crates/core/fission-core/src/input/mod.rs
@@ -1,4 +1,7 @@
-use crate::env::{Clipboard, InteractionStateMap, ScrollStateMap, TextEditStateMap};
+use crate::env::{
+    Clipboard, ContextMenuState, InteractionStateMap, ScrollStateMap, SelectableTextStateMap,
+    TextEditStateMap,
+};
 use crate::event::InputEvent;
 use crate::{ActionEnvelope, ActionInput};
 use fission_ir::{CoreIR, Op, WidgetId};
@@ -7,6 +10,7 @@ use std::sync::Arc;
 
 pub mod gesture;
 pub mod hover;
+pub mod selectable_text;
 pub mod slider;
 pub mod text;
 
@@ -14,6 +18,8 @@ pub struct ControllerContext<'a> {
     pub ir: &'a CoreIR,
     pub layout: &'a LayoutSnapshot,
     pub text_edit: &'a mut TextEditStateMap,
+    pub selectable_text: &'a mut SelectableTextStateMap,
+    pub context_menu: &'a mut ContextMenuState,
     pub interaction: &'a mut InteractionStateMap,
     pub scroll: &'a mut ScrollStateMap,
     pub gesture: &'a mut crate::env::GestureState,

--- a/crates/core/fission-core/src/input/selectable_text.rs
+++ b/crates/core/fission-core/src/input/selectable_text.rs
@@ -1,0 +1,356 @@
+use super::{ControllerContext, InputController};
+use crate::event::{InputEvent, KeyCode, KeyEvent, PointerEvent, MOD_CTRL, MOD_SUPER};
+use crate::ui::widgets::context_menu::{text_context_menu_button_id, TextContextMenuAction};
+use fission_ir::{op::LayoutOp, Op, Semantics, WidgetId};
+use fission_layout::{LayoutNodeGeometry, LayoutPoint};
+
+pub struct SelectableTextController;
+
+impl InputController for SelectableTextController {
+    fn handle_event(&mut self, ctx: &mut ControllerContext, event: &InputEvent) -> bool {
+        match event {
+            InputEvent::Keyboard(KeyEvent::Down {
+                key_code,
+                modifiers,
+            }) => self.handle_key(ctx, key_code.clone(), *modifiers),
+            InputEvent::Pointer(PointerEvent::Down {
+                point,
+                button,
+                modifiers,
+                ..
+            }) => {
+                let hit =
+                    crate::hit_test::hit_test_with_scroll(ctx.ir, ctx.layout, ctx.scroll, *point);
+                if let (Some(owner), Some(hit_node_id)) = (ctx.context_menu.owner, hit) {
+                    if let Some(action) = Self::toolbar_action_hit(ctx.ir, owner, hit_node_id) {
+                        return self.execute_action(ctx, owner, action);
+                    }
+                }
+
+                if !matches!(button, crate::event::PointerButton::Primary) {
+                    return false;
+                }
+
+                let Some(hit_node_id) = hit else {
+                    return false;
+                };
+                let Some((text_id, semantics)) = Self::selectable_text_at_hit(ctx, hit_node_id)
+                else {
+                    return false;
+                };
+                let caret = Self::caret_for_text(ctx, text_id, &semantics, *point);
+                let state = ctx.selectable_text.get_mut_or_default(text_id);
+                if !Self::has_shift(*modifiers) {
+                    state.anchor = caret;
+                }
+                state.caret = caret;
+                state.selecting = true;
+                ctx.interaction.set_focused(Some(text_id));
+                ctx.context_menu.close();
+                true
+            }
+            InputEvent::Pointer(PointerEvent::Move { point, .. }) => {
+                let Some(text_id) = Self::active_selection_owner(ctx) else {
+                    return false;
+                };
+                let Some(semantics) = Self::selectable_text_semantics(ctx, text_id) else {
+                    return false;
+                };
+                let caret = Self::caret_for_text(ctx, text_id, &semantics, *point);
+                ctx.selectable_text.get_mut_or_default(text_id).caret = caret;
+                true
+            }
+            InputEvent::Pointer(PointerEvent::Up { point, button, .. }) => {
+                let Some(text_id) = Self::active_selection_owner(ctx) else {
+                    return false;
+                };
+                let show_menu = ctx
+                    .selectable_text
+                    .get(text_id)
+                    .and_then(|state| state.selection_range())
+                    .is_some()
+                    && matches!(button, crate::event::PointerButton::Secondary);
+                ctx.selectable_text.get_mut_or_default(text_id).selecting = false;
+                if show_menu {
+                    ctx.context_menu.open(text_id, *point);
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl SelectableTextController {
+    fn handle_key(
+        &mut self,
+        ctx: &mut ControllerContext,
+        key_code: KeyCode,
+        modifiers: u8,
+    ) -> bool {
+        let Some(owner) = ctx.interaction.focused else {
+            return false;
+        };
+        let Some(semantics) = Self::selectable_text_semantics(ctx, owner) else {
+            return false;
+        };
+        if !Self::has_primary_shortcut(modifiers) {
+            return false;
+        }
+        match key_code {
+            KeyCode::Char('c') | KeyCode::Char('C') => {
+                if let Some(selected) = Self::selected_text(ctx, owner, &semantics) {
+                    if let Some(clipboard) = ctx.clipboard {
+                        clipboard.set_text(&selected);
+                    }
+                }
+                true
+            }
+            KeyCode::Char('a') | KeyCode::Char('A') => {
+                let len = semantics.value.as_deref().unwrap_or("").len();
+                let state = ctx.selectable_text.get_mut_or_default(owner);
+                state.anchor = 0;
+                state.caret = len;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn selectable_text_at_hit(
+        ctx: &ControllerContext,
+        hit_node_id: WidgetId,
+    ) -> Option<(WidgetId, Semantics)> {
+        let mut current = Some(hit_node_id);
+        while let Some(node_id) = current {
+            let node = ctx.ir.nodes.get(&node_id)?;
+            if let Op::Semantics(semantics) = &node.op {
+                if semantics.selectable_text && !semantics.disabled {
+                    return Some((node_id, semantics.clone()));
+                }
+            }
+            current = node.parent;
+        }
+        None
+    }
+
+    fn selectable_text_semantics(ctx: &ControllerContext, owner: WidgetId) -> Option<Semantics> {
+        let node = ctx.ir.nodes.get(&owner)?;
+        match &node.op {
+            Op::Semantics(semantics) if semantics.selectable_text => Some(semantics.clone()),
+            _ => None,
+        }
+    }
+
+    fn toolbar_action_hit(
+        ir: &fission_ir::CoreIR,
+        owner: WidgetId,
+        hit_node_id: WidgetId,
+    ) -> Option<TextContextMenuAction> {
+        for action in [
+            TextContextMenuAction::Copy,
+            TextContextMenuAction::Cut,
+            TextContextMenuAction::Paste,
+            TextContextMenuAction::SelectAll,
+        ] {
+            if Self::node_or_ancestor_matches(
+                ir,
+                hit_node_id,
+                text_context_menu_button_id(owner, action),
+            ) {
+                return Some(action);
+            }
+        }
+        None
+    }
+
+    fn execute_action(
+        &mut self,
+        ctx: &mut ControllerContext,
+        owner: WidgetId,
+        action: TextContextMenuAction,
+    ) -> bool {
+        let Some(semantics) = Self::selectable_text_semantics(ctx, owner) else {
+            return false;
+        };
+        match action {
+            TextContextMenuAction::Copy => {
+                if let Some(selected) = Self::selected_text(ctx, owner, &semantics) {
+                    if let Some(clipboard) = ctx.clipboard {
+                        clipboard.set_text(&selected);
+                    }
+                }
+                ctx.context_menu.close();
+                true
+            }
+            TextContextMenuAction::SelectAll => {
+                let len = semantics.value.as_deref().unwrap_or("").len();
+                let state = ctx.selectable_text.get_mut_or_default(owner);
+                state.anchor = 0;
+                state.caret = len;
+                state.selecting = false;
+                ctx.context_menu.close();
+                true
+            }
+            TextContextMenuAction::Cut | TextContextMenuAction::Paste => true,
+        }
+    }
+
+    fn selected_text(
+        ctx: &ControllerContext,
+        owner: WidgetId,
+        semantics: &Semantics,
+    ) -> Option<String> {
+        let value = semantics.value.as_deref().unwrap_or("");
+        let state = ctx.selectable_text.get(owner)?;
+        let (anchor, caret) = state.selection_range()?;
+        let start = Self::clamp_to_char_boundary(value, anchor.min(caret));
+        let end = Self::clamp_to_char_boundary(value, anchor.max(caret));
+        value.get(start..end).map(ToString::to_string)
+    }
+
+    fn caret_for_text(
+        ctx: &ControllerContext,
+        owner: WidgetId,
+        semantics: &Semantics,
+        point: LayoutPoint,
+    ) -> usize {
+        let value = semantics.value.as_deref().unwrap_or("");
+        let Some((layout_id, geom)) = Self::layout_geometry(ctx, owner) else {
+            return 0;
+        };
+        let local = Self::local_point(ctx, layout_id, geom, point);
+        let Some(measurer) = ctx.measurer else {
+            return 0;
+        };
+        let width = (geom.rect.size.width > 0.0).then_some(geom.rect.size.width);
+        let caret = if let Some(runs) = Self::rich_runs(ctx.ir, owner) {
+            measurer.hit_test_rich(&runs, width, local.x, local.y)
+        } else {
+            let font_size = Self::font_size(ctx.ir, owner).unwrap_or(14.0);
+            measurer.hit_test(value, font_size, width, local.x, local.y)
+        };
+        Self::clamp_to_char_boundary(value, caret.min(value.len()))
+    }
+
+    fn layout_geometry<'a>(
+        ctx: &'a ControllerContext,
+        owner: WidgetId,
+    ) -> Option<(WidgetId, &'a LayoutNodeGeometry)> {
+        fn walk<'a>(
+            ctx: &'a ControllerContext,
+            node_id: WidgetId,
+        ) -> Option<(WidgetId, &'a LayoutNodeGeometry)> {
+            if let Some(geom) = ctx.layout.get_node_geometry(node_id) {
+                return Some((node_id, geom));
+            }
+            for child in &ctx.ir.nodes.get(&node_id)?.children {
+                if let Some(found) = walk(ctx, *child) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        walk(ctx, owner)
+    }
+
+    fn local_point(
+        ctx: &ControllerContext,
+        node_id: WidgetId,
+        geom: &LayoutNodeGeometry,
+        point: LayoutPoint,
+    ) -> LayoutPoint {
+        let mut scroll_x = 0.0;
+        let mut scroll_y = 0.0;
+        let mut walk = ctx.ir.nodes.get(&node_id).and_then(|node| node.parent);
+        while let Some(parent_id) = walk {
+            let Some(parent) = ctx.ir.nodes.get(&parent_id) else {
+                break;
+            };
+            if let Op::Layout(LayoutOp::Scroll { direction, .. }) = &parent.op {
+                let offset = ctx.scroll.get_offset(parent_id);
+                match direction {
+                    fission_ir::FlexDirection::Row => scroll_x += offset,
+                    fission_ir::FlexDirection::Column => scroll_y += offset,
+                }
+            }
+            walk = parent.parent;
+        }
+        LayoutPoint::new(
+            point.x - geom.rect.origin.x + scroll_x,
+            point.y - geom.rect.origin.y + scroll_y,
+        )
+    }
+
+    fn rich_runs(ir: &fission_ir::CoreIR, owner: WidgetId) -> Option<Vec<fission_ir::op::TextRun>> {
+        fn walk(
+            ir: &fission_ir::CoreIR,
+            node_id: WidgetId,
+        ) -> Option<Vec<fission_ir::op::TextRun>> {
+            let node = ir.nodes.get(&node_id)?;
+            match &node.op {
+                Op::Paint(fission_ir::PaintOp::DrawRichText { runs, .. }) if !runs.is_empty() => {
+                    Some(runs.clone())
+                }
+                _ => node.children.iter().find_map(|child| walk(ir, *child)),
+            }
+        }
+        walk(ir, owner)
+    }
+
+    fn font_size(ir: &fission_ir::CoreIR, owner: WidgetId) -> Option<f32> {
+        fn walk(ir: &fission_ir::CoreIR, node_id: WidgetId) -> Option<f32> {
+            let node = ir.nodes.get(&node_id)?;
+            match &node.op {
+                Op::Paint(fission_ir::PaintOp::DrawText { size, .. }) => Some(*size),
+                Op::Paint(fission_ir::PaintOp::DrawRichText { runs, .. }) => {
+                    runs.first().map(|run| run.style.font_size)
+                }
+                _ => node.children.iter().find_map(|child| walk(ir, *child)),
+            }
+        }
+        walk(ir, owner)
+    }
+
+    fn active_selection_owner(ctx: &ControllerContext) -> Option<WidgetId> {
+        ctx.selectable_text
+            .states
+            .iter()
+            .find_map(|(id, state)| state.selecting.then_some(*id))
+    }
+
+    fn node_or_ancestor_matches(
+        ir: &fission_ir::CoreIR,
+        node_id: WidgetId,
+        expected: WidgetId,
+    ) -> bool {
+        let mut current = Some(node_id);
+        while let Some(id) = current {
+            if id == expected {
+                return true;
+            }
+            current = ir.nodes.get(&id).and_then(|node| node.parent);
+        }
+        false
+    }
+
+    fn clamp_to_char_boundary(value: &str, mut index: usize) -> usize {
+        index = index.min(value.len());
+        while index > 0 && !value.is_char_boundary(index) {
+            index -= 1;
+        }
+        index
+    }
+
+    fn has_shift(modifiers: u8) -> bool {
+        (modifiers & crate::event::MOD_SHIFT) != 0
+    }
+
+    fn has_primary_shortcut(modifiers: u8) -> bool {
+        if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
+            (modifiers & MOD_SUPER) != 0
+        } else {
+            (modifiers & MOD_CTRL) != 0
+        }
+    }
+}

--- a/crates/core/fission-core/src/input/text.rs
+++ b/crates/core/fission-core/src/input/text.rs
@@ -3,9 +3,10 @@ use crate::env::TextSelectionHandleKind;
 use crate::event::{
     InputEvent, KeyCode, KeyEvent, PointerEvent, MOD_ALT, MOD_CTRL, MOD_SHIFT, MOD_SUPER,
 };
+use crate::ui::widgets::context_menu::TextContextMenuAction;
 use crate::ui::widgets::text_input::{
     downcast_text_input_runtime_config, text_input_selection_handle_id,
-    text_input_toolbar_button_id, DragStartBehavior, TextContextMenuAction,
+    text_input_toolbar_button_id, DragStartBehavior,
 };
 use crate::ActionEnvelope;
 use crate::ActionId;
@@ -306,6 +307,7 @@ impl InputController for TextInputController {
                         }
                     }
                 }
+
                 false
             }
             InputEvent::Pointer(PointerEvent::Move { point, .. }) => {
@@ -513,6 +515,7 @@ impl InputController for TextInputController {
                         }
                     }
                 }
+
                 false
             }
             InputEvent::Pointer(PointerEvent::Up { point, button, .. }) => {
@@ -553,6 +556,7 @@ impl InputController for TextInputController {
                         }
                     }
                 }
+
                 false
             }
             _ => false,

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -1060,6 +1060,7 @@ impl Runtime {
         };
         use crate::input::gesture::GestureController;
         use crate::input::hover::HoverController;
+        use crate::input::selectable_text::SelectableTextController;
         use crate::input::slider::SliderController;
         use crate::input::text::TextInputController;
         use crate::input::{ControllerContext, InputController};
@@ -1095,6 +1096,8 @@ impl Runtime {
                     ir,
                     layout,
                     text_edit: &mut self.runtime_state.text_edit,
+                    selectable_text: &mut self.runtime_state.selectable_text,
+                    context_menu: &mut self.runtime_state.context_menu,
                     interaction: &mut self.runtime_state.interaction,
                     scroll: &mut self.runtime_state.scroll,
                     gesture: &mut self.runtime_state.gesture,
@@ -1261,6 +1264,8 @@ impl Runtime {
                 ir,
                 layout,
                 text_edit: &mut self.runtime_state.text_edit,
+                selectable_text: &mut self.runtime_state.selectable_text,
+                context_menu: &mut self.runtime_state.context_menu,
                 interaction: &mut self.runtime_state.interaction,
                 scroll: &mut self.runtime_state.scroll,
                 gesture: &mut self.runtime_state.gesture,
@@ -1272,16 +1277,21 @@ impl Runtime {
             let mut hover_controller = HoverController;
             let _ = hover_controller.handle_event(&mut ctx, &event);
 
-            let mut gesture_controller = GestureController;
-            let handled = if gesture_controller.handle_event(&mut ctx, &event) {
+            let mut selectable_text_controller = SelectableTextController;
+            let handled = if selectable_text_controller.handle_event(&mut ctx, &event) {
                 true
             } else {
-                let mut text_controller = TextInputController;
-                if text_controller.handle_event(&mut ctx, &event) {
+                let mut gesture_controller = GestureController;
+                if gesture_controller.handle_event(&mut ctx, &event) {
                     true
                 } else {
-                    let mut slider_controller = SliderController;
-                    slider_controller.handle_event(&mut ctx, &event)
+                    let mut text_controller = TextInputController;
+                    if text_controller.handle_event(&mut ctx, &event) {
+                        true
+                    } else {
+                        let mut slider_controller = SliderController;
+                        slider_controller.handle_event(&mut ctx, &event)
+                    }
                 }
             };
             (handled, ctx.dispatched_actions)
@@ -1640,6 +1650,8 @@ impl Runtime {
                 ir,
                 layout,
                 text_edit: &mut self.runtime_state.text_edit,
+                selectable_text: &mut self.runtime_state.selectable_text,
+                context_menu: &mut self.runtime_state.context_menu,
                 interaction: &mut self.runtime_state.interaction,
                 scroll: &mut self.runtime_state.scroll,
                 gesture: &mut self.runtime_state.gesture,
@@ -1711,6 +1723,8 @@ impl Runtime {
                     ir,
                     layout,
                     text_edit: &mut self.runtime_state.text_edit,
+                    selectable_text: &mut self.runtime_state.selectable_text,
+                    context_menu: &mut self.runtime_state.context_menu,
                     interaction: &mut self.runtime_state.interaction,
                     scroll: &mut self.runtime_state.scroll,
                     gesture: &mut self.runtime_state.gesture,

--- a/crates/core/fission-core/src/ui/mod.rs
+++ b/crates/core/fission-core/src/ui/mod.rs
@@ -10,11 +10,13 @@ pub use node::{CustomWidget, Widget, WidgetIdExt};
 pub use widgets::{
     provider, ActionScope, Align, BadgeTone, Builder, Button, ButtonContentAlign, ButtonHierarchy,
     ButtonMotion, ButtonVariant, CardPattern, Checkbox, Column, ComponentSize, ComponentState,
-    Composite, Container, FocusScope, GestureDetector, Grid, GridItem, HttpHeader, Icon, Image,
-    ImageAlignment, ImageCachePolicy, ImageErrorBehavior, ImageLoadingBehavior, ImageRequest,
-    ImageSource, IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,
+    Composite, Container, ContextMenu, ContextMenuEntry, ContextMenuItem, ContextMenuRegion,
+    FocusScope, GestureDetector, Grid, GridItem, HttpHeader, Icon, Image, ImageAlignment,
+    ImageCachePolicy, ImageErrorBehavior, ImageLoadingBehavior, ImageRequest, ImageSource,
+    IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,
     IosVideoAudioOptions, LayoutBuilder, LazyColumn, Overlay, Positioned, Provider, Radio,
     RichText, RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text,
-    TextContent, TextFontStyle, TextInput, TextInputChangePayload, TextRunStyle, Video,
-    VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource, ZStack,
+    TextContent, TextContextMenuAction, TextContextMenuConfig, TextFontStyle, TextInput,
+    TextInputChangePayload, TextRunStyle, Video, VideoAudioActivation, VideoAudioOptions,
+    VideoAudioPolicy, VideoSource, ZStack,
 };

--- a/crates/core/fission-core/src/ui/node.rs
+++ b/crates/core/fission-core/src/ui/node.rs
@@ -1,10 +1,10 @@
 use super::custom_render::CustomRenderObject;
 use super::traits::{InternalLower, InternalLowerer};
 use super::widgets::{
-    ActionScope, Align, Button, Checkbox, Clip, Column, Composite, Container, FocusScope,
-    GestureDetector, Grid, GridItem, Icon, Image, LazyColumn, Overlay, Positioned, Radio, RichText,
-    Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text, TextInput, Transform,
-    Video, ZStack,
+    ActionScope, Align, Button, Checkbox, Clip, Column, Composite, Container, ContextMenuRegion,
+    FocusScope, GestureDetector, Grid, GridItem, Icon, Image, LazyColumn, Overlay, Positioned,
+    Radio, RichText, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text,
+    TextInput, Transform, Video, ZStack,
 };
 use crate::lowering::InternalLoweringCx;
 use fission_ir::{Op, StructuralOp, WidgetId};
@@ -37,6 +37,7 @@ enum WidgetKind {
     ZStack(ZStack),
     Overlay(Overlay),
     Container(Container),
+    ContextMenuRegion(ContextMenuRegion),
     GestureDetector(GestureDetector),
     Grid(Grid),
     GridItem(GridItem),
@@ -136,6 +137,10 @@ impl Widget {
             WidgetKind::Container(mut w) => {
                 w.id = Some(id);
                 WidgetKind::Container(w)
+            }
+            WidgetKind::ContextMenuRegion(mut w) => {
+                w.id = Some(id);
+                WidgetKind::ContextMenuRegion(w)
             }
             WidgetKind::GestureDetector(mut w) => {
                 w.id = Some(id);
@@ -238,6 +243,7 @@ impl Widget {
             WidgetKind::ZStack(_) => "ZStack",
             WidgetKind::Overlay(_) => "Overlay",
             WidgetKind::Container(_) => "Container",
+            WidgetKind::ContextMenuRegion(_) => "ContextMenuRegion",
             WidgetKind::GestureDetector(_) => "GestureDetector",
             WidgetKind::Grid(_) => "Grid",
             WidgetKind::GridItem(_) => "GridItem",
@@ -383,6 +389,7 @@ impl Widget {
             WidgetKind::ZStack(w) => w.lower(cx),
             WidgetKind::Overlay(w) => w.lower(cx),
             WidgetKind::Container(w) => w.lower(cx),
+            WidgetKind::ContextMenuRegion(w) => w.lower(cx),
             WidgetKind::GestureDetector(w) => w.lower(cx),
             WidgetKind::Grid(w) => w.lower(cx),
             WidgetKind::GridItem(w) => w.lower(cx),
@@ -607,6 +614,14 @@ impl From<Overlay> for Widget {
         }
     }
 }
+impl From<ContextMenuRegion> for Widget {
+    fn from(w: ContextMenuRegion) -> Self {
+        Self {
+            kind: Box::new(WidgetKind::ContextMenuRegion(w)),
+        }
+    }
+}
+
 impl From<Container> for Widget {
     fn from(w: Container) -> Self {
         Self {

--- a/crates/core/fission-core/src/ui/widgets/button.rs
+++ b/crates/core/fission-core/src/ui/widgets/button.rs
@@ -641,6 +641,8 @@ fn default_button_semantics() -> Semantics {
         ime_preedit_range: None,
         ime_preedit_cursor_range: None,
         text_selection: None,
+        selectable_text: false,
+        context_menu: false,
         checked: None,
         disabled: false,
         read_only: false,

--- a/crates/core/fission-core/src/ui/widgets/checkbox.rs
+++ b/crates/core/fission-core/src/ui/widgets/checkbox.rs
@@ -223,6 +223,8 @@ impl InternalLower for Checkbox {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: Some(self.checked),
             disabled: false,
             read_only: false,

--- a/crates/core/fission-core/src/ui/widgets/context_menu.rs
+++ b/crates/core/fission-core/src/ui/widgets/context_menu.rs
@@ -1,0 +1,553 @@
+use crate::internal::InternalLower;
+use crate::lowering::{InternalIrBuilder, InternalLoweringCx};
+use crate::ui::{Button, ButtonVariant, Column, Container, Positioned, Text, TextContent, Widget};
+use crate::ActionEnvelope;
+use fission_ir::{
+    op::{BoxShadow, Color, LayoutOp, Op},
+    FocusPolicy, Semantics, WidgetId,
+};
+use serde::{Deserialize, Serialize};
+
+/// A popup menu shown for a secondary click or other contextual activation.
+///
+/// Menu items accept arbitrary child widgets, so applications can provide plain
+/// translated text, icons, shortcuts, badges, or richer branded rows without
+/// hard-coding menu strings in the framework.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextMenu {
+    /// Entries rendered in order from top to bottom.
+    pub items: Vec<ContextMenuEntry>,
+    /// Fixed popup width. When omitted, [`ContextMenu::min_width`] is used.
+    pub width: Option<f32>,
+    /// Minimum popup width used by the default layout.
+    pub min_width: f32,
+    /// Maximum popup width before child content wraps or clips according to its own layout.
+    pub max_width: Option<f32>,
+    /// Popup interior padding `[left, right, top, bottom]`.
+    pub padding: [f32; 4],
+    /// Gap between menu rows.
+    pub gap: f32,
+    /// Popup corner radius.
+    pub border_radius: f32,
+    /// Optional popup background colour. Defaults to the framework surface colour.
+    pub background: Option<Color>,
+    /// Optional border colour. Defaults to a subtle neutral border.
+    pub border_color: Option<Color>,
+    /// Border width in logical pixels.
+    pub border_width: f32,
+    /// Optional popup shadow.
+    pub shadow: Option<BoxShadow>,
+}
+
+impl Default for ContextMenu {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            width: None,
+            min_width: 176.0,
+            max_width: Some(320.0),
+            padding: [8.0, 8.0, 8.0, 8.0],
+            gap: 4.0,
+            border_radius: 12.0,
+            background: None,
+            border_color: None,
+            border_width: 1.0,
+            shadow: Some(BoxShadow {
+                offset: (0.0, 12.0),
+                blur_radius: 28.0,
+                color: Color {
+                    r: 15,
+                    g: 23,
+                    b: 42,
+                    a: 52,
+                },
+            }),
+        }
+    }
+}
+
+impl ContextMenu {
+    pub fn with_items(items: impl IntoIterator<Item = ContextMenuEntry>) -> Self {
+        Self {
+            items: items.into_iter().collect(),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn overlay_widget(
+        &self,
+        owner: WidgetId,
+        anchor: fission_layout::LayoutPoint,
+    ) -> Widget {
+        let children = self
+            .items
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| entry.widget(owner, index))
+            .collect();
+
+        let background = self.background.unwrap_or(Color {
+            r: 255,
+            g: 255,
+            b: 255,
+            a: 248,
+        });
+        let border = self.border_color.unwrap_or(Color {
+            r: 226,
+            g: 232,
+            b: 240,
+            a: 255,
+        });
+
+        Positioned {
+            id: Some(context_menu_popup_id(owner)),
+            left: Some(anchor.x),
+            top: Some(anchor.y),
+            child: Some(
+                Container::new(Column {
+                    id: Some(WidgetId::derived(owner.as_u128(), &[0xC0A7, 2])),
+                    children,
+                    gap: Some(self.gap),
+                    ..Default::default()
+                })
+                .width(self.width.unwrap_or(self.min_width))
+                .max_width(self.max_width.unwrap_or(320.0))
+                .padding(self.padding)
+                .bg(background)
+                .border(border, self.border_width)
+                .border_radius(self.border_radius)
+                .shadow(self.shadow.unwrap_or(BoxShadow {
+                    offset: (0.0, 8.0),
+                    blur_radius: 24.0,
+                    color: Color {
+                        r: 15,
+                        g: 23,
+                        b: 42,
+                        a: 38,
+                    },
+                }))
+                .into(),
+            ),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+/// A row inside a [`ContextMenu`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ContextMenuEntry {
+    /// A selectable menu row.
+    Item(ContextMenuItem),
+    /// A one-pixel visual separator between groups.
+    Separator,
+}
+
+impl ContextMenuEntry {
+    fn widget(&self, owner: WidgetId, index: usize) -> Widget {
+        match self {
+            Self::Item(item) => item.widget(owner, index),
+            Self::Separator => Container {
+                id: Some(context_menu_entry_id(owner, index)),
+                child: Some(Text::new("").into()),
+                height: Some(1.0),
+                background_color: Some(Color {
+                    r: 226,
+                    g: 232,
+                    b: 240,
+                    a: 255,
+                }),
+                background_fill: Some(fission_ir::op::Fill::Solid(Color {
+                    r: 226,
+                    g: 232,
+                    b: 240,
+                    a: 255,
+                })),
+                ..Default::default()
+            }
+            .into(),
+        }
+    }
+}
+
+/// A selectable context menu item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextMenuItem {
+    /// Stable id used to derive the row widget identity.
+    pub id: String,
+    /// The visible row content. Use `TextContent::Key` or `KeyWithFallback` for i18n.
+    pub child: Widget,
+    /// Action dispatched when the row is selected.
+    pub on_select: Option<ActionEnvelope>,
+    /// Whether the row can be activated.
+    pub enabled: bool,
+    /// Whether selecting the row should close the menu. Reserved for shells that support persistent menus.
+    pub close_on_select: bool,
+    /// Optional accessible label when the child is not self-describing.
+    pub semantics_label: Option<String>,
+}
+
+impl ContextMenuItem {
+    pub fn new(id: impl Into<String>, child: impl Into<Widget>) -> Self {
+        Self {
+            id: id.into(),
+            child: child.into(),
+            on_select: None,
+            enabled: true,
+            close_on_select: true,
+            semantics_label: None,
+        }
+    }
+
+    pub fn text(id: impl Into<String>, label: impl Into<String>) -> Self {
+        Self::new(id, Text::new(label.into()))
+    }
+
+    pub fn text_key(
+        id: impl Into<String>,
+        key: impl Into<String>,
+        fallback: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            id,
+            Text::new(TextContent::KeyWithFallback {
+                key: key.into(),
+                fallback: fallback.into(),
+            }),
+        )
+    }
+
+    pub fn on_select(mut self, action: ActionEnvelope) -> Self {
+        self.on_select = Some(action);
+        self
+    }
+
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    pub fn semantics_label(mut self, label: impl Into<String>) -> Self {
+        self.semantics_label = Some(label.into());
+        self
+    }
+
+    fn widget(&self, owner: WidgetId, index: usize) -> Widget {
+        let semantics = Semantics {
+            role: fission_ir::Role::Button,
+            label: self.semantics_label.clone(),
+            focusable: true,
+            disabled: !self.enabled,
+            ..Semantics::default()
+        };
+
+        Button {
+            id: Some(
+                context_menu_item_id(owner, &self.id)
+                    .unwrap_or_else(|| context_menu_entry_id(owner, index)),
+            ),
+            child: Some(self.child.clone()),
+            on_press: self.on_select.clone().filter(|_| self.enabled),
+            semantics: Some(semantics),
+            focus_policy: FocusPolicy::PreserveCurrentOnPointer,
+            variant: ButtonVariant::Ghost,
+            padding: Some([10.0, 10.0, 8.0, 8.0]),
+            disabled: !self.enabled,
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+pub(crate) fn text_context_menu_overlay_widget(
+    config: &TextContextMenuConfig,
+    owner: WidgetId,
+    anchor: fission_layout::LayoutPoint,
+    action_enabled: impl Fn(TextContextMenuAction) -> bool,
+) -> Widget {
+    let menu = config.menu.clone();
+    let children = config
+        .actions
+        .iter()
+        .copied()
+        .map(|action| text_context_menu_item_widget(owner, action, action_enabled(action)))
+        .collect();
+
+    let background = menu.background.unwrap_or(Color {
+        r: 255,
+        g: 255,
+        b: 255,
+        a: 248,
+    });
+    let border = menu.border_color.unwrap_or(Color {
+        r: 226,
+        g: 232,
+        b: 240,
+        a: 255,
+    });
+
+    Positioned {
+        id: Some(context_menu_popup_id(owner)),
+        left: Some(anchor.x),
+        top: Some(anchor.y),
+        child: Some(
+            Container::new(Column {
+                id: Some(WidgetId::derived(owner.as_u128(), &[0xC0A7, 4])),
+                children,
+                gap: Some(menu.gap),
+                ..Default::default()
+            })
+            .width(menu.width.unwrap_or(menu.min_width))
+            .max_width(menu.max_width.unwrap_or(320.0))
+            .padding(menu.padding)
+            .bg(background)
+            .border(border, menu.border_width)
+            .border_radius(menu.border_radius)
+            .shadow(menu.shadow.unwrap_or(BoxShadow {
+                offset: (0.0, 8.0),
+                blur_radius: 24.0,
+                color: Color {
+                    r: 15,
+                    g: 23,
+                    b: 42,
+                    a: 38,
+                },
+            }))
+            .into(),
+        ),
+        ..Default::default()
+    }
+    .into()
+}
+
+/// Widget wrapper that gives any subtree a context menu.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextMenuRegion {
+    /// Stable owner id for context-menu open state.
+    pub id: Option<WidgetId>,
+    /// Subtree that can open the menu on secondary click.
+    pub child: Widget,
+    /// Menu rendered when this region is active.
+    pub menu: ContextMenu,
+    /// Whether the region responds to secondary click.
+    pub enabled: bool,
+    /// Optional semantics for the owner node. Fission sets `context_menu` automatically.
+    pub semantics: Option<Semantics>,
+}
+
+impl ContextMenuRegion {
+    pub fn new(child: impl Into<Widget>, menu: ContextMenu) -> Self {
+        Self {
+            id: None,
+            child: child.into(),
+            menu,
+            enabled: true,
+            semantics: None,
+        }
+    }
+
+    pub fn id(mut self, id: WidgetId) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
+        let semantics = self.semantics.get_or_insert_with(Semantics::default);
+        semantics.identifier = Some(identifier.into());
+        self
+    }
+}
+
+impl InternalLower for ContextMenuRegion {
+    fn lower(&self, cx: &mut InternalLoweringCx<'_>) -> WidgetId {
+        let owner = self.id.unwrap_or_else(|| cx.next_node_id());
+        cx.push_scope(owner);
+
+        let child_id = self.child.lower(cx);
+        let visual_id = if self.enabled && cx.runtime_state.context_menu.owner == Some(owner) {
+            let anchor = cx
+                .runtime_state
+                .context_menu
+                .anchor
+                .map(|screen_anchor| anchor_to_local(cx, owner, screen_anchor))
+                .unwrap_or_else(|| fission_layout::LayoutPoint::new(0.0, 0.0));
+            let menu_id = self.menu.overlay_widget(owner, anchor).lower(cx);
+            let mut stack = InternalIrBuilder::new(cx.next_node_id(), Op::Layout(LayoutOp::ZStack));
+            stack.add_child(child_id);
+            stack.add_child(menu_id);
+            stack.build(cx)
+        } else {
+            child_id
+        };
+
+        let mut semantics = self.semantics.clone().unwrap_or_default();
+        semantics.context_menu = self.enabled;
+        let mut builder = InternalIrBuilder::new(owner, Op::Semantics(semantics));
+        builder.add_child(visual_id);
+        cx.pop_scope();
+        builder.build(cx)
+    }
+}
+
+/// Standard editing/selection commands used by built-in text context menus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TextContextMenuAction {
+    Copy,
+    Cut,
+    Paste,
+    SelectAll,
+}
+
+impl TextContextMenuAction {
+    pub fn fallback_label(self) -> &'static str {
+        match self {
+            Self::Copy => "Copy",
+            Self::Cut => "Cut",
+            Self::Paste => "Paste",
+            Self::SelectAll => "Select All",
+        }
+    }
+
+    pub fn label_key(self) -> &'static str {
+        match self {
+            Self::Copy => "fission.context_menu.copy",
+            Self::Cut => "fission.context_menu.cut",
+            Self::Paste => "fission.context_menu.paste",
+            Self::SelectAll => "fission.context_menu.select_all",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextContextMenuConfig {
+    /// Whether the built-in text context menu is enabled.
+    pub enabled: bool,
+    /// Standard text actions shown in order. Unsupported actions are rendered disabled.
+    pub actions: Vec<TextContextMenuAction>,
+    /// Visual menu configuration used by the built-in text menu.
+    pub menu: ContextMenu,
+}
+
+impl TextContextMenuConfig {
+    pub fn read_only() -> Self {
+        Self {
+            enabled: true,
+            actions: vec![
+                TextContextMenuAction::Copy,
+                TextContextMenuAction::SelectAll,
+            ],
+            menu: ContextMenu::default(),
+        }
+    }
+
+    pub fn editing() -> Self {
+        Self {
+            enabled: true,
+            actions: vec![
+                TextContextMenuAction::Copy,
+                TextContextMenuAction::Cut,
+                TextContextMenuAction::Paste,
+                TextContextMenuAction::SelectAll,
+            ],
+            menu: ContextMenu::default(),
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            ..Self::read_only()
+        }
+    }
+}
+
+impl Default for TextContextMenuConfig {
+    fn default() -> Self {
+        Self::read_only()
+    }
+}
+
+pub(crate) fn text_context_menu_item_widget(
+    owner: WidgetId,
+    action: TextContextMenuAction,
+    enabled: bool,
+) -> Widget {
+    let child = Text::new(TextContent::KeyWithFallback {
+        key: action.label_key().to_string(),
+        fallback: action.fallback_label().to_string(),
+    });
+
+    Button {
+        id: Some(text_context_menu_button_id(owner, action)),
+        child: Some(child.into()),
+        semantics: Some(Semantics {
+            role: fission_ir::Role::Button,
+            label: Some(action.fallback_label().to_string()),
+            focusable: true,
+            disabled: !enabled,
+            ..Semantics::default()
+        }),
+        focus_policy: FocusPolicy::PreserveCurrentOnPointer,
+        variant: ButtonVariant::Ghost,
+        padding: Some([10.0, 10.0, 8.0, 8.0]),
+        disabled: !enabled,
+        ..Default::default()
+    }
+    .into()
+}
+
+pub(crate) fn action_index(action: TextContextMenuAction) -> usize {
+    match action {
+        TextContextMenuAction::Copy => 0,
+        TextContextMenuAction::Cut => 1,
+        TextContextMenuAction::Paste => 2,
+        TextContextMenuAction::SelectAll => 3,
+    }
+}
+
+pub(crate) fn context_menu_popup_id(owner: WidgetId) -> WidgetId {
+    WidgetId::derived(owner.as_u128(), &[0xC0A7, 0])
+}
+
+pub(crate) fn context_menu_entry_id(owner: WidgetId, index: usize) -> WidgetId {
+    WidgetId::derived(owner.as_u128(), &[0xC0A7, 1, index as u32])
+}
+
+pub(crate) fn context_menu_item_id(owner: WidgetId, id: &str) -> Option<WidgetId> {
+    if id.is_empty() {
+        None
+    } else {
+        Some(WidgetId::explicit(&format!(
+            "fission.context_menu.{owner}.{id}"
+        )))
+    }
+}
+
+pub(crate) fn text_context_menu_button_id(
+    owner: WidgetId,
+    action: TextContextMenuAction,
+) -> WidgetId {
+    WidgetId::derived(owner.as_u128(), &[0xC0A7, 3, action_index(action) as u32])
+}
+
+pub(crate) fn anchor_to_local(
+    cx: &InternalLoweringCx<'_>,
+    owner: WidgetId,
+    screen_anchor: fission_layout::LayoutPoint,
+) -> fission_layout::LayoutPoint {
+    let Some(layout) = cx.layout else {
+        return screen_anchor;
+    };
+    let Some(rect) = layout.get_node_rect(owner) else {
+        return screen_anchor;
+    };
+    fission_layout::LayoutPoint::new(
+        (screen_anchor.x - rect.origin.x).max(0.0),
+        (screen_anchor.y - rect.origin.y).max(0.0),
+    )
+}

--- a/crates/core/fission-core/src/ui/widgets/focus_scope.rs
+++ b/crates/core/fission-core/src/ui/widgets/focus_scope.rs
@@ -65,6 +65,8 @@ impl InternalLower for FocusScope {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: None,
             disabled: false,
             read_only: false,

--- a/crates/core/fission-core/src/ui/widgets/gesture_detector.rs
+++ b/crates/core/fission-core/src/ui/widgets/gesture_detector.rs
@@ -132,6 +132,8 @@ impl InternalLower for GestureDetector {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: None,
             disabled: false,
             read_only: false,

--- a/crates/core/fission-core/src/ui/widgets/mod.rs
+++ b/crates/core/fission-core/src/ui/widgets/mod.rs
@@ -6,6 +6,7 @@ pub mod checkbox;
 pub mod column;
 pub mod composite;
 pub mod container;
+pub mod context_menu;
 pub mod grid;
 pub mod icon;
 pub mod image;
@@ -35,6 +36,10 @@ pub use checkbox::Checkbox;
 pub use column::Column;
 pub use composite::Composite;
 pub use container::Container;
+pub use context_menu::{
+    ContextMenu, ContextMenuEntry, ContextMenuItem, ContextMenuRegion, TextContextMenuAction,
+    TextContextMenuConfig,
+};
 pub use fission_theme::{BadgeTone, ButtonHierarchy, CardPattern, ComponentSize, ComponentState};
 pub use grid::{Grid, GridItem};
 pub use icon::Icon;

--- a/crates/core/fission-core/src/ui/widgets/radio.rs
+++ b/crates/core/fission-core/src/ui/widgets/radio.rs
@@ -251,6 +251,8 @@ impl InternalLower for Radio {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: Some(self.checked),
             disabled: false,
             read_only: false,

--- a/crates/core/fission-core/src/ui/widgets/slider.rs
+++ b/crates/core/fission-core/src/ui/widgets/slider.rs
@@ -251,6 +251,8 @@ impl InternalLower for Slider {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: None,
             disabled: false,
             read_only: false,

--- a/crates/core/fission-core/src/ui/widgets/switch.rs
+++ b/crates/core/fission-core/src/ui/widgets/switch.rs
@@ -172,6 +172,8 @@ impl InternalLower for Switch {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: Some(self.checked),
             disabled: false,
             read_only: false,

--- a/crates/core/fission-core/src/ui/widgets/text.rs
+++ b/crates/core/fission-core/src/ui/widgets/text.rs
@@ -1,5 +1,8 @@
 use crate::internal::InternalLower;
 use crate::lowering::{InternalIrBuilder, InternalLoweringCx};
+use crate::ui::widgets::context_menu::{
+    anchor_to_local, text_context_menu_overlay_widget, TextContextMenuAction, TextContextMenuConfig,
+};
 use crate::ActionEnvelope;
 use fission_ir::{
     op::{
@@ -21,6 +24,7 @@ use std::sync::Arc;
 pub enum TextContent {
     Literal(String),
     Key(String),
+    KeyWithFallback { key: String, fallback: String },
 }
 
 impl From<&str> for TextContent {
@@ -661,6 +665,10 @@ pub struct Text {
     pub selection_range: Option<(usize, usize)>,
     pub selection_color: Option<IrColor>,
     pub selection_text_color: Option<IrColor>,
+    /// Enables read-only pointer and keyboard text selection for this text block.
+    pub selectable: bool,
+    /// Configures the built-in context menu shown for selectable text.
+    pub context_menu: TextContextMenuConfig,
     pub flex_grow: f32,
     pub flex_shrink: f32,
 }
@@ -828,6 +836,16 @@ impl Text {
         self
     }
 
+    pub fn selectable(mut self, selectable: bool) -> Self {
+        self.selectable = selectable;
+        self
+    }
+
+    pub fn context_menu(mut self, context_menu: TextContextMenuConfig) -> Self {
+        self.context_menu = context_menu;
+        self
+    }
+
     pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
         let mut semantics = self.semantics.take().unwrap_or_default();
         semantics.identifier = Some(identifier.into());
@@ -885,6 +903,12 @@ impl Text {
                 .get(&cx.env.locale, key)
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| format!("MISSING:{}", key)),
+            TextContent::KeyWithFallback { key, fallback } => cx
+                .env
+                .i18n
+                .get(&cx.env.locale, key)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| fallback.clone()),
         }
     }
 
@@ -946,6 +970,10 @@ pub struct RichText {
     pub selection_range: Option<(usize, usize)>,
     pub selection_color: Option<IrColor>,
     pub selection_text_color: Option<IrColor>,
+    /// Enables read-only pointer and keyboard text selection for this rich-text block.
+    pub selectable: bool,
+    /// Configures the built-in context menu shown for selectable rich text.
+    pub context_menu: TextContextMenuConfig,
     pub flex_grow: f32,
     pub flex_shrink: f32,
 }
@@ -1154,6 +1182,16 @@ impl RichText {
 
     pub fn selection_text_color(mut self, color: IrColor) -> Self {
         self.selection_text_color = Some(color);
+        self
+    }
+
+    pub fn selectable(mut self, selectable: bool) -> Self {
+        self.selectable = selectable;
+        self
+    }
+
+    pub fn context_menu(mut self, context_menu: TextContextMenuConfig) -> Self {
+        self.context_menu = context_menu;
         self
     }
 
@@ -1472,9 +1510,65 @@ fn maybe_wrap_semantics(
     }
 }
 
+fn selectable_text_semantics(
+    mut semantics: Option<Semantics>,
+    value: String,
+    multiline: bool,
+    selection: Option<(usize, usize)>,
+    context_menu: bool,
+) -> Semantics {
+    let mut semantics = semantics.take().unwrap_or_default();
+    if semantics.role == Role::Generic {
+        semantics.role = Role::Text;
+    }
+    semantics.value = Some(value);
+    semantics.multiline = multiline;
+    semantics.focusable = true;
+    semantics.read_only = true;
+    semantics.selectable_text = true;
+    semantics.context_menu = context_menu;
+    semantics.text_selection = selection;
+    semantics
+}
+
+fn wrap_selectable_context_menu(
+    cx: &mut InternalLoweringCx<'_>,
+    owner: WidgetId,
+    visual_id: WidgetId,
+    config: &TextContextMenuConfig,
+    selection: Option<(usize, usize)>,
+    text_len: usize,
+) -> WidgetId {
+    if !config.enabled || cx.runtime_state.context_menu.owner != Some(owner) {
+        return visual_id;
+    }
+
+    let anchor = cx
+        .runtime_state
+        .context_menu
+        .anchor
+        .map(|screen_anchor| anchor_to_local(cx, owner, screen_anchor))
+        .unwrap_or_else(|| fission_layout::LayoutPoint::new(0.0, 0.0));
+    let menu = text_context_menu_overlay_widget(config, owner, anchor, |action| match action {
+        TextContextMenuAction::Copy => selection.is_some(),
+        TextContextMenuAction::Cut | TextContextMenuAction::Paste => false,
+        TextContextMenuAction::SelectAll => text_len > 0,
+    });
+    let menu_id = menu.lower(cx);
+    let mut stack = InternalIrBuilder::new(cx.next_node_id(), Op::Layout(LayoutOp::ZStack));
+    stack.add_child(visual_id);
+    stack.add_child(menu_id);
+    stack.build(cx)
+}
+
 impl InternalLower for Text {
     fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {
-        let layout_node_id = self.id.map(Into::into).unwrap_or_else(|| cx.next_node_id());
+        let owner_id = self.id.map(Into::into).unwrap_or_else(|| cx.next_node_id());
+        let layout_node_id = if self.selectable {
+            cx.next_node_id()
+        } else {
+            owner_id
+        };
         let resolved_text = self.resolve_text(cx);
         let style = self.resolved_style(cx);
         let paragraph_style = paragraph_style_metadata(
@@ -1495,14 +1589,20 @@ impl InternalLower for Text {
             ),
         );
         let clip_to_bounds = should_clip_paragraph(self.max_lines, self.overflow);
+        let runtime_selection = if self.selectable {
+            cx.runtime_state.selectable_text.selection_range(owner_id)
+        } else {
+            None
+        };
+        let selection_range = runtime_selection.or(self.selection_range);
 
-        let paint_node_id = if self.needs_rich_text() {
+        let paint_node_id = if self.needs_rich_text() || selection_range.is_some() {
             let runs = apply_selection_to_runs(
                 vec![IrTextRun {
-                    text: resolved_text,
+                    text: resolved_text.clone(),
                     style: style.clone(),
                 }],
-                self.selection_range,
+                selection_range,
                 self.selection_color,
                 self.selection_text_color,
             );
@@ -1524,7 +1624,7 @@ impl InternalLower for Text {
             InternalIrBuilder::new(
                 cx.next_node_id(),
                 Op::Paint(PaintOp::DrawText {
-                    text: resolved_text,
+                    text: resolved_text.clone(),
                     size: style.font_size,
                     color: style.color,
                     underline: style.underline,
@@ -1555,17 +1655,50 @@ impl InternalLower for Text {
             self.flex_shrink,
         );
 
-        maybe_wrap_semantics(cx, layout_node_id, self.semantics.clone(), false)
+        if self.selectable {
+            let visual_id = wrap_selectable_context_menu(
+                cx,
+                owner_id,
+                layout_node_id,
+                &self.context_menu,
+                selection_range,
+                resolved_text.len(),
+            );
+            let semantics = selectable_text_semantics(
+                self.semantics.clone(),
+                resolved_text,
+                false,
+                runtime_selection,
+                self.context_menu.enabled,
+            );
+            let mut builder = InternalIrBuilder::new(owner_id, Op::Semantics(semantics));
+            builder.add_child(visual_id);
+            builder.build(cx)
+        } else {
+            maybe_wrap_semantics(cx, layout_node_id, self.semantics.clone(), false)
+        }
     }
 }
 
 impl InternalLower for RichText {
     fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {
-        let layout_node_id = self.id.map(Into::into).unwrap_or_else(|| cx.next_node_id());
+        let owner_id = self.id.map(Into::into).unwrap_or_else(|| cx.next_node_id());
+        let layout_node_id = if self.selectable {
+            cx.next_node_id()
+        } else {
+            owner_id
+        };
         let runs = self.lower_runs(cx);
+        let plain_text = runs.iter().map(|run| run.text.as_str()).collect::<String>();
+        let runtime_selection = if self.selectable {
+            cx.runtime_state.selectable_text.selection_range(owner_id)
+        } else {
+            None
+        };
+        let selection_range = runtime_selection.or(self.selection_range);
         let runs = apply_selection_to_runs(
             runs,
-            self.selection_range,
+            selection_range,
             self.selection_color,
             self.selection_text_color,
         );
@@ -1627,6 +1760,27 @@ impl InternalLower for RichText {
             self.flex_shrink,
         );
 
-        maybe_wrap_semantics(cx, layout_node_id, self.semantics.clone(), true)
+        if self.selectable {
+            let visual_id = wrap_selectable_context_menu(
+                cx,
+                owner_id,
+                layout_node_id,
+                &self.context_menu,
+                selection_range,
+                plain_text.len(),
+            );
+            let semantics = selectable_text_semantics(
+                self.semantics.clone(),
+                plain_text,
+                true,
+                runtime_selection,
+                self.context_menu.enabled,
+            );
+            let mut builder = InternalIrBuilder::new(owner_id, Op::Semantics(semantics));
+            builder.add_child(visual_id);
+            builder.build(cx)
+        } else {
+            maybe_wrap_semantics(cx, layout_node_id, self.semantics.clone(), true)
+        }
     }
 }

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -1,8 +1,10 @@
 use crate::env::TextSelectionHandleKind;
 use crate::lowering::{InternalIrBuilder, InternalLoweringCx};
 use crate::ui::{
-    traits::InternalLower, Button, ButtonContentAlign, ButtonVariant, Container, Positioned, Row,
-    Spacer, Text, TextContent, TextFontStyle, Widget,
+    traits::InternalLower,
+    widgets::context_menu::{TextContextMenuAction, TextContextMenuConfig},
+    Button, ButtonContentAlign, ButtonVariant, Container, Positioned, Row, Spacer, Text,
+    TextContent, TextFontStyle, Widget,
 };
 use crate::ActionEnvelope;
 use fission_ir::{
@@ -111,51 +113,6 @@ impl TextAlignVertical {
             Self::Top => fission_ir::op::AlignItems::Start,
             Self::Center => fission_ir::op::AlignItems::Center,
             Self::Bottom => fission_ir::op::AlignItems::End,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum TextContextMenuAction {
-    Copy,
-    Cut,
-    Paste,
-    SelectAll,
-}
-
-impl TextContextMenuAction {
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Copy => "Copy",
-            Self::Cut => "Cut",
-            Self::Paste => "Paste",
-            Self::SelectAll => "Select All",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct TextContextMenuConfig {
-    pub enabled: bool,
-    pub actions: Vec<TextContextMenuAction>,
-    pub padding: [f32; 4],
-    pub gap: f32,
-    pub border_radius: f32,
-}
-
-impl Default for TextContextMenuConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            actions: vec![
-                TextContextMenuAction::Copy,
-                TextContextMenuAction::Cut,
-                TextContextMenuAction::Paste,
-                TextContextMenuAction::SelectAll,
-            ],
-            padding: [10.0, 10.0, 8.0, 8.0],
-            gap: 6.0,
-            border_radius: 12.0,
         }
     }
 }
@@ -883,7 +840,7 @@ impl Default for TextInput {
             autofill_hints: Vec::new(),
             scroll_padding: None,
             drag_start_behavior: DragStartBehavior::Start,
-            context_menu: TextContextMenuConfig::default(),
+            context_menu: TextContextMenuConfig::editing(),
             selection_controls: TextSelectionControls::default(),
             magnifier_configuration: TextMagnifierConfiguration::default(),
             undo_controller: None,
@@ -903,6 +860,12 @@ impl TextInput {
                 .get(&cx.env.locale, key)
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| format!("MISSING:{}", key)),
+            TextContent::KeyWithFallback { key, fallback } => cx
+                .env
+                .i18n
+                .get(&cx.env.locale, key)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| fallback.clone()),
         }
     }
 
@@ -1000,24 +963,27 @@ impl TextInput {
         anchor: fission_layout::LayoutPoint,
     ) -> WidgetId {
         let tokens = &cx.env.theme.tokens;
-        let mut row = Row::default().gap(self.context_menu.gap);
+        let mut row = Row::default().gap(self.context_menu.menu.gap);
         for action in &self.context_menu.actions {
             row.children.push(
                 Button {
                     id: Some(text_input_toolbar_button_id(input_id, *action).into()),
                     semantics: Some(Semantics {
                         role: Role::Button,
-                        label: Some(action.label().into()),
+                        label: Some(action.fallback_label().into()),
                         focusable: true,
                         focus_policy: fission_ir::FocusPolicy::PreserveCurrentOnPointer,
                         ..Semantics::default()
                     }),
                     focus_policy: fission_ir::FocusPolicy::PreserveCurrentOnPointer,
                     child: Some(
-                        Text::new(action.label())
-                            .size(tokens.typography.label_large_size)
-                            .color(tokens.colors.text_primary)
-                            .into(),
+                        Text::new(TextContent::KeyWithFallback {
+                            key: action.label_key().to_string(),
+                            fallback: action.fallback_label().to_string(),
+                        })
+                        .size(tokens.typography.label_large_size)
+                        .color(tokens.colors.text_primary)
+                        .into(),
                     ),
                     padding: Some([10.0, 10.0, 6.0, 6.0]),
                     content_align: ButtonContentAlign::Center,
@@ -1031,8 +997,8 @@ impl TextInput {
         let toolbar: Widget = Container::new(row)
             .bg_fill(Fill::Solid(tokens.colors.surface))
             .border(tokens.colors.border, 1.0)
-            .border_radius(self.context_menu.border_radius)
-            .padding(self.context_menu.padding)
+            .border_radius(self.context_menu.menu.border_radius)
+            .padding(self.context_menu.menu.padding)
             .into();
 
         Positioned {
@@ -1902,6 +1868,8 @@ impl InternalLower for TextInput {
             ime_preedit_range: preedit_range,
             ime_preedit_cursor_range: preedit_cursor_range,
             text_selection: Some((anchor, caret)),
+            selectable_text: false,
+            context_menu: false,
             checked: None,
             disabled: !self.enabled,
             read_only: self.read_only,

--- a/crates/core/fission-core/tests/input_controller_tests.rs
+++ b/crates/core/fission-core/tests/input_controller_tests.rs
@@ -1,5 +1,6 @@
 use fission_core::env::{
-    Clipboard, ImeHandler, InteractionStateMap, ScrollStateMap, TextEditStateMap,
+    Clipboard, ContextMenuState, ImeHandler, InteractionStateMap, ScrollStateMap,
+    SelectableTextStateMap, TextEditStateMap,
 };
 use fission_core::event::{
     ImeEvent, InputEvent, KeyCode, KeyEvent, PointerButton, PointerEvent, MOD_CTRL, MOD_SHIFT,
@@ -8,8 +9,9 @@ use fission_core::event::{
 use fission_core::input::text::TextInputController;
 use fission_core::input::{ControllerContext, InputController};
 use fission_core::ui::widgets::text_input::{
-    DragStartBehavior, TextContextMenuAction, TextInputRuntimeConfig, TextUndoController,
+    DragStartBehavior, TextInputRuntimeConfig, TextUndoController,
 };
+use fission_core::ui::TextContextMenuAction;
 use fission_core::Runtime;
 use fission_ir::op::{Color, TextRun, TextStyle};
 use fission_ir::{
@@ -354,10 +356,14 @@ fn setup_ctx<'a>(
     clipboard: &'a Arc<dyn Clipboard>,
     measurer: Option<&'a Arc<dyn TextMeasurer>>,
 ) -> ControllerContext<'a> {
+    let selectable_text = Box::leak(Box::new(SelectableTextStateMap::default()));
+    let context_menu = Box::leak(Box::new(ContextMenuState::default()));
     ControllerContext {
         ir,
         layout,
         text_edit,
+        selectable_text,
+        context_menu,
         interaction,
         scroll,
         gesture,
@@ -396,6 +402,8 @@ fn create_text_node(id: WidgetId, val: &str, multiline: bool) -> CoreIR {
                 ime_preedit_range: None,
                 ime_preedit_cursor_range: None,
                 text_selection: None,
+                selectable_text: false,
+                context_menu: false,
                 checked: None,
                 disabled: false,
                 read_only: false,
@@ -817,6 +825,8 @@ fn create_rich_text_input_tree(
                 ime_preedit_range: None,
                 ime_preedit_cursor_range: None,
                 text_selection: None,
+                selectable_text: false,
+                context_menu: false,
                 checked: None,
                 disabled: false,
                 read_only: false,

--- a/crates/core/fission-core/tests/scrollbar_input.rs
+++ b/crates/core/fission-core/tests/scrollbar_input.rs
@@ -1,5 +1,6 @@
 use fission_core::env::{
-    Clipboard, GestureState, InteractionStateMap, ScrollStateMap, TextEditStateMap,
+    Clipboard, ContextMenuState, GestureState, InteractionStateMap, ScrollStateMap,
+    SelectableTextStateMap, TextEditStateMap,
 };
 use fission_core::event::{InputEvent, PointerButton, PointerEvent};
 use fission_core::input::gesture::GestureController;
@@ -44,6 +45,8 @@ fn dragging_scrollbar_thumb_updates_scroll_offset_directly() {
         ir: &ir,
         layout: &layout,
         text_edit: &mut text_edit,
+        selectable_text: &mut SelectableTextStateMap::default(),
+        context_menu: &mut ContextMenuState::default(),
         interaction: &mut interaction,
         scroll: &mut scroll_map,
         gesture: &mut gesture,
@@ -150,6 +153,8 @@ fn dragging_nested_scrollbar_uses_visual_pointer_coordinates() {
         ir: &ir,
         layout: &layout,
         text_edit: &mut text_edit,
+        selectable_text: &mut SelectableTextStateMap::default(),
+        context_menu: &mut ContextMenuState::default(),
         interaction: &mut interaction,
         scroll: &mut scroll_map,
         gesture: &mut gesture,

--- a/crates/core/fission-core/tests/selectable_text_context_menu.rs
+++ b/crates/core/fission-core/tests/selectable_text_context_menu.rs
@@ -1,0 +1,105 @@
+use fission_core::env::{Env, RuntimeState, SelectableTextState};
+use fission_core::internal::{lower_widget, InternalLoweringCx};
+use fission_core::ui::{
+    ContextMenu, ContextMenuEntry, ContextMenuItem, ContextMenuRegion, Text, TextContent,
+};
+use fission_ir::{Op, PaintOp, Role, WidgetId};
+use fission_layout::LayoutPoint;
+
+#[test]
+fn selectable_text_lowers_semantics_and_runtime_selection() {
+    let env = Env::default();
+    let text_id = WidgetId::explicit("selectable.text");
+    let mut runtime = RuntimeState::default();
+    runtime.selectable_text.states.insert(
+        text_id,
+        SelectableTextState {
+            anchor: 0,
+            caret: 5,
+            selecting: false,
+        },
+    );
+
+    let text = Text {
+        id: Some(text_id),
+        content: TextContent::Literal("hello world".into()),
+        selectable: true,
+        ..Default::default()
+    };
+
+    let mut cx = InternalLoweringCx::new(&env, &runtime, None, None);
+    let root_id = lower_widget(&text.into(), &mut cx);
+    cx.ir.root = Some(root_id);
+
+    let semantics = cx
+        .ir
+        .nodes
+        .get(&text_id)
+        .and_then(|node| match &node.op {
+            Op::Semantics(semantics) => Some(semantics),
+            _ => None,
+        })
+        .expect("selectable text should lower to a semantics owner");
+    assert_eq!(semantics.role, Role::Text);
+    assert!(semantics.selectable_text);
+    assert!(semantics.context_menu);
+    assert!(semantics.focusable);
+    assert!(semantics.read_only);
+    assert_eq!(semantics.value.as_deref(), Some("hello world"));
+    assert_eq!(semantics.text_selection, Some((0, 5)));
+
+    let has_selection_paint = cx.ir.nodes.values().any(|node| match &node.op {
+        Op::Paint(PaintOp::DrawRichText { runs, .. }) => runs
+            .iter()
+            .any(|run| !run.text.is_empty() && run.style.background_color.is_some()),
+        _ => false,
+    });
+    assert!(
+        has_selection_paint,
+        "selected text should paint as rich text"
+    );
+}
+
+#[test]
+fn context_menu_region_accepts_widget_children_and_fallback_i18n_text() {
+    let env = Env::default();
+    let menu_id = WidgetId::explicit("menu.region");
+    let mut runtime = RuntimeState::default();
+    runtime
+        .context_menu
+        .open(menu_id, LayoutPoint::new(12.0, 18.0));
+
+    let menu = ContextMenu::with_items([ContextMenuEntry::Item(ContextMenuItem::new(
+        "copy",
+        Text::new(TextContent::KeyWithFallback {
+            key: "menu.copy".into(),
+            fallback: "Copy".into(),
+        }),
+    ))]);
+    let region = ContextMenuRegion::new(Text::new("target"), menu).id(menu_id);
+
+    let mut cx = InternalLoweringCx::new(&env, &runtime, None, None);
+    let root_id = lower_widget(&region.into(), &mut cx);
+    cx.ir.root = Some(root_id);
+
+    let semantics = cx
+        .ir
+        .nodes
+        .get(&menu_id)
+        .and_then(|node| match &node.op {
+            Op::Semantics(semantics) => Some(semantics),
+            _ => None,
+        })
+        .expect("context menu region should lower to semantics");
+    assert!(semantics.context_menu);
+
+    let rendered_fallback = cx.ir.nodes.values().any(|node| match &node.op {
+        Op::Paint(PaintOp::DrawText { text, .. }) => text == "Copy",
+        Op::Paint(PaintOp::DrawRichText { runs, .. }) => runs.iter().any(|run| run.text == "Copy"),
+        _ => false,
+    });
+    assert!(
+        rendered_fallback,
+        "menu item child should render fallback text"
+    );
+}

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -2,10 +2,13 @@ use fission_core::env::{Env, RuntimeState, TextSelectionHandleKind};
 use fission_core::internal::InternalLoweringCx;
 use fission_core::ui::widgets::text::{RichTextChild, RichTextSpan, TextScaler, WidgetSpan};
 use fission_core::ui::widgets::text_input::{
-    DragStartBehavior, SpellCheckConfiguration, TextAlignVertical, TextContextMenuAction,
-    TextInputRuntimeConfig, TextMagnifierConfiguration, TextSelectionControls, TextUndoController,
+    DragStartBehavior, SpellCheckConfiguration, TextAlignVertical, TextInputRuntimeConfig,
+    TextMagnifierConfiguration, TextSelectionControls, TextUndoController,
 };
-use fission_core::ui::{Button, Container, RichText, RichTextRun, Spacer, Text, TextInput, Widget};
+use fission_core::ui::{
+    Button, Container, RichText, RichTextRun, Spacer, Text, TextContextMenuAction, TextInput,
+    Widget,
+};
 use fission_core::{ActionEnvelope, ActionId};
 use fission_ir::op::{
     decode_inline_widget_marker, Color, Fill, LayoutOp, MouseCursor, Op, PaintOp,

--- a/crates/core/fission-ir/src/semantics.rs
+++ b/crates/core/fission-ir/src/semantics.rs
@@ -331,9 +331,15 @@ pub struct Semantics {
     /// platform IME exposes a pre-edit cursor or marked sub-range.
     #[serde(default)]
     pub ime_preedit_cursor_range: Option<(usize, usize)>,
-    /// Editable text selection as byte offsets `(anchor, focus)`.
+    /// Editable or selectable text selection as byte offsets `(anchor, focus)`.
     #[serde(default)]
     pub text_selection: Option<(usize, usize)>,
+    /// Whether this read-only text node supports pointer/keyboard selection.
+    #[serde(default)]
+    pub selectable_text: bool,
+    /// Whether this node can open a framework-managed context menu.
+    #[serde(default)]
+    pub context_menu: bool,
     /// For checkboxes, radios, and switches: `Some(true)` = checked or selected,
     /// `Some(false)` = unchecked or unselected, and `None` = no checked state.
     pub checked: Option<bool>,
@@ -414,6 +420,8 @@ impl std::hash::Hash for Semantics {
         self.ime_preedit_range.hash(state);
         self.ime_preedit_cursor_range.hash(state);
         self.text_selection.hash(state);
+        self.selectable_text.hash(state);
+        self.context_menu.hash(state);
         self.checked.hash(state);
         self.disabled.hash(state);
         self.read_only.hash(state);
@@ -466,6 +474,8 @@ impl Default for Semantics {
             ime_preedit_range: None,
             ime_preedit_cursor_range: None,
             text_selection: None,
+            selectable_text: false,
+            context_menu: false,
             checked: None,
             disabled: false,
             read_only: false,

--- a/crates/core/fission-semantics/tests/semantics_invariants.rs
+++ b/crates/core/fission-semantics/tests/semantics_invariants.rs
@@ -31,6 +31,8 @@ fn test_semantics_serialization() {
         ime_preedit_range: None,
         ime_preedit_cursor_range: None,
         text_selection: None,
+        selectable_text: false,
+        context_menu: false,
         checked: None,
         disabled: false,
         read_only: false,

--- a/documentation/content/reference/widgets/widget-pages/context-menu-region.mdx
+++ b/documentation/content/reference/widgets/widget-pages/context-menu-region.mdx
@@ -1,0 +1,50 @@
+---
+title: ContextMenuRegion
+description: Attach a widget-backed context menu to any subtree.
+slug: /widgets/context-menu-region
+---
+# ContextMenuRegion
+
+`ContextMenuRegion` gives a widget subtree an explicit secondary-click context menu.
+
+The menu model accepts child widgets, not only strings. That lets applications render translated text, icons, badges, shortcuts, or product-specific rows while Fission handles the right-click activation and menu positioning.
+
+## Example
+
+```rust
+use fission::prelude::*;
+
+let menu = ContextMenu::with_items([
+    ContextMenuEntry::Item(
+        ContextMenuItem::new(
+            "copy-link",
+            Text::new(TextContent::KeyWithFallback {
+                key: "menu.copy_link".into(),
+                fallback: "Copy link".into(),
+            }),
+        )
+        .on_select(copy_link),
+    ),
+]);
+
+let widget: Widget = ContextMenuRegion::new(
+    Text::new("Right-click for actions"),
+    menu,
+)
+.id(WidgetId::explicit("example.context_menu"))
+.into();
+```
+
+## Fields
+
+| Field | Type | Meaning | Notes / default behavior |
+| --- | --- | --- | --- |
+| `id` | `Option<WidgetId>` | Stable owner identity for the region and popup state. | Use an explicit id for menus in dynamic lists. |
+| `child` | `Widget` | The visible subtree that can open the menu. | Any widget can be wrapped. |
+| `menu` | `ContextMenu` | The menu entries and visual configuration. | Items can contain arbitrary child widgets. |
+| `enabled` | `bool` | Whether secondary-click opens the menu. | Defaults to `true`. |
+| `semantics` | `Option<Semantics>` | Optional semantics for the menu region owner. | Fission sets `context_menu = true` when enabled. |
+
+## Related
+
+[`Text`](/reference/widgets/text), [`RichText`](/reference/widgets/rich-text), [`TextContent`](/reference/widgets/text-content), and [`Button`](/reference/widgets/button).

--- a/documentation/content/reference/widgets/widget-pages/rich-text.mdx
+++ b/documentation/content/reference/widgets/widget-pages/rich-text.mdx
@@ -56,12 +56,16 @@ This keeps one logical sentence together while still giving the status word spec
 | `selection_range` | `Option<(usize, usize)>` | Highlighted text selection range. | Defaults to `None`. |
 | `selection_color` | `Option<IrColor>` | Selection highlight color override. | Defaults to `None`. |
 | `selection_text_color` | `Option<IrColor>` | Selected text color override. | Defaults to `None`. |
+| `selectable` | `bool` | Enables native pointer/keyboard selection for the whole rich-text block. | Defaults to `false`; provide a stable `id` when selection should survive rebuilds. |
+| `context_menu` | `TextContextMenuConfig` | Configures the built-in selected-text menu. | Defaults to Copy and Select All for read-only text. |
 | `flex_grow` | `f32` | Extra width or height the text block may absorb in flex layout. | Defaults to `0.0`. |
 | `flex_shrink` | `f32` | How much the block may shrink in tight layouts. | Defaults to `0.0`. |
 
 ## Practical model
 
 There are two common ways to build rich text. For simple styling changes, `RichText::new(vec![...runs...])` is enough. For more advanced cases such as inline widgets, hoverable spans, or nested semantics, the span-based constructors are the better fit because they generate the annotations and inline-widget bookkeeping for you.
+
+In both cases, the widget stays declarative. Use `.selectable(true)` when the rendered rich text should behave like selectable read-only document text with the standard Copy / Select All context menu.
 
 In both cases, the widget stays declarative. You are still describing the paragraph from state, not mutating a text object in place.
 

--- a/documentation/content/reference/widgets/widget-pages/text-content.mdx
+++ b/documentation/content/reference/widgets/widget-pages/text-content.mdx
@@ -15,6 +15,10 @@ You encounter it when a text widget should either render a literal string direct
 use fission::prelude::*;
 let title = Text::new(TextContent::Key("settings.title".into())).into();
 let caption = Text::new(TextContent::Literal("Version 1.2.0".into())).into();
+let menu_item = Text::new(TextContent::KeyWithFallback {
+    key: "menu.copy".into(),
+    fallback: "Copy".into(),
+}).into();
 ```
 
 ## Choice table
@@ -23,10 +27,11 @@ let caption = Text::new(TextContent::Literal("Version 1.2.0".into())).into();
 | --- | --- | --- | --- |
 | `Literal(String)` | `TextContent` | Render this exact string. | Good for dynamic values, ids, or already-translated text. |
 | `Key(String)` | `TextContent` | Look up the string through the current locale in `Env.i18n`. | Missing keys render as `MISSING:key` in the checked-in implementation. |
+| `KeyWithFallback { key, fallback }` | `TextContent` | Look up a translation key, falling back to a supplied string when no translation exists. | Use for framework-provided UI such as default context menu labels where a missing app bundle should not render `MISSING:key`. |
 
 ## Specific advice
 
-Use `Key` for product copy that should participate in internationalization. Use `Literal` for values that are already data, such as file names, counts, or user input.
+Use `Key` for product copy that should participate in internationalization. Use `KeyWithFallback` for built-in or library-provided UI where the component should be localizable but must remain readable if the host app has not supplied a translation. Use `Literal` for values that are already data, such as file names, counts, or user input.
 
 ## Production checklist
 

--- a/documentation/content/reference/widgets/widget-pages/text-input.mdx
+++ b/documentation/content/reference/widgets/widget-pages/text-input.mdx
@@ -80,6 +80,7 @@ The empty string inside `SetEmail(String::new())` is only a placeholder so `ctx.
 | `styled_runs` | `Option<Vec<TextRun>>` | Pre-styled text runs for syntax-highlighted rendering. | When present, the concatenated runs must match `value` exactly. |
 | `locale` | `Option<String>` | Locale override for shaping and accessibility. | Defaults to `None`. |
 | `scroll_padding` | `Option<[f32; 4]>` | Extra space kept around the caret during auto-scroll. | Defaults to `None`. |
+| `context_menu` | `TextContextMenuConfig` | Configures built-in editing actions shown from the text selection context menu. | Defaults to Copy, Cut, Paste, and Select All. Menu labels use localizable child widgets with English fallbacks. |
 | `selection_controls` | `TextSelectionControls` | Configures caret and selection-handle overlays. | Set `enabled` to `false` for mouse-first editors that should not show touch-style handles. Defaults to enabled. |
 
 ## How text, actions, and input method editor state work together

--- a/documentation/content/reference/widgets/widget-pages/text.mdx
+++ b/documentation/content/reference/widgets/widget-pages/text.mdx
@@ -26,7 +26,7 @@ let title = Text::new(TextContent::Key("settings.profile_title".into()))
 | Field | Type | Meaning | Notes / default behavior |
 | --- | --- | --- | --- |
 | `id` | `Option<WidgetId>` | Stable widget identity. | Defaults to `None`. |
-| `content` | `TextContent` | The text source to render. | Use `Literal(...)` for direct strings or `Key(...)` for translated lookup. |
+| `content` | `TextContent` | The text source to render. | Use `Literal(...)` for direct strings, `Key(...)` for translated lookup, or `KeyWithFallback { .. }` when framework UI needs an English fallback. |
 | `semantics` | `Option<Semantics>` | Optional wrapper semantics for the text block. | Defaults to `None`. Builder helpers can also attach labels and actions. |
 
 ## Typography table
@@ -62,13 +62,15 @@ let title = Text::new(TextContent::Key("settings.profile_title".into()))
 | `selection_range` | `Option<(usize, usize)>` | Highlighted selection range. | Defaults to `None`. |
 | `selection_color` | `Option<IrColor>` | Selection highlight override. | Defaults to `None`. |
 | `selection_text_color` | `Option<IrColor>` | Selected text color override. | Defaults to `None`. |
+| `selectable` | `bool` | Enables native pointer/keyboard selection for read-only text. | Defaults to `false`; provide a stable `id` when selection should survive rebuilds. |
+| `context_menu` | `TextContextMenuConfig` | Configures the built-in selected-text menu. | Defaults to Copy and Select All for read-only text. |
 | `flex_grow` / `flex_shrink` | `f32` | Flex behavior inside parent layout. | Defaults to `0.0`. |
 
 ## Plain language behavior
 
 `TextContent::Literal` renders exactly the string you provide. `TextContent::Key` looks up the current locale in `Env.i18n`. In the checked-in implementation, a missing translation key renders visibly as `MISSING:key`, which is useful during development because it fails loudly instead of silently disappearing.
 
-`Text` can also carry semantics and actions through helper methods like `.semantics_label(...)` and `.on_tap(...)`. That is useful for interactive labels or annotated text, but if different parts of one sentence need different actions, `RichText` is the better model.
+`Text` can also carry semantics and actions through helper methods like `.semantics_label(...)` and `.on_tap(...)`. Set `.selectable(true)` for read-only paragraphs that users should be able to select and copy; Fission then exposes text selection in semantics and provides the standard Copy / Select All context menu. That is useful for interactive labels or annotated text, but if different parts of one sentence need different actions, `RichText` is the better model.
 
 ## Specific advice
 

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -1,6 +1,8 @@
 use fission::core::op::Color as IrColor;
 use fission::core::ui::{
-    Button, ButtonVariant, Checkbox, Container, Scroll, Slider, Switch, Text, TextInput, Widget,
+    Button, ButtonVariant, Checkbox, Container, ContextMenu, ContextMenuEntry, ContextMenuItem,
+    ContextMenuRegion, RichText, RichTextRun, Scroll, Slider, Switch, Text, TextContent, TextInput,
+    Widget,
 };
 use fission::core::{reduce_with, ActionEnvelope, FlexDirection, GlobalState, WidgetId};
 use fission::prelude::fission_action;
@@ -240,6 +242,55 @@ impl From<GalleryApp> for Widget {
                     value: "1,234".into(),
                     help_text: Some("+12% this month".into()),
                 }
+                .into(),
+                Text {
+                    id: Some(WidgetId::explicit("gallery.selectable.text")),
+                    content: TextContent::Literal(
+                        "Selectable Text: drag across this sentence, then use Ctrl/Cmd+C or right-click for Copy and Select All.".into(),
+                    ),
+                    selectable: true,
+                    width: Some(control_width),
+                    ..Default::default()
+                }
+                .into(),
+                RichText {
+                    id: Some(WidgetId::explicit("gallery.selectable.rich_text")),
+                    runs: vec![
+                        RichTextRun::new("Selectable RichText: "),
+                        RichTextRun::new("mixed style text can be selected too.")
+                            .color(tokens.colors.primary)
+                            .weight(700),
+                    ],
+                    selectable: true,
+                    width: Some(control_width),
+                    ..Default::default()
+                }
+                .into(),
+                ContextMenuRegion::new(
+                    Container::new(Text::new("Right-click this custom region for a widget-backed context menu."))
+                        .padding_all(12.0)
+                        .border(tokens.colors.border, 1.0)
+                        .border_radius(12.0),
+                    ContextMenu::with_items([ContextMenuEntry::Item(ContextMenuItem::new(
+                        "custom-help",
+                        HStack {
+                            spacing: Some(8.0),
+                            children: vec![
+                                Badge {
+                                    text: "Tip".into(),
+                                    ..Default::default()
+                                }
+                                .into(),
+                                Text::new(TextContent::KeyWithFallback {
+                                    key: "gallery.context_menu.copy_help".into(),
+                                    fallback: "Menu items can be arbitrary widgets".into(),
+                                })
+                                .into(),
+                            ],
+                        },
+                    ))]),
+                )
+                .id(WidgetId::explicit("gallery.custom.context_menu"))
                 .into(),
             ],
         );


### PR DESCRIPTION
## Summary
- adds widget-backed `ContextMenu` / `ContextMenuRegion` APIs, with semantic context-menu metadata and fallback-safe i18n labels
- adds selectable `Text` and `RichText`, including runtime selection state, keyboard copy/select-all handling, and built-in text context menu support
- updates widget docs and the widget gallery with selectable text, selectable rich text, and custom context-menu examples

## Validation
- `cargo fmt --all`
- `cargo test -p fission-core --test selectable_text_context_menu`
- `cargo test -p fission-core --no-run`
- `cargo test -p fission-semantics --no-run`
- `cargo test -p fission-widgets --no-run`
- `cargo check -p widget-gallery`
- `git diff --check`
- `git diff origin/main --check`
