### PR TITLE
Add native packaging hooks for Windows and Linux

### DIFF
--- a/crates/tools/fission-command-core/src/windows_native.rs
+++ b/crates/tools/fission-command-core/src/windows_native.rs
@@ -9,6 +9,14 @@ use std::process::Command;
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NativeWindowsModuleConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cargo_manifest_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cargo_package: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub features: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub no_default_features: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nuget_packages_config: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nuget_packages_directory: Option<String>,
@@ -26,7 +34,11 @@ pub struct NativeWindowsModuleConfig {
 
 impl NativeWindowsModuleConfig {
     pub fn is_empty(&self) -> bool {
-        self.nuget_packages_config.is_none()
+        self.cargo_manifest_path.is_none()
+            && self.cargo_package.is_none()
+            && self.features.is_empty()
+            && !self.no_default_features
+            && self.nuget_packages_config.is_none()
             && self.nuget_packages_directory.is_none()
             && self.msbuild_project.is_none()
             && self.platform.is_none()
@@ -34,6 +46,10 @@ impl NativeWindowsModuleConfig {
             && self.test_binaries.is_empty()
             && self.products.is_empty()
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -74,27 +90,40 @@ pub fn build_windows_native_modules(
         if module.windows.is_empty() {
             continue;
         }
-        let native_tool_paths =
-            restore_windows_native_packages(&project_dir, &module.name, &module.windows)?;
-        let build_project = required_config_path(
-            &project_dir,
-            module.windows.msbuild_project.as_deref(),
-            &module.name,
-        )?;
         let platform = optional_value(module.windows.platform.as_deref()).unwrap_or("x64");
-        let target = optional_value(module.windows.build_target.as_deref()).unwrap_or("Build");
-        let mut command = Command::new("msbuild");
-        command
-            .arg(windows_external_tool_path(&build_project))
-            .arg("/m")
-            .arg(format!("/t:{target}"))
-            .arg(format!("/p:Configuration={configuration}"))
-            .arg(format!("/p:Platform={platform}"));
-        prepend_windows_native_tool_paths(&mut command, &native_tool_paths)?;
-        run_status(
-            &mut command,
-            &format!("Windows native module `{}`", module.name),
-        )?;
+        match windows_build_system(&module.name, &module.windows)? {
+            WindowsBuildSystem::Cargo => run_cargo_module_command(
+                &project_dir,
+                module.path.as_deref(),
+                &module.name,
+                &module.windows,
+                "build",
+                release,
+            )?,
+            WindowsBuildSystem::MsBuild => {
+                let native_tool_paths =
+                    restore_windows_native_packages(&project_dir, &module.name, &module.windows)?;
+                let build_project = required_config_path(
+                    &project_dir,
+                    module.windows.msbuild_project.as_deref(),
+                    &module.name,
+                )?;
+                let target =
+                    optional_value(module.windows.build_target.as_deref()).unwrap_or("Build");
+                let mut command = Command::new("msbuild");
+                command
+                    .arg(windows_external_tool_path(&build_project))
+                    .arg("/m")
+                    .arg(format!("/t:{target}"))
+                    .arg(format!("/p:Configuration={configuration}"))
+                    .arg(format!("/p:Platform={platform}"));
+                prepend_windows_native_tool_paths(&mut command, &native_tool_paths)?;
+                run_status(
+                    &mut command,
+                    &format!("Windows native module `{}`", module.name),
+                )?;
+            }
+        }
 
         for product in &module.windows.products {
             products.push(resolve_product(
@@ -225,6 +254,17 @@ pub fn test_windows_native_modules(project_dir: &Path, project: &FissionProject)
         if module.windows.is_empty() {
             continue;
         }
+        if windows_build_system(&module.name, &module.windows)? == WindowsBuildSystem::Cargo {
+            run_cargo_module_command(
+                &project_dir,
+                module.path.as_deref(),
+                &module.name,
+                &module.windows,
+                "test",
+                false,
+            )?;
+            continue;
+        }
         let platform = optional_value(module.windows.platform.as_deref()).unwrap_or("x64");
         for test_binary in &module.windows.test_binaries {
             let test_binary = expand_path(test_binary, "Debug", platform);
@@ -246,6 +286,120 @@ pub fn test_windows_native_modules(project_dir: &Path, project: &FissionProject)
     }
 
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WindowsBuildSystem {
+    Cargo,
+    MsBuild,
+}
+
+fn windows_build_system(
+    module_name: &str,
+    config: &NativeWindowsModuleConfig,
+) -> Result<WindowsBuildSystem> {
+    match (
+        optional_value(config.cargo_package.as_deref()),
+        optional_value(config.msbuild_project.as_deref()),
+    ) {
+        (Some(_), None) => {
+            if config.nuget_packages_config.is_some()
+                || config.nuget_packages_directory.is_some()
+                || config.build_target.is_some()
+                || !config.test_binaries.is_empty()
+            {
+                bail!(
+                    "Windows native Cargo module `{module_name}` cannot set MSBuild, NuGet, or test-binary options"
+                );
+            }
+            Ok(WindowsBuildSystem::Cargo)
+        }
+        (None, Some(_)) => {
+            if config.cargo_manifest_path.is_some()
+                || !config.features.is_empty()
+                || config.no_default_features
+            {
+                bail!(
+                    "Windows native MSBuild module `{module_name}` cannot set Cargo options"
+                );
+            }
+            Ok(WindowsBuildSystem::MsBuild)
+        }
+        (Some(_), Some(_)) => bail!(
+            "Windows native module `{module_name}` must select either `cargo_package` or `msbuild_project`, not both"
+        ),
+        (None, None) => bail!(
+            "Windows native module `{module_name}` requires `cargo_package` or `msbuild_project`"
+        ),
+    }
+}
+
+fn run_cargo_module_command(
+    project_dir: &Path,
+    module_path: Option<&str>,
+    module_name: &str,
+    config: &NativeWindowsModuleConfig,
+    cargo_command: &str,
+    release: bool,
+) -> Result<()> {
+    let package = optional_value(config.cargo_package.as_deref()).with_context(|| {
+        format!("Windows native module `{module_name}` requires `cargo_package`")
+    })?;
+    let manifest = resolve_cargo_manifest_path(
+        project_dir,
+        module_path,
+        config.cargo_manifest_path.as_deref(),
+        module_name,
+    )?;
+    let mut command = Command::new("cargo");
+    command
+        .arg(cargo_command)
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--package")
+        .arg(package)
+        .current_dir(project_dir);
+    if release && cargo_command == "build" {
+        command.arg("--release");
+    }
+    if config.no_default_features {
+        command.arg("--no-default-features");
+    }
+    if !config.features.is_empty() {
+        let features = config
+            .features
+            .iter()
+            .map(|feature| required_value(feature, "Windows native Cargo feature"))
+            .collect::<Result<Vec<_>>>()?
+            .join(",");
+        command.arg("--features").arg(features);
+    }
+    run_status(
+        &mut command,
+        &format!("Windows native module `{module_name}` Cargo {cargo_command}"),
+    )
+}
+
+fn resolve_cargo_manifest_path(
+    project_dir: &Path,
+    module_path: Option<&str>,
+    configured: Option<&str>,
+    module_name: &str,
+) -> Result<PathBuf> {
+    let manifest = if let Some(configured) = optional_value(configured) {
+        resolve_project_path(project_dir, configured)
+    } else if let Some(module_path) = optional_value(module_path) {
+        resolve_project_path(project_dir, module_path).join("Cargo.toml")
+    } else {
+        project_dir.join("Cargo.toml")
+    };
+    if !manifest.is_file() {
+        bail!(
+            "Windows native Cargo manifest for module `{module_name}` does not exist: {}",
+            manifest.display()
+        );
+    }
+    Ok(manifest)
 }
 
 pub fn stage_windows_runtime_products(
@@ -501,6 +655,57 @@ kind = "driver-package"
             module.products[1].kind,
             NativeWindowsProductKind::DriverPackage
         );
+    }
+
+    #[test]
+    fn parses_windows_cargo_native_products() {
+        let project: FissionProject = toml::from_str(
+            r#"
+targets = ["windows"]
+
+[app]
+name = "demo"
+app_id = "com.example.demo"
+
+[[native.modules]]
+name = "demo-helper"
+path = "../demo-helper"
+
+[native.modules.windows]
+cargo_package = "demo-helper"
+features = ["installer"]
+no_default_features = true
+
+[[native.modules.windows.products]]
+name = "helper"
+path = "../../target/{profile}/demo-helper.exe"
+kind = "runtime"
+destination = "tools/demo-helper.exe"
+"#,
+        )
+        .unwrap();
+
+        let module = &project.native.modules[0].windows;
+        assert_eq!(module.cargo_package.as_deref(), Some("demo-helper"));
+        assert_eq!(module.features, ["installer"]);
+        assert!(module.no_default_features);
+        assert_eq!(
+            windows_build_system("demo-helper", module).unwrap(),
+            WindowsBuildSystem::Cargo
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_windows_native_build_systems() {
+        let config = NativeWindowsModuleConfig {
+            cargo_package: Some("demo".into()),
+            msbuild_project: Some("Demo.sln".into()),
+            ..Default::default()
+        };
+        let error = windows_build_system("demo", &config).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("either `cargo_package` or `msbuild_project`"));
     }
 
     #[test]

--- a/crates/tools/fission-command-core/src/windows_native.rs
+++ b/crates/tools/fission-command-core/src/windows_native.rs
@@ -85,7 +85,7 @@ pub fn build_windows_native_modules(
         let target = optional_value(module.windows.build_target.as_deref()).unwrap_or("Build");
         let mut command = Command::new("msbuild");
         command
-            .arg(&build_project)
+            .arg(windows_external_tool_path(&build_project))
             .arg("/m")
             .arg(format!("/t:{target}"))
             .arg(format!("/p:Configuration={configuration}"))
@@ -141,9 +141,9 @@ fn restore_windows_native_packages(
     let mut command = Command::new("nuget");
     command
         .arg("restore")
-        .arg(&packages_config)
+        .arg(windows_external_tool_path(&packages_config))
         .arg("-PackagesDirectory")
-        .arg(&packages_directory)
+        .arg(windows_external_tool_path(&packages_directory))
         .arg("-NonInteractive");
     run_status(
         &mut command,
@@ -203,7 +203,10 @@ fn prepend_windows_native_tool_paths(command: &mut Command, paths: &[PathBuf]) -
     if paths.is_empty() {
         return Ok(());
     }
-    let mut combined = paths.to_vec();
+    let mut combined = paths
+        .iter()
+        .map(|path| windows_external_tool_path(path))
+        .collect::<Vec<_>>();
     if let Some(current) = env::var_os("PATH") {
         combined.extend(env::split_paths(&current));
     }
@@ -234,7 +237,7 @@ pub fn test_windows_native_modules(project_dir: &Path, project: &FissionProject)
                 );
             }
             let mut command = Command::new("vstest.console.exe");
-            command.arg(&test_binary);
+            command.arg(windows_external_tool_path(&test_binary));
             run_status(
                 &mut command,
                 &format!("Windows native test binary `{}`", test_binary.display()),
@@ -386,6 +389,44 @@ fn canonical_project_dir(project_dir: &Path) -> Result<PathBuf> {
             project_dir.display()
         )
     })
+}
+
+fn windows_external_tool_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+        let encoded = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        return normalize_windows_verbatim_units(&encoded)
+            .map(|units| PathBuf::from(OsString::from_wide(&units)))
+            .unwrap_or_else(|| path.to_path_buf());
+    }
+
+    #[cfg(not(windows))]
+    path.to_path_buf()
+}
+
+#[cfg(any(windows, test))]
+fn normalize_windows_verbatim_units(path: &[u16]) -> Option<Vec<u16>> {
+    const VERBATIM_PREFIX: &[u16] = &[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16];
+    const VERBATIM_UNC_PREFIX: &[u16] = &[
+        b'\\' as u16,
+        b'\\' as u16,
+        b'?' as u16,
+        b'\\' as u16,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        b'\\' as u16,
+    ];
+
+    if let Some(remainder) = path.strip_prefix(VERBATIM_UNC_PREFIX) {
+        let mut normalized = vec![b'\\' as u16, b'\\' as u16];
+        normalized.extend_from_slice(remainder);
+        return Some(normalized);
+    }
+    path.strip_prefix(VERBATIM_PREFIX).map(Vec::from)
 }
 
 fn required_value<'a>(value: &'a str, label: &str) -> Result<&'a str> {
@@ -540,6 +581,37 @@ kind = "driver-package"
         let paths = discover_windows_native_tool_paths(&root, "x86_64").unwrap();
 
         assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn normalizes_verbatim_drive_path_for_windows_tools() {
+        let path = r"\\?\D:\a\demo\packages".encode_utf16().collect::<Vec<_>>();
+        let normalized = normalize_windows_verbatim_units(&path).unwrap();
+
+        assert_eq!(
+            String::from_utf16(normalized.as_slice()).unwrap(),
+            r"D:\a\demo\packages"
+        );
+    }
+
+    #[test]
+    fn normalizes_verbatim_unc_path_for_windows_tools() {
+        let path = r"\\?\UNC\server\share\packages"
+            .encode_utf16()
+            .collect::<Vec<_>>();
+        let normalized = normalize_windows_verbatim_units(&path).unwrap();
+
+        assert_eq!(
+            String::from_utf16(normalized.as_slice()).unwrap(),
+            r"\\server\share\packages"
+        );
+    }
+
+    #[test]
+    fn leaves_non_verbatim_windows_path_unchanged() {
+        let path = r"D:\a\demo\packages".encode_utf16().collect::<Vec<_>>();
+
+        assert!(normalize_windows_verbatim_units(&path).is_none());
     }
 
     fn unique_dir(label: &str) -> PathBuf {

--- a/crates/tools/fission-command-package/src/lib_tests.rs
+++ b/crates/tools/fission-command-package/src/lib_tests.rs
@@ -1215,6 +1215,35 @@ fn windows_msix_readiness_checks_manifest_packager_and_signing_source() {
 }
 
 #[test]
+fn linux_run_readiness_checks_configured_installer_script() {
+    let dir = unique_dir("linux-run-installer-readiness");
+    write_minimal_site(&dir);
+    fs::write(
+        dir.join("fission.toml"),
+        r#"
+targets = ["linux"]
+
+[app]
+name = "demo"
+app_id = "com.example.demo"
+
+[package.linux.run]
+installer_script = "platforms/linux/package-run.sh"
+"#,
+    )
+    .unwrap();
+
+    let checks = readiness_package(&dir, Some(Target::Linux), Some(PackageFormat::Run), false)
+        .expect("readiness should report a missing custom installer");
+    let installer = checks
+        .iter()
+        .find(|check| check.id == "release.package.linux_run_installer_script_exists")
+        .expect("custom Linux installer readiness check");
+
+    assert_eq!(installer.status, CheckStatus::Missing);
+}
+
+#[test]
 fn terminal_run_is_a_supported_package_pair() {
     let dir = unique_dir("terminal-run-readiness");
     write_minimal_site(&dir);

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -30,6 +30,7 @@ struct PackageManifest {
 #[derive(Debug, Deserialize, Default)]
 struct PackageRoot {
     docker: Option<DockerPackageConfig>,
+    linux: Option<LinuxPackageConfig>,
     windows: Option<WindowsPackageConfig>,
     #[serde(default)]
     secondary_artifacts: Vec<SecondaryArtifactConfig>,
@@ -37,6 +38,16 @@ struct PackageRoot {
     symbols: Vec<SecondaryArtifactConfig>,
     #[serde(default)]
     crash_assets: Vec<SecondaryArtifactConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+struct LinuxPackageConfig {
+    run: Option<LinuxRunPackageConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+struct LinuxRunPackageConfig {
+    installer_script: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -252,7 +263,8 @@ fn package_linux_run(options: &PackageOptions) -> Result<ArtifactManifest> {
     let native_products =
         build_linux_native_modules(&options.project_dir, &project, options.release)?;
     stage_linux_native_products(&payload_dir, &native_products)?;
-    write_linux_native_products_manifest(&payload_dir, &native_products, profile, "run")?;
+    let native_products_manifest =
+        write_linux_native_products_manifest(&payload_dir, &native_products, profile, "run")?;
     copy_optional_assets(&options.project_dir, &payload_dir)?;
 
     let package_name = sanitize_file_stem(&project.app.name);
@@ -261,7 +273,45 @@ fn package_linux_run(options: &PackageOptions) -> Result<ArtifactManifest> {
         cargo_package_version(&options.project_dir).unwrap_or_else(|| "0.0.0".to_string()),
         profile
     ));
-    write_linux_run(&payload_dir, &run_path, &project.app.name, &executable_name)?;
+    let linux = linux_package_config(&options.project_dir)?;
+    if let Some(script) = linux
+        .run
+        .and_then(|run| run.installer_script)
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let script = resolve_project_path(&options.project_dir, script.to_string());
+        let environment = linux_packaging_environment(
+            &payload_dir,
+            &payload_dir.join(&executable_name),
+            &native_products_manifest,
+        );
+        let output_path = run_packaging_script_with_env(
+            &options.project_dir,
+            &script,
+            options.release,
+            &environment,
+        )?
+        .with_context(|| format!("{} did not print a .run installer path", script.display()))?;
+        if output_path.extension().and_then(OsStr::to_str) != Some("run") {
+            bail!(
+                "{} printed {}, expected a .run installer",
+                script.display(),
+                output_path.display()
+            );
+        }
+        fs::copy(&output_path, &run_path).with_context(|| {
+            format!(
+                "failed to copy Linux installer {} to {}",
+                output_path.display(),
+                run_path.display()
+            )
+        })?;
+        set_executable(&run_path)?;
+    } else {
+        write_linux_run(&payload_dir, &run_path, &project.app.name, &executable_name)?;
+    }
     fs::remove_dir_all(&payload_dir).ok();
     finish_artifact_manifest(&project, options, &staging_dir, profile)
 }
@@ -683,6 +733,13 @@ fn windows_package_config(project_dir: &Path) -> Result<WindowsPackageConfig> {
     Ok(package_manifest(project_dir)?
         .package
         .and_then(|package| package.windows)
+        .unwrap_or_default())
+}
+
+fn linux_package_config(project_dir: &Path) -> Result<LinuxPackageConfig> {
+    Ok(package_manifest(project_dir)?
+        .package
+        .and_then(|package| package.linux)
         .unwrap_or_default())
 }
 
@@ -2027,6 +2084,27 @@ fn windows_packaging_environment(binary: &Path, manifest: &Path) -> Vec<(OsStrin
     ]
 }
 
+fn linux_packaging_environment(
+    payload_dir: &Path,
+    binary: &Path,
+    manifest: &Path,
+) -> Vec<(OsString, OsString)> {
+    vec![
+        (
+            OsString::from("FISSION_LINUX_PAYLOAD_DIR"),
+            payload_dir.as_os_str().to_os_string(),
+        ),
+        (
+            OsString::from("LINUX_BINARY"),
+            binary.as_os_str().to_os_string(),
+        ),
+        (
+            OsString::from("FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST"),
+            manifest.as_os_str().to_os_string(),
+        ),
+    ]
+}
+
 fn run_packaging_script(
     project_dir: &Path,
     script: &Path,
@@ -2075,6 +2153,7 @@ fn run_packaging_script_with_env(
     if release {
         command.env("ANDROID_PROFILE", "release");
         command.env("IOS_PROFILE", "release");
+        command.env("LINUX_PROFILE", "release");
         command.env("WINDOWS_PROFILE", "release");
     }
     for (key, value) in environment {

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -538,3 +538,60 @@ exe_installer_script = "platforms/windows/package-exe.ps1"
     );
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn linux_package_config_reads_run_installer_script() {
+    let root = std::env::temp_dir().join(format!(
+        "fission-linux-package-config-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("fission.toml"),
+        r#"
+[package.linux.run]
+installer_script = "platforms/linux/package-run.sh"
+"#,
+    )
+    .unwrap();
+
+    let config = linux_package_config(&root).unwrap();
+
+    assert_eq!(
+        config.run.and_then(|run| run.installer_script).as_deref(),
+        Some("platforms/linux/package-run.sh")
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn linux_packaging_environment_exposes_payload_binary_and_manifest() {
+    let root = PathBuf::from("/tmp/fission-linux-package");
+    let environment = linux_packaging_environment(
+        &root,
+        &root.join("demo"),
+        &root.join(".fission/native/linux-products.json"),
+    );
+    let environment = environment
+        .into_iter()
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    assert_eq!(
+        environment.get(&OsString::from("FISSION_LINUX_PAYLOAD_DIR")),
+        Some(&root.as_os_str().to_os_string())
+    );
+    assert_eq!(
+        environment.get(&OsString::from("LINUX_BINARY")),
+        Some(&root.join("demo").as_os_str().to_os_string())
+    );
+    assert_eq!(
+        environment.get(&OsString::from("FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST")),
+        Some(
+            &root
+                .join(".fission/native/linux-products.json")
+                .as_os_str()
+                .to_os_string()
+        )
+    );
+}

--- a/crates/tools/fission-command-package/src/readiness.rs
+++ b/crates/tools/fission-command-package/src/readiness.rs
@@ -627,6 +627,14 @@ pub(super) fn readiness_package_tools(
                 "cargo",
                 "Install Rust from https://rustup.rs/ and ensure cargo is on PATH.",
             ));
+            if let Some(script) = linux_run_installer_script(project_dir) {
+                checks.push(check_path(
+                    "release.package.linux_run_installer_script_exists",
+                    script,
+                    "Linux .run installer script exists",
+                    "Restore package.linux.run.installer_script or remove that field to use Fission's user-local installer.",
+                ));
+            }
         }
         (Target::Terminal, PackageFormat::Run) => {
             checks.push(check_tool(
@@ -813,6 +821,26 @@ fn windows_exe_installer_script(project_dir: &Path) -> Option<PathBuf> {
         .get("package")?
         .get("windows")?
         .get("exe_installer_script")?
+        .as_str()?
+        .trim();
+    if configured.is_empty() {
+        return None;
+    }
+    let path = Path::new(configured);
+    Some(if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_dir.join(path)
+    })
+}
+
+fn linux_run_installer_script(project_dir: &Path) -> Option<PathBuf> {
+    let root = read_package_identity_toml(project_dir).ok()?;
+    let configured = root
+        .get("package")?
+        .get("linux")?
+        .get("run")?
+        .get("installer_script")?
         .as_str()?
         .trim();
     if configured.is_empty() {

--- a/docs/post-build-lifecycle.md
+++ b/docs/post-build-lifecycle.md
@@ -252,6 +252,10 @@ default_scope = "user"
 include_desktop_entry = true
 include_appstream_metadata = true
 compression = "zstd"
+# Optional. The script receives FISSION_LINUX_PAYLOAD_DIR, LINUX_BINARY,
+# FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST, and LINUX_PROFILE, and prints the
+# path to the completed .run installer.
+installer_script = "platforms/linux/package-run.sh"
 
 [package.macos]
 bundle_id = "com.example.todo"


### PR DESCRIPTION
## Summary

This adds the native build and packaging hooks required by applications that ship privileged Windows and Linux components:

- normalize Windows native tool paths before invoking NuGet, MSBuild, WDK, and test tools;
- support Cargo-built Windows native modules alongside existing MSBuild modules;
- allow Linux projects to provide a custom system-level `.run` installer while Fission retains ownership of builds, native-product staging, and artifact manifests.

The retained-effect and intrinsic-flyout fixes originally developed with this branch were split into focused PRs and are already merged as #125 and #127.

## Windows Cargo native modules

A Windows native module may now select Cargo:

```toml
[[native.modules]]
name = "installer-helper"
path = "../installer-helper"

[native.modules.windows]
cargo_package = "installer-helper"
features = ["installer"]
no_default_features = true

[[native.modules.windows.products]]
name = "installer-helper"
path = "../../target/{profile}/installer-helper.exe"
kind = "runtime"
destination = "tools/installer-helper.exe"
```

Windows modules must select exactly one build system: `cargo_package` or `msbuild_project`. Cargo modules support an explicit manifest, features, and `no_default_features`; incompatible Cargo/MSBuild options are rejected. Products continue through the existing typed native-products manifest.

## Windows native paths

External Windows tool paths are normalized before they reach NuGet, MSBuild, WDK, and native test commands. This removes verbatim path prefixes that those tools do not reliably accept while preserving ordinary and UNC paths.

## Linux custom installers

Projects may configure:

```toml
[package.linux.run]
installer_script = "platforms/linux/package-run.sh"
```

Fission builds the application and native products, stages the payload, writes the typed native-products manifest, and invokes the script with:

- `FISSION_LINUX_PAYLOAD_DIR`
- `LINUX_BINARY`
- `FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST`
- `LINUX_PROFILE`

The script returns the generated `.run` path; Fission copies it into the standard package output and emits the normal artifact manifest.

## Validation

- `cargo test -p fission-command-core windows_native -- --nocapture` (11 passed)
- `cargo test -p fission-command-package` (106 passed)
- installed and exercised the patched Fission CLI downstream
