### PR TITLE
feat(desktop): hide tray apps from switchers by default

### DIFF
--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -324,8 +324,8 @@ pub use fission_shell_desktop::{
     not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
 ))]
 pub use fission_shell_desktop::{
-    TrayActivateBehavior, TrayConfig, TrayHostAction, TrayIconSource, TrayMenu, TrayMenuAction,
-    TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
+    TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
+    TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
 };
 #[cfg(all(
     any(
@@ -518,8 +518,9 @@ pub mod prelude {
         not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
     ))]
     pub use fission_shell_desktop::{
-        TrayActivateBehavior, TrayConfig, TrayHostAction, TrayIconSource, TrayMenu, TrayMenuAction,
-        TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
+        TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
+        TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem,
+        WindowCloseBehavior,
     };
 
     // Layout

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -19,8 +19,8 @@ pub use fission_shell_winit::{
 };
 #[cfg(feature = "tray")]
 pub use fission_shell_winit::{
-    TrayActivateBehavior, TrayConfig, TrayHostAction, TrayIconSource, TrayMenu, TrayMenuAction,
-    TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
+    TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
+    TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
 };
 
 pub struct DesktopApp<S: GlobalState, W>

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -23,6 +23,8 @@ use winit::platform::ios::WindowAttributesExtIOS;
 use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::{EventLoopExtWebSys, WindowAttributesExtWebSys, WindowExtWebSys};
+#[cfg(target_os = "windows")]
+use winit::platform::windows::WindowAttributesExtWindows;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{Event, Ime, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent},
@@ -127,8 +129,8 @@ pub use passkey::{MemoryPasskeyHost, PasskeyHost, UnsupportedPasskeyHost};
 pub mod tray;
 #[cfg(feature = "tray")]
 pub use tray::{
-    TrayActivateBehavior, TrayConfig, TrayHostAction, TrayIconSource, TrayMenu, TrayMenuAction,
-    TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
+    TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
+    TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
 };
 pub mod test_control;
 mod wifi;
@@ -1116,6 +1118,7 @@ fn build_window(
     let window_attributes = build_window_attributes(
         title,
         background_test_mode,
+        false,
         _web_mount_selector,
         reported_scale_factor,
     )?;
@@ -1128,11 +1131,17 @@ fn build_window(
 fn build_window_before_run(
     title: &str,
     background_test_mode: bool,
+    tray_skip_taskbar: bool,
     event_loop: &EventLoop<TestEvent>,
     _web_mount_selector: Option<&str>,
 ) -> anyhow::Result<Arc<Window>> {
-    let window_attributes =
-        build_window_attributes(title, background_test_mode, _web_mount_selector, None)?;
+    let window_attributes = build_window_attributes(
+        title,
+        background_test_mode,
+        tray_skip_taskbar,
+        _web_mount_selector,
+        None,
+    )?;
     #[allow(deprecated)]
     Ok(Arc::new(
         event_loop
@@ -1144,6 +1153,7 @@ fn build_window_before_run(
 fn build_window_attributes(
     title: &str,
     background_test_mode: bool,
+    tray_skip_taskbar: bool,
     _web_mount_selector: Option<&str>,
     _reported_scale_factor: Option<f64>,
 ) -> anyhow::Result<WindowAttributes> {
@@ -1158,6 +1168,14 @@ fn build_window_attributes(
         window_attributes = window_attributes.with_scale_factor(ios_effective_scale_factor(
             normalize_scale_factor(reported_scale_factor),
         ));
+    }
+    #[cfg(target_os = "windows")]
+    {
+        window_attributes = window_attributes.with_skip_taskbar(tray_skip_taskbar);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = tray_skip_taskbar;
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -4422,8 +4440,24 @@ where
         if let Some(app) = android_app {
             event_loop_builder.with_android_app(app);
         }
+        #[cfg(all(feature = "tray", not(target_os = "android")))]
+        let tray_skip_taskbar = self
+            .tray_config
+            .as_ref()
+            .map(|config| tray::should_skip_taskbar(config.app_switcher_policy, true))
+            .unwrap_or(false);
+        #[cfg(any(not(feature = "tray"), target_os = "android"))]
+        let tray_skip_taskbar = false;
+        #[cfg(all(feature = "tray", target_os = "macos"))]
+        let tray_starts_as_accessory = self
+            .tray_config
+            .as_ref()
+            .map(|config| tray::macos_starts_as_accessory(config.app_switcher_policy))
+            .unwrap_or(false);
+        #[cfg(any(not(feature = "tray"), not(target_os = "macos")))]
+        let tray_starts_as_accessory = false;
         #[cfg(target_os = "macos")]
-        if background_test_mode {
+        if background_test_mode || tray_starts_as_accessory {
             event_loop_builder.with_activation_policy(ActivationPolicy::Accessory);
             event_loop_builder.with_activate_ignoring_other_apps(false);
             event_loop_builder.with_default_menu(false);
@@ -4462,6 +4496,7 @@ where
         let platform_window = build_window_before_run(
             &window_title,
             background_test_mode,
+            tray_skip_taskbar,
             &event_loop,
             web_mount_selector.as_deref(),
         )?;
@@ -7600,14 +7635,10 @@ where
                         }
                         WindowEvent::CloseRequested => {
                             #[cfg(feature = "tray")]
-                            if active_tray
-                                .as_ref()
-                                .map(|tray| {
-                                    tray.close_behavior() == tray::WindowCloseBehavior::HideToTray
-                                })
-                                .unwrap_or(false)
-                            {
-                                tray::hide_window_to_tray(window);
+                            if let Some(tray) = active_tray.as_ref().filter(|tray| {
+                                tray.close_behavior() == tray::WindowCloseBehavior::HideToTray
+                            }) {
+                                tray::hide_window_to_tray(window, tray.app_switcher_policy());
                                 return;
                             }
                             elwt.exit();

--- a/crates/shell/fission-shell-winit/src/tray.rs
+++ b/crates/shell/fission-shell-winit/src/tray.rs
@@ -44,6 +44,31 @@ impl Default for TrayActivateBehavior {
     }
 }
 
+/// Whether a tray-enabled desktop app should appear in the OS app switcher,
+/// dock, or taskbar where the platform exposes that control.
+///
+/// `Hidden` is the default for tray apps because tray-first apps should keep
+/// running in the status area without also occupying Cmd+Tab, the Dock, or the
+/// Windows taskbar. Linux window managers do not expose one portable switcher
+/// contract through winit, so Fission applies the policy on a best-effort basis
+/// there by keeping hidden tray windows out of the switcher.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TrayAppSwitcherPolicy {
+    /// Hide the tray app from switchers, docks, and taskbars where possible.
+    Hidden,
+    /// Keep regular foreground app behavior.
+    Visible,
+    /// Use regular foreground behavior while the window is visible, then hide
+    /// from switchers/docks/taskbars when the window is sent to tray.
+    HiddenWhenWindowHidden,
+}
+
+impl Default for TrayAppSwitcherPolicy {
+    fn default() -> Self {
+        Self::Hidden
+    }
+}
+
 /// Built-in shell actions that can be used from a tray menu.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TrayHostAction {
@@ -206,6 +231,7 @@ pub struct TrayConfig<S: GlobalState> {
     pub icon_is_template: bool,
     pub close_behavior: WindowCloseBehavior,
     pub activate_behavior: TrayActivateBehavior,
+    pub app_switcher_policy: TrayAppSwitcherPolicy,
     pub menu_on_left_click: bool,
     pub menu_on_right_click: bool,
     pub include_default_quit: bool,
@@ -221,6 +247,7 @@ impl<S: GlobalState> Clone for TrayConfig<S> {
             icon_is_template: self.icon_is_template,
             close_behavior: self.close_behavior,
             activate_behavior: self.activate_behavior,
+            app_switcher_policy: self.app_switcher_policy,
             menu_on_left_click: self.menu_on_left_click,
             menu_on_right_click: self.menu_on_right_click,
             include_default_quit: self.include_default_quit,
@@ -238,6 +265,7 @@ impl<S: GlobalState> TrayConfig<S> {
             icon_is_template: false,
             close_behavior: WindowCloseBehavior::Exit,
             activate_behavior: TrayActivateBehavior::ToggleMainWindow,
+            app_switcher_policy: TrayAppSwitcherPolicy::Hidden,
             menu_on_left_click: false,
             menu_on_right_click: true,
             include_default_quit: true,
@@ -267,6 +295,11 @@ impl<S: GlobalState> TrayConfig<S> {
 
     pub fn activate_behavior(mut self, behavior: TrayActivateBehavior) -> Self {
         self.activate_behavior = behavior;
+        self
+    }
+
+    pub fn app_switcher_policy(mut self, policy: TrayAppSwitcherPolicy) -> Self {
+        self.app_switcher_policy = policy;
         self
     }
 
@@ -315,6 +348,10 @@ pub(crate) struct ActiveTray<S: GlobalState> {
 impl<S: GlobalState> ActiveTray<S> {
     pub(crate) fn close_behavior(&self) -> WindowCloseBehavior {
         self.config.close_behavior
+    }
+
+    pub(crate) fn app_switcher_policy(&self) -> TrayAppSwitcherPolicy {
+        self.config.app_switcher_policy
     }
 
     pub(crate) fn build(config: TrayConfig<S>) -> Result<Self> {
@@ -367,7 +404,11 @@ impl<S: GlobalState> ActiveTray<S> {
         match event {
             TrayRuntimeEvent::TrayIcon(event) => {
                 if should_activate_from_tray_event(&event) {
-                    apply_activate_behavior(self.config.activate_behavior, window);
+                    apply_activate_behavior(
+                        self.config.activate_behavior,
+                        self.config.app_switcher_policy,
+                        window,
+                    );
                 }
                 Ok(TrayEventOutcome::default())
             }
@@ -383,7 +424,7 @@ impl<S: GlobalState> ActiveTray<S> {
                                 quit: true,
                             });
                         }
-                        apply_host_action(action, window);
+                        apply_host_action(action, self.config.app_switcher_policy, window);
                         Ok(TrayEventOutcome::default())
                     }
                     TrayMenuAction::App(action) => {
@@ -422,25 +463,31 @@ pub(crate) fn install_event_forwarders(
     rx
 }
 
-pub(crate) fn hide_window_to_tray(window: &Window) {
+pub(crate) fn hide_window_to_tray(window: &Window, policy: TrayAppSwitcherPolicy) {
     window.set_visible(false);
+    apply_runtime_app_switcher_policy(window, policy, false);
 }
 
-pub(crate) fn show_window_from_tray(window: &Window) {
+pub(crate) fn show_window_from_tray(window: &Window, policy: TrayAppSwitcherPolicy) {
+    apply_runtime_app_switcher_policy(window, policy, true);
     window.set_visible(true);
     window.set_minimized(false);
     window.focus_window();
 }
 
-pub(crate) fn apply_host_action(action: TrayHostAction, window: &Window) {
+pub(crate) fn apply_host_action(
+    action: TrayHostAction,
+    policy: TrayAppSwitcherPolicy,
+    window: &Window,
+) {
     match action {
-        TrayHostAction::ShowMainWindow => show_window_from_tray(window),
-        TrayHostAction::HideMainWindow => hide_window_to_tray(window),
+        TrayHostAction::ShowMainWindow => show_window_from_tray(window, policy),
+        TrayHostAction::HideMainWindow => hide_window_to_tray(window, policy),
         TrayHostAction::ToggleMainWindow => {
             if window.is_visible().unwrap_or(true) {
-                hide_window_to_tray(window);
+                hide_window_to_tray(window, policy);
             } else {
-                show_window_from_tray(window);
+                show_window_from_tray(window, policy);
             }
         }
         TrayHostAction::QuitApp => {
@@ -449,14 +496,67 @@ pub(crate) fn apply_host_action(action: TrayHostAction, window: &Window) {
     }
 }
 
-pub(crate) fn apply_activate_behavior(behavior: TrayActivateBehavior, window: &Window) {
+pub(crate) fn apply_activate_behavior(
+    behavior: TrayActivateBehavior,
+    policy: TrayAppSwitcherPolicy,
+    window: &Window,
+) {
     match behavior {
         TrayActivateBehavior::None => {}
-        TrayActivateBehavior::ShowMainWindow => show_window_from_tray(window),
+        TrayActivateBehavior::ShowMainWindow => show_window_from_tray(window, policy),
         TrayActivateBehavior::ToggleMainWindow => {
-            apply_host_action(TrayHostAction::ToggleMainWindow, window)
+            apply_host_action(TrayHostAction::ToggleMainWindow, policy, window)
         }
     }
+}
+
+pub(crate) fn should_skip_taskbar(policy: TrayAppSwitcherPolicy, visible: bool) -> bool {
+    match policy {
+        TrayAppSwitcherPolicy::Hidden => true,
+        TrayAppSwitcherPolicy::Visible => false,
+        TrayAppSwitcherPolicy::HiddenWhenWindowHidden => !visible,
+    }
+}
+
+pub(crate) fn macos_starts_as_accessory(policy: TrayAppSwitcherPolicy) -> bool {
+    matches!(policy, TrayAppSwitcherPolicy::Hidden)
+}
+
+#[cfg(target_os = "windows")]
+fn apply_runtime_app_switcher_policy(
+    window: &Window,
+    policy: TrayAppSwitcherPolicy,
+    visible: bool,
+) {
+    use winit::platform::windows::WindowExtWindows;
+
+    window.set_skip_taskbar(should_skip_taskbar(policy, visible));
+}
+
+#[cfg(target_os = "macos")]
+fn apply_runtime_app_switcher_policy(
+    _window: &Window,
+    policy: TrayAppSwitcherPolicy,
+    visible: bool,
+) {
+    use cocoa::appkit::{NSApp, NSApplication, NSApplicationActivationPolicy};
+
+    let activation_policy = if should_skip_taskbar(policy, visible) {
+        NSApplicationActivationPolicy::NSApplicationActivationPolicyAccessory
+    } else {
+        NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular
+    };
+    unsafe {
+        NSApp().setActivationPolicy_(activation_policy);
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn apply_runtime_app_switcher_policy(
+    _window: &Window,
+    _policy: TrayAppSwitcherPolicy,
+    _visible: bool,
+) {
 }
 
 fn should_activate_from_tray_event(event: &TrayIconEvent) -> bool {
@@ -635,6 +735,30 @@ mod tests {
     }
 
     #[test]
+    fn app_switcher_policy_maps_to_taskbar_skip_state() {
+        assert!(should_skip_taskbar(TrayAppSwitcherPolicy::Hidden, true));
+        assert!(should_skip_taskbar(TrayAppSwitcherPolicy::Hidden, false));
+        assert!(!should_skip_taskbar(TrayAppSwitcherPolicy::Visible, true));
+        assert!(!should_skip_taskbar(TrayAppSwitcherPolicy::Visible, false));
+        assert!(!should_skip_taskbar(
+            TrayAppSwitcherPolicy::HiddenWhenWindowHidden,
+            true,
+        ));
+        assert!(should_skip_taskbar(
+            TrayAppSwitcherPolicy::HiddenWhenWindowHidden,
+            false,
+        ));
+    }
+
+    #[test]
+    fn tray_config_defaults_to_hidden_app_switcher_policy() {
+        let config =
+            TrayConfig::<TrayTestState>::new(TrayIconSource::rgba(vec![255, 255, 255, 255], 1, 1));
+
+        assert_eq!(config.app_switcher_policy, TrayAppSwitcherPolicy::Hidden);
+    }
+
+    #[test]
     fn tray_config_builder_sets_desktop_policy_and_click_behavior() {
         let config =
             TrayConfig::<TrayTestState>::new(TrayIconSource::rgba(vec![255, 255, 255, 255], 1, 1))
@@ -643,6 +767,7 @@ mod tests {
                 .icon_template(true)
                 .close_behavior(WindowCloseBehavior::HideToTray)
                 .activate_behavior(TrayActivateBehavior::ShowMainWindow)
+                .app_switcher_policy(TrayAppSwitcherPolicy::Visible)
                 .menu_on_left_click(true)
                 .menu_on_right_click(false)
                 .include_default_quit(false);
@@ -655,6 +780,7 @@ mod tests {
             config.activate_behavior,
             TrayActivateBehavior::ShowMainWindow
         );
+        assert_eq!(config.app_switcher_policy, TrayAppSwitcherPolicy::Visible);
         assert!(config.menu_on_left_click);
         assert!(!config.menu_on_right_click);
         assert!(!config.include_default_quit);

--- a/documentation/content/docs/guides/platform-shells-cli-and-testing.mdx
+++ b/documentation/content/docs/guides/platform-shells-cli-and-testing.mdx
@@ -43,6 +43,26 @@ Desktop, web, and mobile are runtime shells: they keep the app running in a host
 
 Those differences are host differences, not app-model differences. The same state, reducers, selectors, widgets, design system, and environment model stay at the center.
 
+## Desktop tray switcher policy
+
+Desktop tray apps should behave like tray apps by default. When you configure `DesktopApp::with_tray(...)`, Fission now defaults `TrayConfig::app_switcher_policy` to `TrayAppSwitcherPolicy::Hidden`. That is a breaking default: on macOS the app uses an accessory activation policy, on Windows the window asks winit to skip the taskbar, and on Linux the behavior is best-effort because window managers do not expose one portable switcher contract through winit.
+
+Use the explicit policy when your product needs the old foreground-app behavior:
+
+```rust
+use fission::prelude::*;
+use fission::{TrayAppSwitcherPolicy, TrayConfig, TrayIconSource};
+
+DesktopApp::<AppState, _>::new(App)
+    .with_tray(
+        TrayConfig::new(TrayIconSource::path("assets/tray.png"))
+            .app_switcher_policy(TrayAppSwitcherPolicy::Visible),
+    )
+    .run()
+```
+
+`TrayAppSwitcherPolicy::HiddenWhenWindowHidden` keeps the app visible in normal switchers while the main window is open, then switches to the tray-first behavior after `WindowCloseBehavior::HideToTray` or a tray action hides the window.
+
 ## The shared runtime is the same, even when wrappers differ
 
 When you choose `DesktopApp`, `WebApp`, `MobileApp`, or `TerminalApp`, you are not choosing a different application model. You are choosing which shell wrapper should boot the same runtime for the host you care about.


### PR DESCRIPTION
## What changed

- Adds `TrayAppSwitcherPolicy` to the desktop tray API.
- Defaults tray apps to `TrayAppSwitcherPolicy::Hidden`, so tray-first apps do not also appear in the app switcher/dock/taskbar where the platform supports that behavior.
- Applies the policy on macOS with the activation policy, on Windows with winit's skip-taskbar support, and as best-effort behavior on Linux where winit does not expose a portable taskbar/switcher contract.
- Documents the breaking default and the opt-out path with `TrayAppSwitcherPolicy::Visible`.

## Breaking change

`TrayConfig::new(...)` now defaults `app_switcher_policy` to `Hidden`. Apps that should keep the old foreground-app behavior must set:

```rust
.app_switcher_policy(TrayAppSwitcherPolicy::Visible)
```

## Validation

- `cargo fmt --all`
- `cargo test -p fission-shell-winit --features tray app_switcher_policy -- --nocapture`
- `cargo test -p fission-shell-winit --features tray tray_config -- --nocapture`
- `cargo check -p fission --features desktop-tray`
- `git diff --check`
