### PR TITLE
Package desktop project assets consistently

### DIFF
--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -1064,6 +1064,44 @@ fn copy_dir_contents(source: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Stages the project's `assets` directory as an application resource tree.
+///
+/// Desktop run and package commands use the same `assets` layout on every
+/// platform so applications can ship large resources without compiling them
+/// into the executable. A project without an `assets` directory is valid.
+pub fn stage_project_assets(
+    project_dir: &Path,
+    destination_root: &Path,
+) -> Result<Option<PathBuf>> {
+    let source = project_dir.join("assets");
+    if !source.exists() {
+        return Ok(None);
+    }
+    if !source.is_dir() {
+        bail!(
+            "project assets path {} must be a directory",
+            source.display()
+        );
+    }
+    let destination = destination_root.join("assets");
+    if destination.exists() {
+        fs::remove_dir_all(&destination).with_context(|| {
+            format!(
+                "failed to clear staged project assets {}",
+                destination.display()
+            )
+        })?;
+    }
+    copy_dir_contents(&source, &destination).with_context(|| {
+        format!(
+            "failed to stage project assets from {} to {}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    Ok(Some(destination))
+}
+
 fn apply_mobile_run_script_hardening(root: &Path, project: &FissionProject) -> Result<()> {
     if project.targets.contains(&Target::Ios) {
         apply_ios_run_script_hardening(root)?;
@@ -5664,6 +5702,48 @@ mod tests {
         fs::remove_dir_all(&dir).ok();
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn project_assets_stage_nested_resources_and_replace_stale_output() {
+        let dir = unique_dir("stage-project-assets");
+        let project = dir.join("project");
+        let destination = dir.join("destination");
+        fs::create_dir_all(project.join("assets/intelligence")).unwrap();
+        fs::create_dir_all(destination.join("assets/stale")).unwrap();
+        fs::write(
+            project.join("assets/intelligence/base.pdb.zst"),
+            b"signed base",
+        )
+        .unwrap();
+        fs::write(destination.join("assets/stale/old"), b"stale").unwrap();
+
+        let staged = stage_project_assets(&project, &destination)
+            .unwrap()
+            .expect("assets directory should be staged");
+
+        assert_eq!(staged, destination.join("assets"));
+        assert_eq!(
+            fs::read(staged.join("intelligence/base.pdb.zst")).unwrap(),
+            b"signed base"
+        );
+        assert!(!staged.join("stale/old").exists());
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn project_assets_are_optional_but_must_be_a_directory_when_present() {
+        let dir = unique_dir("stage-project-assets-validation");
+        let project = dir.join("project");
+        let destination = dir.join("destination");
+        fs::create_dir_all(&project).unwrap();
+
+        assert_eq!(stage_project_assets(&project, &destination).unwrap(), None);
+
+        fs::write(project.join("assets"), b"not a directory").unwrap();
+        let error = stage_project_assets(&project, &destination).unwrap_err();
+        assert!(error.to_string().contains("project assets path"));
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -5,10 +5,10 @@ use fission_command_core::{
     build_linux_native_modules, build_windows_native_modules, cargo_package_name,
     embed_and_sign_macos_native_modules, normalized_extension, read_macos_package_config,
     read_project_config, resolve_app_icon, sign_macos_app_if_configured,
-    stage_linux_native_products, stage_windows_runtime_products, sync_platform_config,
-    BuiltLinuxNativeProduct, BuiltWindowsNativeProduct, FissionProject, MacosNativeBundleMode,
-    MacosPackageConfig, NativeLinuxProductKind, NativeWindowsProductKind, PlatformCapability,
-    Target,
+    stage_linux_native_products, stage_project_assets, stage_windows_runtime_products,
+    sync_platform_config, BuiltLinuxNativeProduct, BuiltWindowsNativeProduct, FissionProject,
+    MacosNativeBundleMode, MacosPackageConfig, NativeLinuxProductKind, NativeWindowsProductKind,
+    PlatformCapability, Target,
 };
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -265,7 +265,7 @@ fn package_linux_run(options: &PackageOptions) -> Result<ArtifactManifest> {
     stage_linux_native_products(&payload_dir, &native_products)?;
     let native_products_manifest =
         write_linux_native_products_manifest(&payload_dir, &native_products, profile, "run")?;
-    copy_optional_assets(&options.project_dir, &payload_dir)?;
+    stage_project_assets(&options.project_dir, &payload_dir)?;
 
     let package_name = sanitize_file_stem(&project.app.name);
     let run_path = staging_dir.join(format!(
@@ -336,7 +336,7 @@ fn package_terminal_run(options: &PackageOptions) -> Result<ArtifactManifest> {
             payload_dir.display()
         )
     })?;
-    copy_optional_assets(&options.project_dir, &payload_dir)?;
+    stage_project_assets(&options.project_dir, &payload_dir)?;
 
     let package_name = sanitize_file_stem(&project.app.name);
     let run_path = staging_dir.join(format!(
@@ -438,7 +438,7 @@ fn package_windows_exe(options: &PackageOptions) -> Result<ArtifactManifest> {
             profile,
             "exe",
         )?;
-        let environment = windows_packaging_environment(&binary, &manifest);
+        let environment = windows_packaging_environment(&options.project_dir, &binary, &manifest)?;
         let output_path = run_packaging_script_with_env(
             &options.project_dir,
             &script,
@@ -471,7 +471,7 @@ fn package_windows_exe(options: &PackageOptions) -> Result<ArtifactManifest> {
             format!("failed to copy {} to {}", binary.display(), dest.display())
         })?;
         stage_windows_runtime_products(&staging_dir, &native_products)?;
-        copy_optional_assets(&options.project_dir, &staging_dir)?;
+        stage_project_assets(&options.project_dir, &staging_dir)?;
     }
     finish_artifact_manifest(&project, options, &staging_dir, profile)
 }
@@ -541,7 +541,7 @@ fn package_with_project_script(
             profile,
             options.format.as_str(),
         )?;
-        environment = windows_packaging_environment(&binary, &manifest);
+        environment = windows_packaging_environment(&options.project_dir, &binary, &manifest)?;
     }
     let output_path = run_packaging_script_with_env(
         &options.project_dir,
@@ -1572,6 +1572,7 @@ fn create_macos_app_bundle(
             )
         })?;
     }
+    stage_project_assets(&options.project_dir, &resources)?;
     let (version, build) = resolved_macos_bundle_version(&options.project_dir)?;
     let plist = render_info_plist(project, &app_name, &executable, macos, &version, &build);
     fs::write(contents.join("Info.plist"), plist)?;
@@ -1911,14 +1912,6 @@ fn set_executable(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn copy_optional_assets(project_dir: &Path, dest: &Path) -> Result<()> {
-    let assets = project_dir.join("assets");
-    if assets.exists() {
-        copy_dir_contents(&assets, &dest.join("assets"))?;
-    }
-    Ok(())
-}
-
 #[derive(Serialize)]
 struct LinuxNativeProductsManifest<'a> {
     schema_version: u32,
@@ -2071,8 +2064,12 @@ fn write_windows_native_products_manifest(
     Ok(path)
 }
 
-fn windows_packaging_environment(binary: &Path, manifest: &Path) -> Vec<(OsString, OsString)> {
-    vec![
+fn windows_packaging_environment(
+    project_dir: &Path,
+    binary: &Path,
+    manifest: &Path,
+) -> Result<Vec<(OsString, OsString)>> {
+    let mut environment = vec![
         (
             OsString::from("WINDOWS_BINARY"),
             binary.as_os_str().to_os_string(),
@@ -2081,7 +2078,21 @@ fn windows_packaging_environment(binary: &Path, manifest: &Path) -> Vec<(OsStrin
             OsString::from("FISSION_WINDOWS_NATIVE_PRODUCTS_MANIFEST"),
             manifest.as_os_str().to_os_string(),
         ),
-    ]
+    ];
+    let assets = project_dir.join("assets");
+    if assets.exists() && !assets.is_dir() {
+        bail!(
+            "project assets path {} must be a directory",
+            assets.display()
+        );
+    }
+    if assets.exists() {
+        environment.push((
+            OsString::from("FISSION_WINDOWS_ASSETS_DIR"),
+            assets.into_os_string(),
+        ));
+    }
+    Ok(environment)
 }
 
 fn linux_packaging_environment(

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -540,6 +540,41 @@ exe_installer_script = "platforms/windows/package-exe.ps1"
 }
 
 #[test]
+fn windows_packaging_environment_exposes_validated_project_assets() {
+    let root = std::env::temp_dir().join(format!(
+        "fission-windows-package-assets-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("assets/intelligence")).unwrap();
+
+    let environment = windows_packaging_environment(
+        &root,
+        &root.join("demo.exe"),
+        &root.join(".fission/native/windows-products.json"),
+    )
+    .unwrap()
+    .into_iter()
+    .collect::<std::collections::BTreeMap<_, _>>();
+
+    assert_eq!(
+        environment.get(&OsString::from("FISSION_WINDOWS_ASSETS_DIR")),
+        Some(&root.join("assets").as_os_str().to_os_string())
+    );
+
+    fs::remove_dir_all(root.join("assets")).unwrap();
+    fs::write(root.join("assets"), b"not a directory").unwrap();
+    let error = windows_packaging_environment(
+        &root,
+        &root.join("demo.exe"),
+        &root.join(".fission/native/windows-products.json"),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("project assets path"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn linux_package_config_reads_run_installer_script() {
     let root = std::env::temp_dir().join(format!(
         "fission-linux-package-config-{}",

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -5,9 +5,10 @@ use fission_command_core::{
     build_linux_native_modules, build_macos_native_modules, build_windows_native_modules,
     embed_and_sign_macos_native_modules, ios_executable_name, normalized_extension,
     read_macos_run_config, read_project_config, resolve_app_icon, sign_macos_app_if_configured,
-    stage_linux_native_products, stage_windows_runtime_products, sync_platform_config,
-    test_linux_native_modules, test_macos_native_modules, test_windows_native_modules,
-    FissionProject, MacosNativeBundleMode, MacosPackageConfig, PlatformCapability, Target,
+    stage_linux_native_products, stage_project_assets, stage_windows_runtime_products,
+    sync_platform_config, test_linux_native_modules, test_macos_native_modules,
+    test_windows_native_modules, FissionProject, MacosNativeBundleMode, MacosPackageConfig,
+    PlatformCapability, Target,
 };
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -1305,6 +1306,7 @@ fn package_macos_run_app(
             )
         })?;
     }
+    stage_project_assets(&project_dir, &resources_dir)?;
 
     fs::write(
         contents.join("Info.plist"),
@@ -1385,6 +1387,7 @@ fn package_linux_run_app(
     )?;
     let native_products = build_linux_native_modules(&project_dir, project, release)?;
     stage_linux_native_products(&app_root, &native_products)?;
+    stage_project_assets(&project_dir, &app_root)?;
     Ok(DesktopRunApp { executable })
 }
 
@@ -1441,6 +1444,7 @@ fn package_windows_run_app(
     )?;
     let native_products = build_windows_native_modules(&project_dir, project, release)?;
     stage_windows_runtime_products(&app_root, &native_products)?;
+    stage_project_assets(&project_dir, &app_root)?;
     Ok(DesktopRunApp { executable })
 }
 

--- a/documentation/content/docs/build-and-package/overview.mdx
+++ b/documentation/content/docs/build-and-package/overview.mdx
@@ -41,6 +41,28 @@ Every package format should produce an `artifact-manifest.json`. That manifest r
 
 Release commands should consume the manifest. That keeps publishing safe to retry because the command can tell exactly what was built and what it is about to upload.
 
+## Application resources
+
+Put runtime files that must travel with a desktop or terminal application under
+the project's `assets/` directory. Fission preserves the complete directory
+tree for both `fission run` and `fission package`; projects without `assets/`
+remain valid.
+
+Desktop applications resolve the staged tree from the application resource
+root:
+
+| Target | Staged path |
+| --- | --- |
+| macOS | `Contents/Resources/assets/` inside the `.app` |
+| Linux | `assets/` beside the packaged application directories |
+| Windows | `assets/` beside the executable |
+
+Custom Windows packaging scripts receive the source directory in
+`FISSION_WINDOWS_ASSETS_DIR` and are responsible for preserving that tree in
+their installer. Fission rejects an `assets` path that exists but is not a
+directory. On macOS, resources are staged before the application bundle is
+signed.
+
 ## Signing boundaries
 
 Signing is platform-owned. Fission orchestrates checks, configuration, command flow, and receipts, but platform signing should use the tools provided by the platform owner.


### PR DESCRIPTION
## Summary

- stage a project's complete `assets/` tree for macOS, Linux, Windows, and terminal packages
- preserve the same resource layout for desktop `fission run` bundles
- expose `FISSION_WINDOWS_ASSETS_DIR` to custom Windows packaging scripts
- validate malformed asset paths and stage macOS resources before app signing
- document the runtime resource layout

## Validation

- `cargo test --locked -p fission-command-core -p fission-command-package -p fission-command-run` (147 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

Strict workspace clippy remains blocked by pre-existing warnings outside this change in design-system codegen, text engine, macros, diagnostics, IR, and command-core scaffolding.