### PR TITLE
Document build, accessibility, and release workflows

### DIFF
--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -1973,15 +1973,12 @@ fn windows_packaging_environment(
     project_dir: &Path,
     binary: &Path,
     manifest: &Path,
-) -> Result<Vec<(OsString, OsString)>> {
+) -> Result<Vec<(OsString, PathBuf)>> {
     let mut environment = vec![
-        (
-            OsString::from("WINDOWS_BINARY"),
-            binary.as_os_str().to_os_string(),
-        ),
+        (OsString::from("WINDOWS_BINARY"), binary.to_path_buf()),
         (
             OsString::from("FISSION_WINDOWS_NATIVE_PRODUCTS_MANIFEST"),
-            manifest.as_os_str().to_os_string(),
+            manifest.to_path_buf(),
         ),
     ];
     let assets = project_dir.join("assets");
@@ -1992,10 +1989,7 @@ fn windows_packaging_environment(
         );
     }
     if assets.exists() {
-        environment.push((
-            OsString::from("FISSION_WINDOWS_ASSETS_DIR"),
-            assets.into_os_string(),
-        ));
+        environment.push((OsString::from("FISSION_WINDOWS_ASSETS_DIR"), assets));
     }
     Ok(environment)
 }
@@ -2004,19 +1998,16 @@ fn linux_packaging_environment(
     payload_dir: &Path,
     binary: &Path,
     manifest: &Path,
-) -> Vec<(OsString, OsString)> {
+) -> Vec<(OsString, PathBuf)> {
     vec![
         (
             OsString::from("FISSION_LINUX_PAYLOAD_DIR"),
-            payload_dir.as_os_str().to_os_string(),
+            payload_dir.to_path_buf(),
         ),
-        (
-            OsString::from("LINUX_BINARY"),
-            binary.as_os_str().to_os_string(),
-        ),
+        (OsString::from("LINUX_BINARY"), binary.to_path_buf()),
         (
             OsString::from("FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST"),
-            manifest.as_os_str().to_os_string(),
+            manifest.to_path_buf(),
         ),
     ]
 }
@@ -2035,11 +2026,13 @@ fn run_packaging_script_with_env(
     script: &Path,
     release: bool,
     variant: Option<&fission_command_core::NativeVariant>,
-    environment: &[(OsString, OsString)],
+    environment: &[(OsString, PathBuf)],
 ) -> Result<Option<PathBuf>> {
     if !script.exists() {
         bail!("packaging script is missing at {}", script.display());
     }
+    let working_dir = absolute_path(project_dir)?;
+    let script = absolute_path(script)?;
     let extension = script.extension().and_then(OsStr::to_str);
     let mut command = if extension == Some("ps1") {
         let program = if cfg!(windows) {
@@ -2058,16 +2051,16 @@ fn run_packaging_script_with_env(
         } else {
             command.arg("-File");
         }
-        command.arg(script);
+        command.arg(&script);
         command
     } else if cfg!(windows) || extension == Some("sh") {
         let mut command = Command::new("bash");
-        command.arg(script);
+        command.arg(&script);
         command
     } else {
-        Command::new(script)
+        Command::new(&script)
     };
-    command.current_dir(project_dir);
+    command.current_dir(&working_dir);
     command.env_remove("FISSION_VARIANT");
     if let Some(variant) = variant {
         command.env("FISSION_VARIANT", variant.as_str());
@@ -2078,8 +2071,8 @@ fn run_packaging_script_with_env(
         command.env("LINUX_PROFILE", "release");
         command.env("WINDOWS_PROFILE", "release");
     }
-    for (key, value) in environment {
-        command.env(key, value);
+    for (key, path) in environment {
+        command.env(key, absolute_path(path)?);
     }
     let output = command
         .output()
@@ -2099,10 +2092,19 @@ fn run_packaging_script_with_env(
             if path.is_absolute() {
                 path
             } else {
-                project_dir.join(path)
+                working_dir.join(path)
             }
         })
         .find(|path| path.exists()))
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(env::current_dir()
+        .context("failed to resolve the current directory")?
+        .join(path))
 }
 
 fn sanitize_file_stem(value: &str) -> String {

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -536,7 +536,7 @@ fn windows_packaging_environment_exposes_validated_project_assets() {
 
     assert_eq!(
         environment.get(&OsString::from("FISSION_WINDOWS_ASSETS_DIR")),
-        Some(&root.join("assets").as_os_str().to_os_string())
+        Some(&root.join("assets"))
     );
 
     fs::remove_dir_all(root.join("assets")).unwrap();
@@ -591,19 +591,43 @@ fn linux_packaging_environment_exposes_payload_binary_and_manifest() {
 
     assert_eq!(
         environment.get(&OsString::from("FISSION_LINUX_PAYLOAD_DIR")),
-        Some(&root.as_os_str().to_os_string())
+        Some(&root)
     );
     assert_eq!(
         environment.get(&OsString::from("LINUX_BINARY")),
-        Some(&root.join("demo").as_os_str().to_os_string())
+        Some(&root.join("demo"))
     );
     assert_eq!(
         environment.get(&OsString::from("FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST")),
-        Some(
-            &root
-                .join(".fission/native/linux-products.json")
-                .as_os_str()
-                .to_os_string()
-        )
+        Some(&root.join(".fission/native/linux-products.json"))
     );
+}
+
+#[test]
+fn packaging_script_resolves_relative_project_script_and_payload_paths() {
+    let current_dir = std::env::current_dir().unwrap();
+    let root = current_dir.join(format!("fission-relative-packager-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    let project_dir = root.strip_prefix(&current_dir).unwrap();
+    let script = project_dir.join("package.sh");
+    let payload = project_dir.join("payload.bin");
+    fs::write(
+        root.join("package.sh"),
+        "#!/bin/sh\nset -eu\ntest -f \"$TEST_PAYLOAD\"\nprintf artifact.run > artifact.run\nprintf '%s\\n' artifact.run\n",
+    )
+    .unwrap();
+    fs::write(root.join("payload.bin"), b"payload").unwrap();
+
+    let output = run_packaging_script_with_env(
+        project_dir,
+        &script,
+        false,
+        None,
+        &[(OsString::from("TEST_PAYLOAD"), payload)],
+    )
+    .unwrap();
+
+    assert_eq!(output.as_deref(), Some(root.join("artifact.run").as_path()));
+    let _ = fs::remove_dir_all(root);
 }

--- a/documentation/content/docs/build-and-package/android-packages.mdx
+++ b/documentation/content/docs/build-and-package/android-packages.mdx
@@ -1,0 +1,120 @@
+---
+title: Android packages
+description: Configure Android package identity, versioning, signing, native additions, and Play Store-ready Fission artifacts.
+---
+
+# Android packages
+
+Android packaging produces an `.apk` for device testing or an `.aab` for store distribution. The important release inputs are package name, version code, version name, signing source, target scaffold, icons, permissions, and Play Store release content.
+
+## Choose the artifact format
+
+| Format | Use it for |
+| --- | --- |
+| `apk` | Emulator/device install, QA, and direct testing. |
+| `aab` | Google Play and most Android store distribution workflows. |
+
+Use `apk` while validating behavior on devices. Use `aab` for Play Store release.
+
+## Realistic package configuration
+
+```toml
+[app]
+name = "Acme Notes"
+app_id = "com.acme.notes"
+version = "1.4.0"
+build = 37
+
+[targets.android]
+enabled = true
+
+[package.android]
+package_name = "com.acme.notes"
+version_code = 37
+version_name = "1.4.0"
+keystore_alias = "upload"
+keystore_env = "ANDROID_KEYSTORE"
+keystore_base64_env = "ANDROID_KEYSTORE_BASE64"
+keystore_password_env = "ANDROID_KEYSTORE_PASSWORD"
+key_password_env = "ANDROID_KEY_PASSWORD"
+```
+
+| Field | Why it exists |
+| --- | --- |
+| `package_name` | Android application id expected by signing, packaging, and Play Store provider checks. Usually matches `[app].app_id`. |
+| `version_code` | Monotonic integer used by Google Play. Reusing it causes upload rejection. |
+| `version_name` | User-visible version string. |
+| `keystore_alias` | Alias inside the upload keystore. |
+| `keystore_env` | Local path to the keystore, read from an environment variable. |
+| `keystore_base64_env` | CI-friendly keystore bytes, read from an environment variable. |
+| `keystore_password_env` | Password source for the keystore. |
+| `key_password_env` | Optional key password source. Defaults/falls back to the keystore password in generated Android packaging. |
+
+Keystore files and passwords do not belong in `fission.toml`. For local publishing, set `ANDROID_KEYSTORE` to a file outside the repository, commonly under `~/.fission/<app-name>/`. For CI, store the keystore as a base64 secret and expose it through `ANDROID_KEYSTORE_BASE64`.
+
+## Version codes and provider checks
+
+Before upload, ask the provider whether the version code is already used:
+
+```bash
+fission release-config version-state \
+  --project-dir . \
+  --provider play-store \
+  --target android \
+  --track internal \
+  --json
+```
+
+If the version code is used, bump the build and rebuild:
+
+```bash
+fission release-config bump-build --project-dir . --target android --yes
+fission package --project-dir . --target android --format aab --release
+```
+
+The package manifest records the resolved version and build. Publish the manifest, not a guessed `.aab` path.
+
+## Native Android additions
+
+Use native modules for Gradle dependencies, repositories, permissions, Java/Kotlin source directories, or manifest application entries that the generated Android host must include.
+
+```toml
+[[native.modules]]
+name = "scanner-sdk"
+
+[native.modules.android]
+repositories = ["https://maven.example.com/releases"]
+gradle_dependencies = ["com.example:scanner:1.2.3"]
+source_dirs = ["platforms/android/scanner/src/main/java"]
+permissions = ["android.permission.CAMERA"]
+manifest_application_entries = ["<meta-data android:name=\"scanner\" android:value=\"enabled\" />"]
+```
+
+Keep privacy and product policy visible. Native modules should add native build inputs; they should not hide why a permission is requested or what capability the app exposes.
+
+## Readiness and packaging loop
+
+```bash
+fission readiness package --project-dir . --target android --format apk
+fission package --project-dir . --target android --format apk --release
+
+fission readiness package --project-dir . --target android --format aab
+fission package --project-dir . --target android --format aab --release
+```
+
+For Play Store release content:
+
+```bash
+fission release-content validate --project-dir . --provider play-store
+```
+
+That validation covers release notes, screenshots, metadata, and provider-facing content where configured. Packaging still produces the artifact; publishing/distribution submits it.
+
+## Verify on Android
+
+Before upload:
+
+- Install the APK on an emulator and at least one physical device when the app uses hardware features.
+- Verify app icon, label, splash, safe areas, keyboard behavior, permissions, back navigation, and deep links.
+- Verify the AAB upload key is the intended key, not a debug key.
+- Verify Play Store track, testers, release notes, screenshots, and privacy declarations before submission.

--- a/documentation/content/docs/build-and-package/desktop-packages.mdx
+++ b/documentation/content/docs/build-and-package/desktop-packages.mdx
@@ -7,6 +7,16 @@ description: Package Fission desktop apps for Windows, macOS, and Linux.
 
 Desktop packaging takes the shared Fission app and gives it the operating-system metadata users expect: name, icon, bundle identity, installer shape, signing references, and a predictable artifact manifest.
 
+Use this page for the shared desktop lifecycle. Use the platform pages when you
+are filling in real release values:
+
+| Platform | Detailed page |
+| --- | --- |
+| macOS | [macOS packages](/docs/build-and-package/macos-packages/) |
+| macOS app extensions or system extensions | [macOS native XcodeGen](/docs/build-and-package/macos-native-xcodegen/) |
+| Windows | [Windows packages](/docs/build-and-package/windows-packages/) |
+| Linux | [Linux packages](/docs/build-and-package/linux-packages/) |
+
 ## 1. Check the desktop target
 
 Start with readiness. It catches missing target setup and packaging tools before the release build starts.
@@ -49,6 +59,18 @@ selected. Variant artifacts are written below
 `target/fission/<profile>/<target>/<format>/variants/<name>/`, and custom
 packager scripts receive the same name as `FISSION_VARIANT`.
 
+Run with `--json` in CI when a downstream job needs to discover the manifest
+path or primary artifact without scraping console output:
+
+```bash
+fission package --project-dir . --target windows --format msix --release --json
+```
+
+The manifest is the only handoff the release workflow should need. It records
+target, format, package profile, hashes, sizes, validation checks, source
+configuration hashes, signing/notarization facts where available, and any
+secondary artifacts such as symbols or crash diagnostics.
+
 Keep production macOS signing in the release overlay:
 
 ```toml
@@ -69,6 +91,8 @@ enabled, Fission signs the `.app`, creates a private temporary `ditto` ZIP for
 that stapled app, signs the installer, then notarizes, staples, and validates the
 `.pkg` as before. Temporary submission archives and environment-provided key
 material are removed when each operation finishes.
+
+## 4. Add native products when the package needs them
 
 For macOS apps with native extensions, declare the Xcode project and products
 under `[[native.modules]]` in `fission.toml`. Fission builds the native schemes,
@@ -95,7 +119,47 @@ program rather than stage the application executable itself. Set
 pins the supported WDK NuGet packages; Fission restores them non-interactively
 before every MSBuild invocation.
 
-## 4. Verify the result
+For a complete field-by-field guide, use
+[Native modules](/docs/build-and-package/native-modules/). The practical rule is
+that native products are normal release inputs, not hidden build script side
+effects. If the app needs them at runtime, declare them as runtime products. If
+an installer needs them but the app should not load them directly, classify them
+as `driver-package` or `privileged-helper`.
+
+## 5. Use installer scripts only at the installer boundary
+
+Fission can create simple desktop package artifacts itself, but some products
+need a real installer: drivers, services, privileged helpers, repair/uninstall
+behavior, or machine-level integration. Use the package script hooks for those
+cases.
+
+Linux `.run` package script:
+
+```toml
+[package.linux.run]
+installer_script = "platforms/linux/package-run.sh"
+```
+
+The script receives `FISSION_LINUX_PAYLOAD_DIR`, `LINUX_BINARY`,
+`FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST`, and `LINUX_PROFILE` on release builds.
+It prints the completed `.run` path on stdout.
+
+Windows `.exe` installer script:
+
+```toml
+[package.windows]
+exe_installer_script = "platforms/windows/package-exe.ps1"
+```
+
+The script receives `WINDOWS_BINARY`,
+`FISSION_WINDOWS_NATIVE_PRODUCTS_MANIFEST`, and `WINDOWS_PROFILE` on release
+builds. It prints the completed `.exe` path on stdout.
+
+Keep installer scripts deterministic. They should consume the staged package
+inputs, create one installer artifact, and let Fission record the final artifact
+in `artifact-manifest.json`.
+
+## 6. Verify the result
 
 Open or install the produced package on the target operating system. Check the app name, icon, dock or taskbar behavior, permission prompts, window title, and any capability the app needs. Packaging is not complete until the installed app behaves like an app, not like an unnamed development binary.
 

--- a/documentation/content/docs/build-and-package/ios-packages.mdx
+++ b/documentation/content/docs/build-and-package/ios-packages.mdx
@@ -1,0 +1,110 @@
+---
+title: iOS packages
+description: Configure iOS bundle identity, signing, native additions, and App Store-ready Fission IPA artifacts.
+---
+
+# iOS packages
+
+iOS packaging produces an `.ipa` through Apple tooling. The important release inputs are bundle id, marketing version, build number, team id, entitlements, provisioning profile, signing identity, generated host files, icons, launch assets, privacy strings, and App Store Connect release content.
+
+## Realistic package configuration
+
+```toml
+[app]
+name = "Acme Notes"
+app_id = "com.acme.notes"
+version = "1.4.0"
+build = 37
+
+[targets.ios]
+enabled = true
+
+[package.ios]
+bundle_id = "com.acme.notes"
+marketing_version = "1.4.0"
+build_number = "37"
+team_id = "ABCDE12345"
+entitlements = "platforms/ios/AcmeNotes.entitlements"
+provisioning_profile = "profiles/ios/AcmeNotes.mobileprovision"
+signing_identity = "Apple Distribution"
+```
+
+| Field | Why it exists |
+| --- | --- |
+| `bundle_id` | iOS bundle identifier used by signing, generated host metadata, and App Store Connect. Usually matches `[app].app_id`. |
+| `marketing_version` | User-visible iOS version. |
+| `build_number` | Provider-facing build number. It must be incremented for new uploads. |
+| `team_id` | Apple Developer Team ID used by signing and readiness checks. |
+| `entitlements` | iOS entitlements plist passed into signing. |
+| `provisioning_profile` | Mobile provisioning profile for the release build. |
+| `signing_identity` | Release signing identity. |
+
+Keep Apple API keys, private signing material, and passwords outside `fission.toml`.
+
+## App Store Connect configuration
+
+Publishing to TestFlight or App Review uses provider credentials and release content in addition to the IPA.
+
+```toml
+[distribution.app_store]
+bundle_id = "com.acme.notes"
+issuer_id = "00000000-0000-0000-0000-000000000000"
+key_id = "ABC123DEFG"
+api_key_env = "APP_STORE_CONNECT_API_KEY"
+api_key_base64_env = "APP_STORE_CONNECT_API_KEY_BASE64"
+default_track = "testflight"
+```
+
+The API key value should come from the named environment variable or CI secret. Use base64 for CI when that is easier to store safely.
+
+## Native iOS additions
+
+Use native modules when the generated iOS host needs Swift source directories, linked frameworks, or Swift package dependencies.
+
+```toml
+[[native.modules]]
+name = "scanner-sdk"
+
+[native.modules.ios]
+source_dirs = ["platforms/ios/Scanner"]
+linked_frameworks = ["AVFoundation.framework", "CoreImage.framework"]
+
+[[native.modules.ios.swift_packages]]
+url = "https://github.com/example/scanner-ios"
+product = "ScannerSDK"
+from = "1.2.3"
+```
+
+Native modules supply native build inputs. Keep user-facing privacy strings, usage descriptions, and product policy in the visible target/capability configuration so reviewers and teammates can audit why the app needs each capability.
+
+## Version and build checks
+
+When provider credentials are available, check App Store state before upload:
+
+```bash
+fission release-config version-state \
+  --project-dir . \
+  --provider app-store \
+  --target ios \
+  --json
+```
+
+If the build number is already used, update release configuration and rebuild the IPA. Do not upload a known-bad artifact.
+
+## Readiness and packaging loop
+
+```bash
+fission readiness package --project-dir . --target ios --format ipa
+fission package --project-dir . --target ios --format ipa --release
+```
+
+The output contains the `.ipa` and `artifact-manifest.json`. Publish the manifest so the release command has the artifact hash, version, build number, package identity, and secondary files in one immutable handoff.
+
+## Verify on iOS
+
+Before App Store submission:
+
+- Run on simulator for layout, safe areas, keyboard, navigation, and common device sizes.
+- Run on a real device for camera, Bluetooth, file, push, health, location, or other hardware/platform capabilities.
+- Verify icons, launch screen, permission prompts, deep links, and any native module behavior.
+- Validate release notes, screenshots, privacy declarations, review notes, and TestFlight tester targeting.

--- a/documentation/content/docs/build-and-package/linux-packages.mdx
+++ b/documentation/content/docs/build-and-package/linux-packages.mdx
@@ -1,0 +1,110 @@
+---
+title: Linux packages
+description: Configure Fission Linux .run packages, native helpers, installer scripts, and verification.
+---
+
+# Linux packages
+
+Linux packaging produces a self-contained `.run` artifact. Fission can write a built-in user-local installer, or your project can supply an installer script when the product needs services, privileged helpers, custom layout, repair, or uninstall behavior.
+
+## Realistic package configuration
+
+```toml
+[app]
+name = "Acme Notes"
+app_id = "com.acme.notes"
+version = "1.4.0"
+build = 37
+
+[targets.linux]
+enabled = true
+
+[package.linux.run]
+installer_script = "platforms/linux/package-run.sh"
+```
+
+`installer_script` is optional. If it is omitted, Fission uses the built-in user-local installer. Add a script only when installation policy belongs to the product.
+
+## Native helper products
+
+Linux native modules currently use Cargo. Use them for helper binaries that must be built, tested, staged, and described in the package manifest.
+
+```toml
+[[native.modules]]
+name = "linux-file-helper"
+path = "platforms/linux/native"
+
+[native.modules.linux]
+cargo_manifest_path = "platforms/linux/native/Cargo.toml"
+cargo_package = "linux-file-helper"
+features = ["fuse"]
+no_default_features = true
+
+[[native.modules.linux.products]]
+name = "file-helper"
+path = "target/{profile}/linux-file-helper"
+kind = "runtime"
+destination = "libexec/linux-file-helper"
+
+[[native.modules.linux.products]]
+name = "mount-helper"
+path = "target/{profile}/mount-helper"
+kind = "privileged-helper"
+destination = "libexec/mount-helper"
+```
+
+| Product kind | Meaning |
+| --- | --- |
+| `runtime` | Staged into the run/package root for the app to execute or load. |
+| `privileged-helper` | Staged and explicitly identified for installer policy and review. Fission does not grant privileges. |
+
+A `privileged-helper` is metadata, not a privilege escalation. If the helper needs setuid, Linux capabilities, polkit, a systemd unit, or another elevation model, the installer script must do that explicitly and audibly.
+
+## Custom .run installer script
+
+When configured, the script receives:
+
+| Environment variable | Meaning |
+| --- | --- |
+| `FISSION_LINUX_PAYLOAD_DIR` | Directory containing the staged app payload. |
+| `LINUX_BINARY` | Path to the staged app binary. |
+| `FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST` | JSON manifest describing native products. |
+| `LINUX_PROFILE` | Set to `release` for release builds. |
+
+The script must print the completed `.run` artifact path on stdout.
+
+A minimal shape:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload="$FISSION_LINUX_PAYLOAD_DIR"
+out="target/fission/release/linux/run/acme-notes.run"
+
+# Build your installer from "$payload" and write "$out".
+# The installer should own service/helper policy; Fission only stages inputs.
+
+printf '%s\n' "$out"
+```
+
+Keep package scripts deterministic. They should not rebuild the app, discover random files outside the package root, or upload artifacts. Packaging creates artifacts; distribution uploads them.
+
+## Readiness and packaging loop
+
+```bash
+fission readiness package --project-dir . --target linux --format run
+fission package --project-dir . --target linux --format run --release
+```
+
+The package output includes `artifact-manifest.json`. Use that manifest for release commands and CI handoff.
+
+## Verify on Linux
+
+Before distribution:
+
+- Run the `.run` artifact on a clean Linux VM matching your supported distro baseline.
+- Verify install location, executable permissions, desktop entry, icon, and uninstall path.
+- If native helpers are included, verify their final installed path and permissions.
+- If a privileged helper is used, verify the privilege grant is explicit, reversible, and documented.
+- Check that the app still launches without relying on local development paths.

--- a/documentation/content/docs/build-and-package/macos-native-xcodegen.mdx
+++ b/documentation/content/docs/build-and-package/macos-native-xcodegen.mdx
@@ -1,0 +1,156 @@
+---
+title: macOS native XcodeGen
+description: Explain platforms/macos/native/project.yml and how Fission builds, tests, embeds, and signs macOS native products.
+---
+
+# macOS native XcodeGen
+
+`platforms/macos/native/project.yml` is an XcodeGen specification. It describes the native Xcode project that builds macOS app extensions, system extensions, tests, and any native framework code that must live beside the Fission app.
+
+It is not the app's Fission configuration. Fission reads `fission.toml`; XcodeGen reads `project.yml`; `xcodebuild` reads the generated `.xcodeproj`.
+
+## How the files fit together
+
+| File | Owner | Purpose |
+| --- | --- | --- |
+| `fission.toml` | Fission | Declares the native module, which Xcode project to build, which schemes are tests, which products must be embedded, and how they are signed. |
+| `platforms/macos/native/project.yml` | XcodeGen | Generates the `.xcodeproj`, target graph, sources, build settings, dependencies, Info.plist paths, and entitlements references. |
+| `platforms/macos/native/SecurityExtensions.xcodeproj` | Generated | Consumed by `xcodebuild`. Usually regenerated rather than edited by hand. |
+| `platforms/macos/native/*/*.entitlements` | Apple signing | Entitlements used by native targets. Fission can pass package/run entitlements when signing the built products. |
+
+A typical command flow is:
+
+1. Fission sees `native.modules.macos.xcodegen_spec`.
+2. Fission runs `xcodegen` to produce the configured `.xcodeproj`.
+3. Fission runs `xcodebuild` for native tests during `fission test --target macos`.
+4. Fission builds each declared product scheme during `fission package` or `fission run`.
+5. Fission embeds the built `.appex` or `.systemextension` in the containing `.app`.
+6. Fission signs nested products before signing the containing app.
+
+## fission.toml side
+
+```toml
+[[native.modules]]
+name = "security-extensions"
+path = "platforms/macos/native"
+
+[native.modules.macos]
+xcodegen_spec = "platforms/macos/native/project.yml"
+xcode_project = "platforms/macos/native/SecurityExtensions.xcodeproj"
+derived_data = ".fission/native/macos/security-extensions/DerivedData"
+test_schemes = ["SecurityExtensionsTests"]
+
+[[native.modules.macos.products]]
+scheme = "FileProvider"
+bundle = "FileProvider.appex"
+kind = "app-extension"
+entitlements = "platforms/macos/native/FileProvider/FileProvider.entitlements"
+provisioning_profile = "profiles/macos/FileProvider.provisionprofile"
+signing_identity = "Developer ID Application: Acme Software Ltd (ABCDE12345)"
+```
+
+Important details:
+
+| Field | Meaning |
+| --- | --- |
+| `xcodegen_spec` | Project-relative XcodeGen YAML file. If set, Fission regenerates the project before using it. |
+| `xcode_project` | Project-relative `.xcodeproj` path passed to `xcodebuild`. |
+| `derived_data` | Optional build output root. Use it when you want deterministic CI cache paths or easier diagnostics. |
+| `test_schemes` | Schemes run by `fission test --target macos` with code signing disabled. |
+| `products.scheme` | Xcode scheme built for packaging and local run. It should produce the named bundle. |
+| `products.bundle` | Output bundle file name, such as `FileProvider.appex` or `NetworkFilter.systemextension`. |
+| `products.kind` | Selects the embed location: `app-extension` goes to `Contents/PlugIns`; `system-extension` goes to `Contents/Library/SystemExtensions`. |
+
+## project.yml example
+
+This is a realistic app-extension project. Adjust framework dependencies, bundle ids, deployment target, and sources to match the native API you are using.
+
+```yaml
+name: SecurityExtensions
+options:
+  bundleIdPrefix: com.acme.notes
+  deploymentTarget:
+    macOS: "13.0"
+settings:
+  base:
+    MACOSX_DEPLOYMENT_TARGET: "13.0"
+    SWIFT_VERSION: "5.0"
+    CODE_SIGN_STYLE: Manual
+    DEVELOPMENT_TEAM: ABCDE12345
+
+targets:
+  FileProvider:
+    type: app-extension
+    platform: macOS
+    deploymentTarget: "13.0"
+    sources:
+      - path: FileProvider
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.acme.notes.fileprovider
+        INFOPLIST_FILE: FileProvider/Info.plist
+        CODE_SIGN_ENTITLEMENTS: FileProvider/FileProvider.entitlements
+        PRODUCT_NAME: FileProvider
+    dependencies:
+      - sdk: FileProvider.framework
+
+  SecurityExtensionsTests:
+    type: unit-test
+    platform: macOS
+    deploymentTarget: "13.0"
+    sources:
+      - path: SecurityExtensionsTests
+    dependencies:
+      - target: FileProvider
+```
+
+The Xcode target product identity must match the Fission product declaration. If the `FileProvider` scheme produces `FileProvider.appex`, use `bundle = "FileProvider.appex"` in `fission.toml`. If the bundle id is `com.acme.notes.fileprovider`, the provisioning profile and entitlements must also match that id.
+
+## Info.plist and entitlements
+
+Keep target metadata explicit in the native target directory:
+
+```text
+platforms/macos/native/
+  project.yml
+  FileProvider/
+    FileProvider.swift
+    Info.plist
+    FileProvider.entitlements
+  SecurityExtensionsTests/
+    FileProviderTests.swift
+```
+
+`Info.plist` is owned by the native target because extension points are Apple-specific. `fission.toml` should reference the built product and signing inputs, not duplicate every Xcode setting.
+
+## Testing native targets
+
+Run native tests through Fission so CI exercises the same declared module graph:
+
+```bash
+fission test --project-dir . --target macos
+```
+
+Fission runs configured `test_schemes` with signing disabled. That keeps unit tests cheap and avoids requiring distribution certificates just to test native code.
+
+## Packaging and signing checks
+
+Before packaging, check readiness:
+
+```bash
+fission readiness package --project-dir . --target macos --format app
+```
+
+Common failures and fixes:
+
+| Failure | Fix |
+| --- | --- |
+| `xcodegen` missing | Install XcodeGen and rerun readiness. |
+| Scheme not found | Make sure `project.yml` defines the target/scheme and the generated `.xcodeproj` is current. |
+| Bundle name mismatch | Align `products.bundle` with the built `.appex` or `.systemextension` file name. |
+| Provisioning profile without identity | Configure a real signing identity; profile-backed entitlements cannot be ad-hoc signed. |
+| Wrong embed location | Use `kind = "app-extension"` for `.appex` and `kind = "system-extension"` for `.systemextension`. |
+
+## Keep generated projects disposable
+
+Prefer editing `project.yml` and regenerating the `.xcodeproj`. If a team chooses to commit the generated project, treat it as derived state: review it for changes, but do not make hand edits that are not represented in `project.yml`.

--- a/documentation/content/docs/build-and-package/macos-packages.mdx
+++ b/documentation/content/docs/build-and-package/macos-packages.mdx
@@ -1,0 +1,135 @@
+---
+title: macOS packages
+description: Configure, sign, package, and verify Fission macOS .app and .pkg artifacts.
+---
+
+# macOS packages
+
+A macOS package is more than the Rust binary. It is an `.app` bundle with a stable bundle identifier, Info.plist metadata, icons, entitlements, optional embedded provisioning, nested native products, code signing, and optionally a `.pkg` installer and notarization receipt.
+
+Use this page when the target is `macos`. If the app contains app extensions or system extensions, also read [macOS native XcodeGen](/docs/build-and-package/macos-native-xcodegen/).
+
+## Choose the artifact format
+
+| Format | Use it for | Command |
+| --- | --- | --- |
+| `app` | Local validation, direct app-bundle distribution, notarized `.app` handoff. | `fission package --target macos --format app --release` |
+| `pkg` | Installer-based distribution, MDM, managed deployment, or machine-level install policy. | `fission package --target macos --format pkg --release` |
+
+Start with `app` until the app identity, icon, permissions, and signing are correct. Move to `pkg` when installer behavior matters.
+
+## Realistic package configuration
+
+```toml
+[app]
+name = "Acme Notes"
+app_id = "com.acme.notes"
+version = "1.4.0"
+build = 37
+
+[targets.macos]
+enabled = true
+
+[package.macos]
+bundle_id = "com.acme.notes"
+marketing_version = "1.4.0"
+build_number = "37"
+team_id = "ABCDE12345"
+minimum_os = "13.0"
+entitlements = "platforms/macos/AcmeNotes.entitlements"
+provisioning_profile = "profiles/macos/AcmeNotes.provisionprofile"
+signing_identity = "Developer ID Application: Acme Software Ltd (ABCDE12345)"
+installer_identity = "Developer ID Installer: Acme Software Ltd (ABCDE12345)"
+notarize = true
+
+[run.macos]
+entitlements = "platforms/macos/AcmeNotes.dev.entitlements"
+provisioning_profile = "profiles/macos/AcmeNotesDevelopment.provisionprofile"
+signing_identity = "Apple Development: Jane Developer (ABCDE12345)"
+```
+
+The values are deliberately duplicated where the platform needs them:
+
+| Field | Why it exists |
+| --- | --- |
+| `app.app_id` | Fission's cross-platform app identity. Keep it stable before release. |
+| `package.macos.bundle_id` | The bundle identifier written into macOS package metadata. It usually matches `app.app_id`, but can differ when one repository ships multiple platform identities. |
+| `marketing_version` | The user-visible `CFBundleShortVersionString`, such as `1.4.0`. |
+| `build_number` | The macOS `CFBundleVersion`, usually monotonically increasing for release artifacts. |
+| `team_id` | Used by signing, provisioning, notarization readiness, and review diagnostics. |
+| `minimum_os` | Documents and propagates the intended minimum macOS version. |
+| `entitlements` | The app-level entitlements used when signing the containing `.app`. |
+| `provisioning_profile` | Embedded at `Contents/embedded.provisionprofile` before signing when profile-backed entitlements are required. |
+| `signing_identity` | The application signing identity passed to `codesign`. |
+| `installer_identity` | The installer signing identity used for `.pkg` output. |
+| `notarize` | Enables the notarization step. Notarization still needs Apple API credentials from environment variables or platform tools. |
+
+Keep private signing material out of `fission.toml`. The file may reference public identity names and project-relative entitlement/profile files, but passwords, App Store Connect keys, and private certificates must come from environment variables, CI secrets, the login keychain, or platform tooling.
+
+## Development signing versus release signing
+
+`fission run --target macos` builds a development `.app`. It inherits `[package.macos]` signing by default, but many teams need weaker development entitlements or an Apple Development identity locally. Put that difference under `[run.macos]`.
+
+This matters for restricted capabilities. Ad-hoc signing with `"-"` can be useful for unrestricted local experiments, but it cannot satisfy restricted entitlement and provisioning requirements. If a provisioning profile is configured, Fission requires a real signing identity.
+
+## Add app extensions or system extensions
+
+A macOS app extension is not a loose file. It must be built by Xcode, embedded under a platform-defined location, signed with the right entitlements, and then the containing app must be signed last.
+
+Use native modules for this:
+
+```toml
+[[native.modules]]
+name = "security-extensions"
+path = "platforms/macos/native"
+
+[native.modules.macos]
+xcodegen_spec = "platforms/macos/native/project.yml"
+xcode_project = "platforms/macos/native/SecurityExtensions.xcodeproj"
+test_schemes = ["SecurityExtensionsTests"]
+
+[[native.modules.macos.products]]
+scheme = "FileProvider"
+bundle = "FileProvider.appex"
+kind = "app-extension"
+entitlements = "platforms/macos/native/FileProvider.entitlements"
+provisioning_profile = "profiles/macos/FileProvider.provisionprofile"
+signing_identity = "Developer ID Application: Acme Software Ltd (ABCDE12345)"
+
+[native.modules.macos.products.run]
+provisioning_profile = "profiles/macos/FileProviderDevelopment.provisionprofile"
+signing_identity = "Apple Development: Jane Developer (ABCDE12345)"
+```
+
+Use [macOS native XcodeGen](/docs/build-and-package/macos-native-xcodegen/) for the `platforms/macos/native/project.yml` file itself.
+
+## Readiness and packaging loop
+
+Run readiness before packaging:
+
+```bash
+fission readiness package --project-dir . --target macos --format app
+fission readiness package --project-dir . --target macos --format pkg
+```
+
+Build the package:
+
+```bash
+fission package --project-dir . --target macos --format app --release
+fission package --project-dir . --target macos --format pkg --release
+```
+
+The output directory contains the app or installer plus `artifact-manifest.json`. Release commands should consume the manifest, not a guessed `.app` or `.pkg` path.
+
+## Verify the installed behavior
+
+Before publishing or handing the artifact to users, verify on macOS:
+
+- The app name, icon, menu bar name, Dock behavior, and window title are correct.
+- The app launches from Finder, not just from `fission run`.
+- Permission prompts match the capability being used.
+- App extensions appear in the expected system UI and work after a clean install.
+- The `.pkg` installs to the expected location and can be upgraded over the previous build.
+- Gatekeeper and notarization checks pass on a clean machine.
+
+Use [Release and distribute](/docs/release-and-distribute/overview/) when the artifact manifest is ready.

--- a/documentation/content/docs/build-and-package/mobile-packages.mdx
+++ b/documentation/content/docs/build-and-package/mobile-packages.mdx
@@ -7,6 +7,15 @@ description: Package Fission apps for Android and iOS release workflows.
 
 Mobile packaging turns the shared app into the artifact expected by the mobile platform. The shell keeps your app model shared; the package owns platform metadata, capabilities, signing references, store identity, icons, splash screens, and generated host files.
 
+Use this page for the shared mobile lifecycle. Use the platform pages when you
+are configuring real app ids, version/build values, signing inputs, native
+dependencies, and store handoff:
+
+| Platform | Detailed page |
+| --- | --- |
+| Android | [Android packages](/docs/build-and-package/android-packages/) |
+| iOS | [iOS packages](/docs/build-and-package/ios-packages/) |
+
 ## 1. Run mobile readiness
 
 ```bash
@@ -33,11 +42,51 @@ For local debugging, use `fission run` and the emulator or simulator first. For 
 fission package --project-dir . --target android --format aab --release
 ```
 
+Android release packages are versioned by `versionCode` and `versionName`. Fission
+resolves those values from release configuration, synchronizes generated Android
+packaging files where it owns them, and records the result in the artifact
+manifest. Before a Play Store upload, check provider state so a reused
+`versionCode` fails locally instead of after a long upload:
+
+```bash
+fission release-config version-state \
+  --project-dir . \
+  --provider play-store \
+  --target android \
+  --track internal \
+  --json
+```
+
+If the provider reports the build is already used, bump the build and rebuild:
+
+```bash
+fission release-config bump-build --project-dir . --target android --yes
+fission package --project-dir . --target android --format aab --release
+```
+
 Before publishing, validate release content for the destination provider:
 
 ```bash
 fission release-content validate --project-dir . --provider play-store
 ```
+
+Android signing uses secret sources, not project-local secret paths. Keep
+`[package.android]` limited to stable names and environment-variable names:
+
+```toml
+[package.android]
+package_name = "com.example.notes"
+keystore_alias = "upload"
+keystore_env = "ANDROID_KEYSTORE"
+keystore_base64_env = "ANDROID_KEYSTORE_BASE64"
+keystore_password_env = "ANDROID_KEYSTORE_PASSWORD"
+key_password_env = "ANDROID_KEY_PASSWORD"
+```
+
+For local release builds, `ANDROID_KEYSTORE` can point to a file outside the
+repository or to a file in the private local workspace under
+`~/.fission/<app-name>/`. For CI, prefer `ANDROID_KEYSTORE_BASE64` plus password
+secrets.
 
 ## 4. Package iOS
 
@@ -46,6 +95,36 @@ fission package --project-dir . --target ios --format ipa --release
 ```
 
 iOS packaging depends on Apple tooling and signing configuration. Keep credentials in the platform toolchain, CI secrets, environment variables, or the operating-system key store. Do not put private signing material directly into [`fission.toml`](/reference/config/fission-toml/).
+
+The package should resolve a marketing version, build number, bundle id, team id,
+entitlements, provisioning profile reference, and signing identity:
+
+```toml
+[package.ios]
+bundle_id = "com.example.notes"
+team_id = "ABCDE12345"
+entitlements = "platforms/ios/Entitlements.plist"
+provisioning_profile = "release-content/signing/ios/App.mobileprovision"
+signing_identity = "Apple Distribution"
+```
+
+For App Store Connect, keep API key material in configured environment variables
+or base64 CI secrets:
+
+```toml
+[distribution.app_store]
+bundle_id = "com.example.notes"
+issuer_id = "00000000-0000-0000-0000-000000000000"
+key_id = "ABC123DEFG"
+api_key_env = "APP_STORE_CONNECT_API_KEY"
+api_key_base64_env = "APP_STORE_CONNECT_API_KEY_BASE64"
+default_track = "testflight"
+```
+
+Use `fission release-config version-state --provider app-store --target ios`
+before uploading when the provider credentials are available. Uploading and
+assigning a build to TestFlight or App Review are separate provider operations,
+so keep receipts from both.
 
 ## 5. Verify on the host
 

--- a/documentation/content/docs/build-and-package/native-modules.mdx
+++ b/documentation/content/docs/build-and-package/native-modules.mdx
@@ -1,0 +1,297 @@
+---
+title: Native modules
+description: Attach platform-owned native code, helpers, extensions, drivers, and tests to the Fission build, run, test, package, and release lifecycle.
+---
+
+# Native modules
+
+Most Fission code should stay in the shared Rust app: state, reducers, widgets, resources, and capabilities. Native modules are for the smaller set of work that must live beside a platform host: app extensions, system extensions, drivers, privileged helpers, existing platform SDK code, or platform-owned test binaries.
+
+Declare native modules in [`fission.toml`](/reference/config/fission-toml/) so the same configuration is used by `fission build`, `fission run`, `fission test`, and `fission package`. Do not duplicate native build steps in ad-hoc scripts unless the package format explicitly asks for an installer script.
+
+Use this page for the cross-platform native module model. Use the platform
+pages for packaging policy and realistic release values:
+[macOS packages](/docs/build-and-package/macos-packages/),
+[macOS native XcodeGen](/docs/build-and-package/macos-native-xcodegen/),
+[Windows packages](/docs/build-and-package/windows-packages/),
+[Linux packages](/docs/build-and-package/linux-packages/),
+[Android packages](/docs/build-and-package/android-packages/), and
+[iOS packages](/docs/build-and-package/ios-packages/).
+
+## When to add a native module
+
+Use a native module when the code is platform-owned and must be built, staged, signed, or tested with the app.
+
+| Need | Native module fit | Reason |
+| --- | --- | --- |
+| macOS app extension or system extension | Yes | The product must be embedded in a specific bundle location and signed with the app. |
+| Windows helper DLL, service runtime, or driver package | Yes | The package needs explicit runtime files or installer-only driver inputs. |
+| Linux helper executable or privileged helper | Yes | The package needs predictable staging and an audit trail for installer policy. |
+| Android Gradle dependency, source directory, or manifest entry | Yes | The generated Android host needs the native dependency in its platform build. |
+| iOS Swift package, linked framework, or native source directory | Yes | The generated iOS host needs native package/source/linkage metadata. |
+| Normal Fission UI logic | No | Keep it in shared Rust app code. |
+| A shell command that only uploads the final artifact | No | Use `fission distribute`, `fission publish`, or a release workflow. |
+
+A native module can be shared by more than one platform, but each platform section remains explicit. That keeps review simple: a macOS extension cannot accidentally become part of the Windows package because both entries happen to share a directory.
+
+## Basic shape
+
+Each module has a stable `name`, an optional project-relative `path`, and platform-specific configuration under `[native.modules.<target>]`.
+
+```toml
+[[native.modules]]
+name = "device-protection"
+path = "platforms/native/device-protection"
+
+[native.modules.macos]
+xcode_project = "platforms/native/device-protection/DeviceProtection.xcodeproj"
+
+[native.modules.windows]
+msbuild_project = "platforms/native/device-protection/DeviceProtection.sln"
+platform = "x64"
+
+[native.modules.linux]
+cargo_package = "device-protection-helper"
+```
+
+The module `path` is only a source-root hint. Platform paths still resolve from the project root unless the field says otherwise in the [`fission.toml` reference](/reference/config/fission-toml/). Prefer project-relative paths so CI, teammates, and release reviewers see the same structure.
+
+## macOS extensions
+
+macOS native modules build Xcode schemes with signing disabled, then Fission embeds and signs the produced extension inside the containing app.
+
+```toml
+[[native.modules]]
+name = "security-extensions"
+path = "platforms/macos/native"
+
+[native.modules.macos]
+xcodegen_spec = "platforms/macos/native/project.yml"
+xcode_project = "platforms/macos/native/SecurityExtensions.xcodeproj"
+test_schemes = ["SecurityExtensionsTests"]
+
+[[native.modules.macos.products]]
+scheme = "FileProvider"
+bundle = "FileProvider.appex"
+kind = "app-extension"
+entitlements = "platforms/macos/native/FileProvider.entitlements"
+provisioning_profile = "profiles/FileProvider.provisionprofile"
+
+[native.modules.macos.products.run]
+provisioning_profile = "profiles/FileProviderDevelopment.provisionprofile"
+signing_identity = "Apple Development"
+```
+
+| Product kind | Bundle requirement | Embedded into |
+| --- | --- | --- |
+| `app-extension` | `*.appex` | `Contents/PlugIns` |
+| `system-extension` | `*.systemextension` | `Contents/Library/SystemExtensions` |
+
+Run and package signing can differ. Product-level `run` overrides let development use an Apple Development identity while package output uses the distribution identity from `[package.macos]`.
+
+Important signing rules:
+
+- If a provisioning profile is configured, Fission requires a signing identity.
+- Ad-hoc signing with `-` can be useful for unrestricted local app testing, but it cannot satisfy restricted profile-backed entitlements.
+- Fission signs nested native products before signing the containing `.app`.
+
+## Linux helper products
+
+Linux modules currently use Cargo. The module package is built and tested through the same lifecycle as the app, then declared products are staged into local run/package roots.
+
+```toml
+[[native.modules]]
+name = "linux-file-helper"
+path = "platforms/linux/native"
+
+[native.modules.linux]
+cargo_manifest_path = "platforms/linux/native/Cargo.toml"
+cargo_package = "linux-file-helper"
+features = ["fuse"]
+no_default_features = true
+
+[[native.modules.linux.products]]
+name = "file-helper"
+path = "target/{profile}/linux-file-helper"
+kind = "runtime"
+destination = "libexec/linux-file-helper"
+
+[[native.modules.linux.products]]
+name = "mount-helper"
+path = "target/{profile}/mount-helper"
+kind = "privileged-helper"
+destination = "libexec/mount-helper"
+```
+
+| Product kind | What Fission does | What Fission does not do |
+| --- | --- | --- |
+| `runtime` | Stages the file or directory into the run/package root. | It does not install system services or grant privileges. |
+| `privileged-helper` | Stages and records the helper in the native-products manifest. | It does not add setuid bits, capabilities, polkit rules, or elevation policy. |
+
+Use `privileged-helper` as metadata for your installer and reviewer. The package script or operating-system installer must still perform an explicit, auditable privilege transaction.
+
+Linux product `path` supports `{profile}`, `{configuration}`, and `{architecture}` placeholders. `destination` must stay inside the application or installer root; traversal and overwrites are rejected.
+
+## Windows native products
+
+Windows supports two build systems. A module must choose exactly one:
+
+- Cargo, by setting `cargo_package`; or
+- MSBuild/WDK, by setting `msbuild_project`.
+
+Fission rejects mixed module configuration because Cargo features and NuGet/MSBuild/WDK settings belong to different toolchains.
+
+### Windows Cargo module
+
+Use a Cargo module for Rust helper binaries or DLLs that should be built with the workspace.
+
+```toml
+[[native.modules]]
+name = "windows-helper"
+path = "platforms/windows/helper"
+
+[native.modules.windows]
+cargo_manifest_path = "platforms/windows/helper/Cargo.toml"
+cargo_package = "windows-helper"
+features = ["installer"]
+no_default_features = true
+
+[[native.modules.windows.products]]
+name = "helper"
+path = "target/{profile}/windows-helper.exe"
+kind = "runtime"
+destination = "native/windows-helper.exe"
+```
+
+Cargo modules may use `features` and `no_default_features`. They may not set `msbuild_project`, `nuget_packages_config`, `nuget_packages_directory`, `build_target`, or `test_binaries`.
+
+### Windows MSBuild or WDK module
+
+Use an MSBuild module for Visual Studio projects, WDK driver packages, native tests, or projects that require NuGet-restored build tools.
+
+```toml
+[[native.modules]]
+name = "windows-protection"
+path = "platforms/windows/native"
+
+[native.modules.windows]
+nuget_packages_config = "platforms/windows/native/packages.config"
+nuget_packages_directory = "platforms/windows/native/packages"
+msbuild_project = "platforms/windows/native/Protection.sln"
+platform = "x64"
+build_target = "Build"
+test_binaries = ["platforms/windows/native/{platform}/{configuration}/ProtectionTests.exe"]
+
+[[native.modules.windows.products]]
+name = "cloud-files-provider"
+path = "platforms/windows/native/{platform}/{configuration}/Provider.dll"
+kind = "runtime"
+destination = "native/Provider.dll"
+
+[[native.modules.windows.products]]
+name = "filesystem-minifilter"
+path = "platforms/windows/native/{platform}/{configuration}/DriverPackage"
+kind = "driver-package"
+```
+
+| Product kind | Package behavior |
+| --- | --- |
+| `runtime` | Staged beside the app for local runs and package outputs. |
+| `driver-package` | Written to the native-products manifest for installer scripts; excluded from MSIX app manifests. |
+
+MSBuild product `path` and `test_binaries` support `{configuration}`, `{profile}`, and `{platform}`. Fission restores configured NuGet packages before MSBuild and prepends discovered native build-tool paths for the build process.
+
+## Android and iOS native additions
+
+Android and iOS module sections are host-scaffold inputs. They do not replace platform app code; they tell the generated host what to include.
+
+```toml
+[[native.modules]]
+name = "scanner-sdk"
+
+[native.modules.android]
+repositories = ["https://maven.example.com/releases"]
+gradle_dependencies = ["com.example:scanner:1.2.3"]
+source_dirs = ["platforms/android/scanner/src/main/java"]
+permissions = ["android.permission.CAMERA"]
+manifest_application_entries = ["<meta-data android:name=\"scanner\" android:value=\"enabled\" />"]
+
+[native.modules.ios]
+source_dirs = ["platforms/ios/Scanner"]
+linked_frameworks = ["AVFoundation.framework"]
+
+[[native.modules.ios.swift_packages]]
+url = "https://github.com/example/scanner-ios"
+product = "ScannerSDK"
+from = "1.2.3"
+```
+
+Keep privacy strings, usage descriptions, entitlements, and capability declarations in the normal target/capability configuration. Native modules should supply native source/dependency information, not hide product policy.
+
+## How native modules flow through commands
+
+| Command | Native module behavior |
+| --- | --- |
+| `fission build --target <target>` | Builds native modules for the selected target before the host build needs their products. |
+| `fission run --target <target>` | Builds and stages runtime native products into the local run root. macOS also embeds/signs native products in the development `.app`. |
+| `fission test --target <target>` | Runs native module tests where configured: Xcode schemes, Linux Cargo tests, Windows Cargo tests, or VSTest binaries. |
+| `fission package --target <target> --format <format>` | Builds/stages package products and writes native-products manifests where installers need structured input. |
+| `fission readiness package ...` | Checks missing scripts, package paths, signing references, and target/format-specific native requirements that can be known before packaging. |
+
+The artifact manifest produced by `fission package` remains the release handoff. Native product manifests are package-internal inputs or secondary metadata that explain what native outputs were staged.
+
+## Custom installer scripts
+
+Native products often need an installer stage that a raw application bundle cannot express. Fission supports project-defined package scripts for the formats that need that escape hatch.
+
+### Linux `.run`
+
+```toml
+[package.linux.run]
+installer_script = "platforms/linux/package-run.sh"
+```
+
+The script receives:
+
+| Environment variable | Meaning |
+| --- | --- |
+| `FISSION_LINUX_PAYLOAD_DIR` | Directory containing the app binary, assets, and staged native products. |
+| `LINUX_BINARY` | Path to the app binary inside the payload. |
+| `FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST` | JSON manifest describing staged Linux native products. |
+| `LINUX_PROFILE` | `release` when the package command runs with `--release`. |
+
+The script must print the path to the completed `.run` installer on stdout. Fission copies that installer into the normal package output and records it in `artifact-manifest.json`.
+
+### Windows `.exe`
+
+```toml
+[package.windows]
+exe_installer_script = "platforms/windows/package-exe.ps1"
+```
+
+The script receives:
+
+| Environment variable | Meaning |
+| --- | --- |
+| `WINDOWS_BINARY` | Path to the built app executable. |
+| `FISSION_WINDOWS_NATIVE_PRODUCTS_MANIFEST` | JSON manifest describing Windows native products. |
+| `WINDOWS_PROFILE` | `release` when the package command runs with `--release`. |
+
+The script must print the path to the completed `.exe` installer on stdout. Use this when the release installer must install services, drivers, helper processes, repair/uninstall logic, or machine-level integration that a simple staged executable cannot express.
+
+## Review checklist
+
+Before merging a native module change, verify these points:
+
+- The shared app still owns product behavior; native code is only the platform edge.
+- All paths are project-relative unless they intentionally name provider or environment-owned state.
+- The module chooses one build system per platform.
+- Runtime products have deterministic `destination` values and cannot overwrite each other.
+- Privileged helpers and driver packages are classified explicitly.
+- Signing and provisioning references are non-secret; secret material comes from environment variables, provider tools, key stores, or local `~/.fission/<app-name>/` state.
+- `fission test --target <target>` covers native tests where the platform supports them.
+- `fission package ... --release` writes an artifact manifest that includes the native package output you expect.
+
+## Next steps
+
+Use [Desktop packages](/docs/build-and-package/desktop-packages/) for target-specific packaging commands and [Release lifecycle details](/docs/release-and-distribute/post-build-lifecycle/) for how the native-aware package artifact moves into provider readiness, publish, and receipts.

--- a/documentation/content/docs/build-and-package/overview.mdx
+++ b/documentation/content/docs/build-and-package/overview.mdx
@@ -9,6 +9,23 @@ Packaging turns a working Fission app into something another person, device, sto
 
 Use this overview to choose the correct target page, then follow that page for the exact package shape.
 
+## Build, package, release, and publish are different steps
+
+Fission keeps the release pipeline explicit. That makes local developer releases
+and CI releases easier to reason about because each step has a concrete input
+and output.
+
+| Step | Command family | Input | Output |
+| --- | --- | --- | --- |
+| Build | `fission build` | Shared app source, generated target files, native modules | Target build output for local validation. |
+| Package | `fission package` | Build output, icons, signing references, package config | Installable/uploadable artifact plus `artifact-manifest.json`. |
+| Release content | `fission release-content` and `fission release-config` | Release notes, screenshots, store metadata, review/privacy files | Validated provider-facing release files. |
+| Publish | `fission publish` or `fission distribute` | Artifact manifest, provider config, credentials, release content | Provider upload/submission plus receipt. |
+
+Do not publish raw build output. Publish the artifact manifest produced by the
+package step. It records exactly which files, hashes, versions, package ids,
+checks, and secondary artifacts are being handed to a provider.
+
 ## The package loop
 
 A reliable package flow has four steps:
@@ -26,14 +43,35 @@ Do not skip readiness when preparing a release. It is cheaper to discover a miss
 
 | Output | Start here | Typical package formats |
 | --- | --- | --- |
-| Windows, macOS, Linux app | [Desktop packages](/docs/build-and-package/desktop-packages/) | `.exe`, `.msi`, `.msix`, `.app`, `.pkg`, `.run` |
-| Android or iOS app | [Mobile packages](/docs/build-and-package/mobile-packages/) | `.apk`, `.aab`, `.ipa` |
+| macOS app | [macOS packages](/docs/build-and-package/macos-packages/) | `.app`, `.pkg` |
+| Windows app | [Windows packages](/docs/build-and-package/windows-packages/) | `.exe`, `.msi`, `.msix` |
+| Linux app | [Linux packages](/docs/build-and-package/linux-packages/) | `.run` |
+| Android app | [Android packages](/docs/build-and-package/android-packages/) | `.apk`, `.aab` |
+| iOS app | [iOS packages](/docs/build-and-package/ios-packages/) | `.ipa` |
 | Browser app | [Web packages](/docs/build-and-package/web-packages/) | static web artifact directory or archive |
 | Terminal app or command tool | [Terminal packages](/docs/build-and-package/terminal-packages/) | release binary and manifest |
 | Documentation, marketing, reference, blog | [Static site packages](/docs/build-and-package/static-site-packages/) | static artifact or Docker image |
 | Ecommerce, portal, dashboard, dynamic web process | [Server site packages](/docs/build-and-package/server-site-packages/) | Docker image |
 
 If a page is mostly read-only and should be crawlable, use the static site target. If it needs request-time data, sessions, signed actions, cache revalidation, workers, or islands, use the server site target. If it is a full interactive browser app, use the web target.
+
+## Native products belong in native modules
+
+If the package needs platform-owned code such as a macOS extension, Windows
+driver package, Linux helper binary, Android Gradle dependency, or iOS Swift
+package, declare it with `[[native.modules]]` in
+[`fission.toml`](/reference/config/fission-toml/). Fission then builds, tests,
+stages, signs, and manifests the native outputs as part of the normal command
+lifecycle.
+
+Start with [Native modules](/docs/build-and-package/native-modules/) before
+adding ad-hoc scripts. For macOS extensions specifically, also read
+[macOS native XcodeGen](/docs/build-and-package/macos-native-xcodegen/), which
+explains the `platforms/macos/native/project.yml` file Fission-generated
+projects use for Xcode target graphs. Use package scripts only at the installer
+boundary, for example when `linux/run` or `windows/exe` must install services,
+drivers, privileged helpers, repair/uninstall logic, or other
+operating-system-owned integration.
 
 ## Artifact manifests are the handoff point
 
@@ -62,6 +100,40 @@ Custom Windows packaging scripts receive the source directory in
 their installer. Fission rejects an `assets` path that exists but is not a
 directory. On macOS, resources are staged before the application bundle is
 signed.
+
+Use the manifest path directly:
+
+```bash
+fission publish \
+  --project-dir . \
+  --provider play-store \
+  --artifact target/fission/release/android/aab/artifact-manifest.json \
+  --track internal \
+  --yes
+```
+
+If a publish flow does not receive `--artifact`, it packages the provider's
+default target/format first. That is useful for local guided publishing. CI
+should usually pass the manifest explicitly so the build and publish jobs share
+one immutable handoff file.
+
+## Version and build numbers are release inputs
+
+Store targets are sensitive to version/build values. Google Play rejects reused
+Android `versionCode` values. App Store Connect and Microsoft Store also have
+provider-side version and package-state rules. Use release-config commands to
+make those values explicit before packaging:
+
+```bash
+fission release-config add-release --project-dir . --version 1.2.3 --build 42 --yes
+fission release-config bump-build --project-dir . --target android --yes
+fission release-config version-state --project-dir . --provider play-store --target android --track internal --json
+```
+
+Package commands sync the resolved version/build into target-native config where
+Fission owns that generated configuration. If provider state says a build number
+has already been used, fix the release config and rebuild instead of uploading a
+known-bad artifact.
 
 ## Signing boundaries
 

--- a/documentation/content/docs/build-and-package/windows-packages.mdx
+++ b/documentation/content/docs/build-and-package/windows-packages.mdx
@@ -1,0 +1,151 @@
+---
+title: Windows packages
+description: Configure Fission Windows .exe, .msi, and .msix packages with signing, identity, installers, and native products.
+---
+
+# Windows packages
+
+Windows packaging produces artifacts for different installation models. The app configuration must express package identity, version, publisher, signing source, and whether the package is a raw executable, an MSIX package, or a project-defined installer.
+
+## Choose the artifact format
+
+| Format | Use it for |
+| --- | --- |
+| `exe` | Direct app executable packaging, or a project-defined setup program through `exe_installer_script`. |
+| `msi` | Managed enterprise installer workflows. |
+| `msix` | Microsoft Store and modern Windows package identity workflows. |
+
+Use `msix` for Microsoft Store distribution. Use `exe` or `msi` when the product needs an installer outside MSIX, for example services, drivers, repair, or uninstall behavior.
+
+## Realistic package configuration
+
+```toml
+[app]
+name = "Acme Notes"
+app_id = "com.acme.notes"
+version = "1.4.0"
+build = 37
+
+[targets.windows]
+enabled = true
+
+[package.windows]
+identity_name = "AcmeSoftware.AcmeNotes"
+version = "1.4.37.0"
+publisher = "CN=Acme Software Ltd, O=Acme Software Ltd, C=GB"
+certificate_thumbprint = "0123456789ABCDEF0123456789ABCDEF01234567"
+certificate_env = "WINDOWS_CERTIFICATE"
+certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"
+certificate_password_env = "WINDOWS_CERTIFICATE_PASSWORD"
+exe_installer_script = "platforms/windows/package-exe.ps1"
+```
+
+| Field | Why it exists |
+| --- | --- |
+| `identity_name` | MSIX package identity. For Store packages this should match Partner Center. |
+| `version` | Windows package version. Use four numeric components for MSIX, for example `1.4.37.0`. |
+| `publisher` | Distinguished name expected by package signing and Store identity. |
+| `certificate_thumbprint` | Uses a certificate already installed in the Windows certificate store. |
+| `certificate_env` | Environment variable containing a local certificate path when not using the certificate store. |
+| `certificate_base64_env` | CI-friendly certificate bytes. |
+| `certificate_password_env` | Secret source for the certificate password. |
+| `exe_installer_script` | Optional project-defined setup script for `windows/exe`. |
+
+Do not commit certificate files or passwords. Use the Windows certificate store for local signing or environment/CI secrets for file-based signing.
+
+## Native runtime products
+
+Use Windows native modules when the package needs helper binaries, DLLs, services, or driver installer inputs.
+
+### Cargo helper
+
+```toml
+[[native.modules]]
+name = "windows-helper"
+path = "platforms/windows/helper"
+
+[native.modules.windows]
+cargo_manifest_path = "platforms/windows/helper/Cargo.toml"
+cargo_package = "windows-helper"
+features = ["installer"]
+no_default_features = true
+
+[[native.modules.windows.products]]
+name = "helper"
+path = "target/{profile}/windows-helper.exe"
+kind = "runtime"
+destination = "native/windows-helper.exe"
+```
+
+Cargo native modules are for Rust products built with Cargo. They may set Cargo features, but they must not also declare MSBuild fields.
+
+### MSBuild or WDK module
+
+```toml
+[[native.modules]]
+name = "windows-protection"
+path = "platforms/windows/native"
+
+[native.modules.windows]
+nuget_packages_config = "platforms/windows/native/packages.config"
+nuget_packages_directory = "platforms/windows/native/packages"
+msbuild_project = "platforms/windows/native/Protection.sln"
+platform = "x64"
+build_target = "Build"
+test_binaries = ["platforms/windows/native/{platform}/{configuration}/ProtectionTests.exe"]
+
+[[native.modules.windows.products]]
+name = "cloud-files-provider"
+path = "platforms/windows/native/{platform}/{configuration}/Provider.dll"
+kind = "runtime"
+destination = "native/Provider.dll"
+
+[[native.modules.windows.products]]
+name = "filesystem-minifilter"
+path = "platforms/windows/native/{platform}/{configuration}/DriverPackage"
+kind = "driver-package"
+```
+
+MSBuild modules can restore pinned NuGet packages, build Visual Studio or WDK projects, run native test binaries, and stage products. Product paths support `{configuration}`, `{profile}`, and `{platform}`.
+
+`driver-package` products are installer inputs. Fission records them in the native-products manifest but excludes them from MSIX app manifests because drivers are installed by platform installer policy, not loaded as app files.
+
+## Custom exe installer
+
+When `package.windows.exe_installer_script` is configured, `fission package --target windows --format exe` runs that script instead of treating the app executable as the final installer.
+
+The script receives:
+
+| Environment variable | Meaning |
+| --- | --- |
+| `WINDOWS_BINARY` | Path to the staged application executable. |
+| `FISSION_WINDOWS_NATIVE_PRODUCTS_MANIFEST` | JSON manifest describing staged native products. |
+| `WINDOWS_PROFILE` | Set to `release` for release builds. |
+
+The script must print the completed `.exe` installer path on stdout. Keep the script deterministic: consume the staged inputs, create one installer, and let Fission record it in `artifact-manifest.json`.
+
+## Readiness and packaging loop
+
+```bash
+fission readiness package --project-dir . --target windows --format msix
+fission package --project-dir . --target windows --format msix --release
+```
+
+For a custom setup executable:
+
+```bash
+fission readiness package --project-dir . --target windows --format exe
+fission package --project-dir . --target windows --format exe --release
+```
+
+Readiness checks package identity, signing source, packaging scripts, and native tooling where it can. Microsoft Store provider checks happen during the release/distribute phase.
+
+## Verify on Windows
+
+Before distribution:
+
+- Install on a clean Windows machine or VM.
+- Check Start menu name, icon, publisher, package identity, and uninstall behavior.
+- Verify native helper DLLs or services are installed where expected.
+- Verify any driver installation uses explicit installer policy and can be repaired/uninstalled.
+- For Store packages, validate identity and version against Partner Center before upload.

--- a/documentation/content/docs/cookbook/add-accessible-semantics.mdx
+++ b/documentation/content/docs/cookbook/add-accessible-semantics.mdx
@@ -1,0 +1,219 @@
+---
+title: Add accessible semantics
+sidebar_label: Add accessible semantics
+slug: /cookbook/add-accessible-semantics
+description: Add roles, labels, semantic identifiers, focus behavior, and LiveTest checks to a Fission screen.
+---
+
+# Add accessible semantics
+
+This recipe takes a small settings panel and makes it understandable to screen readers, keyboard users, and selector-driven tests.
+
+The goal is not to add a second accessibility UI. The goal is to make the normal Fission widget tree expose the product meaning it already has.
+
+## Step 1: start from meaningful state and actions
+
+Accessibility works best when the app already has explicit product actions.
+
+```rust
+use fission::prelude::*;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SettingsState {
+    pub email: String,
+    pub marketing_enabled: bool,
+    pub saving: bool,
+}
+
+impl GlobalState for SettingsState {}
+
+#[derive(Action)]
+pub struct EmailChanged(pub String);
+
+#[derive(Action)]
+pub struct ToggleMarketing;
+
+#[derive(Action)]
+pub struct SaveSettings;
+
+#[fission_reducer(EmailChanged)]
+fn email_changed(state: &mut SettingsState, action: EmailChanged) {
+    state.email = action.0;
+}
+
+#[fission_reducer(ToggleMarketing)]
+fn toggle_marketing(state: &mut SettingsState) {
+    state.marketing_enabled = !state.marketing_enabled;
+}
+
+#[fission_reducer(SaveSettings)]
+fn save_settings(state: &mut SettingsState) {
+    state.saving = true;
+}
+```
+
+A screen reader activation should eventually dispatch `SaveSettings`, not a parallel accessibility-specific path.
+
+## Step 2: resolve labels from the current locale
+
+Visible text can use translation keys directly. Semantic labels are strings, so resolve them from `Env` while converting the widget.
+
+```rust
+fn tr<S: GlobalState>(view: &ViewHandle<S>, key: &str, fallback: &str) -> String {
+    view.i18n()
+        .get(&view.env().locale, key)
+        .unwrap_or(fallback)
+        .to_string()
+}
+```
+
+Use stable translation keys. Do not build labels by concatenating translated fragments.
+
+## Step 3: make the section a semantic region
+
+Use `SemanticsRegion` when a subtree is meaningful as a region, panel, dialog, or custom control.
+
+```rust
+pub struct AccountSettings;
+
+impl From<AccountSettings> for Widget {
+    fn from(_settings: AccountSettings) -> Widget {
+        let (ctx, view) = fission::build::current::<SettingsState>();
+        let state = view.state();
+
+        let email_label = tr(&view, "settings.email", "Email address");
+        let marketing_label = tr(&view, "settings.marketing", "Marketing emails");
+        let save_label = tr(&view, "settings.save", "Save settings");
+        let panel_label = tr(&view, "settings.account", "Account settings");
+
+        let email_changed = ctx.bind(EmailChanged(String::new()), reduce_with!(email_changed));
+        let toggle_marketing = ctx.bind(ToggleMarketing, reduce_with!(toggle_marketing));
+        let save_settings = ctx.bind(SaveSettings, reduce_with!(save_settings));
+
+        SemanticsRegion::new(
+            Column {
+                gap: Some(12.0),
+                children: widgets![
+                    Text::new(panel_label.clone()).into(),
+                    TextInput {
+                        value: state.email.clone(),
+                        label: Some(email_label.into()),
+                        on_change: Some(email_changed),
+                        ..Default::default()
+                    }
+                    .semantics_identifier("settings.email")
+                    .into(),
+                    Checkbox {
+                        checked: state.marketing_enabled,
+                        label: Some(marketing_label),
+                        on_toggle: Some(toggle_marketing),
+                        ..Default::default()
+                    }
+                    .semantics_identifier("settings.marketing")
+                    .into(),
+                    Button {
+                        child: Some(Text::new(save_label).into()),
+                        on_press: Some(save_settings),
+                        disabled: state.saving,
+                        ..Default::default()
+                    }
+                    .semantics_identifier("settings.save")
+                    .into(),
+                ],
+                ..Default::default()
+            }
+        )
+        .identifier("settings.account")
+        .label(panel_label)
+        .role(Role::Generic)
+        .into()
+    }
+}
+```
+
+The region identifier gives tests and platform tooling a stable target for the panel. The individual controls expose stable identifiers for automation and clear labels for assistive technology.
+
+## Step 4: add explicit labels for visual-only controls
+
+If a control uses only an icon or custom drawing, do not rely on pixels to communicate meaning.
+
+```rust
+let close_settings = ctx.bind(CloseSettings, reduce_with!(close_settings));
+
+Button {
+    child: Some(Icon::new("x").into()),
+    on_press: Some(close_settings),
+    semantics: Some(Semantics {
+        role: Role::Button,
+        label: Some(tr(&view, "settings.close", "Close settings")),
+        identifier: Some("settings.close".into()),
+        focusable: true,
+        ..Semantics::default()
+    }),
+    ..Default::default()
+}
+.into()
+```
+
+Use this pattern for icon buttons, custom canvas controls, drag handles, toolbar buttons, disclosure affordances, and any status indicator that is not already represented by text.
+
+## Step 5: keep focus predictable
+
+Most focusable controls should use normal pointer focus. Use `FocusPolicy::PreserveCurrentOnPointer` for toolbar or ribbon buttons that should not steal focus from an editor.
+
+```rust
+let toggle_bold = ctx.bind(ToggleBold, reduce_with!(toggle_bold));
+
+Button {
+    child: Some(Text::new(TextContent::Key("editor.bold".into())).into()),
+    on_press: Some(toggle_bold),
+    focus_policy: FocusPolicy::PreserveCurrentOnPointer,
+    ..Default::default()
+}
+.semantics_identifier("editor.bold")
+.into()
+```
+
+This lets the button activate while the editor remains the focused text field.
+
+## Step 6: test with semantic selectors
+
+Live tests should target product semantics instead of coordinates when the requirement is semantic behavior.
+
+```rust
+client.wait_for_visible("settings.email")?;
+client.fill_text_semantic_identifier("settings.email", "alex@example.com")?;
+client.tap_semantic_identifier("settings.marketing")?;
+client.tap_semantic_identifier("settings.save")?;
+
+let tree = client.get_tree()?;
+let save = tree
+    .nodes
+    .iter()
+    .find(|node| node.identifier.as_deref() == Some("settings.save"))
+    .expect("save button semantics");
+
+assert_eq!(save.label.as_deref(), Some("Save settings"));
+assert!(!save.disabled);
+```
+
+If a selector fails, inspect the returned candidates and visibility information. A good failure should tell you whether the target was missing, disabled, hidden, clipped, or ambiguous.
+
+## Step 7: run manual screen-reader QA
+
+Before shipping a native app, run the app with the platform screen reader enabled.
+
+Check at least these behaviors:
+
+- the screen title and major regions are discoverable;
+- each control announces a useful role and label;
+- checked, disabled, read-only, masked, and value states are announced correctly;
+- focus order matches visible order;
+- activating controls dispatches the same reducers as pointer input;
+- text fields can be focused, edited, selected, and submitted;
+- dialogs trap or guide focus appropriately;
+- errors and loading states are not communicated by color alone.
+
+## Related reference
+
+Read [Accessibility in Fission](/docs/learn/accessibility/) for the conceptual model. Read [Accessibility reference](/reference/platform/accessibility/) for the platform matrix and exact native bridge behavior. Read [LiveTest command API](/reference/core/live-test-command-api/) for selector commands such as `TapSelector`, `FocusSelector`, `FillText`, `WaitForVisible`, and `GetTree`.

--- a/documentation/content/docs/fission/for/compose-developers.mdx
+++ b/documentation/content/docs/fission/for/compose-developers.mdx
@@ -1,0 +1,500 @@
+---
+title: Fission for Compose developers
+description: Translate Jetpack Compose composables, remember state, ViewModel flows, LaunchedEffect, MaterialTheme, Navigation, and tests into Fission state, reducers, jobs, routers, theme tokens, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Compose developers
+
+Compose and Fission both describe UI from state and make composition central. Your instincts around unidirectional data flow and small reusable UI pieces transfer well.
+
+The main shift is that Fission reducers are the default mutation boundary. Instead of updating remembered or ViewModel-owned state from composables, widgets dispatch typed actions and reducers update app state.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Compose">
+
+```kotlin title="TodoScreen.kt"
+@Composable
+fun TodoScreen() {
+    val todos = listOf(
+        Todo(1, "Write release notes", false),
+        Todo(2, "Test Android package", true),
+    )
+
+    Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("Ship checklist", style = MaterialTheme.typography.headlineMedium)
+        todos.forEach { todo ->
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(if (todo.done) "Done" else "Open")
+                Text(todo.title)
+            }
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Compose">
+
+```kotlin title="TodoScreen.kt"
+@Composable
+fun TodoScreen(viewModel: TodoViewModel = viewModel()) {
+    val state by viewModel.state.collectAsState()
+
+    TodoContent(
+        state = state,
+        onDraftChanged = viewModel::setDraft,
+        onAdd = viewModel::addDraftTodo,
+        onToggle = viewModel::toggleTodo,
+    )
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Compose">
+
+```kotlin title="TodoScreen.kt"
+LaunchedEffect(Unit) {
+    viewModel.loadTodos()
+}
+
+class TodoViewModel : ViewModel() {
+    fun loadTodos() = viewModelScope.launch {
+        _state.update { it.copy(loading = true) }
+        _state.update { it.copy(todos = repository.loadTodos(), loading = false) }
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Compose">
+
+```kotlin title="TodoScreen.kt"
+Surface(
+    shape = RoundedCornerShape(16.dp),
+    color = MaterialTheme.colorScheme.surface,
+    tonalElevation = 1.dp,
+) {
+    Row(Modifier.padding(16.dp)) {
+        Checkbox(checked = todo.done, onCheckedChange = { onToggle(todo.id) })
+        Text(todo.title, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Compose">
+
+```kotlin title="TodoScreen.kt"
+NavHost(navController, startDestination = "todos") {
+    composable("todos") { TodoScreen() }
+    composable("todos/{id}") { entry ->
+        TodoDetail(entry.arguments?.getString("id")?.toLong() ?: 0)
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Compose">
+
+```kotlin title="TodoScreen.kt"
+composeTestRule.setContent { TodoScreen() }
+
+composeTestRule.onNodeWithText("New task").performTextInput("Publish release")
+composeTestRule.onNodeWithText("Add task").performClick()
+composeTestRule.onNodeWithText("Publish release").assertIsDisplayed()
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Compose concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| `@Composable` | Rust struct plus `impl From<T> for Widget` | Fission conversion is not a suspending/composable function. |
+| `remember` | `#[local_state]` | Retained by widget identity and updated through local reducers. |
+| `ViewModel` state | `GlobalState` | Product state is the framework-level app model. |
+| `LaunchedEffect` | Jobs/resources/effects | Outside work is requested outside conversion. |
+| `MaterialTheme` | Generated design-system tokens in `Env` | Theme is target-lowerable runtime data. |
+| `NavHost` | Fission `Router` | Route state is app-owned. |
+
+## Common instincts to adjust
+
+Do not make composable-local state the home for product truth. Keep important state in `GlobalState`.
+
+Do not use side-effect blocks as the default loading mechanism. Reducers request work and receive typed results.
+
+Keep Compose's semantic testing instinct, but prefer stable semantic identifiers over visible text when tests should survive i18n and layout changes.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/dioxus-developers.mdx
+++ b/documentation/content/docs/fission/for/dioxus-developers.mdx
@@ -1,0 +1,507 @@
+---
+title: Fission for Dioxus developers
+description: Translate Dioxus components, signals, resources, router, desktop/mobile targets, and tests into Fission GlobalState, reducers, widgets, resources, shells, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Dioxus developers
+
+Dioxus and Fission both target Rust developers who want one UI model across more than one platform. Component composition, Rust types, and cross-platform ambition transfer directly.
+
+The main shift is that Fission's retained app model is reducer-driven and widget-based rather than virtual-DOM/RSX-driven. Shells host the app model; they do not redefine product behavior.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Dioxus">
+
+```rust title="src/todo.rs"
+#[component]
+fn TodoApp() -> Element {
+    let todos = vec![
+        Todo::new(1, "Write release notes", false),
+        Todo::new(2, "Test Android package", true),
+    ];
+
+    rsx! {
+        section {
+            h1 { "Ship checklist" }
+            for todo in todos {
+                {
+                    let status = if todo.done { "Done" } else { "Open" };
+                    rsx! {
+                        div {
+                            span { "{status}" }
+                            span { "{todo.title}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Dioxus">
+
+```rust title="src/todo.rs"
+#[component]
+fn TodoApp() -> Element {
+    let mut draft = use_signal(String::new);
+    let mut todos = use_signal(Vec::<Todo>::new);
+
+    let add = move |_| {
+        let title = draft.read().trim().to_string();
+        if title.is_empty() { return; }
+        todos.write().push(Todo::new(title));
+        draft.set(String::new());
+    };
+
+    rsx! { TodoContent { draft, todos, onadd: add } }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Dioxus">
+
+```rust title="src/todo.rs"
+let todos = use_resource(move || async move {
+    api::load_todos().await
+});
+
+match &*todos.read_unchecked() {
+    Some(Ok(items)) => rsx! { TodoList { todos: items.clone() } },
+    Some(Err(_)) => rsx! { "Unable to load" },
+    None => rsx! { "Loading" },
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Dioxus">
+
+```rust title="src/todo.rs"
+rsx! {
+    button { class: "rounded-xl border bg-white px-4 py-3 shadow-sm",
+        input { r#type: "checkbox", checked: todo.done }
+        span { "{todo.title}" }
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Dioxus">
+
+```rust title="src/todo.rs"
+#[derive(Routable, Clone, PartialEq)]
+enum Route {
+    #[route("/")]
+    Todos {},
+    #[route("/todos/:id")]
+    TodoDetail { id: u64 },
+}
+
+rsx! { Router::<Route> {} }
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Dioxus">
+
+```rust title="src/todo.rs"
+// Dioxus tests often target the rendered app or platform runner.
+// Assert user-visible behavior rather than internal component structure.
+app.find("New task").type_text("Publish release");
+app.find("Add task").click();
+app.find("Publish release").assert_exists();
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Dioxus concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| RSX component | Rust struct plus `impl From<T> for Widget` | Fission is widget-lowering, not virtual-DOM rendering. |
+| Signal | `GlobalState` or `#[local_state]` | State lives where ownership says it belongs. |
+| Resource | Resource/job/service/effect | Outside work is explicit runtime work. |
+| Dioxus router | Fission `Router` | Fission routes are shared app state. |
+| Desktop/mobile runner | Fission shell and target | Shells adapt one app model to each platform. |
+
+## Common instincts to adjust
+
+Do not treat a virtual DOM mental model as the core abstraction. Fission lowers widgets through layout, semantics, and render pipelines.
+
+Do not update product truth from arbitrary component closures. Dispatch actions and let reducers own transitions.
+
+Keep the Rust and multi-platform instincts, but use Fission's shells and package manifests for the platform lifecycle.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/electron-developers.mdx
+++ b/documentation/content/docs/fission/for/electron-developers.mdx
@@ -1,0 +1,497 @@
+---
+title: Fission for Electron developers
+description: Translate Electron renderer state, browser windows, IPC, native packaging, and web UI tests into Fission shared state, reducers, shells, native capabilities, targets, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Electron developers
+
+Electron developers already understand desktop product concerns: windows, menus, filesystem access, packaging, updates, and web-driven UI. Fission keeps those concerns, but removes the assumption that the DOM/webview is the app substrate.
+
+The main shift is that platform access is not ad-hoc IPC from a renderer process. Fission uses typed actions, reducers, capabilities, services, jobs, native modules, and shells around one shared app model.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Electron">
+
+```tsx title="src/TodoApp.tsx"
+export function TodoApp() {
+  const todos = [
+    { id: 1, title: "Write release notes", done: false },
+    { id: 2, title: "Test Android package", done: true },
+  ];
+
+  return (
+    <section className="todo-screen">
+      <h1>Ship checklist</h1>
+      {todos.map((todo) => (
+        <div key={todo.id} className="todo-row">
+          <span>{todo.done ? "Done" : "Open"}</span>
+          <span>{todo.title}</span>
+        </div>
+      ))}
+    </section>
+  );
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Electron">
+
+```tsx title="src/TodoApp.tsx"
+export function TodoApp() {
+  const [draft, setDraft] = useState("");
+  const [todos, setTodos] = useState<Todo[]>([]);
+
+  function addDraftTodo() {
+    const title = draft.trim();
+    if (!title) return;
+    setTodos((items) => [...items, { id: crypto.randomUUID(), title, done: false }]);
+    setDraft("");
+  }
+
+  return <TodoContent draft={draft} todos={todos} onDraft={setDraft} onAdd={addDraftTodo} />;
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Electron">
+
+```tsx title="src/TodoApp.tsx"
+// renderer
+const todos = await window.electron.todos.load();
+
+// preload
+contextBridge.exposeInMainWorld("electron", {
+  todos: { load: () => ipcRenderer.invoke("todos:load") },
+});
+
+// main
+ipcMain.handle("todos:load", async () => loadTodosFromDisk());
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Electron">
+
+```tsx title="src/TodoApp.tsx"
+<button className="todo-row rounded-xl border bg-white px-4 py-3 shadow-sm">
+  <input type="checkbox" checked={todo.done} readOnly />
+  <span>{todo.title}</span>
+</button>
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Electron">
+
+```tsx title="src/TodoApp.tsx"
+createRoot(root).render(
+  <HashRouter>
+    <Routes>
+      <Route path="/" element={<TodoApp />} />
+      <Route path="/todos/:id" element={<TodoDetail />} />
+    </Routes>
+  </HashRouter>
+);
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Electron">
+
+```tsx title="src/TodoApp.tsx"
+await app.client.$('[aria-label="New task"]').setValue('Publish release');
+await app.client.$('[data-testid="todo.add"]').click();
+await expect(app.client.$('text=Publish release')).toBeDisplayed();
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Electron concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| Renderer component | Fission widget | Fission does not require a DOM/webview substrate. |
+| `ipcRenderer.invoke` | Capability, job, service, or resource | Host work is typed and reducer-driven. |
+| Main process | Shell/native provider boundary | Shells adapt platform behavior around shared app state. |
+| CSS | Design-system tokens and widget fields | Styling remains target-lowerable. |
+| Electron packaging | Fission targets and package manifests | Package handoff is manifest-backed. |
+| WebDriver/Playwright | `LiveTestClient` and `/cmd` | Tests can target semantic identifiers, not DOM selectors. |
+
+## Common instincts to adjust
+
+Do not design the app around renderer-to-main string channels. Name product intent as actions and use typed host work.
+
+Do not let desktop packaging become unrelated scripts. Use Fission package targets and artifact manifests.
+
+Keep the Electron instinct that desktop app lifecycle matters: windows, files, permissions, installers, and release notes are product commitments, not afterthoughts.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/flutter-developers.mdx
+++ b/documentation/content/docs/fission/for/flutter-developers.mdx
@@ -1,0 +1,535 @@
+---
+title: Fission for Flutter developers
+description: Translate Flutter widgets, setState, inherited data, platform channels, routing, and tests into Fission reducers, widgets, providers, shells, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Flutter developers
+
+Flutter and Fission both treat UI as a tree of widgets and both care about retained identity, layout constraints, and target shells. Your instinct to compose small visual pieces still applies.
+
+The main shift is where mutation happens. Flutter often updates widget-owned state with `setState` or state-management packages. Fission asks you to name user intent as actions and update durable product data in reducers.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Flutter">
+
+```dart title="lib/todo_app.dart"
+class TodoApp extends StatelessWidget {
+  const TodoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final todos = [
+      Todo(1, 'Write release notes', false),
+      Todo(2, 'Test Android package', true),
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Ship checklist', style: Theme.of(context).textTheme.headlineMedium),
+          for (final todo in todos)
+            Row(children: [Text(todo.done ? 'Done' : 'Open'), Text(todo.title)]),
+        ],
+      ),
+    );
+  }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Flutter">
+
+```dart title="lib/todo_app.dart"
+class TodoScreenState extends State<TodoScreen> {
+  final controller = TextEditingController();
+  final todos = <Todo>[];
+  var nextId = 1;
+
+  void addTodo() {
+    final title = controller.text.trim();
+    if (title.isEmpty) return;
+
+    setState(() {
+      todos.add(Todo(nextId++, title, false));
+      controller.clear();
+    });
+  }
+
+  void toggleTodo(int id) {
+    setState(() {
+      final index = todos.indexWhere((todo) => todo.id == id);
+      todos[index] = todos[index].copyWith(done: !todos[index].done);
+    });
+  }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Flutter">
+
+```dart title="lib/todo_app.dart"
+class TodoScreenState extends State<TodoScreen> {
+  var loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    loadTodos();
+  }
+
+  Future<void> loadTodos() async {
+    setState(() => loading = true);
+    final todos = await api.fetchTodos();
+    if (!mounted) return;
+    setState(() {
+      this.todos
+        ..clear()
+        ..addAll(todos);
+      loading = false;
+    });
+  }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Flutter">
+
+```dart title="lib/todo_app.dart"
+Card(
+  color: Theme.of(context).colorScheme.surface,
+  child: Padding(
+    padding: const EdgeInsets.all(16),
+    child: Row(
+      children: [
+        Checkbox(value: todo.done, onChanged: (_) => onToggle(todo.id)),
+        Text(todo.title, style: Theme.of(context).textTheme.bodyMedium),
+      ],
+    ),
+  ),
+)
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Flutter">
+
+```dart title="lib/todo_app.dart"
+MaterialApp(
+  routes: {
+    '/': (_) => const TodoScreen(),
+    '/todos': (_) => const TodoListScreen(),
+  },
+  onGenerateRoute: (settings) => TodoDetailRoute.from(settings),
+)
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Flutter">
+
+```dart title="lib/todo_app.dart"
+testWidgets('adds a todo', (tester) async {
+  await tester.pumpWidget(const TodoApp());
+
+  await tester.enterText(find.bySemanticsLabel('New task'), 'Publish release');
+  await tester.tap(find.text('Add task'));
+  await tester.pump();
+
+  expect(find.text('Publish release'), findsOneWidget);
+});
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Flutter concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| `Widget` | `Widget` | Fission widgets are Rust values converted through `impl From<T> for Widget`. |
+| `StatefulWidget` + `setState` | `GlobalState`, reducers, and `#[local_state]` | Product state belongs in app state; isolated retained UI memory uses local state. |
+| `InheritedWidget` / provider | `Env`, providers, and app state | Fission keeps environment and product data separate. |
+| Platform channel | Capability, service, or native module | Host work is typed and requested explicitly. |
+| `Navigator` | Fission `Router` | Route state is app-owned and target-normalized. |
+| `testWidgets` | `fission-test` and `LiveTestClient` | Choose headless runtime tests or real shell tests by requirement. |
+
+## Common instincts to adjust
+
+Do not translate every `StatefulWidget` into hidden product state. If the data is durable product truth, put it in `GlobalState`.
+
+Do not start platform work inside widget conversion. Use a reducer to request the work and handle completion as another action.
+
+Keep the useful Flutter instinct around layout constraints, but remember Fission targets more than native/mobile runtimes, including Terminal, Static site, and SSR.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/leptos-developers.mdx
+++ b/documentation/content/docs/fission/for/leptos-developers.mdx
@@ -1,0 +1,498 @@
+---
+title: Fission for Leptos developers
+description: Translate Leptos signals, resources, components, router, SSR instincts, and Rust web UI tests into Fission app state, reducers, resources, routers, shells, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Leptos developers
+
+Leptos and Fission both use Rust for UI authoring and both value state-driven rendering. If you know signals, resources, and Rust component syntax, you already have useful instincts.
+
+The main shift is that Fission is not browser-first. It uses Rust widgets and a multi-target runtime rather than DOM hydration as the default substrate.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Leptos">
+
+```rust title="src/todo.rs"
+#[component]
+fn TodoApp() -> impl IntoView {
+    let todos = vec![
+        Todo { id: 1, title: "Write release notes".into(), done: false },
+        Todo { id: 2, title: "Test Android package".into(), done: true },
+    ];
+
+    view! {
+        <section>
+            <h1>"Ship checklist"</h1>
+            {todos.into_iter().map(|todo| view! {
+                <div><span>{if todo.done { "Done" } else { "Open" }}</span><span>{todo.title}</span></div>
+            }).collect_view()}
+        </section>
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Leptos">
+
+```rust title="src/todo.rs"
+#[component]
+fn TodoApp() -> impl IntoView {
+    let (draft, set_draft) = create_signal(String::new());
+    let (todos, set_todos) = create_signal(Vec::<Todo>::new());
+
+    let add = move |_| {
+        let title = draft.get().trim().to_string();
+        if title.is_empty() { return; }
+        set_todos.update(|items| items.push(Todo::new(title)));
+        set_draft.set(String::new());
+    };
+
+    view! { <TodoContent draft=draft set_draft=set_draft todos=todos on:add=add /> }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Leptos">
+
+```rust title="src/todo.rs"
+let todos = create_resource(
+    || (),
+    |_| async move { load_todos().await }
+);
+
+view! {
+    <Suspense fallback=move || view! { <p>"Loading"</p> }>
+        {move || todos.get().map(|items| view! { <TodoList todos=items /> })}
+    </Suspense>
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Leptos">
+
+```rust title="src/todo.rs"
+view! {
+    <div class="rounded-xl border bg-white px-4 py-3 shadow-sm">
+        <input type="checkbox" prop:checked=todo.done />
+        <span>{todo.title}</span>
+    </div>
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Leptos">
+
+```rust title="src/todo.rs"
+view! {
+    <Router>
+        <Routes fallback=|| view! { <p>"Not found"</p> }>
+            <Route path=path!("/") view=TodoApp />
+            <Route path=path!("/todos/:id") view=TodoDetail />
+        </Routes>
+    </Router>
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Leptos">
+
+```rust title="src/todo.rs"
+// Browser-level tests usually drive rendered DOM.
+page.get_by_label("New task").fill("Publish release").await?;
+page.get_by_role("button").click().await?;
+page.get_by_text("Publish release").wait_for().await?;
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Leptos concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| Signal | `GlobalState`, selector, or `#[local_state]` | Fission chooses state storage by ownership and lifetime. |
+| Resource | Resource/job/service/effect | Outside work is explicit runtime work. |
+| Component function | Struct plus `impl From<T> for Widget` | Fission avoids hidden render-time side effects. |
+| Leptos Router | Fission `Router` | Route state is shared across all targets. |
+| DOM hydration | Shell lowering | Fission can lower to native, web canvas, terminal, static HTML, or SSR. |
+
+## Common instincts to adjust
+
+Do not assume the browser DOM is the primary runtime. Fission's app model must also work in native, mobile, terminal, static, and SSR shells.
+
+Do not use signals as an undifferentiated state bucket. Durable product truth goes in `GlobalState`; local retained UI memory uses `#[local_state]`.
+
+Keep the Rust-first instinct, but let Fission's reducer and widget model set the boundaries.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/overview.mdx
+++ b/documentation/content/docs/fission/for/overview.mdx
@@ -13,18 +13,20 @@ These pages are not benchmark pages and not dismissal pages. They are translatio
 
 ## The series
 
-The full series is planned around developer backgrounds rather than platform targets.
+The series is organized around developer backgrounds rather than platform targets.
 
-| Background | What the page will focus on |
+| Background | What the page focuses on |
 | --- | --- |
-| [React developers](/docs/from/react/) | Hooks, component state, context, effects, CSS, routing, and tests translated into Fission state, reducers, widgets, environment, resources, theme tokens, routers, and target tests. |
-| Flutter developers | Widget trees, `setState`, inherited data, platform channels, layout constraints, animation, and native packaging translated into Fission widgets, reducers, providers, shells, motion, and targets. |
-| SwiftUI and Compose developers | Declarative UI, value-driven state, bindings, previews, modifiers, navigation, and native capability access translated into Fission's shared app model and shell boundary. |
-| Electron and Tauri developers | Desktop app structure, webview assumptions, IPC, native packaging, file system access, and update flows translated into Fission's native, web, mobile, terminal, static, and SSR target model. |
-| Leptos, Yew, and Dioxus developers | Rust UI experience, browser-first reactivity, signals, hydration, and WASM assumptions translated into Fission's multi-target runtime and deterministic widget model. |
-| Terminal UI developers | Cell layout, keyboard-first interaction, command workflows, logs, scrollback, and snapshot testing translated into Fission's terminal shell and shared app architecture. |
-
-The React guide is the first complete page in this pattern. The other backgrounds use the same structure so the series can grow without changing the learning model underneath it.
+| [React developers](/docs/fission/for/react-developers/) | Hooks, component state, context, effects, CSS, routing, and tests translated into Fission state, reducers, widgets, environment, resources, theme tokens, routers, and target tests. |
+| [Flutter developers](/docs/fission/for/flutter-developers/) | Widget trees, `setState`, inherited data, platform channels, layout constraints, routing, theme, and widget tests translated into Fission widgets, reducers, providers, shells, routers, tokens, and LiveTest. |
+| [SwiftUI developers](/docs/fission/for/swiftui-developers/) | `View`, `@State`, `ObservableObject`, environment, `.task`, `NavigationStack`, modifiers, and XCTest translated into Fission's shared app model. |
+| [Compose developers](/docs/fission/for/compose-developers/) | Composables, `remember`, ViewModels, `LaunchedEffect`, `MaterialTheme`, `NavHost`, and Compose tests translated into Fission state, reducers, jobs, theme tokens, routers, and LiveTest. |
+| [Electron developers](/docs/fission/for/electron-developers/) | Renderer state, browser windows, IPC, native packaging, filesystem access, and web UI tests translated into Fission's native shell and typed runtime boundary. |
+| [Tauri developers](/docs/fission/for/tauri-developers/) | Web frontend state, Rust commands, plugins, windows, packaging, and tests translated into Fission's Rust-first shared UI model and targets. |
+| [Leptos developers](/docs/fission/for/leptos-developers/) | Signals, resources, components, routers, SSR instincts, and Rust browser UI tests translated into Fission's multi-target runtime. |
+| [Yew developers](/docs/fission/for/yew-developers/) | Function components, hooks, properties, callbacks, browser routing, and browser tests translated into Fission widgets, reducers, resources, routers, and LiveTest. |
+| [Dioxus developers](/docs/fission/for/dioxus-developers/) | RSX components, signals, resources, routers, desktop/mobile runners, and tests translated into Fission widgets, app state, reducers, shells, and package targets. |
+| [Terminal UI developers](/docs/fission/for/terminal-ui-developers/) | Cell layout, keyboard-first interaction, command workflows, logs, scrollback, and snapshot testing translated into Fission's Terminal shell and shared app architecture. |
 
 ## The shared pattern
 
@@ -82,4 +84,4 @@ When a page says "this maps loosely," take that seriously. Some concepts are cou
 
 ## Start here
 
-Begin with [Fission for React developers](/docs/from/react/) if your background is web UI or component-driven frontend work. It introduces the translation pattern the rest of this section will reuse.
+Begin with [Fission for React developers](/docs/fission/for/react-developers/) if your background is web UI or component-driven frontend work. It introduces the translation pattern the rest of this section will reuse.

--- a/documentation/content/docs/fission/for/react-developers.mdx
+++ b/documentation/content/docs/fission/for/react-developers.mdx
@@ -788,7 +788,7 @@ This map comes after the todo app because the names are easier once you have see
 | `useEffect` | Effects, jobs, services, resources, and capabilities | Outside work is requested from reducers or declared resources, not started during conversion. |
 | CSS/classes | Theme tokens and widget fields | Styling is structured and target-lowerable. Static site output can still emit CSS. |
 | React Router | Fission `Router` plus route state | Shell URLs and deep links normalize into app route actions. |
-| React Testing Library | Reducer tests, `TestHarness`, and `LiveTestClient` | Pick the smallest surface that proves the behavior. |
+| React Testing Library | Reducer tests, `TestHarness`, and `LiveTestClient` | Pick the smallest test layer that proves the behavior. |
 
 ## Common React instincts to adjust
 
@@ -810,4 +810,4 @@ Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) 
 
 Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.
 
-Read [Testing and diagnostics](/docs/guides/testing-and-diagnostics/) and [Write a live UI test](/docs/cookbook/write-a-live-ui-test/) when you are ready to test a real shell.
+Read [Testing Fission apps](/docs/learn/testing/) and [Write a live UI test](/docs/cookbook/write-a-live-ui-test/) when you are ready to test reducers, widgets, selectors, `/cmd`, and a real shell.

--- a/documentation/content/docs/fission/for/swiftui-developers.mdx
+++ b/documentation/content/docs/fission/for/swiftui-developers.mdx
@@ -1,0 +1,509 @@
+---
+title: Fission for SwiftUI developers
+description: Translate SwiftUI View structs, @State, @StateObject, Environment, task, NavigationStack, modifiers, and tests into Fission state, reducers, widgets, environment, jobs, routers, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for SwiftUI developers
+
+SwiftUI and Fission both favor declarative UI from values. Struct-shaped screens, environment input, navigation state, and previewable composition are familiar starting points.
+
+The main shift is that Fission keeps product mutation in reducers rather than property wrappers inside views. A Fission widget conversion reads state and wires actions; reducers perform the state transition.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="SwiftUI">
+
+```swift title="TodoView.swift"
+struct TodoView: View {
+    let todos = [
+        Todo(id: 1, title: "Write release notes", done: false),
+        Todo(id: 2, title: "Test Android package", done: true),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Ship checklist").font(.title).bold()
+            ForEach(todos) { todo in
+                HStack {
+                    Text(todo.done ? "Done" : "Open")
+                    Text(todo.title)
+                }
+            }
+        }
+        .padding(24)
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="SwiftUI">
+
+```swift title="TodoView.swift"
+@MainActor
+final class TodoModel: ObservableObject {
+    @Published var draft = ""
+    @Published var todos: [Todo] = []
+    private var nextId = 1
+
+    func addDraftTodo() {
+        let title = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+        todos.append(Todo(id: nextId, title: title, done: false))
+        nextId += 1
+        draft = ""
+    }
+
+    func toggle(_ id: Int) {
+        guard let index = todos.firstIndex(where: { $0.id == id }) else { return }
+        todos[index].done.toggle()
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="SwiftUI">
+
+```swift title="TodoView.swift"
+.task {
+    do {
+        todos = try await api.loadTodos()
+    } catch {
+        self.error = error.localizedDescription
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="SwiftUI">
+
+```swift title="TodoView.swift"
+HStack {
+    Toggle("", isOn: $todo.done)
+    Text(todo.title)
+}
+.padding(16)
+.background(.regularMaterial)
+.clipShape(RoundedRectangle(cornerRadius: 16))
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="SwiftUI">
+
+```swift title="TodoView.swift"
+NavigationStack(path: $path) {
+    TodoList(model: model)
+        .navigationDestination(for: Todo.ID.self) { id in
+            TodoDetail(id: id)
+        }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="SwiftUI">
+
+```swift title="TodoView.swift"
+func testAddsTodo() throws {
+    let app = XCUIApplication()
+    app.launch()
+
+    app.textFields["New task"].tap()
+    app.textFields["New task"].typeText("Publish release")
+    app.buttons["Add task"].tap()
+
+    XCTAssertTrue(app.staticTexts["Publish release"].exists)
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| SwiftUI concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| `View` | Rust struct plus `impl From<T> for Widget` | Fission conversion returns a target-lowerable widget tree. |
+| `@State` | `#[local_state]` or `GlobalState` | Choose by lifetime and ownership, not convenience. |
+| `@StateObject` / model | `GlobalState` and services/resources | Durable product state is serializable app state. |
+| `Environment` | `Env` | Theme, locale, viewport, route, and shell context are environment. |
+| `.task` | Job/resource/effect | Outside work is requested explicitly. |
+| `NavigationStack` | Fission `Router` | Route state is app-owned and shell-normalized. |
+
+## Common instincts to adjust
+
+Do not hide product state in view-local property wrappers. Keep the durable model visible in `GlobalState`.
+
+Do not treat modifiers as an unstructured styling stack. Prefer typed widgets and generated design-system tokens.
+
+Keep the SwiftUI instinct that accessibility labels matter; in Fission, add stable semantic identifiers as well so automation can target meaning across platforms.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/tauri-developers.mdx
+++ b/documentation/content/docs/fission/for/tauri-developers.mdx
@@ -1,0 +1,478 @@
+---
+title: Fission for Tauri developers
+description: Translate Tauri frontend state, Rust commands, IPC, plugins, windows, packaging, and tests into Fission shared app state, reducers, capabilities, native modules, targets, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Tauri developers
+
+Tauri and Fission both appeal to developers who want Rust in desktop/mobile app architecture. Tauri keeps a web frontend plus Rust commands. Fission makes the UI model itself Rust-first and shared across more target shells.
+
+The main shift is that Fission does not treat Rust as only the backend behind a webview. State, widgets, reducers, routing, theme, and tests are all part of the shared Rust app model.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Tauri">
+
+```tsx title="src/TodoApp.tsx"
+export function TodoApp() {
+  return (
+    <main>
+      <h1>Ship checklist</h1>
+      <TodoRow title="Write release notes" done={false} />
+      <TodoRow title="Test Android package" done />
+    </main>
+  );
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Tauri">
+
+```tsx title="src/TodoApp.tsx"
+export function TodoApp() {
+  const [draft, setDraft] = useState("");
+  const [todos, setTodos] = useState<Todo[]>([]);
+
+  async function addDraftTodo() {
+    const todo = await invoke<Todo>("add_todo", { title: draft });
+    setTodos((items) => [...items, todo]);
+    setDraft("");
+  }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Tauri">
+
+```tsx title="src/TodoApp.tsx"
+#[tauri::command]
+async fn load_todos(state: tauri::State<'_, TodoStore>) -> Result<Vec<Todo>, String> {
+    state.load().await.map_err(|err| err.to_string())
+}
+
+const todos = await invoke<Todo[]>("load_todos");
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Tauri">
+
+```tsx title="src/TodoApp.tsx"
+<button className="rounded-xl border bg-white px-4 py-3 shadow-sm">
+  <input type="checkbox" checked={todo.done} readOnly />
+  <span>{todo.title}</span>
+</button>
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Tauri">
+
+```tsx title="src/TodoApp.tsx"
+<BrowserRouter>
+  <Routes>
+    <Route path="/" element={<TodoApp />} />
+    <Route path="/todos/:id" element={<TodoDetail />} />
+  </Routes>
+</BrowserRouter>
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Tauri">
+
+```tsx title="src/TodoApp.tsx"
+await page.getByLabel('New task').fill('Publish release');
+await page.getByRole('button', { name: 'Add task' }).click();
+await expect(page.getByText('Publish release')).toBeVisible();
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Tauri concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| Web frontend | Fission widget tree | The UI is Rust-native, not a webview app model. |
+| `#[tauri::command]` | Job, service, resource, or capability | Calls are typed runtime work requested by reducers. |
+| Plugin | Capability/provider/native module | Host integration is explicit and target-aware. |
+| `tauri.conf.json` bundle config | `fission.toml` targets/package config | Package artifacts produce manifest handoffs. |
+| Web tests | `LiveTestClient` and `/cmd` | Tests target semantics rather than DOM selectors. |
+
+## Common instincts to adjust
+
+Do not split product state between a frontend store and Rust command state unless there is a real ownership reason. Fission product state should be one visible app model.
+
+Do not turn every host operation into a generic stringly IPC call. Prefer typed jobs, services, capabilities, and reducers.
+
+Keep the Tauri instinct that packaging, signing, and native capabilities are first-class app concerns.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/terminal-ui-developers.mdx
+++ b/documentation/content/docs/fission/for/terminal-ui-developers.mdx
@@ -1,0 +1,479 @@
+---
+title: Fission for Terminal UI developers
+description: Translate Ratatui-style app state, event loops, command palettes, keyboard interaction, scrollback, and snapshot tests into Fission widgets, reducers, Terminal shell, semantics, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Terminal UI developers
+
+Terminal UI developers already care about keyboard-first flows, focus, layout constraints, logs, progress, and deterministic rendering. Those instincts fit Fission well.
+
+The main shift is that terminal is one Fission shell, not a separate app architecture. The same state, reducers, widgets, semantics, and tests can also run through desktop, web, mobile, static, and SSR targets where appropriate.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Terminal UI">
+
+```rust title="src/app.rs"
+pub struct App {
+    todos: Vec<Todo>,
+}
+
+impl Widget for TodoView<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let block = Block::bordered().title("Ship checklist");
+        let rows = self.todos.iter().map(|todo| {
+            Line::from(vec![Span::raw(if todo.done { "Done" } else { "Open" }), Span::raw(&todo.title)])
+        });
+        Paragraph::new(rows.collect::<Vec<_>>()).block(block).render(area, buf);
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Terminal UI">
+
+```rust title="src/app.rs"
+match event::read()? {
+    Event::Key(key) if key.code == KeyCode::Enter => app.add_draft_todo(),
+    Event::Key(key) if key.code == KeyCode::Char(' ') => app.toggle_selected(),
+    Event::Key(key) if key.code == KeyCode::Char(c) => app.draft.push(c),
+    _ => {}
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Terminal UI">
+
+```rust title="src/app.rs"
+if app.should_load {
+    let todos = repository.load_todos()?;
+    app.todos = todos;
+    app.should_load = false;
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Terminal UI">
+
+```rust title="src/app.rs"
+Paragraph::new(todo.title.as_str())
+    .style(Style::default().fg(Color::White).bg(Color::Black))
+    .block(Block::bordered().border_style(Style::new().fg(Color::DarkGray)))
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Terminal UI">
+
+```rust title="src/app.rs"
+enum Screen {
+    Todos,
+    TodoDetail(u64),
+    Settings,
+}
+
+app.screen = Screen::TodoDetail(selected_id);
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Terminal UI">
+
+```rust title="src/app.rs"
+let backend = TestBackend::new(80, 24);
+let mut terminal = Terminal::new(backend)?;
+terminal.draw(|frame| render_app(frame, &app))?;
+insta::assert_snapshot!(terminal.backend());
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Terminal UI concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| App struct | `GlobalState` | Product truth stays visible and reducer-owned. |
+| Event loop match | Bound actions and reducers | Raw input becomes named user intent. |
+| Ratatui widget | Fission widget | The same widget model can lower to terminal and other shells. |
+| Style | Design-system token fields | Terminal gets a target-specific theme without hard-coded duplicated sizes. |
+| Screen enum | Fission `Router` or route state | Routing remains app-owned. |
+| Snapshot test | `fission-test` and LiveTest screenshots | Use semantics and display output, not only terminal cell snapshots. |
+
+## Common instincts to adjust
+
+Do not build a terminal-only product model unless the product is truly terminal-only. Keep reusable state, reducers, resources, and widgets shared.
+
+Do not hard-code every terminal dimension into the UI. Use responsive layout and target-aware theme tokens.
+
+Keep the keyboard-first and deterministic-testing instincts. Add semantic identifiers so terminal workflows can be tested through meaning, not only cell coordinates.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/fission/for/yew-developers.mdx
+++ b/documentation/content/docs/fission/for/yew-developers.mdx
@@ -1,0 +1,503 @@
+---
+title: Fission for Yew developers
+description: Translate Yew function components, hooks, messages, properties, router, and browser tests into Fission state, reducers, widgets, resources, routers, and LiveTest.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Fission for Yew developers
+
+Yew and Fission both let Rust developers build user interfaces with component composition and typed data. The useful instinct is that UI can be strongly typed instead of stringly DOM wiring.
+
+The main shift is that Fission is not a Rust wrapper around browser components. It owns a multi-target widget/runtime model and uses reducers as the standard state transition path.
+
+This page uses the same todo app shape as the React guide: a checklist with a draft field, add/toggle actions, loading from an outside source, token-driven styling, routing, and tests.
+
+## The state ownership rule
+
+Before translating syntax, decide where state belongs:
+
+- Use `#[fission_component]` and `#[local_state]` for retained UI memory owned by one widget identity.
+- Use `GlobalState` for product truth: todos, routing, persistence, sync state, user preferences, and shared filters.
+- Use reducers for named user intent and state transitions.
+- Use jobs, services, resources, capabilities, or runtime effects for outside work.
+- Add semantic identifiers to interactive widgets and meaningful regions so tests and accessibility tools can target product meaning instead of coordinates.
+
+## 1. Static UI
+
+<Tabs>
+<TabItem value="source" label="Yew">
+
+```rust title="src/todo.rs"
+#[function_component(TodoApp)]
+fn todo_app() -> Html {
+    let todos = vec![
+        Todo::new(1, "Write release notes", false),
+        Todo::new(2, "Test Android package", true),
+    ];
+
+    html! {
+        <section>
+            <h1>{ "Ship checklist" }</h1>
+            { for todos.iter().map(|todo| html! {
+                <div><span>{ if todo.done { "Done" } else { "Open" } }</span><span>{ &todo.title }</span></div>
+            }) }
+        </section>
+    }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_app.rs"
+use fission::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u64,
+    pub title: String,
+    pub done: bool,
+}
+
+pub struct TodoApp;
+
+impl From<TodoApp> for Widget {
+    fn from(_app: TodoApp) -> Widget {
+        let todos = vec![
+            Todo { id: 1, title: "Write release notes".into(), done: false },
+            Todo { id: 2, title: "Test Android package".into(), done: true },
+        ];
+
+        let rows = todos.into_iter().map(|todo| {
+            let status = if todo.done { "Done" } else { "Open" };
+            Row {
+                gap: Some(12.0),
+                children: widgets![Text::new(status), Text::new(todo.title)],
+                ..Default::default()
+            }
+            .into()
+        });
+
+        Container::new(Column {
+            gap: Some(12.0),
+            children: std::iter::once(Text::new("Ship checklist").size(28.0).weight(800).into())
+                .chain(rows)
+                .collect(),
+            ..Default::default()
+        })
+        .padding_all(24.0)
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The Fission side is a concrete widget value. Conversion reads inputs and returns a widget tree; it is not the place to start outside work or hide product state.
+
+## 2. Product state and interaction
+
+<Tabs>
+<TabItem value="source" label="Yew">
+
+```rust title="src/todo.rs"
+#[function_component(TodoApp)]
+fn todo_app() -> Html {
+    let draft = use_state(String::new);
+    let todos = use_state(Vec::<Todo>::new);
+
+    let add = {
+        let draft = draft.clone();
+        let todos = todos.clone();
+        Callback::from(move |_| {
+            let title = draft.trim().to_string();
+            if title.is_empty() { return; }
+            let mut next = (*todos).clone();
+            next.push(Todo::new(title));
+            todos.set(next);
+            draft.set(String::new());
+        })
+    };
+
+    html! { <TodoContent {add} /> }
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/state.rs"
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TodoState {
+    pub draft: String,
+    pub todos: Vec<Todo>,
+    pub next_id: u64,
+    pub current_path: String,
+}
+
+impl Default for TodoState {
+    fn default() -> Self {
+        Self {
+            draft: String::new(),
+            todos: Vec::new(),
+            next_id: 1,
+            current_path: "/".into(),
+        }
+    }
+}
+
+impl GlobalState for TodoState {}
+
+#[fission_reducer(SetDraft)]
+fn set_draft(state: &mut TodoState, draft: String) {
+    state.draft = draft;
+}
+
+#[fission_reducer(AddDraftTodo)]
+fn add_draft_todo(state: &mut TodoState) {
+    let title = state.draft.trim();
+    if title.is_empty() {
+        return;
+    }
+
+    state.todos.push(Todo {
+        id: state.next_id,
+        title: title.to_string(),
+        done: false,
+    });
+    state.next_id += 1;
+    state.draft.clear();
+}
+
+#[fission_reducer(ToggleTodo)]
+fn toggle_todo(state: &mut TodoState, id: u64) {
+    if let Some(todo) = state.todos.iter_mut().find(|todo| todo.id == id) {
+        todo.done = !todo.done;
+    }
+}
+```
+
+```rust title="src/widgets/todo_screen.rs"
+pub struct TodoScreen;
+
+impl From<TodoScreen> for Widget {
+    fn from(_screen: TodoScreen) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
+
+        let rows = view.state().todos.iter().map(|todo| {
+            let toggle = with_reducer!(ctx, ToggleTodo(todo.id), toggle_todo);
+            Row {
+                gap: Some(12.0),
+                children: widgets![
+                    Checkbox {
+                        checked: todo.done,
+                        on_toggle: Some(toggle),
+                        ..Default::default()
+                    }
+                    .semantics_identifier(format!("todo.toggle.{}", todo.id)),
+                    Text::new(todo.title.clone()),
+                ],
+                ..Default::default()
+            }
+            .semantics_identifier(format!("todo.row.{}", todo.id))
+            .into()
+        });
+
+        Column {
+            gap: Some(16.0),
+            children: widgets![
+                Text::new("Ship checklist").size(28.0).weight(800),
+                Row {
+                    gap: Some(12.0),
+                    children: widgets![
+                        TextInput {
+                            id: Some(WidgetId::explicit("todo-title")),
+                            value: view.state().draft.clone(),
+                            label: Some("New task".into()),
+                            placeholder: Some("Add a task".into()),
+                            on_change: Some(update_draft),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.title"),
+                        Button {
+                            child: Some(Text::new("Add task").into()),
+                            on_press: Some(add_todo),
+                            ..Default::default()
+                        }
+                        .semantics_identifier("todo.add"),
+                    ],
+                    ..Default::default()
+                },
+                Column { gap: Some(10.0), children: rows.collect(), ..Default::default() },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Fission makes the state transition explicit. The button does not mutate a captured local variable; it dispatches a named action and the reducer updates product state.
+
+## 3. Outside work
+
+<Tabs>
+<TabItem value="source" label="Yew">
+
+```rust title="src/todo.rs"
+use_effect_with((), move |_| {
+    wasm_bindgen_futures::spawn_local(async move {
+        let todos = load_todos().await;
+        set_todos.set(todos);
+    });
+    || ()
+});
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/api.rs"
+use fission::core::{JobRef, JobSpec};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LoadTodosRequest;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    pub message: String,
+}
+
+pub struct LoadTodosJob;
+
+impl JobSpec for LoadTodosJob {
+    type Request = LoadTodosRequest;
+    type Ok = Vec<Todo>;
+    type Err = ApiError;
+
+    const NAME: &'static str = "todo.load";
+}
+
+pub const LOAD_TODOS_JOB: JobRef<LoadTodosJob> = JobRef::new(LoadTodosJob::NAME);
+```
+
+```rust title="src/state.rs"
+#[fission_reducer(LoadTodos)]
+fn load_todos(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    state.loading = true;
+    ctx.effects
+        .app(LOAD_TODOS_JOB, LoadTodosRequest)
+        .on_ok(ctx.effects.bind(TodosLoaded, reduce_with!(todos_loaded)))
+        .on_err(ctx.effects.bind(TodosFailed, reduce_with!(todos_failed)));
+}
+```
+
+</TabItem>
+</Tabs>
+
+Do not perform outside work during component conversion. Reducers request work; jobs, services, resources, or capabilities perform it; results return as actions.
+
+## 4. Styling and theme
+
+<Tabs>
+<TabItem value="source" label="Yew">
+
+```rust title="src/todo.rs"
+html! {
+    <button class="rounded-xl border bg-white px-4 py-3 shadow-sm">
+        <input type="checkbox" checked={todo.done} />
+        <span>{ &todo.title }</span>
+    </button>
+}
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/widgets/todo_row.rs"
+pub struct TodoRow {
+    pub todo: Todo,
+}
+
+impl From<TodoRow> for Widget {
+    fn from(row: TodoRow) -> Widget {
+        let (ctx, view) = fission::build::current::<TodoState>();
+        let tokens = &view.env().theme.tokens;
+        let toggle = with_reducer!(ctx, ToggleTodo(row.todo.id), toggle_todo);
+
+        Container::new(Row {
+            gap: Some(tokens.spacing.s),
+            children: widgets![
+                Checkbox {
+                    checked: row.todo.done,
+                    on_toggle: Some(toggle),
+                    ..Default::default()
+                }
+                .semantics_identifier(format!("todo.toggle.{}", row.todo.id)),
+                Text::new(row.todo.title)
+                    .size(tokens.typography.font_size_base)
+                    .color(tokens.colors.text_primary),
+            ],
+            ..Default::default()
+        })
+        .bg(tokens.colors.surface)
+        .border(tokens.colors.border, 1.0)
+        .border_radius(tokens.radii.large)
+        .padding([tokens.spacing.m, tokens.spacing.m, tokens.spacing.s, tokens.spacing.s])
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+In Fission, the active theme is runtime environment. Read token values from `view.env().theme.tokens` and apply them through widget fields. That keeps the UI target-lowerable across native, web, mobile, terminal, static, and SSR shells.
+
+## 5. Routing
+
+<Tabs>
+<TabItem value="source" label="Yew">
+
+```rust title="src/todo.rs"
+#[derive(Clone, Routable, PartialEq)]
+enum Route {
+    #[at("/")]
+    Todos,
+    #[at("/todos/:id")]
+    Todo { id: u64 },
+}
+
+html! { <BrowserRouter><Switch<Route> render={switch} /></BrowserRouter> }
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="src/routes.rs"
+use fission::widgets::{Route, Router};
+use std::sync::Arc;
+
+#[fission_reducer(NavigateTo)]
+fn navigate_to(state: &mut TodoState, path: String) {
+    state.current_path = path;
+}
+
+pub struct TodoRoutes;
+
+impl From<TodoRoutes> for Widget {
+    fn from(_routes: TodoRoutes) -> Widget {
+        let (_, view) = fission::build::current::<TodoState>();
+
+        Router::<TodoState> {
+            current_path: view.state().current_path.clone(),
+            routes: vec![
+                Route {
+                    path: "/".into(),
+                    builder: Arc::new(|_, _, _| TodoScreen.into()),
+                },
+                Route {
+                    path: "/todos/:id".into(),
+                    builder: Arc::new(|_, _, params| TodoDetail {
+                        id: params["id"].parse().unwrap_or(0),
+                    }
+                    .into()),
+                },
+            ],
+            not_found: Some(Arc::new(|_, _, _| Text::new("Not found").into())),
+        }
+        .into()
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Use Fission's native `Router` and `RouterParams`. Shell URLs, deep links, static routes, server routes, and terminal route-like state should normalize into the same app-owned route state instead of each target inventing a different navigation model.
+
+## 6. Testing
+
+<Tabs>
+<TabItem value="source" label="Yew">
+
+```rust title="src/todo.rs"
+// Browser-driven test against rendered Yew app.
+page.get_by_label("New task").fill("Publish release").await?;
+page.get_by_text("Add task").click().await?;
+page.get_by_text("Publish release").wait_for().await?;
+```
+
+</TabItem>
+<TabItem value="fission" label="Fission">
+
+```rust title="tests/live.rs"
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+#[test]
+#[ignore]
+fn user_can_add_a_todo_in_a_real_shell() {
+    let control_port = reserve_control_port();
+    let mut child = launch_todo_app(control_port);
+    let client = LiveTestClient::connect(control_port);
+
+    client.wait_for_ready(15_000).expect("app ready");
+    client
+        .fill_text_semantic_identifier("todo.title", "Publish release")
+        .expect("fill draft");
+    client
+        .tap_semantic_identifier("todo.add")
+        .expect("add todo");
+    client
+        .wait_for_visible(SelectorQuery::label("Publish release"), 5_000)
+        .expect("todo visible");
+    client
+        .screenshot(".artifacts/screenshots/todos/added.png")
+        .expect("screenshot");
+
+    client.quit().expect("quit app");
+    let _ = child.wait();
+}
+```
+
+</TabItem>
+</Tabs>
+
+Keep fast reducer tests for business rules. Use headless `fission-test` for widget/layout/semantics assertions. Use `LiveTestClient` and `/cmd` for real shell input, focus, screenshots, selectors, and target behavior.
+
+## Vocabulary map
+
+| Yew concept | Closest Fission concept | Important difference |
+| --- | --- | --- |
+| `Html` | `Widget` | Fission widgets are target-lowerable beyond the DOM. |
+| Properties | Struct fields | Typed Rust fields configure widgets. |
+| `use_state` | `#[local_state]` or `GlobalState` | Choose by ownership and lifetime. |
+| Callback | Bound action | Fission names intent and dispatches reducers. |
+| `use_effect_with` | Jobs/resources/effects | Outside work is explicit and reducer-driven. |
+| Yew Router | Fission `Router` | Same route model can run across shells. |
+
+## Common instincts to adjust
+
+Do not carry DOM assumptions into core app structure. Use Fission widgets and let shells lower appropriately.
+
+Do not bury product state in hook-local values once it matters outside one component identity.
+
+Keep the typed-Rust component instinct, but make reducers and semantic identifiers part of your default design.
+
+## What to read next
+
+Read [Testing Fission apps](/docs/learn/testing/) for unit, headless integration, LiveTest, and `/cmd` workflows.
+
+Read [State, handles, and providers](/docs/guides/state-handles-and-providers/) for the durable-state, local-state, provider, and environment decision model.
+
+Read [Resources and async](/docs/guides/resources-and-async/) for jobs, services, resources, capabilities, and reducer effects.

--- a/documentation/content/docs/learn/accessibility.mdx
+++ b/documentation/content/docs/learn/accessibility.mdx
@@ -1,0 +1,146 @@
+---
+title: Accessibility in Fission
+sidebar_label: Accessibility
+slug: /learn/accessibility
+summary: Learn how Fission turns widget semantics into screen-reader structure, keyboard focus, native accessibility actions, and testable UI metadata.
+description: Learn how Fission models accessibility semantics, which shells expose them to native accessibility APIs, and how to design screens that screen readers and automation can control.
+---
+
+# Accessibility in Fission
+
+Fission accessibility starts in the shared widget tree, not in a separate platform-specific layer.
+
+Widgets lower into Core IR. Meaningful widgets also lower semantic metadata: role, label, value, focusability, disabled state, checked state, text selection, scrollability, and actions. Native shells can then translate that semantic tree into the host accessibility API. Tests use the same semantic information through LiveTest selector commands and `GetTree`.
+
+That gives Fission one accessibility model for three jobs:
+
+- screen readers and other assistive technology need to know what the UI means;
+- keyboard and accessibility actions need to activate the same reducers as pointer input;
+- tests need stable selectors that do not depend on pixels or generated node order.
+
+## Can screen readers control Fission apps?
+
+On supported native shells, yes. The winit-based native shell builds an AccessKit tree from Fission Core IR and layout. AccessKit then bridges that tree to the operating-system accessibility stack.
+
+Current native support is:
+
+| Target | Native accessibility bridge | Practical status |
+| --- | --- | --- |
+| macOS | AccessKit through the AppKit accessibility stack | Supported for roles, labels, values, focus, text editing actions, control actions, scrolling, and range adjustment. |
+| Windows | AccessKit through the Windows accessibility stack | Supported for the same Fission semantics exposed by the winit bridge. Validate with Narrator, NVDA, or JAWS for product releases. |
+| Linux | AccessKit through the AT-SPI accessibility stack | Supported where the desktop session and assistive technology expose the expected AT-SPI path. Validate with Orca on your target desktop. |
+| iOS | AccessKit through the iOS accessibility adapter | Supported by the shared native bridge where the iOS shell uses the winit path. Validate with VoiceOver on simulator and device. |
+| Android | No native TalkBack bridge yet | Fission still produces semantics for tests and runtime behavior, but the current winit AccessKit bridge is disabled on Android because the AccessKit Android adapter expects winit GameActivity while Fission's Android shell uses NativeActivity. |
+
+Static site and SSR targets are different: they render semantic HTML, native inputs, buttons, links, headings, labels, and ARIA/data attributes where the static/server renderer has enough information. Browser screen readers then see the browser accessibility tree rather than AccessKit. The canvas Web target does not currently expose a DOM accessibility tree for the canvas-rendered app.
+
+Terminal targets are also different. The terminal shell renders through the terminal emulator. Accessibility depends on the terminal and screen-reader combination. Fission semantics can inform terminal rendering and tests, but the terminal backend does not currently expose the full selector command tree that the winit LiveTest backend exposes.
+
+## What Fission exports today
+
+The native bridge exports the semantic data that widgets lower into Core IR.
+
+| Fission data | Accessibility output |
+| --- | --- |
+| Role | Button, label, text input, password input, multiline input, email input, number input, phone input, URL input, image, checkbox, radio, switch, dialog, slider, list, list item, or generic container. |
+| Label | Explicit semantic label, or inferred text from descendants where appropriate. |
+| Value | Text input contents, range value, or explicit semantic value. |
+| Bounds | Layout bounds converted into platform accessibility coordinates. |
+| Focus | Runtime focus mirrored into the accessibility tree; accessibility focus and blur requests update runtime focus. |
+| Disabled and read-only state | Exposed as disabled or read-only metadata. |
+| Checked state | Exposed for checkbox, radio, and switch roles. |
+| Text selection | Editable text selection is exposed and can be set through accessibility actions. |
+| Scroll state | Scrollable nodes expose scroll actions and current scroll offsets. |
+| Actions | Click/default, focus, blur, replace selected text, set value, set selection, scroll, increment, and decrement map back into the Fission runtime. |
+
+This is not a promise that every possible platform accessibility feature is complete. It is the current public contract. Advanced features such as rich native announcements, custom rotor behavior, platform-specific landmarks beyond current roles, and complete Android TalkBack support need additional implementation.
+
+## Design accessible widgets from the start
+
+A screen-reader user should get the same product meaning that a sighted pointer user gets. That requires explicit semantics where visuals alone are not enough.
+
+Use built-in widgets when possible. `Button`, `TextInput`, `Checkbox`, `Radio`, `Switch`, `Slider`, `Image`, `Text`, `RichText`, `Scroll`, `Modal`, and other widgets lower useful semantics automatically or expose fields/builders for semantic labels and identifiers.
+
+Add stable semantic identifiers to interactive controls that tests, automation, or host integrations need to target.
+
+```rust
+Button {
+    child: Some(Text::new(TextContent::Key("checkout.pay".into())).into()),
+    on_press: Some(pay_action),
+    ..Default::default()
+}
+.semantics_identifier("checkout.pay")
+.into()
+```
+
+Do not use semantic identifiers as user-facing labels. Identifiers are stable machine-readable names. Labels are what the user hears or reads.
+
+For icon-only controls, add an explicit label through custom semantics or wrap the region in `SemanticsRegion`.
+
+```rust
+use fission::prelude::*;
+
+Button {
+    child: Some(Icon::new("trash").into()),
+    on_press: Some(delete_action),
+    semantics: Some(Semantics {
+        role: Role::Button,
+        label: Some("Delete item".into()),
+        identifier: Some("todo.delete".into()),
+        focusable: true,
+        ..Semantics::default()
+    }),
+    ..Default::default()
+}
+.into()
+```
+
+Prefer translated labels for real apps. Visible text can use `TextContent::Key`; semantic labels that are plain strings should be resolved from `view.i18n()` using the current locale before they are placed into `Semantics`.
+
+## Keep focus and actions meaningful
+
+Accessible interaction should dispatch the same product action as pointer interaction. Do not create a separate accessibility-only behavior path unless the product genuinely needs one.
+
+Fission maps semantic actions back into reducers through the same action entries used by widgets. A screen reader activating a button should run the same `on_press` action that a tap or click would run.
+
+Focus should follow visible structure. Use focus scopes for dialogs and panels, and use `FocusPolicy::PreserveCurrentOnPointer` only for controls such as editor toolbars that intentionally should not steal focus from the editable region when clicked.
+
+## Test accessibility as behavior
+
+Do not test accessibility only by looking at screenshots. Use semantic tests as part of the normal test ladder.
+
+- Reducer tests prove the action changes state correctly.
+- Headless Fission tests inspect semantics without launching a real window.
+- Live tests use `/cmd` selector actions such as `TapSelector`, `FocusSelector`, `FillText`, `WaitForVisible`, and `GetTree` against a real shell.
+- Manual QA should include at least one platform screen reader on every target you ship.
+
+Example LiveTest-style checks:
+
+```rust
+client.tap_semantic_identifier("checkout.pay")?;
+client.fill_text_semantic_identifier("profile.email", "user@example.com")?;
+
+let tree = client.get_tree()?;
+assert!(tree.nodes.iter().any(|node| {
+    node.identifier.as_deref() == Some("checkout.pay")
+        && node.role == fission_test_driver::Role::Button
+        && !node.disabled
+}));
+```
+
+## Screen readers and tools to validate with
+
+Fission apps should be tested with the assistive technology that real users use on each target. These are compatibility targets, not substitute test suites.
+
+| Platform | Common tools to include in QA |
+| --- | --- |
+| macOS | VoiceOver, Switch Control, Keyboard navigation, Accessibility Inspector. |
+| Windows | Narrator, NVDA, JAWS, Windows Magnifier, Inspect. |
+| Linux | Orca, AT-SPI inspection tools, desktop keyboard navigation. |
+| iOS | VoiceOver, Switch Control, Dynamic Type, Full Keyboard Access. |
+| Android | TalkBack, Switch Access, Voice Access, system font scale. Native TalkBack control of Fission apps is not complete yet. |
+| Browser-hosted Static site or SSR | VoiceOver with Safari, VoiceOver with Chrome, NVDA with Firefox/Chrome, JAWS with Chrome/Edge, browser accessibility inspectors. |
+
+## Read next
+
+Use [Add accessible semantics](/docs/cookbook/add-accessible-semantics/) for a concrete recipe. Use [Accessibility reference](/reference/platform/accessibility/) for the platform support matrix and exact shell contract. Use [LiveTest command API](/reference/core/live-test-command-api/) when writing selector-driven tests against semantic identifiers.

--- a/documentation/content/docs/learn/overview.mdx
+++ b/documentation/content/docs/learn/overview.mdx
@@ -80,4 +80,10 @@ Then read [Runtime model](/docs/learn/runtime-model) to learn what your app owns
 
 After that, read [Rendering pipeline](/docs/learn/rendering-pipeline) to see how widgets become layout, accessibility information, and painted output.
 
+Then read [Accessibility in Fission](/docs/learn/accessibility) to understand how roles, labels, semantic identifiers, focus, text selection, and control actions reach screen readers, LiveTest selectors, static HTML, and target-specific shells.
+
+Then read [Testing Fission apps](/docs/learn/testing) to connect the architecture
+to reducer tests, headless integration tests, LiveTest, selector-driven
+automation, screenshots, and the `/cmd` protocol.
+
 When you want to connect the model to real targets, continue to [Examples and targets](/docs/learn/examples-and-targets). The checked-in examples there are useful confirmation that the architecture is not only theoretical, but they are meant to support the explanation rather than replace it.

--- a/documentation/content/docs/learn/testing.mdx
+++ b/documentation/content/docs/learn/testing.mdx
@@ -1,0 +1,218 @@
+---
+title: Testing Fission apps
+description: Learn when to use reducer tests, headless integration tests, LiveTest shell tests, selector-driven commands, and screenshots.
+---
+
+# Testing Fission apps
+
+Fission testing follows the same architecture as Fission apps. Start with the smallest layer that proves the requirement, then move outward only when the behavior depends on rendering, input, accessibility semantics, or a real platform shell.
+
+The practical ladder is:
+
+| Layer | Use it for | Main tools |
+| --- | --- | --- |
+| Unit tests | Reducer rules, selector functions, state invariants, small pure helpers. | Ordinary Rust tests. |
+| Effect tests | Proving a reducer requested a job, service, capability, resource, or runtime effect. | `ReducerContext`, `Effects`, action input inspection. |
+| Headless integration tests | Component conversion, layout, display output, semantic output, runtime interaction without a real window. | `fission-test`, `TestHarness`, `TestDriver`. |
+| Live shell tests | Real shell input, focus, IME, scrolling, screenshots, accessibility metadata, window behavior, and end-to-end release screenshots. | `fission-test-driver`, `LiveTestClient`, `/cmd`. |
+| Target smoke tests | Generated platform host builds and starts for Web, Android, iOS, desktop, terminal, static, or SSR targets. | `fission test`, target smoke commands, package readiness. |
+
+Do not make every behavior a live test. Reducer tests should carry most product rules. Live tests should prove the real integration layers that unit tests cannot see.
+
+## Unit tests: state rules first
+
+Reducers are normal Rust functions. If a business rule can be tested without widgets, test it there.
+
+```rust title="tests/todos_reducer.rs"
+#[test]
+fn add_draft_todo_adds_item_and_clears_draft() {
+    let mut state = TodoState {
+        draft: "Publish release".into(),
+        next_id: 7,
+        ..Default::default()
+    };
+
+    add_draft_todo(&mut state);
+
+    assert_eq!(state.todos.len(), 1);
+    assert_eq!(state.todos[0].id, 7);
+    assert_eq!(state.todos[0].title, "Publish release");
+    assert!(state.draft.is_empty());
+    assert_eq!(state.next_id, 8);
+}
+```
+
+This is the cheapest and most reliable test. It says nothing about pixels, but it proves the product rule.
+
+## Effect tests: outside work is requested explicitly
+
+Reducers are synchronous. They do not `await`; they update state and request outside work through effects, jobs, services, capabilities, resources, or runtime effects.
+
+Test that request directly when the behavior is about orchestration.
+
+```rust title="tests/load_todos_effect.rs"
+use fission::core::{ActionInput, ActionRegistry, Effects, ReducerContext};
+
+#[test]
+fn load_todos_marks_loading_and_requests_job() {
+    let mut state = TodoState::default();
+    let mut registry = ActionRegistry::new();
+    let mut effects = Effects::new(1, &mut registry);
+    let input = ActionInput::None;
+    let mut ctx = ReducerContext {
+        effects: &mut effects,
+        input: &input,
+    };
+
+    load_todos(&mut state, &mut ctx);
+
+    assert!(state.loading);
+    assert_eq!(effects.out.len(), 1);
+}
+```
+
+Use this layer for "did the app request the right work?" Use a service or job test for "did the worker perform the work correctly?"
+
+## Headless integration tests: real widgets without a real shell
+
+`fission-test` runs the shared runtime in-process. It can build the widget tree, lower it, lay it out, pump frames, inspect display operations, inspect semantics, and drive many interaction paths without launching a native window.
+
+```rust title="tests/todos_headless.rs"
+use fission_test::TestHarness;
+use fission_test::prelude::DisplayOp;
+
+#[test]
+fn todo_screen_renders_seed_items() {
+    let state = TodoState {
+        todos: vec![Todo {
+            id: 1,
+            title: "Write release notes".into(),
+            done: false,
+        }],
+        next_id: 2,
+        ..Default::default()
+    };
+
+    let mut harness = TestHarness::new(state).with_root_widget(TodoApp);
+    harness.pump().expect("pump todo app");
+
+    let display_list = harness.get_last_display_list().expect("display list");
+    assert!(display_list.ops.iter().any(|op| matches!(
+        op,
+        DisplayOp::DrawText { text, .. } if text == "Write release notes"
+    )));
+}
+```
+
+Use this layer when the requirement is "the app renders this meaning" rather than "the OS delivered this input."
+
+## Live tests: real shell, semantic selectors, and screenshots
+
+Live tests launch the app as a separate process with the test-control server enabled:
+
+```rust
+Command::new(env!("CARGO_BIN_EXE_todo"))
+    .env("FISSION_TEST_CONTROL_PORT", control_port.to_string())
+    .spawn()?;
+```
+
+The test connects with `LiveTestClient`:
+
+```rust
+use fission_test_driver::{LiveTestClient, SelectorQuery};
+
+let client = LiveTestClient::connect(control_port);
+client.wait_for_ready(15_000)?;
+```
+
+Prefer semantic selectors over coordinates. Coordinates are still useful for low-level input bugs, but product tests should name the UI element they intend to use.
+
+```rust
+client.fill_text_semantic_identifier("todo.title", "Publish 0.8.0")?;
+client.tap_semantic_identifier("todo.add")?;
+client.wait_for_visible(
+    SelectorQuery::semantic_identifier("todo.row.0"),
+    5_000,
+)?;
+client.screenshot(".artifacts/screenshots/todo-added.png")?;
+```
+
+The selector-driven API targets the semantic tree from the current frame. It can resolve semantic identifiers, widget ids, test/accessibility identifiers, labels, role plus label, scopes, duplicate indexes, visibility, enabled/disabled state, values, and text.
+
+## Add semantic identifiers to important UI
+
+A live test is only as stable as the UI it can target. Interactive widgets and meaningful regions should expose stable semantic identifiers.
+
+```rust title="src/widgets/todo_form.rs"
+TextInput {
+    id: Some(WidgetId::explicit("todo-title-input")),
+    value: view.state().draft.clone(),
+    label: Some("New task".into()),
+    on_change: Some(update_draft),
+    ..Default::default()
+}
+.semantics_identifier("todo.title")
+```
+
+```rust title="src/widgets/todo_form.rs"
+Button {
+    variant: ButtonVariant::Primary,
+    child: Some(Text::new("Add task").into()),
+    on_press: Some(add),
+    ..Default::default()
+}
+.semantics_identifier("todo.add")
+```
+
+Use identifiers based on product meaning, not wording or layout. `todo.add` is better than `blue-button-right` because it survives translation and layout changes.
+
+## The `/cmd` API
+
+`LiveTestClient` is a typed Rust wrapper around the same HTTP API that screenshot capture and manual QA can use directly.
+
+The app exposes:
+
+| Endpoint | Meaning |
+| --- | --- |
+| `GET /health` | Returns when the test-control server is alive. |
+| `POST /cmd` | Accepts one JSON command with a `cmd` field and returns a JSON response. |
+
+Example with `curl`:
+
+```bash
+curl -s http://127.0.0.1:9876/cmd \
+  -H 'content-type: application/json' \
+  -d '{"cmd":"TapSelector","query":{"selector":{"kind":"semantic_identifier","identifier":"todo.add"}}}'
+```
+
+For visual QA, capture a screenshot without writing any test code:
+
+```bash
+curl -s http://127.0.0.1:9876/cmd \
+  -H 'content-type: application/json' \
+  -d '{"cmd":"CaptureScreenshot"}' \
+  | jq -r '.png_base64' \
+  | base64 --decode > .artifacts/manual/todo.png
+```
+
+The full command list is in [LiveTest command API](/reference/core/live-test-command-api/).
+
+## What to test where
+
+| Requirement | Best first test |
+| --- | --- |
+| A reducer rejects invalid data | Unit reducer test. |
+| A reducer requests a network job | Effect test. |
+| A screen renders an empty state | Headless `fission-test` test. |
+| A button is reachable by screen readers and automation | Headless semantic assertion or live `GetTree`. |
+| A partially visible button can be clicked after scrolling | Live selector test. |
+| A text field handles focus, IME, paste, or keyboard input | Live test. |
+| A modal, popover, drawer, menu, or portal can be used | Live selector test. |
+| The shipped app starts on a device or browser | Target smoke or package test. |
+| Store screenshots are correct | LiveTest screenshot scenario plus human review. |
+
+## Read next
+
+Use [Write a live interface test](/docs/cookbook/write-a-live-ui-test/) for a complete live-test recipe.
+
+Use [LiveTest command API](/reference/core/live-test-command-api/) when you need the exact `/cmd` JSON payload for automation or manual QA.

--- a/documentation/content/docs/release-and-distribute/app-stores.mdx
+++ b/documentation/content/docs/release-and-distribute/app-stores.mdx
@@ -1,54 +1,257 @@
 ---
 title: App store distribution
-description: Distribute Android, iOS, and desktop store packages with release content, tracks, testers, and receipts.
+description: Distribute Android, iOS, and desktop store packages with version checks, release content, tracks, testers, metadata locks, and receipts.
 ---
 
 # App store distribution
 
-Store distribution is provider-owned. Fission should orchestrate readiness, metadata validation, package upload, tracks, testers, rollouts, and receipts while using the platform owner's tools and APIs for the provider-specific operation.
+Store distribution is provider-owned. Fission orchestrates readiness, version/build management, release content, package upload, tracks, testers, rollout decisions, and receipts while using the platform owner's tooling or APIs for the final provider operation.
 
-## 1. Package the store artifact
+The important rule is that store upload is not just "send this file." A production release also has package identity, signing, version/build rules, localized metadata, screenshots, privacy answers, review information, tester groups, track state, provider processing, and follow-up status.
+
+## Store workflow
+
+A reliable store release follows this shape:
+
+| Step | Command | Purpose |
+| --- | --- | --- |
+| Inspect config | `fission release-config validate ...` | Checks app identity, active release, metadata paths, provider config, and obvious missing fields. |
+| Check provider version state | `fission release-config version-state ...` | Catches reused build numbers or provider-side conflicts before upload. |
+| Package | `fission package ... --release` | Creates the store artifact and `artifact-manifest.json`. |
+| Validate release content | `fission release-content validate ...` | Checks notes, screenshots, listings, privacy, review files, and skippable recommendations. |
+| Check release readiness | `fission readiness release ...` | Combines target, package, artifact, provider, track, credential, and content checks. |
+| Publish | `fission publish ... --artifact ... --yes` | Uploads or submits the manifest-backed artifact. |
+| Observe | `fission distribute status ...` or provider-specific commands | Checks processing, review, certification, rollout, or deployment state. |
+
+For CI, use direct commands with `--json` and `--yes`. For local publishing,
+`fission publish --provider <provider>` opens the guided flow, and
+`fission publish --provider <provider> --app` opens the windowed Fission app.
+Both guided shells drive the same release plan as direct CLI commands.
+
+## Android and Google Play
+
+Package an Android App Bundle for Play:
 
 ```bash
 fission package --project-dir . --target android --format aab --release
+```
+
+Minimum project configuration:
+
+```toml
+[package.android]
+package_name = "com.example.notes"
+keystore_alias = "upload"
+keystore_env = "ANDROID_KEYSTORE"
+keystore_base64_env = "ANDROID_KEYSTORE_BASE64"
+keystore_password_env = "ANDROID_KEYSTORE_PASSWORD"
+key_password_env = "ANDROID_KEY_PASSWORD"
+
+[distribution.play_store]
+package_name = "com.example.notes"
+default_track = "internal"
+release_status = "draft"
+service_account_json_env = "PLAY_STORE_SERVICE_ACCOUNT_JSON"
+service_account_json_base64_env = "PLAY_STORE_SERVICE_ACCOUNT_JSON_BASE64"
+google_application_credentials_env = "GOOGLE_APPLICATION_CREDENTIALS"
+```
+
+Before upload, check whether the selected build number is usable:
+
+```bash
+fission release-config version-state \
+  --project-dir . \
+  --provider play-store \
+  --target android \
+  --track internal \
+  --json
+```
+
+If Play already has the Android `versionCode`, do not upload and wait for Play
+to reject it. Bump, rebuild, and publish the new artifact:
+
+```bash
+fission release-config bump-build --project-dir . --target android --yes
+fission package --project-dir . --target android --format aab --release
+fission publish \
+  --project-dir . \
+  --provider play-store \
+  --artifact target/fission/release/android/aab/artifact-manifest.json \
+  --track internal \
+  --yes
+```
+
+Play metadata should be managed through release-config and release-content. A
+first internal test can skip provider-optional marketing assets, but it still
+needs provider-required package access, credentials, package identity, and any
+required release notes.
+
+## iOS and App Store Connect
+
+Package an iOS archive/IPA:
+
+```bash
 fission package --project-dir . --target ios --format ipa --release
+```
+
+Minimum project configuration:
+
+```toml
+[package.ios]
+bundle_id = "com.example.notes"
+team_id = "ABCDE12345"
+entitlements = "platforms/ios/Entitlements.plist"
+provisioning_profile = "release-content/signing/ios/App.mobileprovision"
+signing_identity = "Apple Distribution"
+
+[distribution.app_store]
+app_id = "1234567890"
+bundle_id = "com.example.notes"
+issuer_id = "00000000-0000-0000-0000-000000000000"
+key_id = "ABC123DEFG"
+api_key_env = "APP_STORE_CONNECT_API_KEY"
+api_key_base64_env = "APP_STORE_CONNECT_API_KEY_BASE64"
+default_track = "testflight"
+```
+
+App Store Connect has separate concepts for upload, build processing, TestFlight
+assignment, and App Review submission. Keep those decisions explicit. A common
+beta flow is:
+
+```bash
+fission release-config version-state --project-dir . --provider app-store --target ios --json
+fission package --project-dir . --target ios --format ipa --release
+fission release-content validate --project-dir . --provider app-store
+fission publish \
+  --project-dir . \
+  --provider app-store \
+  --artifact target/fission/release/ios/ipa/artifact-manifest.json \
+  --track testflight \
+  --yes
+fission beta groups list --project-dir . --provider app-store
+```
+
+Use release receipts to track which upload created which App Store build id and
+what provider-side processing remains.
+
+## Windows and Microsoft Store
+
+Package MSIX for Microsoft Store or a desktop distribution flow:
+
+```bash
 fission package --project-dir . --target windows --format msix --release
 ```
 
-## 2. Validate release content
+Minimum project configuration:
 
-```bash
-fission release-content validate --project-dir . --provider play-store
-fission release-content validate --project-dir . --provider app-store
-fission release-content validate --project-dir . --provider microsoft-store
+```toml
+[package.windows]
+identity_name = "ExampleSoftware.Notes"
+publisher = "CN=Example Software Ltd, O=Example Software Ltd, C=GB"
+certificate_thumbprint = "0123456789ABCDEF"
+certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"
+certificate_password_env = "WINDOWS_CERTIFICATE_PASSWORD"
+
+[distribution.microsoft_store]
+product_id = "9N0000000000"
+package_identity_name = "ExampleSoftware.Notes"
+package_type = "msix"
+tenant_id_env = "AZURE_TENANT_ID"
+client_id_env = "AZURE_CLIENT_ID"
+client_secret_env = "MICROSOFT_STORE_CLIENT_SECRET"
+seller_id_env = "MICROSOFT_STORE_SELLER_ID"
+submit = false
 ```
 
-Release content includes localized notes, screenshots, preview videos, privacy answers, review attachments, tester groups, rollout settings, and provider-specific listing fields.
+Microsoft Store flows can involve draft submissions, private flights, public
+submissions, certification, staged rollout, and package URL flows for MSI/EXE
+where supported. Keep `submit = false` while validating package identity and
+metadata. Set submission behavior only when the publish operation should mutate
+provider state beyond package upload.
 
-## 3. Check provider readiness
+For `windows/exe`, configure `package.windows.exe_installer_script` when the
+release must produce an installer rather than a staged app executable. For
+`windows/msix`, runtime native products are staged into the package, while
+`driver-package` products are excluded from the MSIX manifest and passed to
+installer workflows through the native-products manifest.
+
+## Release metadata locks
+
+Store metadata can change in the provider portal while your branch is under
+review. Fission uses provider locks to prevent accidental overwrites.
+
+1. Import or inspect remote metadata.
+2. Review the diff.
+3. Lock the remote baseline.
+4. Push local metadata only if the remote baseline still matches.
 
 ```bash
-fission readiness distribute \
+fission release-config import --project-dir . --provider play-store --locales en-US --yes
+fission release-config diff --project-dir . --provider play-store
+fission release-config lock --project-dir . --provider play-store --locales en-US --yes
+fission release-config push --project-dir . --provider play-store --locales en-US --yes
+```
+
+If remote metadata changed, Fission blocks the push. Refresh the lock after
+review or pass `--overwrite-remote` only when replacing the provider state is the
+intentional operation.
+
+## Release content and skippable recommendations
+
+Store providers differ in what they require. Fission reports each missing item as
+provider required, Fission recommended, optional, or not applicable. Recommended
+items are shown because they materially improve release quality, but they should
+not block a provider that permits omission.
+
+Use an explicit skip when the team has reviewed a recommendation and decided not
+to include it for this release:
+
+```bash
+fission release-config skip-requirement \
+  --project-dir . \
+  --id release_content.play_store.feature_graphic \
+  --yes
+```
+
+The skip id is stable and reviewable in [`fission.toml`](/reference/config/fission-toml/). Provider-required items cannot be skipped.
+
+## Guided local publishing versus CI
+
+Local guided publishing can help discover missing setup:
+
+```bash
+fission publish --project-dir . --provider play-store
+fission publish --project-dir . --provider play-store --app
+```
+
+CI should be explicit and non-interactive:
+
+```bash
+fission readiness release \
+  --project-dir . \
+  --target android \
+  --format aab \
+  --provider play-store \
+  --track internal \
+  --locale en-US \
+  --json
+
+fission package --project-dir . --target android --format aab --release --json
+
+fission publish \
   --project-dir . \
   --provider play-store \
   --artifact target/fission/release/android/aab/artifact-manifest.json \
-  --track internal
+  --track internal \
+  --locale en-US \
+  --yes \
+  --json
 ```
 
-Readiness should report missing credentials, package identity mismatches, unsupported tracks, missing first-release setup, invalid screenshots, and provider CLI or API problems before upload.
+CI must provide secrets through environment variables, base64 environment
+variables, provider CLI auth state, or platform-owned stores. It must not depend
+on `~/.fission/<app-name>/`, and it must not prompt.
 
-## 4. Distribute
+## Keep receipts
 
-```bash
-fission distribute \
-  --project-dir . \
-  --provider play-store \
-  --artifact target/fission/release/android/aab/artifact-manifest.json \
-  --track internal
-```
-
-Use the same pattern for App Store and Microsoft Store providers, changing the provider, artifact, track or flight, and release profile.
-
-## 5. Keep receipts
-
-Store distribution can involve review, certification, beta tracks, staged rollout, and later status changes. Keep Fission receipts in CI artifacts or release records so the team can see what was uploaded, which provider id was returned, and what follow-up state remains.
+Store distribution can involve review, certification, beta tracks, staged rollout, and later status changes. Keep Fission receipts in CI artifacts or release records so the team can see what was uploaded, which provider id was returned, what metadata changed, and what follow-up state remains.

--- a/documentation/content/docs/release-and-distribute/overview.mdx
+++ b/documentation/content/docs/release-and-distribute/overview.mdx
@@ -18,6 +18,22 @@ Release begins after packaging. At this stage you already have an artifact manif
 
 Release commands should fail with diagnosable errors. Missing credentials, expired auth, invalid tracks, absent screenshots, and provider rejections should be safe to fix and retry.
 
+## Choose a local or CI release path
+
+Use the same release model in every shell, but choose the interface that matches
+the job.
+
+| Path | Command | Best fit |
+| --- | --- | --- |
+| Guided local flow | `fission publish --provider play-store` | A developer is setting up a provider, signing, release notes, screenshots, or tracks for the first time. |
+| Windowed local flow | `fission publish --provider play-store --app` | A developer wants the visual release wizard and native file dialogs. |
+| Direct CI flow | `fission readiness ... --json`, `fission package ... --json`, `fission publish ... --artifact ... --yes --json` | Automation should build one artifact, publish that exact manifest, and fail without prompting. |
+| Provider lifecycle operation | `fission distribute status|promote|rollback ...` | A release has already been uploaded and needs provider-specific follow-up. |
+
+The guided shells can help discover missing setup, but they are not a different
+release system. They render the same plan, requirements, jobs, and receipts as
+direct commands.
+
 ## Pick the provider page
 
 | Destination | Start here | Common artifacts |

--- a/documentation/content/docs/release-and-distribute/post-build-lifecycle.mdx
+++ b/documentation/content/docs/release-and-distribute/post-build-lifecycle.mdx
@@ -30,6 +30,21 @@ fission distribute --project-dir . --provider microsoft-store --artifact target/
 
 The same pattern works for other providers. The target, package format, provider, and track change; the workflow remains recognizable.
 
+## Choose the right entry point
+
+The release engine is shared, but developers enter it in different ways:
+
+| Entry point | Use it when | Behavior |
+| --- | --- | --- |
+| `fission publish --provider <provider>` | Local interactive publishing | Opens the guided terminal flow and builds/packages the provider default target when no artifact is supplied. |
+| `fission publish --provider <provider> --app` | Local visual publishing | Opens the windowed Fission flow. It is interactive and should not be combined with CI flags. |
+| `fission publish --provider <provider> --artifact <manifest> --yes --json` | CI or scripted release | Uses the manifest exactly as produced by `fission package`, does not prompt, and writes JSON diagnostics. |
+| `fission distribute ...` | Lower-level provider operation | Runs setup, status, promote, rollback, or publish against a provider profile. |
+| `fission release-workflow run <name>` | Project-owned repeatable release recipe | Runs named Fission commands declared in `fission.toml`; arbitrary shell commands are rejected. |
+
+Use guided flows for discovery. Use direct manifest-backed commands for CI and
+repeatable automation.
+
 ## Keep release metadata reviewable
 
 ## Lifecycle fit and verification
@@ -90,6 +105,32 @@ A readiness check should answer three questions:
 | What should I do next? | Stable error IDs, human-readable explanation, and concrete remediation steps. |
 
 Use `--json` in CI so a workflow can fail with structured diagnostics instead of parsing console text. The JSON report is printed before exit, and a blocked report still exits non-zero so CI cannot accidentally treat provider-required failures as successful readiness.
+
+## Version and build preflight
+
+Store providers reject avoidable version mistakes. Fission treats version/build
+state as part of release readiness, not as an afterthought.
+
+```bash
+fission release-config version-state \
+  --project-dir . \
+  --provider play-store \
+  --target android \
+  --track internal \
+  --json
+```
+
+If the provider reports that the selected build is unusable, update the release
+configuration before packaging:
+
+```bash
+fission release-config bump-build --project-dir . --target android --yes
+fission package --project-dir . --target android --format aab --release
+```
+
+The same principle applies to App Store and Microsoft Store releases even though
+the provider rules differ. Resolve version/build, sync target-native
+configuration, package, then publish the resulting manifest.
 
 ## Package commands produce artifact manifests
 

--- a/documentation/content/docs/release-and-distribute/release-content.mdx
+++ b/documentation/content/docs/release-and-distribute/release-content.mdx
@@ -9,6 +9,26 @@ Release content is the human-facing and provider-facing material that travels wi
 
 Keep [`fission.toml`](/reference/config/fission-toml/) as the root reference, but keep long content in files.
 
+## What belongs in release content
+
+Release content is broader than release notes. A store release may need many
+separate files and decisions:
+
+| Content | Typical location | Required? |
+| --- | --- | --- |
+| Release notes | `release-content/metadata/<release>/notes/<locale>.md` | Often provider-required for store tracks. |
+| Store listing text | `release-content/metadata/<release>/release.toml` plus short fields in `fission.toml` | Provider-specific. |
+| Screenshots | `release-content/screenshots/rendered/<provider>/...` | Provider-specific; recommended even when not required. |
+| Preview video or trailer | `release-content/assets/...` | Optional or provider-specific. |
+| Privacy/data-safety answers | `release-content/metadata/<release>/privacy.toml` | Required for many stores before public release. |
+| Review instructions | `release-content/metadata/<release>/review.toml` | Required when reviewers need credentials or special setup. |
+| Tester groups | `fission.toml` beta tables or provider state | Track/provider-specific. |
+
+Fission classifies missing items as provider required, Fission recommended,
+optional, or not applicable. Provider-required items block the selected
+operation. Recommended items should be reviewed and either fixed or explicitly
+skipped.
+
 ## 1. Use a versioned content folder
 
 ```text
@@ -29,10 +49,23 @@ release-content/
 The manifest can point to those files through a release block.
 
 ```toml
+[release]
+active_release = "1.2.3+42"
+metadata_root = "release-content/metadata"
+content_output_dir = "release-content"
+default_locales = ["en-US"]
+
 [[releases]]
-version = "1.2.3+42"
+id = "1.2.3+42"
+version = "1.2.3"
+build = 42
+status = "candidate"
+tracks = ["play-store:internal"]
+locales = ["en-US"]
 metadata = "release-content/metadata/1.2.3+42/release.toml"
-notes = "release-content/metadata/1.2.3+42/notes/en-US.md"
+release_notes = "release-content/metadata/1.2.3+42/notes"
+review = "release-content/metadata/1.2.3+42/review.toml"
+privacy = "release-content/metadata/1.2.3+42/privacy.toml"
 ```
 
 ## 2. Validate before upload
@@ -43,10 +76,79 @@ fission release-content validate --project-dir . --provider app-store
 
 Validation should fail early when screenshots are missing, notes are empty, privacy answers are incomplete, review credentials are absent, or localized content does not match the provider's requirements.
 
+Use JSON in CI and in tools that render the release plan:
+
+```bash
+fission release-content validate --project-dir . --provider play-store --json
+```
+
+When an item is recommended rather than provider-required, the team can record a
+deliberate skip by id:
+
+```bash
+fission release-config skip-requirement \
+  --project-dir . \
+  --id release_content.play_store.feature_graphic \
+  --yes
+```
+
+Do not skip provider-required items. Fission reports those skip attempts as
+warnings and keeps the requirement blocking.
+
 ## 3. Capture screenshots intentionally
 
 Screenshots are release assets, not random test leftovers. Capture them from the target shell and viewport the provider expects. Store them under the release-content version so the release remains reproducible.
 
-## 4. Connect release content to distribution
+Release screenshot capture uses the same LiveTest command channel as normal UI
+testing. Define stable scenarios in [`fission.toml`](/reference/config/fission-toml/)
+so they can be replayed locally and in CI:
+
+```toml
+[release.screenshots]
+raw_dir = "release-content/screenshots/raw"
+rendered_dir = "release-content/screenshots/rendered"
+
+[[release.screenshots.scenarios]]
+id = "android-onboarding"
+name = "Android onboarding"
+targets = ["android"]
+script = "platforms/android/test-emulator.sh"
+timeout_ms = 60000
+
+[[release.screenshots.scenarios.steps]]
+cmd = "tap_text"
+text = "Get started"
+
+[[release.screenshots.scenarios.steps]]
+cmd = "screenshot"
+name = "01-onboarding"
+```
+
+Capture and render:
+
+```bash
+fission release-content capture --project-dir . --target android --set play-store --json
+fission release-content render --project-dir . --provider play-store --json
+```
+
+Screenshots should be reviewed visually before publishing. Automated capture is
+there to make the release reproducible, not to replace product judgment.
+
+## 4. Keep provider metadata reviewable
+
+Use `release-config import`, `diff`, `lock`, and `push` for provider metadata:
+
+```bash
+fission release-config import --project-dir . --provider play-store --locales en-US --yes
+fission release-config diff --project-dir . --provider play-store
+fission release-config lock --project-dir . --provider play-store --locales en-US --yes
+fission release-config push --project-dir . --provider play-store --locales en-US --yes
+```
+
+The lock records the remote baseline that you reviewed. A later push checks that
+the provider metadata has not changed underneath you. If it has, run `diff`,
+refresh the lock, or pass `--overwrite-remote` only after an explicit review.
+
+## 5. Connect release content to distribution
 
 Distribution commands should read validated content, upload the package, upload or reference release assets, and write a receipt. If metadata validation fails, fix content before retrying the upload.

--- a/documentation/content/reference/cli/overview.mdx
+++ b/documentation/content/reference/cli/overview.mdx
@@ -52,7 +52,16 @@ Fission exposes these public command-line interface entry points:
 | `fission server serve` | Runs the server-rendered app locally | When reviewing dynamic pages, jobs, workers, and islands |
 | `fission server artifacts` | Generates per-worker and per-island browser artifacts | Before packaging server pages with browser enhancements |
 | `fission package` | Packages an app, static site, or server into a release artifact manifest | Before publishing or archiving release output |
-| `fission publish` | Publishes a packaged artifact to a configured provider | When uploading to static hosts, GitHub Releases, object storage, stores, or Docker registries |
+| `fission readiness` | Runs focused package, distribution, or full release preflight | Before an expensive package or provider mutation |
+| `fission release-config` | Edits, validates, imports, diffs, locks, and pushes release metadata | When managing versions, build numbers, store metadata, and release records |
+| `fission release-content` | Captures, renders, validates, and pushes release assets | When preparing notes, screenshots, previews, privacy files, and review material |
+| `fission distribute` | Runs lower-level provider setup, publish, status, promote, or rollback operations | When a provider action is not just the common publish path |
+| `fission publish` | Runs the shared package/publish workflow or opens an interactive publish flow | When uploading to static hosts, GitHub Releases, object storage, stores, or Docker registries |
+| `fission beta` | Manages beta groups, testers, and beta distribution | When a store release needs TestFlight, Play tracks, or provider tester state |
+| `fission signing` | Inspects or imports signing references without storing secrets in the project | When preparing Android, iOS, macOS, or Windows release signing |
+| `fission reviews` | Lists and replies to store reviews where provider support exists | When release operations need provider feedback loops |
+| `fission release-workflow` | Runs named project-defined release recipes | When CI needs a repeatable sequence of Fission commands |
+| `fission auth` | Shows provider authentication setup, status, import, rotation, and audit guidance | When credentials or provider auth state are missing |
 
 Repository developers may see the package name `cargo-fission` in workspace commands. That is the package that builds and installs the developer-facing `fission` command; product documentation and generated project files should use `fission ...`.
 
@@ -406,6 +415,141 @@ fission publish --provider <provider> --artifact <artifact-manifest.json> [--sit
 Without `--artifact`, `fission publish` opens the guided local publish flow. It shows preflight checks, creates/uses `~/.fission/<app-name>/release.env`, helps select or generate signing/provider files, builds the artifact, runs a dry-run, and then asks for explicit confirmation before publishing. Add `--app` to open the same workflow as a native windowed Fission app with native file dialogs. `--app` is interactive, so do not combine it with `--guided`, `--dry-run`, `--yes`, `--json`, or `--overwrite-remote`.
 
 With `--artifact`, `fission publish` keeps the direct non-interactive behavior for scripts and CI. `fission distribute publish ...` is still available, but `publish` is the direct command developers should reach for in normal release workflows.
+
+### `fission distribute`
+
+```sh
+fission distribute [setup|publish|status|promote|rollback] \
+  --provider <provider> \
+  [--artifact <artifact-manifest.json>] \
+  [--site <profile>] \
+  [--deploy <id>] \
+  [--track <track>] \
+  [--locale <locale>] \
+  [--dry-run] \
+  [--yes] \
+  [--project-dir <dir>] \
+  [--json]
+```
+
+Runs a provider lifecycle operation. `publish` is the default action when no
+action is supplied. Use `distribute` when you need setup, status, promote, or
+rollback operations, or when provider-specific release automation is clearer as
+a lower-level command than `publish`.
+
+Supported providers are `app-store`, `github-pages`, `github-releases`,
+`cloudflare-pages`, `docker-registry`, `dropbox`, `google-drive`,
+`microsoft-store`, `netlify`, `onedrive`, `play-store`, and `s3`.
+
+### `fission release-config`
+
+```sh
+fission release-config validate [--provider <provider>] [--project-dir <dir>] [--json]
+fission release-config set <field> <value> [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission release-config add-release --version <version> --build <n> [--from <release-id>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission release-config bump-build [--target <target>] [--by <n>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission release-config version-state --provider <provider> [--target <target>] [--format <format>] [--track <track>] [--artifact <manifest>] [--project-dir <dir>] [--json]
+fission release-config import --provider <provider> [--locales <list>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission release-config diff --provider <provider> [--project-dir <dir>] [--json]
+fission release-config lock --provider <provider> [--locales <list>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission release-config push --provider <provider> [--locales <list>] [--overwrite-remote] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission release-config skip-requirement --id <requirement-id> [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission release-config edit [--provider <provider>] [--tui] [--project-dir <dir>]
+fission release-config edit-file --release <release-id> --kind <kind> [--locale <locale>] [--project-dir <dir>]
+fission release-config write-file --release <release-id> --kind <kind> [--locale <locale>] [--value <text>|--from-file <path>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+```
+
+Release config commands manage reviewable release state in
+[`fission.toml`](/reference/config/fission-toml/) and referenced sidecar files.
+Use them to create releases, set scalar fields with the right TOML type, bump
+build numbers, compare local state with provider state, and prevent stale store
+metadata overwrites.
+
+`version-state` is the preflight command to run before store uploads. It checks
+local version/build state against provider state where the provider API exposes
+enough information. For example, Google Play reused `versionCode` values should
+be caught before artifact upload.
+
+### `fission release-content`
+
+```sh
+fission release-content capture --target <target> --set <set> [--project-dir <dir>] [--json]
+fission release-content render --provider <provider> [--project-dir <dir>] [--json]
+fission release-content validate [--provider <provider>] [--project-dir <dir>] [--json]
+fission release-content push --provider <provider> [--locales <list>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+```
+
+Release content commands prepare the human-facing material around a binary:
+notes, screenshots, store listing text, previews, privacy answers, review files,
+and provider assets. Capture uses configured scenarios and LiveTest-style
+commands. Render turns raw captures into provider-ready assets. Validate checks
+required and recommended content before publish.
+
+### `fission beta`
+
+```sh
+fission beta groups list --provider <provider> [--project-dir <dir>] [--json]
+fission beta groups sync --provider <provider> [--from <path>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission beta testers import --provider <provider> [--group <group>|--track <track>] --csv <path> [--project-dir <dir>] [--dry-run] [--yes] [--json]
+fission beta testers export --provider <provider> [--group <group>|--track <track>] --output <path> [--project-dir <dir>] [--json]
+fission beta distribute --provider <provider> --artifact <manifest> [--group <group>|--track <track>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+```
+
+Beta commands manage provider beta surfaces such as App Store groups and Google
+Play tracks/tester configuration where support is implemented.
+
+### `fission signing`
+
+```sh
+fission signing status --target <target> [--project-dir <dir>] [--json]
+fission signing sync --target <target> [--readonly] [--project-dir <dir>] [--json]
+fission signing import --target <target> [--keystore <path>] [--alias <alias>] [--project-dir <dir>] [--dry-run] [--yes] [--json]
+```
+
+Signing commands inspect or import signing references. They do not store
+passwords, private keys, service-account JSON, or machine-local secret paths in
+the project manifest. Secret material should come from environment variables,
+base64 CI secrets, platform key stores, provider tools, or local private
+workspace files under `~/.fission/<app-name>/`.
+
+### `fission reviews`
+
+```sh
+fission reviews list --provider <provider> [--since <duration>] [--project-dir <dir>] [--json]
+fission reviews reply --provider <provider> --review <id> --message-file <path> [--project-dir <dir>] [--dry-run] [--yes] [--json]
+```
+
+Review commands are provider lifecycle helpers. Replies are explicit mutating
+operations and should use `--dry-run` while drafting and `--yes` only after the
+message file has been reviewed.
+
+### `fission release-workflow`
+
+```sh
+fission release-workflow list [--project-dir <dir>] [--json]
+fission release-workflow run <name> [--project-dir <dir>] [--dry-run] [--yes] [--json]
+```
+
+Runs named release workflows from [`fission.toml`](/reference/config/fission-toml/).
+Workflow commands must be Fission commands; arbitrary shell commands are
+rejected before execution. Use workflows for CI recipes that should stay
+reviewable in the project manifest.
+
+### `fission auth`
+
+```sh
+fission auth login [provider] [--json]
+fission auth setup [provider] [--json]
+fission auth status [provider] [--json]
+fission auth logout [provider] [--json]
+fission auth import <provider> [--from <file-or-env>] [--json]
+fission auth rotate [provider] [--json]
+fission auth audit [--json]
+```
+
+Auth commands explain and inspect provider credential setup. They do not create a
+hidden project vault. The project manifest may name environment variables, but
+secret values and secret file paths stay outside source control.
 
 ## Static site workflow
 

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -10,6 +10,15 @@ description: Complete reference for every fission.toml section currently read by
 
 Keep this file human-reviewable. Short identifiers and non-secret paths belong here. Long release notes, localized store descriptions, review instructions, privacy declarations, screenshots, and videos can live in referenced files. Certificates, private keys, signing passwords, tokens, keystores, and service-account JSON must come from environment variables, provider tools, platform key stores, or CI secrets.
 
+This reference lists accepted fields. For the release reasoning behind those
+fields, use the platform guides:
+[macOS](/docs/build-and-package/macos-packages/),
+[macOS native XcodeGen](/docs/build-and-package/macos-native-xcodegen/),
+[Windows](/docs/build-and-package/windows-packages/),
+[Linux](/docs/build-and-package/linux-packages/),
+[Android](/docs/build-and-package/android-packages/), and
+[iOS](/docs/build-and-package/ios-packages/).
+
 ## Minimal app manifest
 
 Most app projects need only this at the start:
@@ -193,22 +202,25 @@ destination = "libexec/linux-mount-helper"
 ### `[native.modules.windows]`
 
 Windows native modules attach either a Cargo package or an MSBuild/WDK project
-to the desktop lifecycle. `fission build`, `fission run`, and Windows package
-commands build the declared module. `fission test --target windows` runs Cargo
-tests or each declared MSBuild test binary through `vstest.console.exe`.
+to the desktop lifecycle. A module must choose exactly one build system:
+`cargo_package` or `msbuild_project`. Fission rejects mixed configuration so
+Cargo features cannot be combined accidentally with NuGet/MSBuild/WDK settings.
+`fission build`, `fission run`, and Windows package commands build the declared
+module. `fission test --target windows` runs Cargo tests for Cargo modules and
+each declared VSTest binary for MSBuild modules.
 
 | Field | Type | Required | Default | Meaning |
 | --- | --- | --- | --- | --- |
-| `cargo_manifest_path` | string | No | `<native.modules.path>/Cargo.toml`, then the app `Cargo.toml` | Project-relative Cargo manifest used for a Cargo native module. |
-| `cargo_package` | string | Yes for Cargo modules | none | Exact Cargo package passed with `--package`. Mutually exclusive with `msbuild_project`. |
-| `features` | array of strings | No | `[]` | Cargo features enabled for build and test. |
+| `cargo_manifest_path` | string | No | `<native.modules.path>/Cargo.toml`, then app `Cargo.toml` | Project-relative Cargo manifest for Cargo modules. |
+| `cargo_package` | string | Required for Cargo modules | none | Exact Cargo package passed with `--package`. Mutually exclusive with `msbuild_project`. |
+| `features` | array of strings | No | `[]` | Cargo features enabled for Cargo module build and test. |
 | `no_default_features` | boolean | No | `false` | Passes `--no-default-features` to Cargo. |
-| `nuget_packages_config` | string | No | none | Project-relative `packages.config` restored before MSBuild. Restored WDK host-tool directories are added to the MSBuild environment. |
-| `nuget_packages_directory` | string | No | sibling `packages` directory | Project-relative restore destination. Requires `nuget_packages_config`. |
-| `msbuild_project` | string | Yes for MSBuild modules | none | Project-relative `.sln`, `.slnx`, or MSBuild project passed to `msbuild`. Mutually exclusive with `cargo_package`. |
+| `nuget_packages_config` | string | No | none | MSBuild-only project-relative `packages.config` restored before MSBuild. Restored WDK host-tool directories are added to the MSBuild environment. |
+| `nuget_packages_directory` | string | No | sibling `packages` directory | MSBuild-only project-relative restore destination. Requires `nuget_packages_config`. |
+| `msbuild_project` | string | Required for MSBuild modules | none | Project-relative `.sln`, `.slnx`, or MSBuild project passed to `msbuild`. Mutually exclusive with `cargo_package`. |
 | `platform` | string | No | `x64` | MSBuild platform, such as `x64` or `ARM64`. |
 | `build_target` | string | No | `Build` | MSBuild target invoked for the module. |
-| `test_binaries` | array of strings | No | `[]` | VSTest executables. Paths may contain `{configuration}`, `{profile}`, and `{platform}`. |
+| `test_binaries` | array of strings | No | `[]` | MSBuild/VSTest executables. Paths may contain `{configuration}`, `{profile}`, and `{platform}`. |
 
 Each `[[native.modules.windows.products]]` entry accepts:
 
@@ -241,8 +253,7 @@ path = "platforms/windows/native/{platform}/{configuration}/DriverPackage"
 kind = "driver-package"
 ```
 
-Cargo-native Windows products use the same product table without an MSBuild
-project:
+Cargo-native Windows module example:
 
 ```toml
 [[native.modules]]
@@ -250,7 +261,10 @@ name = "windows-helper"
 path = "../windows-helper"
 
 [native.modules.windows]
+cargo_manifest_path = "../windows-helper/Cargo.toml"
 cargo_package = "windows-helper"
+features = ["installer"]
+no_default_features = true
 
 [[native.modules.windows.products]]
 name = "windows-helper"
@@ -267,6 +281,8 @@ destination = "tools/windows-helper.exe"
 | --- | --- | --- | --- |
 | `name` | string | Yes | Rust package/app name used by generated scripts and site fallback title. Prefer a Cargo-compatible kebab-case name such as `field-inspector`. |
 | `app_id` | string | Yes | Stable application identifier used by generated mobile/desktop package metadata. Use a reverse-domain identifier such as `com.example.field_inspector`. `id` is accepted as a shorter alias when reading config; generated files still write `app_id` for compatibility with existing projects. |
+| `version` | string | Recommended for release | Default user-facing version used by release version resolution when target/package-specific fields are absent. |
+| `build` | integer | Recommended for release | Default monotonically increasing build number used by release version resolution when target/package-specific fields are absent. |
 | `publisher` | string | Recommended for release | Publisher or legal owner shown in store/package metadata where applicable. |
 | `homepage` | string | Recommended for release | Product website used by store listings, package metadata, and support surfaces where applicable. |
 | `support_url` | string | Recommended for release | Support URL used by store listings and release checks where applicable. |
@@ -696,6 +712,25 @@ port = 8080
 tags = ["ghcr.io/example/pokemon-card-store:0.1.0", "ghcr.io/example/pokemon-card-store:latest"]
 ```
 
+### `[package.linux.run]`
+
+`[package.linux.run]` configures `fission package --target linux --format run`.
+When no script is configured, Fission writes its built-in user-local `.run`
+installer. Configure a script when the installer must handle services,
+privileged helpers, custom layout, repair/uninstall behavior, or other
+product-owned installation policy.
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `installer_script` | string | No | Project-relative executable or shell script. The script receives `FISSION_LINUX_PAYLOAD_DIR`, `LINUX_BINARY`, `FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST`, and `LINUX_PROFILE` on release builds, then prints the completed `.run` path on stdout. |
+
+Example:
+
+```toml
+[package.linux.run]
+installer_script = "platforms/linux/package-run.sh"
+```
+
 ### `[package.macos]`
 
 | Field | Type | Required | Meaning |
@@ -765,6 +800,8 @@ entitlements.
 | `keystore_password_env` | string | No | Environment variable containing the keystore password. Defaults to `ANDROID_KEYSTORE_PASSWORD`. |
 | `key_password_env` | string | No | Environment variable containing the key password. Defaults to `ANDROID_KEY_PASSWORD`; falls back to `ANDROID_KEYSTORE_PASSWORD` in generated Android packaging. |
 | `package_name` | string | Required for Android signing readiness | Android package name expected by signing/release checks. Usually matches `[app].app_id`. |
+| `version_code` | integer | Recommended for store releases | Android `versionCode`. If omitted, Fission falls back to the active release or `[app].build` where available. |
+| `version_name` | string | Recommended for store releases | Android `versionName`. If omitted, Fission falls back to the active release or `[app].version` where available. |
 
 Keystore files and passwords are not stored in `fission.toml`. For local release builds, set `ANDROID_KEYSTORE` to a path outside the repo. For CI, store the keystore as a base64 secret and expose it through `ANDROID_KEYSTORE_BASE64`. Set `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEYSTORE_ALIAS`, and optionally `ANDROID_KEY_PASSWORD` through your shell or CI secret store.
 
@@ -773,6 +810,8 @@ Keystore files and passwords are not stored in `fission.toml`. For local release
 | Field | Type | Required | Meaning |
 | --- | --- | --- | --- |
 | `bundle_id` | string | No | iOS bundle identifier used by signing readiness. Usually matches `[app].app_id`. |
+| `marketing_version` | string | Recommended for App Store releases | iOS marketing version. If omitted, Fission falls back to the active release or `[app].version` where available. |
+| `build_number` | string | Recommended for App Store releases | iOS build number. If omitted, Fission falls back to the active release or `[app].build` where available. |
 | `team_id` | string | No | Apple Developer Team ID for signing workflows. |
 | `entitlements` | string | No | Project-relative entitlements plist. |
 | `provisioning_profile` | string | No | Project-relative provisioning profile reference. |
@@ -783,6 +822,7 @@ Keystore files and passwords are not stored in `fission.toml`. For local release
 | Field | Type | Required | Meaning |
 | --- | --- | --- | --- |
 | `identity_name` | string | No | MSIX package identity name. |
+| `version` | string | Recommended for Store packages | Windows package version. Fission normalizes release/app version state for package output where applicable. |
 | `publisher` | string | No | Windows package publisher distinguished name. |
 | `certificate_thumbprint` | string | No | Certificate thumbprint used when signing through the Windows certificate store. |
 | `certificate_env` | string | No | Environment variable containing a local certificate path. Defaults to `WINDOWS_CERTIFICATE`. |
@@ -994,6 +1034,7 @@ Release configuration keeps long content out of `fission.toml` by referencing si
 | `metadata_root` | string | Yes | Root directory for release metadata sidecar files. |
 | `content_output_dir` | string | Yes | Output directory for generated/captured release content. |
 | `default_locales` | array of strings | Yes | Locales used when a release entry does not override `locales`. |
+| `skip_requirements` | array of strings | No | Explicit requirement ids the team reviewed and chose to skip. Only provider-optional or Fission-recommended requirements can be skipped; provider-required requirements remain blocking. |
 
 ### `[release.provider_locks.<provider>]`
 
@@ -1261,9 +1302,13 @@ capabilities = ["camera", "geolocation", "notifications"]
 [app]
 name = "example-app"
 app_id = "com.example.app"
+version = "1.0.0"
+build = 1
 
 [package.android]
 package_name = "com.example.app"
+version_code = 1
+version_name = "1.0.0"
 keystore_alias = "upload"
 keystore_env = "ANDROID_KEYSTORE"
 keystore_base64_env = "ANDROID_KEYSTORE_BASE64"
@@ -1272,6 +1317,8 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.example.app"
+marketing_version = "1.0.0"
+build_number = "1"
 team_id = "ABCDE12345"
 entitlements = "platforms/ios/Entitlements.plist"
 provisioning_profile = "release-content/signing/ios/App.mobileprovision"
@@ -1290,6 +1337,7 @@ notarize = true
 
 [package.windows]
 identity_name = "Example.App"
+version = "1.0.0.0"
 publisher = "CN=Example Ltd"
 certificate_thumbprint = "0123456789ABCDEF"
 exe_installer_script = "platforms/windows/package-exe.ps1"
@@ -1324,6 +1372,7 @@ active_release = "1.0.0+1"
 metadata_root = "release-content/metadata"
 content_output_dir = "release-content"
 default_locales = ["en-US"]
+skip_requirements = []
 
 [release.store_listing.play_store.en-US]
 title = "Example App"

--- a/documentation/content/reference/core/live-test-command-api.mdx
+++ b/documentation/content/reference/core/live-test-command-api.mdx
@@ -1,0 +1,453 @@
+---
+title: LiveTest command API
+description: Reference for the Fission test-control /cmd protocol, selector queries, semantic tree response, screenshots, input simulation, and wait commands.
+---
+
+# LiveTest command API
+
+Fission live tests drive a running app through an HTTP test-control server. The server is enabled by launching a supported shell with `FISSION_TEST_CONTROL_PORT=<port>`.
+
+```bash
+FISSION_TEST_CONTROL_PORT=9876 cargo run --example counter
+```
+
+The protocol has two endpoints:
+
+| Endpoint | Method | Meaning |
+| --- | --- | --- |
+| `/health` | `GET` | Readiness probe for the test-control server. |
+| `/cmd` | `POST` | Executes one JSON command and returns one JSON response. |
+
+Every `/cmd` payload is tagged by the exact `cmd` variant name:
+
+```json
+{"cmd":"GetTree"}
+```
+
+`LiveTestClient` in `fission-test-driver` wraps this protocol for Rust tests. Direct `/cmd` calls are still useful for manual QA, screenshot capture, CI diagnostics, and non-Rust clients.
+
+## Selector queries
+
+Selector-driven commands receive a `query` object:
+
+```json
+{
+  "selector": {
+    "kind": "semantic_identifier",
+    "identifier": "settings.save"
+  }
+}
+```
+
+`SelectorQuery` fields:
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `selector` | selector object | required | Primary selector. |
+| `scope` | nested selector query | omitted | Restrict matches to descendants of the scoped node. |
+| `index` | number | omitted | Select the Nth candidate after filtering. Useful for intentional duplicate labels. |
+| `include_hidden` | boolean | `false` | Include hidden nodes during resolution. Most user-level tests should leave this false. |
+
+Selector kinds:
+
+| Kind | Fields | Matches |
+| --- | --- | --- |
+| `semantic_identifier` | `identifier` | `Semantics::identifier`, exposed as `SemanticNode.identifier`. |
+| `widget_id` | `widget_id` | Stable widget id. Accepts an explicit widget id key or raw id string. |
+| `test_id` | `test_id` | Test identifier. Currently aliases semantic identifier. |
+| `accessibility_identifier` | `identifier` | Accessibility identifier. Currently aliases semantic identifier. |
+| `role_label` | `role`, `label` | Node with both matching role and label. |
+| `label` | `label` | Node with matching label. |
+
+Scoped query example:
+
+```json
+{
+  "selector": { "kind": "label", "label": "Continue" },
+  "scope": {
+    "selector": {
+      "kind": "semantic_identifier",
+      "identifier": "checkout.payment_dialog"
+    }
+  }
+}
+```
+
+## Responses
+
+All responses are tagged by `status`.
+
+| Status | Fields | Meaning |
+| --- | --- | --- |
+| `Ok` | none | Command completed. |
+| `Text` | `items` | Visible text records returned by `GetText`. |
+| `Tree` | `nodes` | Semantic tree returned by `GetTree`. |
+| `Screenshot` | `png_base64`, `width`, `height` | PNG screenshot payload. |
+| `SelectorResolved` | `node` | Selector resolved to one node. |
+| `SelectorError` | `failure` | Selector failed with structured diagnostic data. |
+| `Error` | `message` | Non-selector command failure. |
+
+`SelectorError.failure.kind` is one of `NoMatch`, `Ambiguous`, `FoundButNotVisible`, `Disabled`, `ReadOnly`, `UnsupportedAction`, `Timeout`, or `StaleFrame`. The failure also includes the selector, considered candidates, rejection reasons, and a message.
+
+## Semantic nodes returned by GetTree
+
+`GetTree` returns `SemanticNode` records. Bounds are logical test-space pixels.
+
+| Field | Meaning |
+| --- | --- |
+| `identifier` | First-class semantic identifier. Do not overload `value` for this. |
+| `widget_id` | Widget id string. |
+| `stable_node_id` | Stable test node id for parent/child relationships. |
+| `parent` | Parent `stable_node_id`, if any. |
+| `children` | Child `stable_node_id` values. |
+| `role` | Semantic/accessibility role, such as `Button`, `TextInput`, `Checkbox`, or `Radio`. |
+| `label` | User-facing or accessibility label. |
+| `value` | Current value if the node exposes one. |
+| `value_present` | Whether a value exists, including masked or empty values. |
+| `focusable` | Whether the node can receive focus. |
+| `disabled` | Whether activation should be blocked. |
+| `read_only` | Whether text/value editing should be blocked. |
+| `checked` | Toggle state for checkbox, switch, radio, or similar controls. |
+| `actions` | Supported semantic actions. |
+| `text_selection` | Text selection byte offsets when exposed. |
+| `masked` | Whether the value is masked, for example password input. |
+| `scrollable_x`, `scrollable_y` | Whether the node scrolls in that axis. |
+| `logical_bounds` | Full logical bounds before clipping. |
+| `visible_bounds` | Bounds after viewport/clipping, or `null` when hidden. |
+| `visibility` | `FullyVisible`, `PartiallyVisible`, or `Hidden`. |
+| `x`, `y`, `width`, `height` | Compatibility bounds matching `logical_bounds`. |
+
+## Command reference
+
+### Tap
+
+```json
+{"cmd":"Tap","x":120,"y":48}
+```
+
+Taps logical coordinates with the primary pointer button. Use selector commands for product tests; use `Tap` for low-level hit-testing bugs.
+
+### Drag
+
+```json
+{"cmd":"Drag","start_x":40,"start_y":40,"end_x":240,"end_y":120,"steps":12}
+```
+
+Sends mouse move, primary down, intermediate moves, and primary up.
+
+### TapText
+
+```json
+{"cmd":"TapText","text":"Add task"}
+```
+
+Finds visible text containing `text` and taps its center. Kept for simple tests and backward compatibility. Prefer selectors when possible.
+
+### ResolveSelector
+
+```json
+{"cmd":"ResolveSelector","query":{"selector":{"kind":"semantic_identifier","identifier":"todo.add"}}}
+```
+
+Resolves a selector and returns `SelectorResolved` with the matching semantic node, or `SelectorError`.
+
+### TapSelector
+
+```json
+{"cmd":"TapSelector","query":{"selector":{"kind":"semantic_identifier","identifier":"todo.add"}}}
+```
+
+Auto-scrolls the target into view, then sends a primary pointer click at the visible target. Fails clearly if the node is missing, ambiguous, disabled, or still not visible.
+
+### ActivateSelector
+
+```json
+{"cmd":"ActivateSelector","query":{"selector":{"kind":"role_label","role":"Button","label":"Save"}}}
+```
+
+Invokes the node's semantic activation path. Use when you want to express "activate this control" rather than pointer-click mechanics.
+
+### FocusSelector
+
+```json
+{"cmd":"FocusSelector","query":{"selector":{"kind":"semantic_identifier","identifier":"login.email"}}}
+```
+
+Auto-scrolls and focuses a focusable node.
+
+### HoverSelector
+
+```json
+{"cmd":"HoverSelector","query":{"selector":{"kind":"semantic_identifier","identifier":"toolbar.help"}}}
+```
+
+Moves the pointer to the selector target without clicking. Useful for tooltip, hover, and drag-hover states.
+
+### RightClickSelector
+
+```json
+{"cmd":"RightClickSelector","query":{"selector":{"kind":"semantic_identifier","identifier":"editor.selection"}}}
+```
+
+Auto-scrolls and right-clicks the selector target. Use for context menus and secondary-click behavior.
+
+### ScrollIntoView
+
+```json
+{"cmd":"ScrollIntoView","query":{"selector":{"kind":"semantic_identifier","identifier":"page.3"}}}
+```
+
+Scrolls the nearest scroll container so the target is visible, then returns the resolved node. This reuses the runtime scroll-into-view behavior rather than duplicating scrolling in tests.
+
+### FillText
+
+```json
+{"cmd":"FillText","query":{"selector":{"kind":"semantic_identifier","identifier":"login.password"}},"text":"secret"}
+```
+
+Auto-scrolls, focuses, replaces the editable value, and pumps the result. For masked fields, assert `value_present` or `masked` through `GetTree` instead of printing the secret.
+
+### ClearText
+
+```json
+{"cmd":"ClearText","query":{"selector":{"kind":"semantic_identifier","identifier":"search.query"}}}
+```
+
+Auto-scrolls, focuses, and clears an editable value.
+
+### Toggle
+
+```json
+{"cmd":"Toggle","query":{"selector":{"kind":"semantic_identifier","identifier":"settings.sync"}}}
+```
+
+Toggles a checkbox, switch, radio-like control where supported, or another control exposing a toggle action. Disabled nodes fail with `SelectorError`.
+
+### SelectOption
+
+```json
+{"cmd":"SelectOption","query":{"selector":{"kind":"semantic_identifier","identifier":"plan.pro"}}}
+```
+
+Activates a selectable option. This is useful for options rendered in menus, popovers, portals, or dropdown lists.
+
+### WaitForSelector
+
+```json
+{"cmd":"WaitForSelector","query":{"selector":{"kind":"semantic_identifier","identifier":"toast.saved"}},"timeout_ms":5000}
+```
+
+Polls until a selector resolves.
+
+### WaitForVisible
+
+```json
+{"cmd":"WaitForVisible","query":{"selector":{"kind":"semantic_identifier","identifier":"toast.saved"}},"timeout_ms":5000}
+```
+
+Polls until a selector resolves to a visible node.
+
+### WaitForEnabled
+
+```json
+{"cmd":"WaitForEnabled","query":{"selector":{"kind":"semantic_identifier","identifier":"submit"}},"timeout_ms":5000}
+```
+
+Polls until a selector resolves to a node that is not disabled.
+
+### WaitForDisabled
+
+```json
+{"cmd":"WaitForDisabled","query":{"selector":{"kind":"semantic_identifier","identifier":"submit"}},"timeout_ms":5000}
+```
+
+Polls until a selector resolves to a disabled node.
+
+### WaitForValue
+
+```json
+{"cmd":"WaitForValue","query":{"selector":{"kind":"semantic_identifier","identifier":"search.query"}},"value":"release","timeout_ms":5000}
+```
+
+Polls until the selector's semantic value matches `value`.
+
+### WaitForText
+
+```json
+{"cmd":"WaitForText","text":"Saved","timeout_ms":5000}
+```
+
+Polls visible text until any item contains `text`.
+
+### WaitForGone
+
+```json
+{"cmd":"WaitForGone","query":{"selector":{"kind":"semantic_identifier","identifier":"loading.spinner"}},"timeout_ms":5000}
+```
+
+Polls until a selector no longer resolves.
+
+### Scroll
+
+```json
+{"cmd":"Scroll","x":400,"y":300,"dx":0,"dy":480}
+```
+
+Sends a wheel/scroll event at logical coordinates.
+
+### ExternalFileHover
+
+```json
+{"cmd":"ExternalFileHover","x":320,"y":240,"paths":["/tmp/example.txt"]}
+```
+
+Simulates dragging external files over the app at coordinates.
+
+### ExternalFileDrop
+
+```json
+{"cmd":"ExternalFileDrop","x":320,"y":240,"paths":["/tmp/example.txt"]}
+```
+
+Simulates dropping external files on the app at coordinates.
+
+### ExternalFileCancel
+
+```json
+{"cmd":"ExternalFileCancel"}
+```
+
+Cancels an external file drag session.
+
+### TypeText
+
+```json
+{"cmd":"TypeText","text":"hello"}
+```
+
+Sends text input to the currently focused control. Prefer `FillText` for form automation.
+
+### ImePreedit
+
+```json
+{"cmd":"ImePreedit","text":"かな","cursor_start":0,"cursor_end":2}
+```
+
+Sends an IME preedit update to the focused control.
+
+### ImeCommit
+
+```json
+{"cmd":"ImeCommit","text":"かな"}
+```
+
+Commits IME text to the focused control.
+
+### ImeCancel
+
+```json
+{"cmd":"ImeCancel"}
+```
+
+Cancels the active IME preedit session.
+
+### PressKey
+
+```json
+{"cmd":"PressKey","key":"Enter","modifiers":0}
+```
+
+Sends key down and key up for the named key. `modifiers` is the shell modifier bitmask used by the test driver.
+
+### Screenshot
+
+```json
+{"cmd":"Screenshot","path":"/tmp/app.png"}
+```
+
+Requests a screenshot written by the app process to `path` and returns `Ok` or `Error`. Prefer `CaptureScreenshot` when the caller should own the file write.
+
+### CaptureScreenshot
+
+```json
+{"cmd":"CaptureScreenshot"}
+```
+
+Returns `Screenshot` with `png_base64`, `width`, and `height`.
+
+### GetText
+
+```json
+{"cmd":"GetText"}
+```
+
+Returns visible text items with text and logical bounds.
+
+### GetTree
+
+```json
+{"cmd":"GetTree"}
+```
+
+Returns the current semantic tree, including first-class `identifier`, role, label, value state, focusability, disabled/read-only state, checked state, actions, text selection, masking, scrollability, parent/child relationships, logical bounds, visible bounds, and visibility.
+
+### Wait
+
+```json
+{"cmd":"Wait","ms":250}
+```
+
+Sleeps on the test-control side and returns `Ok`. Prefer condition-based waits when possible.
+
+### Pump
+
+```json
+{"cmd":"Pump"}
+```
+
+Requests a frame pump and returns after the shell has processed it.
+
+### Quit
+
+```json
+{"cmd":"Quit"}
+```
+
+Requests application shutdown.
+
+### SimulateMouseMove
+
+```json
+{"cmd":"SimulateMouseMove","x":100,"y":100}
+```
+
+Sends a low-level mouse move through the shell event path.
+
+### SimulateRightClick
+
+```json
+{"cmd":"SimulateRightClick","x":100,"y":100}
+```
+
+Sends low-level mouse move, secondary down, and secondary up events.
+
+### SimulateResize
+
+```json
+{"cmd":"SimulateResize","width":390,"height":844}
+```
+
+Resizes the logical test viewport. Use this for responsive layout tests.
+
+## Best-practice command order
+
+For stable end-to-end tests:
+
+1. `GET /health` or `LiveTestClient::wait_for_ready`.
+2. `WaitForVisible` on a stable semantic identifier.
+3. Selector action such as `FillText`, `TapSelector`, or `ActivateSelector`.
+4. `WaitForValue`, `WaitForText`, `WaitForGone`, or `GetTree` assertion.
+5. `CaptureScreenshot` only when visual evidence is required.
+6. `Quit` during teardown.
+
+Avoid fixed `Wait` sleeps unless you are debugging timing itself.

--- a/documentation/content/reference/core/testing-and-diagnostics.mdx
+++ b/documentation/content/reference/core/testing-and-diagnostics.mdx
@@ -35,6 +35,13 @@ Important public types include `LiveTestClient`, `TestCommand`, `TestResponse`, 
 
 Use this layer when a real shell matters, such as end-to-end interaction in a real presented app, screenshots, or shell-managed window behavior.
 
+The live shell exposes a test-control HTTP server with `GET /health` and
+`POST /cmd`. Prefer `LiveTestClient` in Rust tests, but the `/cmd` API is also
+public enough for manual QA, screenshot capture, release-content scenarios, and
+non-Rust test drivers. See [LiveTest command API](/reference/core/live-test-command-api/)
+for every supported command, selector shape, semantic tree field, and response
+type.
+
 ### Target smoke validation
 
 Target smoke scripts and generated host launchers are not substitutes for the earlier test layers. They are host-level validation tools.
@@ -100,4 +107,7 @@ Do not use diagnostics as a substitute for ordinary tests. Diagnostics explain a
 
 ## Related reference pages
 
-For shell-specific test boundaries, continue to [Platform testing](/reference/platform/testing). For the teaching guide that explains test order and practical workflow, see [Testing and diagnostics](/docs/guides/testing-and-diagnostics).
+For shell-specific test boundaries, continue to [Platform testing](/reference/platform/testing).
+For the teaching guide that explains unit, headless integration, LiveTest, and
+`/cmd` workflow order, see [Testing Fission apps](/docs/learn/testing/). For
+the exact HTTP protocol, see [LiveTest command API](/reference/core/live-test-command-api/).

--- a/documentation/content/reference/overview/overview.mdx
+++ b/documentation/content/reference/overview/overview.mdx
@@ -52,7 +52,7 @@ The platform pages explain what happens after the shared runtime reaches a real 
 
 [Targets](/reference/platform/targets) is the page to open when you need to understand generated host output, target folders, and the practical expectations for macOS, Windows, Linux, Web, Android, iOS, Terminal, Static site, and SSR targets.
 
-[Accessibility and internationalization](/reference/platform/accessibility-and-i18n) focuses on how semantic meaning and locale-sensitive behavior connect to platform adapters and testing.
+[Accessibility reference](/reference/platform/accessibility) is the support matrix for native screen-reader bridges, semantic HTML output, role mapping, exported node data, and known gaps. [Accessibility and internationalization](/reference/platform/accessibility-and-i18n) focuses on how semantic meaning and locale-sensitive behavior connect to platform adapters and testing together.
 
 [Testing](/reference/platform/testing) explains target-level validation: what can be proved headlessly, what needs a live shell, and what the current host-level test APIs look like.
 
@@ -61,6 +61,8 @@ The platform pages explain what happens after the shared runtime reaches a real 
 The command-line interface is part of the public workflow, from project setup through run, logs, readiness, package, release content, distribution, and release receipts.
 
 Open [command-line interface overview](/reference/cli/overview) when you want the exact scaffold and target-management commands, the meaning of their major flags, and the files they generate. Open the [`fission.toml` manifest](/reference/config/fission-toml) when you need the complete project manifest schema for targets, capabilities, site builds, packaging, signing, release metadata, publishing providers, beta testing, and workflows.
+
+Maintainers preparing a framework release should use [Fission release checklist](/reference/project/fission-release-checklist) for the exact version bump, changelog, blog post, crates.io, GitHub release, tag, and website verification sequence.
 
 ## Widget reference
 

--- a/documentation/content/reference/platform/accessibility-and-i18n.mdx
+++ b/documentation/content/reference/platform/accessibility-and-i18n.mdx
@@ -10,6 +10,8 @@ Accessibility and internationalization are not finishing touches. They affect ho
 
 In Fission, both concerns start in the shared app model. Widgets produce semantic information as part of the normal tree. Text can come from translation keys. Locale and translation bundles live in `Env`. Shells then bridge the resolved result to the host platform.
 
+For the dedicated accessibility support matrix, native bridge contract, role mapping, and screen-reader compatibility targets, use [Accessibility reference](/reference/platform/accessibility/). This page keeps accessibility and locale together because platform shells often need to validate both at the same time.
+
 ## Accessibility contract
 
 Fission widgets can carry semantic metadata. That metadata is used by tests, diagnostics, and platform shells.

--- a/documentation/content/reference/platform/accessibility.mdx
+++ b/documentation/content/reference/platform/accessibility.mdx
@@ -1,0 +1,137 @@
+---
+title: Accessibility reference
+sidebar_label: Accessibility
+slug: /platform/accessibility
+description: Reference for Fission semantics, native accessibility bridge support, platform matrix, screen-reader compatibility targets, and known limitations.
+---
+
+# Accessibility reference
+
+This page is the technical contract for Fission accessibility support.
+
+Fission's shared runtime lowers accessibility information into `Op::Semantics` nodes in Core IR. Shells and renderers consume those semantics differently depending on the target.
+
+## Current support matrix
+
+| Target | Runtime path | Native accessibility API exposure | Screen-reader expectation | Status |
+| --- | --- | --- | --- | --- |
+| macOS | winit native shell | Yes, through AccessKit and the macOS accessibility stack | VoiceOver, Switch Control, Accessibility Inspector | Supported; product apps still need manual QA. |
+| Windows | winit native shell | Yes, through AccessKit and the Windows accessibility stack | Narrator, NVDA, JAWS, Inspect | Supported; validate on target Windows versions. |
+| Linux | winit native shell | Yes, through AccessKit and AT-SPI where available | Orca and AT-SPI tooling | Supported with desktop/session dependency; validate on the distribution and desktop environment you ship for. |
+| iOS | winit mobile/native shell | Yes, through AccessKit's iOS adapter | VoiceOver, Switch Control, Full Keyboard Access | Supported by the native bridge; validate on simulator and device. |
+| Android | winit mobile shell using NativeActivity | No native TalkBack bridge today | TalkBack, Switch Access, Voice Access | Semantics exist for runtime/tests, but native TalkBack control is not complete because the current AccessKit Android adapter expects winit GameActivity. |
+| Web canvas | winit/Web canvas shell | No DOM accessibility tree for the canvas-rendered app today | Browser screen readers only see surrounding host DOM | Not complete for screen-reader control of the canvas app. Prefer Static site or SSR for accessible document-like pages today. |
+| Static site | static HTML renderer | Yes, through semantic HTML and browser accessibility tree | Browser screen readers and browser accessibility inspectors | Supported for rendered HTML semantics, native form controls, links, headings, labels, and ARIA/data attributes produced by the static renderer. |
+| SSR | server HTML renderer | Yes, through semantic HTML and browser accessibility tree | Browser screen readers and browser accessibility inspectors | Supported for server-rendered HTML semantics and forms, with progressive enhancement preserving semantic targets. |
+| Terminal | terminal shell | No OS accessibility tree owned by Fission | Terminal emulator plus screen reader, for example VoiceOver terminal navigation or Orca terminal use | Partial; Fission semantics inform rendering and tests, but full selector command semantics are not exposed by the terminal backend yet. |
+
+## Native bridge implementation
+
+The winit shell owns the native accessibility bridge. It uses AccessKit on non-Web, non-Android targets.
+
+The bridge builds an AccessKit `TreeUpdate` from:
+
+- `CoreIR`, especially `Op::Semantics` and text paint operations;
+- the latest `LayoutSnapshot` for bounds and viewport size;
+- `RuntimeState` for focus, text editing state, scroll offsets, and current values.
+
+The root AccessKit node is a window node. Fission semantics nodes become child nodes when they carry meaningful metadata: a non-generic role, label, identifier, value, focusability, checked state, numeric value, scrollability, or actions.
+
+Text paint nodes become read-only labels when they are not already represented by a higher-level semantics node.
+
+## Role mapping
+
+| Fission role | AccessKit/native role |
+| --- | --- |
+| `Role::Button` | Button |
+| `Role::Text` | Label |
+| `Role::TextInput` | Text input, password input, multiline text input, email input, number input, phone input, or URL input depending on text-input metadata |
+| `Role::Image` | Image |
+| `Role::Checkbox` | Checkbox |
+| `Role::Radio` | Radio button |
+| `Role::Switch` | Switch |
+| `Role::Dialog` | Dialog |
+| `Role::Slider` | Slider |
+| `Role::Input` | Text input |
+| `Role::List` | List |
+| `Role::ListItem` | List item |
+| `Role::Generic` | Generic container, only emitted when other metadata makes the node meaningful |
+
+Static site and SSR targets map some roles to native HTML elements instead: `button`, `input`, `textarea`, `input type="checkbox"`, `input type="radio"`, `input type="range"`, `a`, `ul`, `li`, `figure`, headings, tables, forms, and labelled wrappers where appropriate.
+
+## Exported node data
+
+| Fission field or derived data | Native bridge behavior |
+| --- | --- |
+| `Semantics::identifier` | Exposed as AccessKit author id and as `data-fission-semantics` in HTML renderers. Used by LiveTest selectors. |
+| `Semantics::label` | Exposed as accessible label. If absent, some controls derive a label from descendant text. |
+| `Semantics::value` | Exposed as node value. Text inputs can fall back to retained runtime text-edit state when lowered semantics do not carry a value. |
+| `Semantics::focusable` | Adds focus and blur actions when the node is enabled. |
+| Runtime focused node | Mirrored into the AccessKit tree focus field. |
+| `Semantics::disabled` | Exposed as disabled; native action dispatch rejects disabled targets. |
+| `Semantics::read_only` | Exposed for text inputs and native HTML inputs. |
+| `Semantics::checked` | Exposed as toggled/checked state for checkbox, radio, and switch controls. |
+| `Semantics::masked` | Maps text input to password input. The platform accessibility stack decides how to present the value; app code should not place raw secrets in custom semantic values. |
+| `Semantics::multiline` and `text_input_type` | Selects multiline, email, number, phone, URL, password, or generic text input role/type. |
+| `Semantics::text_selection` | Exposed as AccessKit text selection using character indices derived from byte offsets. |
+| `Semantics::min_value`, `max_value`, `current_value` | Exposed as numeric range metadata and supports increment, decrement, and set value. |
+| `Semantics::scrollable_x`, `scrollable_y` | Exposes scroll actions and current scroll offsets where layout has scroll geometry. |
+| Action entries | Default, focus, blur, change, cursor change, and related action triggers connect platform actions back to Fission reducers. |
+
+## Supported native actions
+
+| Platform accessibility action | Fission behavior |
+| --- | --- |
+| Click | Dispatches the semantic node's default action if present and enabled. |
+| Focus | Sets Fission runtime focus and dispatches the focus trigger. |
+| Blur | Clears or moves Fission runtime focus and dispatches the blur trigger. |
+| Replace selected text | Focuses the text input and commits replacement text through the IME/text-edit pipeline. |
+| Set value | Updates text input text or numeric range value, then dispatches the relevant change action. |
+| Set text selection | Converts character indices to byte offsets, updates Fission text selection, and dispatches cursor change. |
+| Scroll up/down/left/right | Finds the relevant scroll node, updates runtime scroll offset, and schedules a new frame. |
+| Increment/decrement | Adjusts numeric range values for sliders and similar controls. |
+
+Unsupported AccessKit actions are ignored by the bridge today. Add a Fission issue when a product needs a specific missing platform action.
+
+## Compatible assistive technology targets
+
+The compatibility target is the operating-system accessibility API, not one named screen reader. Still, product release testing should include common tools.
+
+| Platform | Tools worth testing |
+| --- | --- |
+| macOS | VoiceOver, Switch Control, Accessibility Inspector, Keyboard navigation. |
+| Windows | Narrator, NVDA, JAWS, Windows Magnifier, Inspect. |
+| Linux | Orca, AT-SPI inspection tools, high-contrast desktop themes, keyboard-only navigation. |
+| iOS | VoiceOver, Switch Control, Dynamic Type, Full Keyboard Access. |
+| Android | TalkBack, Switch Access, Voice Access, large font scale. Native TalkBack control is not complete yet. |
+| Browser for Static site/SSR | VoiceOver with Safari, VoiceOver with Chrome, NVDA with Firefox/Chrome, JAWS with Chrome/Edge, browser accessibility tree inspectors. |
+
+Compatibility still depends on app quality. A supported bridge cannot invent a useful label for an unlabeled icon button, cannot make a color-only error understandable, and cannot choose the right focus order for an ambiguous layout.
+
+## Known gaps
+
+| Gap | Impact | Current workaround |
+| --- | --- | --- |
+| Android native TalkBack bridge | Android users cannot rely on a complete native screen-reader tree from Fission apps yet. | Keep semantics correct, test with LiveTest, and track Android accessibility bridge work separately. |
+| Web canvas accessibility tree | Browser screen readers cannot inspect the canvas-rendered app as native DOM controls. | Use Static site or SSR for document-like accessible experiences where possible. |
+| Advanced native announcements | Apps may need explicit status announcements for async completion, validation errors, or live regions. | Render visible and semantic status text; add a platform announcement API when needed. |
+| Rich text navigation | Basic text labels and editable selection are exposed, but advanced rich text navigation is not complete. | Keep important prose in normal `Text`/`RichText` nodes and validate with target screen readers. |
+| Custom rotors/landmarks | Platform-specific navigation affordances beyond current roles are not fully modeled. | Use clear region labels and roles today; propose additional semantic roles when product needs prove them. |
+| Terminal semantic command tree | Terminal backend does not expose the same selector command semantics as winit LiveTest today. | Use terminal-focused tests and manual terminal/screen-reader QA. |
+
+## Developer obligations
+
+Framework support is necessary but not sufficient. App code should:
+
+- prefer built-in widgets for built-in semantics;
+- provide explicit labels for icon-only and custom controls;
+- add stable semantic identifiers for test and automation targets;
+- avoid color-only status;
+- expose disabled, read-only, checked, masked, selected, and loading states truthfully;
+- keep focus order close to visual order;
+- use focus scopes for dialogs and modal surfaces;
+- test with selector APIs and at least one real assistive technology per target.
+
+## Related pages
+
+Read [Accessibility in Fission](/docs/learn/accessibility/) for the learning path, [Add accessible semantics](/docs/cookbook/add-accessible-semantics/) for a concrete recipe, [LiveTest command API](/reference/core/live-test-command-api/) for semantic selectors, and [Accessibility and internationalization](/reference/platform/accessibility-and-i18n/) for the combined platform presentation contract.

--- a/documentation/content/reference/project/fission-release-checklist.mdx
+++ b/documentation/content/reference/project/fission-release-checklist.mdx
@@ -1,0 +1,324 @@
+---
+title: Fission release checklist
+sidebar_label: Fission release checklist
+slug: /project/fission-release-checklist
+description: Maintainer checklist for preparing, validating, publishing, tagging, and documenting a Fission framework release.
+---
+
+# Fission release checklist
+
+This checklist is for maintainers releasing the Fission framework itself. It is
+not the app-store publishing flow for apps built with Fission.
+
+Run the release from the repository root on `main`, after every PR intended for
+the release has merged and CI is green.
+
+```sh
+cd /Users/zcourts/projects/fission/fission
+git switch main
+git pull --ff-only origin main
+git status --short
+```
+
+The working tree should be clean before the version bump. If local changes are
+intentional release prep, commit them before tagging. Do not tag from a dirty
+tree.
+
+## 1. Confirm release scope
+
+Decide the exact version and whether it is breaking.
+
+- Patch releases fix bugs or docs without requiring app code changes.
+- Minor releases can include public API additions and coordinated workflow
+  changes.
+- Breaking changes must be called out in the blog post, changelog, GitHub
+  release notes, and migration section.
+
+Collect the merged work since the last tag:
+
+```sh
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --oneline --decorate
+gh pr list --state merged --base main --limit 100
+```
+
+Group the scope by user impact rather than by commit order: runtime, widgets,
+shells, CLI, packaging, docs, examples, tests, and migration notes.
+
+## 2. Update versions
+
+Bump every Fission workspace crate and internal dependency requirement to the
+new version. Do not bump forked third-party packages unless that fork actually
+changed.
+
+For a release from `<old-version>` to `<new-version>`, update these values:
+
+- every first-party `package.version = "<old-version>"` to `"<new-version>"`;
+- every first-party dependency `version = "<old-version>"` to `"<new-version>"`;
+- documentation snippets that tell users to depend on the old Fission version;
+- generated-app snippets and `fission init` templates, including the generated
+  `AGENTS.md` design-system codegen version;
+- `documentation/Cargo.toml` and site chrome that displays the current version;
+- `CHANGELOG.md`, release blog post, and any release notes source file.
+
+Keep these dependency versions unchanged unless the corresponding fork release
+is part of the same release:
+
+- `fission-vello`, `fission-vello-encoding`, `fission-vello-shaders`;
+- `fission-winit`;
+- `fission-accesskit-winit`.
+
+Useful search before and after the bump:
+
+```sh
+OLD_VERSION=0.8.0
+rg -n "${OLD_VERSION}|fission = \\{ version|fission-design-system-codegen" \
+  README.md CHANGELOG.md crates documentation examples
+```
+
+After editing, regenerate the lockfile:
+
+```sh
+cargo metadata --format-version 1 >/dev/null
+```
+
+## 3. Update documentation and examples
+
+A release is not ready when the crates compile but the public docs still point
+at the previous version or old behavior.
+
+Check these areas explicitly:
+
+- `README.md` and crate READMEs under `crates/**/README.md`;
+- Learn, Guides, Cookbook, and Reference dependency snippets;
+- CLI reference pages for new or changed commands;
+- `fission.toml` reference for manifest shape changes;
+- platform target pages for generated Android, iOS, macOS, Windows, Linux, Web,
+  Terminal, Static site, and SSR output;
+- examples that demonstrate changed widgets, shell behavior, package flows, or
+  testing APIs;
+- generated project templates and generated `AGENTS.md` content.
+
+When docs describe a breaking change, include the old behavior, the new behavior,
+and the concrete migration step.
+
+## 4. Write the changelog entry
+
+Add the new version to the top of `CHANGELOG.md`.
+
+Use the existing structure:
+
+```md
+## [<new-version>] - YYYY-MM-DD
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Migration notes
+```
+
+Only include headings that have content. Keep entries user-facing: explain the
+capability or bug that changed, not just the module name.
+
+## 5. Write the release blog post
+
+Create a blog post under `documentation/content/blog/` using the existing naming
+pattern:
+
+```text
+documentation/content/blog/YYYY-MM-DD-fission-<version-with-dashes>-short-title.mdx
+```
+
+The post must include:
+
+- frontmatter with `title`, `authors`, `tags`, and `categories`;
+- a short opening that states the release theme;
+- sections for the major user-facing changes;
+- a migration section with the dependency snippet for the new version;
+- any target-specific package prerequisites or feature flags;
+- links to issues or PRs when they clarify why the change exists.
+
+Use the blog post as the source for GitHub release notes unless the release has a
+separate notes file.
+
+## 6. Run pre-release checks
+
+Start with deterministic checks that do not mutate external services.
+
+```sh
+cargo fmt --all -- --check
+cargo test --workspace
+cargo run -p cargo-fission --bin fission -- site check --project-dir documentation --release
+cargo run -p cargo-fission --bin fission -- package --project-dir documentation --target site --format static --release
+```
+
+For release workflow changes, run the narrow package/release tests too:
+
+```sh
+cargo test -p fission-command-package
+cargo test -p fission-command-release
+cargo test -p fission-command-ui
+cargo test -p fission-test-driver
+```
+
+For shell or widget changes, run the affected examples or LiveTests. Prefer
+semantic LiveTest commands and screenshots over coordinate-only checks when the
+feature is visible UI.
+
+If a platform cannot be tested locally, record that limitation in the release
+notes and do not imply it was validated.
+
+## 7. Dry-run crates.io publishing
+
+Publish only first-party crates, not examples or the documentation site crate
+unless that is an explicit release goal.
+
+Use `--dry-run` first. The publish order must respect internal dependencies.
+The current first-party order is:
+
+```text
+fission-command-core
+fission-command-server
+fission-design-system-codegen
+fission-diagnostics
+fission-i18n
+fission-icons
+fission-ir
+fission-macros
+fission-test-driver
+fission-text-engine
+fission-layout
+fission-semantics
+fission-theme
+fission-render
+fission-core
+fission-render-vello
+fission-3d
+fission-shell
+fission-shell-terminal
+fission-widgets
+fission-charts
+fission-shell-site
+fission-shell-winit
+fission-command-site
+fission-shell-server
+fission-shell-desktop
+fission-shell-mobile
+fission-shell-web
+fission-command-run
+fission-test
+fission
+fission-command-package
+fission-command-release
+fission-command-ui
+cargo-fission
+```
+
+Command pattern:
+
+```sh
+cargo publish -p fission-ir --dry-run
+cargo publish -p fission-ir
+```
+
+Wait for crates.io indexing when a later crate depends on a newly published
+version. If a publish fails because the index has not caught up, retry after a
+short wait; do not change versions to work around indexing delay.
+
+## 8. Commit, tag, and push
+
+Create one release-prep commit after all local checks pass.
+
+```sh
+git status --short
+git add CHANGELOG.md README.md crates documentation examples
+git diff --cached --check
+git commit -m "chore(release): prepare fission <new-version>"
+git tag -a v<new-version> -m "Fission <new-version>"
+git push origin main
+git push origin v<new-version>
+```
+
+Do not move a pushed release tag casually. If a tag is wrong, stop and decide
+whether to delete/recreate it before crates are published or issue a follow-up
+patch release after crates are live.
+
+## 9. Publish crates
+
+Run the real `cargo publish -p ...` sequence after the release-prep commit is on
+`main`. Publish from the same commit that carries the version bump and docs.
+
+After publishing, verify the public index for the main user-facing crates:
+
+```sh
+cargo search fission --limit 5
+cargo search cargo-fission --limit 5
+```
+
+If one crate publishes and a later crate fails, fix forward with the smallest
+safe change. Do not yank a crate unless the published artifact is harmful or
+unusable. Document any partial-publish state in the release issue or PR.
+
+## 10. Create the GitHub release
+
+Use the tag and the prepared release notes.
+
+```sh
+gh release create v<new-version> \
+  --title "Fission <new-version>" \
+  --notes-file /tmp/fission-<new-version>-release-notes.md
+```
+
+The GitHub release notes should include:
+
+- a short release theme;
+- added, changed, and fixed sections;
+- migration notes;
+- known limitations;
+- links to the blog post, changelog, and important issues/PRs.
+
+If binaries or generated artifacts are attached, record their source commit and
+how they were built.
+
+## 11. Publish and verify the website
+
+The website publishes through the repository workflow when docs change on `main`.
+Verify the workflow and the live site.
+
+```sh
+gh run list --workflow publish-website.yml --limit 5
+gh run watch <run-id>
+```
+
+Check the live pages after deployment:
+
+- the release blog post is reachable;
+- dependency snippets show the new version;
+- the reference sidebar includes any new reference pages;
+- search indexes include the new pages;
+- the footer/version chrome does not show an old release.
+
+## 12. Post-release verification
+
+Install the released CLI in a clean environment or from crates.io once the index
+is available:
+
+```sh
+cargo install cargo-fission --version <new-version> --locked
+fission --version
+```
+
+Create or update a small app and verify the public happy path:
+
+```sh
+fission init /tmp/fission-release-smoke --name release-smoke
+cd /tmp/fission-release-smoke
+fission add target macos
+fission readiness package --target macos --format app --json
+```
+
+Record any failures as follow-up issues. If the failure blocks normal use, ship a
+patch release rather than editing the already-published release in place.

--- a/documentation/site/docs-sidebar.toml
+++ b/documentation/site/docs-sidebar.toml
@@ -56,6 +56,16 @@ href = "/docs/learn/rendering-pipeline/"
 level = 2
 
 [[items]]
+title = "Accessibility"
+href = "/docs/learn/accessibility/"
+level = 2
+
+[[items]]
+title = "Testing"
+href = "/docs/learn/testing/"
+level = 2
+
+[[items]]
 title = "Layout and widgets"
 href = "/docs/guides/layout-and-widgets/"
 level = 2
@@ -97,18 +107,63 @@ level = 2
 
 [[items]]
 title = "Fission for..."
-href = "/docs/from/overview/"
+href = "/docs/fission/for/overview/"
 level = 1
 group = true
 
 [[items]]
 title = "Overview"
-href = "/docs/from/overview/"
+href = "/docs/fission/for/overview/"
 level = 2
 
 [[items]]
 title = "React developers"
-href = "/docs/from/react/"
+href = "/docs/fission/for/react-developers/"
+level = 2
+
+[[items]]
+title = "Flutter developers"
+href = "/docs/fission/for/flutter-developers/"
+level = 2
+
+[[items]]
+title = "SwiftUI developers"
+href = "/docs/fission/for/swiftui-developers/"
+level = 2
+
+[[items]]
+title = "Compose developers"
+href = "/docs/fission/for/compose-developers/"
+level = 2
+
+[[items]]
+title = "Electron developers"
+href = "/docs/fission/for/electron-developers/"
+level = 2
+
+[[items]]
+title = "Tauri developers"
+href = "/docs/fission/for/tauri-developers/"
+level = 2
+
+[[items]]
+title = "Leptos developers"
+href = "/docs/fission/for/leptos-developers/"
+level = 2
+
+[[items]]
+title = "Yew developers"
+href = "/docs/fission/for/yew-developers/"
+level = 2
+
+[[items]]
+title = "Dioxus developers"
+href = "/docs/fission/for/dioxus-developers/"
+level = 2
+
+[[items]]
+title = "Terminal UI developers"
+href = "/docs/fission/for/terminal-ui-developers/"
 level = 2
 
 [[items]]
@@ -337,8 +392,43 @@ href = "/docs/build-and-package/desktop-packages/"
 level = 2
 
 [[items]]
+title = "macOS packages"
+href = "/docs/build-and-package/macos-packages/"
+level = 2
+
+[[items]]
+title = "macOS native XcodeGen"
+href = "/docs/build-and-package/macos-native-xcodegen/"
+level = 2
+
+[[items]]
+title = "Windows packages"
+href = "/docs/build-and-package/windows-packages/"
+level = 2
+
+[[items]]
+title = "Linux packages"
+href = "/docs/build-and-package/linux-packages/"
+level = 2
+
+[[items]]
 title = "Mobile packages"
 href = "/docs/build-and-package/mobile-packages/"
+level = 2
+
+[[items]]
+title = "Android packages"
+href = "/docs/build-and-package/android-packages/"
+level = 2
+
+[[items]]
+title = "iOS packages"
+href = "/docs/build-and-package/ios-packages/"
+level = 2
+
+[[items]]
+title = "Native modules"
+href = "/docs/build-and-package/native-modules/"
 level = 2
 
 [[items]]
@@ -434,6 +524,11 @@ href = "/docs/cookbook/theme-and-locale-toggle/"
 level = 2
 
 [[items]]
+title = "Add accessible semantics"
+href = "/docs/cookbook/add-accessible-semantics/"
+level = 2
+
+[[items]]
 title = "Modal text flow"
 href = "/docs/cookbook/modal-text-flow/"
 level = 2
@@ -467,6 +562,26 @@ level = 2
 [[items]]
 title = "CLI reference"
 href = "/reference/cli/overview/"
+level = 2
+
+[[items]]
+title = "Testing and diagnostics"
+href = "/reference/core/testing-and-diagnostics/"
+level = 2
+
+[[items]]
+title = "LiveTest command API"
+href = "/reference/core/live-test-command-api/"
+level = 2
+
+[[items]]
+title = "Accessibility reference"
+href = "/reference/platform/accessibility/"
+level = 2
+
+[[items]]
+title = "Fission release checklist"
+href = "/reference/project/fission-release-checklist/"
 level = 2
 
 [[items]]

--- a/documentation/site/reference-sidebar.toml
+++ b/documentation/site/reference-sidebar.toml
@@ -157,6 +157,11 @@ href = "/reference/platform/targets/"
 level = 1
 
 [[items]]
+title = "Accessibility"
+href = "/reference/platform/accessibility/"
+level = 1
+
+[[items]]
 title = "Accessibility and internationalization"
 href = "/reference/platform/accessibility-and-i18n/"
 level = 1
@@ -174,6 +179,11 @@ level = 1
 [[items]]
 title = "fission.toml manifest"
 href = "/reference/config/fission-toml/"
+level = 1
+
+[[items]]
+title = "Fission release checklist"
+href = "/reference/project/fission-release-checklist/"
 level = 1
 
 [[items]]


### PR DESCRIPTION
## Summary

- Fix native package script execution so relative project dirs, script paths, emitted artifact paths, and env-provided payload paths resolve deterministically.
- Expand build/package/release docs with platform-specific guides for Android, iOS, macOS, Windows, Linux, native modules, release content, app stores, and `fission.toml` release fields.
- Move the framework-transition docs to `/docs/fission/for/*-developers/` and add Flutter, SwiftUI, Compose, Electron, Tauri, Leptos, Yew, Dioxus, and Terminal developer guides.
- Add accessibility Learn/Cookbook/Reference docs, including platform support matrix, AccessKit/native bridge behavior, semantic selector testing, screen-reader QA targets, and known gaps.
- Add a maintainer-facing Fission release checklist covering version bumps, changelog, blog post, crates.io, GitHub releases, tags, tests, site publishing, and post-release verification.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p fission-command-package`
- `cargo run -p cargo-fission --bin fission -- site check --project-dir documentation --release`
