### PR TITLE
fix(widgets): preserve intrinsic flyout sizing

### DIFF
--- a/crates/authoring/fission-widgets/src/lib.rs
+++ b/crates/authoring/fission-widgets/src/lib.rs
@@ -348,24 +348,18 @@ struct FlyoutLowerer {
 impl InternalLowerer for FlyoutLowerer {
     fn lower_dyn(&self, cx: &mut InternalLoweringCx) -> WidgetId {
         let content_id = fission_core::internal::lower_widget(&self.content, cx);
-        // Create a marker node that tells the layout engine to reposition `content_id`
-        let marker_id = InternalIrBuilder::new(
+        let mut flyout = InternalIrBuilder::new(
             cx.next_node_id(),
             Op::Layout(fission_core::LayoutOp::Flyout {
                 anchor: self.anchor,
                 content: content_id,
             }),
-        )
-        .build(cx);
-
-        // Ensure both the content and marker are attached to the tree via a structural group.
-        let mut wrapper = InternalIrBuilder::new(
-            cx.next_node_id(),
-            Op::Structural(StructuralOp::Group { stable_hash: 0 }),
         );
-        wrapper.add_child(content_id);
-        wrapper.add_child(marker_id);
-        wrapper.build(cx)
+        // The flyout must own its content so layout measures that content with
+        // the flyout's loose constraints instead of the portal wrapper's tight
+        // viewport constraints.
+        flyout.add_child(content_id);
+        flyout.build(cx)
     }
 }
 

--- a/crates/tools/fission-test/tests/flyout_bounds.rs
+++ b/crates/tools/fission-test/tests/flyout_bounds.rs
@@ -1,7 +1,8 @@
 use fission_core::ui::{Button, Container, Positioned, Text, Widget, ZStack};
 use fission_core::{GlobalState, WidgetId, WidgetIdExt};
+use fission_render::{DisplayOp, Fill};
 use fission_test::TestHarness;
-use fission_widgets::Popover;
+use fission_widgets::{Popover, Tooltip};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -89,5 +90,66 @@ fn flyout_content_stays_within_viewport_bounds() {
     assert!(
         popup_rect.y() >= viewport.y() && popup_rect.bottom() <= viewport.bottom(),
         "popup should be clamped vertically within viewport: popup={popup_rect:?} viewport={viewport:?}"
+    );
+}
+
+#[derive(Clone)]
+struct TooltipRoot;
+
+impl From<TooltipRoot> for Widget {
+    fn from(_component: TooltipRoot) -> Self {
+        Tooltip {
+            id: WidgetId::explicit("intrinsic-tooltip"),
+            child: Container::new(Text::new("Anchor"))
+                .width(64.0)
+                .height(24.0)
+                .into(),
+            text: "Critical: 34".into(),
+            is_visible: true,
+            motion: None,
+        }
+        .into()
+    }
+}
+
+#[test]
+fn tooltip_surface_uses_intrinsic_size_inside_viewport_portal() {
+    let mut harness =
+        TestHarness::new_with_mock_measurer(State::default()).with_root_widget(TooltipRoot);
+    let tooltip_background = harness.env.theme.components.tooltip.bg_color;
+
+    harness.pump().expect("tooltip frame");
+
+    let display_list = harness
+        .get_last_display_list()
+        .expect("tooltip display list");
+    let tooltip_rect = display_list
+        .ops
+        .iter()
+        .find_map(|op| match op {
+            DisplayOp::DrawRect {
+                rect,
+                fill: Some(Fill::Solid(color)),
+                ..
+            } if color.r == tooltip_background.r
+                && color.g == tooltip_background.g
+                && color.b == tooltip_background.b
+                && color.a == tooltip_background.a =>
+            {
+                Some(*rect)
+            }
+            _ => None,
+        })
+        .expect("tooltip background");
+
+    assert!(
+        tooltip_rect.width() < display_list.bounds.width(),
+        "tooltip must not fill the viewport width: tooltip={tooltip_rect:?} viewport={:?}",
+        display_list.bounds
+    );
+    assert!(
+        tooltip_rect.height() < display_list.bounds.height(),
+        "tooltip must not fill the viewport height: tooltip={tooltip_rect:?} viewport={:?}",
+        display_list.bounds
     );
 }


### PR DESCRIPTION
## Summary

- make the `Flyout` layout node own its content instead of attaching the content as a structural sibling
- ensure flyout content is measured with the layout operation's loose constraints rather than a portal wrapper's tight viewport constraints
- add a regression test that renders a real tooltip through the desktop-style full-viewport portal wrapper

## Problem

A tooltip without explicit dimensions inherited the portal wrapper's tight viewport constraints. Its background therefore covered the entire window, with only the tooltip text visible in the top-left corner.

The flyout marker already contained the content ID, but the content was attached as a sibling under a structural group. This caused the group to measure it before the `Flyout` layout operation could apply loose constraints.

## Validation

- regression test fails before the fix with an 800x600 tooltip surface
- `cargo test -p fission-test --test flyout_bounds --test debug_menu_portal --test flyout_does_not_affect_content`
- `cargo test -p fission-widgets --tests`
