### PR TITLE
fix(core): retain reducer-bound effect callbacks

### DIFF
--- a/crates/core/fission-core/src/build.rs
+++ b/crates/core/fission-core/src/build.rs
@@ -423,7 +423,8 @@ impl<S: GlobalState> BuildCtxHandle<S> {
                   envelope: &crate::ActionEnvelope,
                   _target,
                   _effects,
-                  _input|
+                  _input,
+                  _callback_registry|
                   -> anyhow::Result<()> {
                 let action: A = serde_json::from_slice(&envelope.payload).map_err(|error| {
                     anyhow::anyhow!("Failed to deserialize local action: {error}")

--- a/crates/core/fission-core/src/context.rs
+++ b/crates/core/fission-core/src/context.rs
@@ -5,7 +5,7 @@
 //! an [`Effects`] builder for issuing capabilities, jobs, services, and
 //! runtime-control effects plus binding callback actions.
 
-use crate::action::{Action, ActionEnvelope, GlobalState};
+use crate::action::{Action, ActionEnvelope, ActionId, GlobalState};
 use crate::async_runtime::{
     JobRef, JobRequestPayload, JobSpec, ServiceBindings, ServiceCommandPayload, ServiceSlot,
     ServiceSpec, ServiceStartPayload, ServiceStopPayload,
@@ -74,7 +74,16 @@ use crate::platform_wifi::{
     SCAN_WIFI_NETWORKS,
 };
 use crate::registry::{ActionRegistry, IntoHandler};
-use std::marker::PhantomData;
+use crate::EffectCallbackRegistry;
+use std::{
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+static NEXT_EFFECT_CALLBACK_ID: AtomicU64 = AtomicU64::new(1);
 
 /// The context passed to modern 3-argument reducer handlers.
 ///
@@ -129,6 +138,7 @@ pub struct Effects<'a, S: GlobalState> {
     pub out: Vec<EffectEnvelope>,
     next_req_id: u64,
     pub(crate) registry: Option<&'a mut ActionRegistry<S>>,
+    callback_registry: Option<Arc<EffectCallbackRegistry>>,
     _phantom: PhantomData<S>,
 }
 
@@ -138,6 +148,7 @@ impl<'a, S: GlobalState> Effects<'a, S> {
             out: Vec::new(),
             next_req_id,
             registry: Some(registry),
+            callback_registry: None,
             _phantom: PhantomData,
         }
     }
@@ -147,6 +158,20 @@ impl<'a, S: GlobalState> Effects<'a, S> {
             out: Vec::new(),
             next_req_id,
             registry: None,
+            callback_registry: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(crate) fn new_runtime(
+        next_req_id: u64,
+        callback_registry: Arc<EffectCallbackRegistry>,
+    ) -> Self {
+        Self {
+            out: Vec::new(),
+            next_req_id,
+            registry: None,
+            callback_registry: Some(callback_registry),
             _phantom: PhantomData,
         }
     }
@@ -155,11 +180,25 @@ impl<'a, S: GlobalState> Effects<'a, S> {
     where
         H: IntoHandler<S, A> + Send + Sync + 'static,
     {
+        let action_id = effect_callback_action_id(A::static_id());
         if let Some(registry) = &mut self.registry {
-            registry.register(handler);
+            registry.register_with_id(action_id, handler);
+        } else {
+            let callback_registry = self
+                .callback_registry
+                .as_ref()
+                .unwrap_or_else(|| panic!("Effects::bind requires a runtime or action registry"));
+            let mut registry = ActionRegistry::new();
+            registry.register_with_id(action_id, handler);
+            let mut reducers = registry.into_runtime_reducers();
+            let reducer = reducers
+                .remove(&action_id)
+                .and_then(|mut reducers| reducers.pop())
+                .expect("effect callback reducer must be registered");
+            callback_registry.register(action_id, reducer);
         }
         ActionEnvelope {
-            id: A::static_id(),
+            id: action_id,
             payload: action.encode(),
         }
     }
@@ -464,6 +503,14 @@ impl<'a, S: GlobalState> Effects<'a, S> {
     pub fn ensure_visible(&mut self, request: ScrollIntoViewRequest) -> u64 {
         self.scroll_into_view(request)
     }
+}
+
+fn effect_callback_action_id(action_id: ActionId) -> ActionId {
+    let sequence = NEXT_EFFECT_CALLBACK_ID.fetch_add(1, Ordering::Relaxed);
+    ActionId::from_name(&format!(
+        "fission::effect_callback::{:032x}::{sequence}",
+        action_id.as_u128()
+    ))
 }
 
 /// Convenience builder for the standard notification host capabilities.

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -38,6 +38,7 @@ use anyhow::Result;
 use lazy_static::lazy_static;
 use std::any::TypeId;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 extern crate self as fission_core;
 
@@ -681,7 +682,41 @@ pub(crate) type BoxedReducer = Box<
             WidgetId,
             &mut Vec<EffectEnvelope>,
             &ActionInput,
+            &Arc<EffectCallbackRegistry>,
         ) -> Result<()>
         + Send
         + Sync,
 >;
+
+/// One-shot reducers bound to async effect completion actions.
+///
+/// These reducers are separate from the per-frame widget registry so a
+/// completion remains deliverable after the frame that issued the effect.
+pub(crate) struct EffectCallbackRegistry {
+    reducers: Mutex<HashMap<ActionId, Vec<BoxedReducer>>>,
+}
+
+impl EffectCallbackRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            reducers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn register(&self, action_id: ActionId, reducer: BoxedReducer) {
+        self.reducers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entry(action_id)
+            .or_default()
+            .push(reducer);
+    }
+
+    pub(crate) fn take(&self, action_id: ActionId) -> Vec<BoxedReducer> {
+        self.reducers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&action_id)
+            .unwrap_or_default()
+    }
+}

--- a/crates/core/fission-core/src/registry.rs
+++ b/crates/core/fission-core/src/registry.rs
@@ -92,8 +92,14 @@ impl<S: GlobalState> ActionRegistry<S> {
         &mut self,
         handler: H,
     ) {
-        let action_id = A::static_id();
+        self.register_with_id(A::static_id(), handler);
+    }
 
+    pub(crate) fn register_with_id<A: Action, H: IntoHandler<S, A> + Send + Sync + 'static>(
+        &mut self,
+        action_id: ActionId,
+        handler: H,
+    ) {
         let typed_reducer: TypedReducer<S> = Box::new(
             move |state: &mut S,
                   envelope: &ActionEnvelope,
@@ -176,7 +182,8 @@ impl<S: GlobalState> ActionRegistry<S> {
                           action: &ActionEnvelope,
                           target: WidgetId,
                           out_effects: &mut Vec<EffectEnvelope>,
-                          input: &ActionInput|
+                          input: &ActionInput,
+                          callback_registry|
                           -> Result<()> {
                         if let Some(state_box) = app_states.get_mut(&state_type_id) {
                             let concrete_state =
@@ -184,7 +191,8 @@ impl<S: GlobalState> ActionRegistry<S> {
                                     anyhow!("Failed to downcast GlobalState to concrete type")
                                 })?;
 
-                            let mut effects_builder = Effects::new_headless(0);
+                            let mut effects_builder =
+                                Effects::new_runtime(0, callback_registry.clone());
 
                             typed_reducer(
                                 concrete_state,

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -9,7 +9,7 @@ use crate::registry::{
     ActionRegistry, ResourcePolicy, RuntimeResourceDeclaration, RuntimeResourceKind, TimerResource,
     VideoRegistration,
 };
-use crate::BoxedReducer;
+use crate::{BoxedReducer, EffectCallbackRegistry};
 use crate::{
     Clipboard, Clock, CurrentTime, ImeHandler, InputEvent, KeyCode, KeyEvent, PointerButton,
     PointerEvent, ResourceExecutionContext,
@@ -104,6 +104,8 @@ pub struct Runtime {
     /// Persistent reducers that survive [`clear_reducers`](Runtime::clear_reducers)
     /// calls, installed once at app startup.
     pub(crate) persistent_reducers: HashMap<ActionId, Vec<BoxedReducer>>,
+    /// One-shot reducers bound by reducers to async effect completions.
+    effect_callbacks: Arc<EffectCallbackRegistry>,
     /// Type-indexed application state store.
     pub app_states: HashMap<TypeId, Box<dyn GlobalState>>,
     /// Mutable runtime state (interaction, scroll, text editing, motions).
@@ -131,6 +133,7 @@ impl Default for Runtime {
         let mut runtime = Self {
             reducers: HashMap::new(),
             persistent_reducers: HashMap::new(),
+            effect_callbacks: Arc::new(EffectCallbackRegistry::new()),
             app_states: HashMap::new(),
             runtime_state: RuntimeState::default(),
             measurer: None,
@@ -209,7 +212,8 @@ impl Runtime {
                   action: &ActionEnvelope,
                   target: WidgetId,
                   _effects: &mut Vec<EffectEnvelope>,
-                  _input: &ActionInput|
+                  _input: &ActionInput,
+                  _callback_registry|
                   -> Result<()> {
                 if let Some(state_box) = app_states.get_mut(&state_type_id) {
                     let concrete_state = state_box.downcast_mut::<S>().ok_or_else(|| {
@@ -377,6 +381,19 @@ impl Runtime {
 
         // Collect effects from this dispatch (both persistent and per-frame reducers).
         let mut effects = Vec::new();
+        let callback_registry = self.effect_callbacks.clone();
+
+        let mut callback_reducers = callback_registry.take(action_id);
+        for reducer_wrapper in callback_reducers.iter_mut() {
+            reducer_wrapper(
+                &mut self.app_states,
+                &action,
+                target,
+                &mut effects,
+                input,
+                &callback_registry,
+            )?;
+        }
 
         if let Some(reducers) = self.persistent_reducers.get_mut(&action_id) {
             diag::emit(
@@ -391,7 +408,14 @@ impl Runtime {
 
             let mut temp_reducers: Vec<BoxedReducer> = reducers.drain(..).collect();
             for reducer_wrapper in temp_reducers.iter_mut() {
-                reducer_wrapper(&mut self.app_states, &action, target, &mut effects, input)?;
+                reducer_wrapper(
+                    &mut self.app_states,
+                    &action,
+                    target,
+                    &mut effects,
+                    input,
+                    &callback_registry,
+                )?;
             }
             reducers.extend(temp_reducers);
         }
@@ -409,7 +433,14 @@ impl Runtime {
 
             let mut temp_reducers: Vec<BoxedReducer> = reducers.drain(..).collect();
             for reducer_wrapper in temp_reducers.iter_mut() {
-                reducer_wrapper(&mut self.app_states, &action, target, &mut effects, input)?;
+                reducer_wrapper(
+                    &mut self.app_states,
+                    &action,
+                    target,
+                    &mut effects,
+                    input,
+                    &callback_registry,
+                )?;
             }
             reducers.extend(temp_reducers);
         }

--- a/crates/core/fission-core/src/tests/effect_test.rs
+++ b/crates/core/fission-core/src/tests/effect_test.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 struct TestState {
     data: String,
     loading: bool,
+    completions: usize,
 }
 impl GlobalState for TestState {}
 
@@ -61,6 +62,7 @@ fn on_upload_finished<'a, 'b, 'c>(
     ctx: &mut ReducerContext<'a, 'b, 'c, TestState>,
 ) {
     state.loading = false;
+    state.completions += 1;
     if let Some(result) = ctx.input.capability_ok(UPLOAD_FILE) {
         state.data = format!("uploaded {} bytes", result.bytes);
     }
@@ -93,7 +95,6 @@ fn test_capability_effect_loop() {
 
     let mut registry = crate::registry::ActionRegistry::new();
     registry.register(reduce_with!(on_upload_requested));
-    registry.register(reduce_with!(on_upload_finished));
     runtime.absorb_registry(registry);
 
     runtime
@@ -108,9 +109,10 @@ fn test_capability_effect_loop() {
 
     let env = runtime.pending_effects.pop().unwrap();
     let on_ok = env.on_ok.clone().expect("capability continuation");
+    runtime.clear_reducers();
     runtime
         .dispatch_with_input(
-            on_ok,
+            on_ok.clone(),
             crate::WidgetId::from_u128(0),
             &crate::ActionInput::CapabilityOk {
                 capability: "upload-file".into(),
@@ -123,6 +125,22 @@ fn test_capability_effect_loop() {
     let state = runtime.get_global_state::<TestState>().unwrap();
     assert!(!state.loading);
     assert_eq!(state.data, "uploaded 11 bytes");
+    assert_eq!(state.completions, 1);
+
+    runtime
+        .dispatch_with_input(
+            on_ok,
+            crate::WidgetId::from_u128(0),
+            &crate::ActionInput::CapabilityOk {
+                capability: "upload-file".into(),
+                req_id: env.req_id,
+                payload: serde_json::to_vec(&UploadFileOk { bytes: 99 }).unwrap(),
+            },
+        )
+        .unwrap();
+    let state = runtime.get_global_state::<TestState>().unwrap();
+    assert_eq!(state.data, "uploaded 11 bytes");
+    assert_eq!(state.completions, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- retain reducers bound through `ctx.effects.bind(...)` until their async effect completes
- assign one-shot callback action identities so concurrent and repeated operations do not accumulate handlers
- keep callbacks alive across frame rebuilds and `clear_reducers()`

## Problem

Reducers run with a headless `Effects` builder after the widget registry is absorbed. `Effects::bind` therefore returned a completion action but silently registered no reducer. Capabilities and jobs completed their work, but the shell dispatched completion actions with no handler.

## Validation

- `cargo test -p fission-core`
- `cargo check -p fission-shell-winit`
- regression test clears per-frame reducers before delivering a capability result and verifies the callback runs exactly once