### PR TITLE
Reconcile pending TextInput edits with transformed model values

### DIFF
--- a/crates/core/fission-core/src/env.rs
+++ b/crates/core/fission-core/src/env.rs
@@ -225,6 +225,12 @@ pub struct TextEditState {
     pub history: TextEditHistory,
     pub preedit: Option<TextPreeditState>,
     pub pending_model_sync: bool, // True when edits are newer than the currently lowered semantics value
+    /// Last semantic model value observed for this input.
+    ///
+    /// While a local edit is pending, this lets the input distinguish "the app
+    /// has not observed the edit yet" from "the app observed it and produced a
+    /// transformed value".
+    pub last_model_text: String,
     /// Last cursor position that was dispatched as a CursorChanged action.
     /// Used to deduplicate dispatches and prevent unnecessary model updates
     /// that could cause extra rebuild cycles.
@@ -241,6 +247,7 @@ impl Default for TextEditState {
             history: TextEditHistory::default(),
             preedit: None,
             pending_model_sync: false,
+            last_model_text: String::new(),
             last_dispatched_cursor: None,
             affordances: TextInputAffordanceState::default(),
         }
@@ -408,6 +415,7 @@ impl TextEditState {
         self.anchor = snapshot.anchor.min(snapshot.value.len());
         self.preedit = None;
         self.pending_model_sync = false;
+        self.last_model_text = snapshot.value.clone();
         self.last_dispatched_cursor = None;
         self.history = TextEditHistory::default();
     }
@@ -430,17 +438,41 @@ impl TextEditState {
     }
 
     pub fn sync_from_model(&mut self, semantic_value: &str) {
-        if self.pending_model_sync && self.buffer.to_string() == semantic_value {
+        let buffer_text = self.buffer.to_string();
+        if self.pending_model_sync {
+            if buffer_text == semantic_value {
+                self.pending_model_sync = false;
+                self.last_model_text = semantic_value.to_string();
+                return;
+            }
+            if semantic_value == self.last_model_text {
+                return;
+            }
+
+            let selection_was_collapsed = self.caret == self.anchor;
+            self.buffer = TextBuffer::from_str(semantic_value);
+            if selection_was_collapsed {
+                self.caret = semantic_value.len();
+                self.anchor = semantic_value.len();
+            } else {
+                self.caret = self.caret.min(semantic_value.len());
+                self.anchor = self.anchor.min(semantic_value.len());
+            }
+            self.preedit = None;
+            self.history = TextEditHistory::default();
             self.pending_model_sync = false;
+            self.last_model_text = semantic_value.to_string();
+            return;
         }
 
-        if !self.pending_model_sync && self.buffer.to_string() != semantic_value {
+        if buffer_text != semantic_value {
             self.buffer = TextBuffer::from_str(semantic_value);
             self.caret = self.caret.min(semantic_value.len());
             self.anchor = self.anchor.min(semantic_value.len());
             self.preedit = None;
             self.history = TextEditHistory::default();
         }
+        self.last_model_text = semantic_value.to_string();
     }
 
     pub fn selection_range(&self) -> (usize, usize) {

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -1262,9 +1262,17 @@ impl InternalLower for TextInput {
 
         // 2. Text Preparation
         let session = cx.runtime_state.text_edit.get(input_id);
+        let pending_model_transform = session.is_some_and(|state| {
+            state.pending_model_sync
+                && state.preedit.is_none()
+                && state.committed_text() != self.value
+                && state.last_model_text != self.value
+        });
         let retained_session = if is_focused {
             session.filter(|state| {
-                state.pending_model_sync
+                (state.pending_model_sync
+                    && (state.committed_text() == self.value
+                        || state.last_model_text == self.value))
                     || state.preedit.is_some()
                     || (self.restoration_id.is_some() && self.value.is_empty())
                     || state.committed_text() == self.value
@@ -1275,10 +1283,14 @@ impl InternalLower for TextInput {
         let session_display = retained_session.map(|state| state.display_text());
         let model_selection = session
             .map(|state| {
-                (
-                    clamp_text_offset(&self.value, state.caret),
-                    clamp_text_offset(&self.value, state.anchor),
-                )
+                if pending_model_transform && state.caret == state.anchor {
+                    (self.value.len(), self.value.len())
+                } else {
+                    (
+                        clamp_text_offset(&self.value, state.caret),
+                        clamp_text_offset(&self.value, state.anchor),
+                    )
+                }
             })
             .unwrap_or((self.value.len(), self.value.len()));
         let semantic_value = retained_session

--- a/crates/core/fission-core/tests/input_controller_tests.rs
+++ b/crates/core/fission-core/tests/input_controller_tests.rs
@@ -581,6 +581,27 @@ fn test_ime_preedit_tracks_cursor_without_dispatching_change() {
 }
 
 #[test]
+fn pending_text_edit_accepts_transformed_model_value_on_sync() {
+    let node_id = WidgetId::derived(40, &[3]);
+    let mut text_edit = TextEditStateMap::default();
+    text_edit.sync_from_runtime(node_id, "First item\n", None, None);
+    text_edit.get_mut_or_default(node_id).apply_edit(
+        "First item".len().."First item".len(),
+        "Second item",
+        "First itemSecond item".len(),
+        "First itemSecond item".len(),
+    );
+
+    text_edit.sync_from_runtime(node_id, "First item\nSecond item", None, None);
+
+    let state = text_edit.get(node_id).expect("text input state");
+    assert_eq!(state.committed_text(), "First item\nSecond item");
+    assert!(!state.pending_model_sync);
+    assert_eq!(state.caret, "First item\nSecond item".len());
+    assert_eq!(state.anchor, "First item\nSecond item".len());
+}
+
+#[test]
 fn runtime_updates_ime_cursor_area_from_text_caret() {
     let input_id = WidgetId::derived(45, &[0]);
     let scroll_id = WidgetId::derived(45, &[1]);

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -1227,6 +1227,60 @@ fn focused_text_input_keeps_pending_local_value_until_model_catches_up() {
 }
 
 #[test]
+fn focused_text_input_accepts_transformed_model_value_after_pending_local_edit() {
+    let input_id = fission_ir::WidgetId::derived(87, &[4]);
+    let mut runtime = RuntimeState::default();
+    runtime.interaction.set_focused(Some(input_id));
+    runtime
+        .text_edit
+        .sync_from_runtime(input_id, "First item\n", None, None);
+    runtime.text_edit.get_mut_or_default(input_id).apply_edit(
+        "First item".len().."First item".len(),
+        "Second item",
+        "First itemSecond item".len(),
+        "First itemSecond item".len(),
+    );
+
+    let accepted_model_value = "First item\nSecond item";
+    let ir = lower_node_with_runtime(
+        TextInput {
+            id: Some(input_id.into()),
+            value: accepted_model_value.into(),
+            ..Default::default()
+        }
+        .into(),
+        runtime,
+    );
+
+    let rendered = paint_ops(&ir)
+        .find_map(|op| match op {
+            PaintOp::DrawRichText { runs, .. } => {
+                Some(runs.iter().map(|run| run.text.as_str()).collect::<String>())
+            }
+            _ => None,
+        })
+        .expect("text input rich text paint op");
+
+    assert_eq!(rendered, accepted_model_value);
+
+    let semantics = ir
+        .nodes
+        .values()
+        .find_map(|node| match &node.op {
+            Op::Semantics(semantics) if semantics.role == fission_ir::Role::TextInput => {
+                Some(semantics)
+            }
+            _ => None,
+        })
+        .expect("text input semantics");
+    assert_eq!(semantics.value.as_deref(), Some(accepted_model_value));
+    assert_eq!(
+        semantics.text_selection,
+        Some((accepted_model_value.len(), accepted_model_value.len()))
+    );
+}
+
+#[test]
 fn focused_text_input_lowers_toolbar_handles_and_magnifier_overlays() {
     assert!(TextSelectionControls::default().enabled);
 

--- a/crates/shell/fission-shell-winit/src/accessibility.rs
+++ b/crates/shell/fission-shell-winit/src/accessibility.rs
@@ -628,12 +628,13 @@ mod imp {
         semantics: &Semantics,
     ) -> Option<String> {
         if semantics.role == Role::TextInput {
-            runtime
-                .runtime_state
-                .text_edit
-                .get(node_id)
-                .map(|state| state.committed_text())
-                .or_else(|| semantics.value.clone())
+            semantics.value.clone().or_else(|| {
+                runtime
+                    .runtime_state
+                    .text_edit
+                    .get(node_id)
+                    .map(|state| state.committed_text())
+            })
         } else {
             semantics.value.clone()
         }
@@ -1158,6 +1159,37 @@ mod imp {
             };
 
             assert_eq!(access_role_for(&semantics), AccessRole::RadioButton);
+        }
+
+        #[test]
+        fn text_input_value_prefers_lowered_semantics_over_retained_runtime_buffer() {
+            let input = WidgetId::from_u128(20);
+            let mut runtime = Runtime::default();
+            runtime.runtime_state.text_edit.sync_from_runtime(
+                input,
+                "Stale retained buffer",
+                None,
+                None,
+            );
+
+            let semantics = Semantics {
+                role: Role::TextInput,
+                value: Some("Lowered model value".into()),
+                ..Semantics::default()
+            };
+            assert_eq!(
+                semantic_value(&runtime, input, &semantics).as_deref(),
+                Some("Lowered model value")
+            );
+
+            let fallback_semantics = Semantics {
+                role: Role::TextInput,
+                ..Semantics::default()
+            };
+            assert_eq!(
+                semantic_value(&runtime, input, &fallback_semantics).as_deref(),
+                Some("Stale retained buffer")
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #120.

This teaches controlled `TextInput` state to distinguish between two pending-edit cases:

- the app has not observed the local edit yet, so the retained pending text should still win
- the app has observed the edit and produced a transformed model value, so the lowered model value should replace the retained buffer

The change stores the last observed model text in `TextEditState`, uses it during `TextInput` lowering to accept or reject the retained session once, and keeps display text, semantic value, preedit ranges, and selection aligned to that same decision.

The winit accessibility adapter now prefers the lowered semantic value for text inputs before falling back to retained runtime text, so AccessKit output follows the same lowerer decision.

## Tests

- `env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p fission-core --test text_surface_api focused_text_input_accepts_transformed_model_value_after_pending_local_edit -- --nocapture`
- `env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p fission-shell-winit text_input_value_prefers_lowered_semantics_over_retained_runtime_buffer -- --nocapture`

The winit test emits existing `video_backend.rs` unreachable-code/unused-import warnings.