### PR TITLE
fix(cli): resolve native Cargo products from metadata target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "anyhow",
  "clap",
  "serde",
+ "serde_json",
  "toml 0.8.2",
  "toml_edit 0.23.10+spec-1.0.0",
 ]

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -13,5 +13,6 @@ readme = "README.md"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 toml = "0.8"
 toml_edit = "0.23"

--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -16,6 +16,7 @@ mod icons;
 mod linux_native;
 mod macos_native;
 mod macos_signing;
+mod native_cargo;
 mod splash;
 mod windows_native;
 pub use icons::{copy_icon_for_bundle, normalized_extension, resolve_app_icon, ResolvedIcon};

--- a/crates/tools/fission-command-core/src/linux_native.rs
+++ b/crates/tools/fission-command-core/src/linux_native.rs
@@ -1,4 +1,7 @@
-use crate::FissionProject;
+use crate::{
+    FissionProject,
+    native_cargo::{cargo_target_directory, expand_cargo_target_directory},
+};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -72,7 +75,7 @@ pub fn build_linux_native_modules(
         if module.linux.is_empty() {
             continue;
         }
-        run_cargo_module_command(
+        let target_directory = run_cargo_module_command(
             &project_dir,
             module.path.as_deref(),
             &module.name,
@@ -88,6 +91,7 @@ pub fn build_linux_native_modules(
                 product,
                 profile,
                 env::consts::ARCH,
+                &target_directory,
             )?);
         }
     }
@@ -138,7 +142,7 @@ fn run_cargo_module_command(
     config: &NativeLinuxModuleConfig,
     cargo_command: &str,
     release: bool,
-) -> Result<()> {
+) -> Result<PathBuf> {
     let package = required_optional_value(
         config.cargo_package.as_deref(),
         &format!("Linux native module `{module_name}` requires `cargo_package`"),
@@ -175,7 +179,8 @@ fn run_cargo_module_command(
     run_status(
         &mut command,
         &format!("Linux native module `{module_name}` Cargo {cargo_command}"),
-    )
+    )?;
+    cargo_target_directory(project_dir, &manifest, module_name, "Linux")
 }
 
 fn resolve_manifest_path(
@@ -211,10 +216,18 @@ fn resolve_product(
     product: &NativeLinuxProductConfig,
     profile: &str,
     architecture: &str,
+    cargo_target_directory: &Path,
 ) -> Result<BuiltLinuxNativeProduct> {
     let name = required_value(&product.name, "Linux native product name")?;
     let path = required_value(&product.path, "Linux native product path")?;
-    let source = resolve_project_path(project_dir, &expand_path(path, profile, architecture));
+    let expanded = expand_path(
+        path,
+        profile,
+        architecture,
+        cargo_target_directory,
+        module_name,
+    )?;
+    let source = resolve_project_path(project_dir, &expanded);
     if !source.exists() {
         bail!(
             "Linux native product `{name}` from module `{module_name}` does not exist: {}",
@@ -264,16 +277,28 @@ fn validate_relative_destination(destination: &Path) -> Result<()> {
     Ok(())
 }
 
-fn expand_path(value: &str, profile: &str, architecture: &str) -> String {
+fn expand_path(
+    value: &str,
+    profile: &str,
+    architecture: &str,
+    cargo_target_directory: &Path,
+    module_name: &str,
+) -> Result<String> {
     let configuration = if profile == "release" {
         "Release"
     } else {
         "Debug"
     };
-    value
+    let value = value
         .replace("{profile}", profile)
         .replace("{configuration}", configuration)
-        .replace("{architecture}", architecture)
+        .replace("{architecture}", architecture);
+    expand_cargo_target_directory(
+        &value,
+        Some(cargo_target_directory),
+        module_name,
+        "Linux",
+    )
 }
 
 fn copy_product(source: &Path, destination: &Path) -> Result<()> {
@@ -389,11 +414,14 @@ destination = "libexec/demo-mount-helper"
     fn expands_profile_configuration_and_architecture_tokens() {
         assert_eq!(
             expand_path(
-                "target/{architecture}/{configuration}/{profile}",
+                "{cargo_target_dir}/{architecture}/{configuration}/{profile}",
                 "release",
-                "x86_64"
-            ),
-            "target/x86_64/Release/release"
+                "x86_64",
+                Path::new("/shared/cargo"),
+                "demo-native",
+            )
+            .unwrap(),
+            "/shared/cargo/x86_64/Release/release"
         );
     }
 

--- a/crates/tools/fission-command-core/src/native_cargo.rs
+++ b/crates/tools/fission-command-core/src/native_cargo.rs
@@ -1,0 +1,108 @@
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) const CARGO_TARGET_DIRECTORY_TOKEN: &str = "{cargo_target_dir}";
+
+#[derive(Deserialize)]
+struct CargoMetadata {
+    target_directory: PathBuf,
+}
+
+pub(crate) fn cargo_target_directory(
+    project_dir: &Path,
+    manifest: &Path,
+    module_name: &str,
+    platform: &str,
+) -> Result<PathBuf> {
+    let output = Command::new("cargo")
+        .arg("metadata")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--no-deps")
+        .arg("--manifest-path")
+        .arg(manifest)
+        .current_dir(project_dir)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to resolve the Cargo target directory for {platform} native module `{module_name}`"
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        bail!(
+            "Cargo metadata failed for {platform} native module `{module_name}` with {}{}",
+            output.status,
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        );
+    }
+    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout).with_context(|| {
+        format!(
+            "Cargo returned invalid metadata for {platform} native module `{module_name}`"
+        )
+    })?;
+    if !metadata.target_directory.is_absolute() {
+        bail!(
+            "Cargo returned a non-absolute target directory for {platform} native module `{module_name}`: {}",
+            metadata.target_directory.display()
+        );
+    }
+    Ok(metadata.target_directory)
+}
+
+pub(crate) fn expand_cargo_target_directory(
+    value: &str,
+    target_directory: Option<&Path>,
+    module_name: &str,
+    platform: &str,
+) -> Result<String> {
+    if !value.contains(CARGO_TARGET_DIRECTORY_TOKEN) {
+        return Ok(value.to_owned());
+    }
+    let target_directory = target_directory.with_context(|| {
+        format!(
+            "{platform} native module `{module_name}` uses {CARGO_TARGET_DIRECTORY_TOKEN} for a product that is not built by Cargo"
+        )
+    })?;
+    Ok(value.replace(
+        CARGO_TARGET_DIRECTORY_TOKEN,
+        &target_directory.to_string_lossy(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_the_configured_cargo_target_directory() {
+        let expanded = expand_cargo_target_directory(
+            "{cargo_target_dir}/release/demo-helper",
+            Some(Path::new("/shared/cargo")),
+            "demo",
+            "Linux",
+        )
+        .unwrap();
+
+        assert_eq!(expanded, "/shared/cargo/release/demo-helper");
+    }
+
+    #[test]
+    fn rejects_the_token_for_non_cargo_products() {
+        let error = expand_cargo_target_directory(
+            "{cargo_target_dir}/release/demo-helper",
+            None,
+            "demo",
+            "Windows",
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("not built by Cargo"));
+    }
+}

--- a/crates/tools/fission-command-core/src/windows_native.rs
+++ b/crates/tools/fission-command-core/src/windows_native.rs
@@ -1,4 +1,7 @@
-use crate::FissionProject;
+use crate::{
+    FissionProject,
+    native_cargo::{cargo_target_directory, expand_cargo_target_directory},
+};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -91,15 +94,15 @@ pub fn build_windows_native_modules(
             continue;
         }
         let platform = optional_value(module.windows.platform.as_deref()).unwrap_or("x64");
-        match windows_build_system(&module.name, &module.windows)? {
-            WindowsBuildSystem::Cargo => run_cargo_module_command(
+        let target_directory = match windows_build_system(&module.name, &module.windows)? {
+            WindowsBuildSystem::Cargo => Some(run_cargo_module_command(
                 &project_dir,
                 module.path.as_deref(),
                 &module.name,
                 &module.windows,
                 "build",
                 release,
-            )?,
+            )?),
             WindowsBuildSystem::MsBuild => {
                 let native_tool_paths =
                     restore_windows_native_packages(&project_dir, &module.name, &module.windows)?;
@@ -122,8 +125,9 @@ pub fn build_windows_native_modules(
                     &mut command,
                     &format!("Windows native module `{}`", module.name),
                 )?;
+                None
             }
-        }
+        };
 
         for product in &module.windows.products {
             products.push(resolve_product(
@@ -132,6 +136,7 @@ pub fn build_windows_native_modules(
                 product,
                 configuration,
                 platform,
+                target_directory.as_deref(),
             )?);
         }
     }
@@ -267,7 +272,7 @@ pub fn test_windows_native_modules(project_dir: &Path, project: &FissionProject)
         }
         let platform = optional_value(module.windows.platform.as_deref()).unwrap_or("x64");
         for test_binary in &module.windows.test_binaries {
-            let test_binary = expand_path(test_binary, "Debug", platform);
+            let test_binary = expand_path(test_binary, "Debug", platform, None, &module.name)?;
             let test_binary = resolve_project_path(&project_dir, &test_binary);
             if !test_binary.is_file() {
                 bail!(
@@ -341,7 +346,7 @@ fn run_cargo_module_command(
     config: &NativeWindowsModuleConfig,
     cargo_command: &str,
     release: bool,
-) -> Result<()> {
+) -> Result<PathBuf> {
     let package = optional_value(config.cargo_package.as_deref()).with_context(|| {
         format!("Windows native module `{module_name}` requires `cargo_package`")
     })?;
@@ -377,7 +382,8 @@ fn run_cargo_module_command(
     run_status(
         &mut command,
         &format!("Windows native module `{module_name}` Cargo {cargo_command}"),
-    )
+    )?;
+    cargo_target_directory(project_dir, &manifest, module_name, "Windows")
 }
 
 fn resolve_cargo_manifest_path(
@@ -447,10 +453,18 @@ fn resolve_product(
     product: &NativeWindowsProductConfig,
     configuration: &str,
     platform: &str,
+    cargo_target_directory: Option<&Path>,
 ) -> Result<BuiltWindowsNativeProduct> {
     let name = required_value(&product.name, "Windows native product name")?;
     let path = required_value(&product.path, "Windows native product path")?;
-    let source = resolve_project_path(project_dir, &expand_path(path, configuration, platform));
+    let expanded = expand_path(
+        path,
+        configuration,
+        platform,
+        cargo_target_directory,
+        module_name,
+    )?;
+    let source = resolve_project_path(project_dir, &expanded);
     if !source.exists() {
         bail!(
             "Windows native product `{name}` from module `{module_name}` does not exist: {}",
@@ -497,11 +511,18 @@ fn validate_relative_destination(destination: &Path) -> Result<()> {
     Ok(())
 }
 
-fn expand_path(value: &str, configuration: &str, platform: &str) -> String {
-    value
+fn expand_path(
+    value: &str,
+    configuration: &str,
+    platform: &str,
+    cargo_target_directory: Option<&Path>,
+    module_name: &str,
+) -> Result<String> {
+    let value = value
         .replace("{configuration}", configuration)
         .replace("{profile}", &configuration.to_ascii_lowercase())
-        .replace("{platform}", platform)
+        .replace("{platform}", platform);
+    expand_cargo_target_directory(&value, cargo_target_directory, module_name, "Windows")
 }
 
 fn copy_product(source: &Path, destination: &Path) -> Result<()> {
@@ -712,11 +733,14 @@ destination = "tools/demo-helper.exe"
     fn expands_configuration_and_platform_tokens() {
         assert_eq!(
             expand_path(
-                "out/{platform}/{configuration}/{profile}",
+                "{cargo_target_dir}/{platform}/{configuration}/{profile}",
                 "Release",
-                "ARM64"
-            ),
-            "out/ARM64/Release/release"
+                "ARM64",
+                Some(Path::new("C:/shared/cargo")),
+                "demo-native",
+            )
+            .unwrap(),
+            "C:/shared/cargo/ARM64/Release/release"
         );
     }
 

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -134,7 +134,7 @@ Each `[[native.modules.linux.products]]` entry accepts:
 | Field | Type | Required | Meaning |
 | --- | --- | --- | --- |
 | `name` | string | Yes | Stable product identity recorded in the native-products manifest. |
-| `path` | string | Yes | Built file or directory. Supports `{configuration}`, `{profile}`, and `{architecture}`. |
+| `path` | string | Yes | Built file or directory. Supports `{cargo_target_dir}`, `{configuration}`, `{profile}`, and `{architecture}`. `{cargo_target_dir}` resolves from `cargo metadata`, so it follows workspace and user Cargo configuration. |
 | `kind` | string | Yes | `runtime` or `privileged-helper`. Both are staged, but privileged helpers remain explicitly classified for installer policy and review. |
 | `destination` | string | No | Safe relative path under the run/package root. Defaults to the source file or directory name. |
 
@@ -155,23 +155,27 @@ features = ["kernel-fuse"]
 
 [[native.modules.linux.products]]
 name = "mount-helper"
-path = "../../target/{profile}/linux-mount-helper"
+path = "{cargo_target_dir}/{profile}/linux-mount-helper"
 kind = "privileged-helper"
 destination = "libexec/linux-mount-helper"
 ```
 
 ### `[native.modules.windows]`
 
-Windows native modules attach an MSBuild/WDK project to the desktop lifecycle.
-`fission build`, `fission run`, and Windows package commands build the declared
-project. `fission test --target windows` also runs each declared test binary
-through `vstest.console.exe`.
+Windows native modules attach either a Cargo package or an MSBuild/WDK project
+to the desktop lifecycle. `fission build`, `fission run`, and Windows package
+commands build the declared module. `fission test --target windows` runs Cargo
+tests or each declared MSBuild test binary through `vstest.console.exe`.
 
 | Field | Type | Required | Default | Meaning |
 | --- | --- | --- | --- | --- |
+| `cargo_manifest_path` | string | No | `<native.modules.path>/Cargo.toml`, then the app `Cargo.toml` | Project-relative Cargo manifest used for a Cargo native module. |
+| `cargo_package` | string | Yes for Cargo modules | none | Exact Cargo package passed with `--package`. Mutually exclusive with `msbuild_project`. |
+| `features` | array of strings | No | `[]` | Cargo features enabled for build and test. |
+| `no_default_features` | boolean | No | `false` | Passes `--no-default-features` to Cargo. |
 | `nuget_packages_config` | string | No | none | Project-relative `packages.config` restored before MSBuild. Restored WDK host-tool directories are added to the MSBuild environment. |
 | `nuget_packages_directory` | string | No | sibling `packages` directory | Project-relative restore destination. Requires `nuget_packages_config`. |
-| `msbuild_project` | string | Yes when products or tests are declared | none | Project-relative `.sln`, `.slnx`, or MSBuild project passed to `msbuild`. |
+| `msbuild_project` | string | Yes for MSBuild modules | none | Project-relative `.sln`, `.slnx`, or MSBuild project passed to `msbuild`. Mutually exclusive with `cargo_package`. |
 | `platform` | string | No | `x64` | MSBuild platform, such as `x64` or `ARM64`. |
 | `build_target` | string | No | `Build` | MSBuild target invoked for the module. |
 | `test_binaries` | array of strings | No | `[]` | VSTest executables. Paths may contain `{configuration}`, `{profile}`, and `{platform}`. |
@@ -181,7 +185,7 @@ Each `[[native.modules.windows.products]]` entry accepts:
 | Field | Type | Required | Meaning |
 | --- | --- | --- | --- |
 | `name` | string | Yes | Stable product identity used in package manifests. |
-| `path` | string | Yes | Built file or directory. Supports `{configuration}`, `{profile}`, and `{platform}`. |
+| `path` | string | Yes | Built file or directory. Supports `{configuration}`, `{profile}`, and `{platform}`. Cargo products also support `{cargo_target_dir}`, resolved from `cargo metadata`. |
 | `kind` | string | Yes | `runtime` or `driver-package`. Runtime products are staged beside the app; driver packages are installer inputs and are excluded from MSIX manifests. |
 | `destination` | string | No | Safe relative path under the run/package root. Defaults to the source file or directory name. |
 
@@ -205,6 +209,24 @@ destination = "native/Provider.dll"
 name = "filesystem-minifilter"
 path = "platforms/windows/native/{platform}/{configuration}/DriverPackage"
 kind = "driver-package"
+```
+
+Cargo-native Windows products use the same product table without an MSBuild
+project:
+
+```toml
+[[native.modules]]
+name = "windows-helper"
+path = "../windows-helper"
+
+[native.modules.windows]
+cargo_package = "windows-helper"
+
+[[native.modules.windows.products]]
+name = "windows-helper"
+path = "{cargo_target_dir}/{profile}/windows-helper.exe"
+kind = "runtime"
+destination = "tools/windows-helper.exe"
 ```
 
 ## `[app]`


### PR DESCRIPTION
## Summary

- add `{cargo_target_dir}` for Linux and Windows Cargo-native product paths
- resolve the value from `cargo metadata` so workspace and user Cargo target configuration are honoured
- reject the token for non-Cargo products and document Cargo-native Windows modules

## Why

Fission already lets Cargo choose its configured target directory when it builds a native module, but product discovery only supported literal project-relative paths. A workspace using a shared or configured Cargo target therefore built successfully and then failed product staging because Fission looked under a repo-local `target` directory.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p fission-command-core` (38 passed)
- all compilation used the configured shared Cargo target directory; no per-worktree target was created