### PR TITLE
Prepare Fission 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-19
+
+### Added
+
+- **Native packaging variants** - Android, iOS, macOS, Windows, and Linux packaging can now describe package variants, native module Cargo products, target-specific assets, and release-signing overlays from the project manifest.
+- **macOS release signing and notarization flow** - macOS package builds can resolve app-owned signing identities, provisioning profiles, entitlements, notarization credentials, and package-artifact decisions without hard-coding shell-specific scripts.
+- **Desktop drag and drop** - Fission now tracks drag sessions, external file drops, dropzone state, drag previews, copy/move effects, cancellation, and gallery demonstrations for app-internal and OS-originated drag flows.
+- **Selectable text and context menus** - `Text` and `RichText` can opt into selection, expose standard text actions, and use widget-backed context menus so applications can localize and customize menu contents.
+- **Tray app switcher policy** - Desktop tray applications can control Dock/taskbar/app-switcher visibility, with tray-style apps hidden from switchers by default where the platform supports it.
+- **Accessibility documentation set** - Added Learn, Cookbook, and Reference pages that explain semantics, assistive technology support, platform coverage, and screen-reader-compatible authoring practices.
+- **Release maintainer checklist** - Added a framework release checklist covering scope, version bumps, validation, crates.io publishing, tags, GitHub releases, website verification, and post-release smoke testing.
+
+### Changed
+
+- **Native package resolution is metadata-driven** - Package scripts resolve native Cargo products from Cargo metadata targets and use project-relative paths consistently, avoiding stale absolute path assumptions in generated scripts.
+- **Desktop package assets are included consistently** - Desktop packages now carry project assets and artifact manifests across the supported package formats instead of relying on shell-specific incidental behavior.
+- **Flyouts size to their content** - Tooltip and other flyout surfaces preserve intrinsic sizing instead of expanding to fill the host window.
+- **Scroll and widget state are isolated more aggressively** - Route/tab changes prune stale scroll state and avoid carrying slider/scroll positions into unrelated pages.
+- **Generated app guidance is identifiable** - Generated `AGENTS.md` content carries Fission-specific guidance markers so future CLI runs can recognize files produced by Fission instead of blindly creating duplicates.
+- **Build and platform documentation is broader** - Platform pages, package lifecycle docs, testing docs, selector command references, and framework-transition guides now describe the current CLI and shell behavior in more detail.
+
+### Fixed
+
+- **Reducer-bound effect callback lifetime** - Reducer-bound callbacks stay retained long enough for delayed effects and shell callbacks instead of being dropped while still referenced.
+- **Text input pending edits** - Controlled text inputs reconcile pending edits against transformed model values so rendered text, semantics, and reducer state remain aligned.
+- **Modal and barrier focus lifecycle** - Focus is captured and restored around modal/barrier lifecycles so closing a flyout or dialog does not lose the previous interaction target unnecessarily.
+- **Oversized `ScrollIntoView` targets** - Nearest-alignment scrolling keeps oversized targets anchored at the leading edge instead of choosing unstable offsets.
+- **Colour picker and slider QA issues** - Slider thumbs align with their tracks, click positions dispatch the expected values, colour picker swatches are labeled, and route/tab state no longer leaks into unrelated picker pages.
+- **Native packaging edge cases** - macOS native output paths, Windows native handles/tool paths/NuGet preflight, Linux native products, nested desktop package selection, and static-site scaffold path detection were hardened.
+- **Native notification responses** - macOS notification response callbacks now reach the Fission application layer.
+
+### Migration notes
+
+- Tray-style applications are hidden from the Dock/taskbar/app switcher by default where supported. Set the tray app switcher policy explicitly if an application should remain visible while minimized or closed to the tray.
+- Native package configurations should prefer the manifest-driven package variant, asset, signing, and native module fields over ad hoc script paths.
+- Update Fission dependencies to `0.9.0`:
+
+```toml
+fission = { version = "0.9.0", default-features = false, features = ["desktop"] }
+```
+
 ## [0.8.0] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "animation-gallery"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fission"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1635,7 +1635,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chart-gallery"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "counter"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "embed-3d"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "embed-video"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "embed-webview"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "field-inspector"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2578,7 +2578,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fission"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "fission-3d",
  "fission-charts",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "fission-3d"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "fission-charts"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "fission-core",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-package"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-release"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-run"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-command-core",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "toml 0.8.2",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-site"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-shell-site",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-ui"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "fission-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "fission-design-system-codegen"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "fission-diagnostics"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags 2.13.0",
  "once_cell",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "fission-documentation"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "fission-editor"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2816,14 +2816,14 @@ dependencies = [
 
 [[package]]
 name = "fission-i18n"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fission-icons"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "heck 0.4.1",
  "serde_json",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "fission-ir"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "blake3",
  "serde",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "fission-layout"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "fission-macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-ir",
@@ -2873,7 +2873,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render-vello"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "fission-semantics"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "fission-ir",
  "serde",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-desktop"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-mobile"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-site"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-terminal"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-web"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-winit"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test-driver"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3118,14 +3118,14 @@ dependencies = [
 
 [[package]]
 name = "fission-text-engine"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "fission-theme"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "fission-design-system-codegen",
  "fission-ir",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "fission-widgets"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "icons_gallery"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -4558,7 +4558,7 @@ checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "inbox"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-smoke"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "motion-memory-repro"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -6233,7 +6233,7 @@ dependencies = [
 
 [[package]]
 name = "pokemon-card-store"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "product-browser"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8074,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "text-lab"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8234,7 +8234,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todo-design-system"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8946,7 +8946,7 @@ dependencies = [
 
 [[package]]
 name = "web-smoke"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -9206,7 +9206,7 @@ dependencies = [
 
 [[package]]
 name = "widget-gallery"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "fission",

--- a/crates/authoring/fission-charts/Cargo.toml
+++ b/crates/authoring/fission-charts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-charts"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 license = "MIT"
@@ -11,9 +11,9 @@ description = "Native chart widgets and data visualization primitives for Fissio
 readme = "README.md"
 [dependencies]
 chrono = "0.4.44"
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-widgets = { path = "../fission-widgets", version = "0.8.0" }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/authoring/fission-charts/README.md
+++ b/crates/authoring/fission-charts/README.md
@@ -6,7 +6,7 @@ Chart widgets and data-visualization primitives for Fission applications.
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["desktop", "charts"] }
+fission = { version = "0.9.0", features = ["desktop", "charts"] }
 ```
 
 Most application code should import from `fission::prelude::*` and `fission::charts::*` rather than depending on this crate directly. Depend on `fission-charts` only when you are extending the chart layer itself.

--- a/crates/authoring/fission-icons/Cargo.toml
+++ b/crates/authoring/fission-icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-icons"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-macros/Cargo.toml
+++ b/crates/authoring/fission-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-macros"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-widgets"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -19,22 +19,22 @@ terminal = [
 ]
 
 [dependencies]
-fission-macros = { path = "../fission-macros", version = "0.8.0" }
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
-fission-icons = { path = "../fission-icons", version = "0.8.0" }
+fission-macros = { path = "../fission-macros", version = "0.9.0" }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
+fission-icons = { path = "../fission-icons", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.8.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.0" }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 
 [dev-dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -45,30 +45,30 @@ video = [
 web = ["dep:fission-shell-web"]
 
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-3d = { path = "../../core/fission-3d", version = "0.8.0", optional = true }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-text-engine = { path = "../../core/fission-text-engine", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.8.0" }
-fission-widgets = { path = "../fission-widgets", version = "0.8.0" }
-fission-macros = { path = "../fission-macros", version = "0.8.0" }
-fission-icons = { path = "../fission-icons", version = "0.8.0" }
-fission-charts = { path = "../fission-charts", version = "0.8.0", optional = true }
-fission-render = { path = "../../rendering/fission-render", version = "0.8.0" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.8.0" }
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.8.0", optional = true }
-fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.8.0", optional = true }
-fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.8.0", optional = true }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.8.0", optional = true }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-3d = { path = "../../core/fission-3d", version = "0.9.0", optional = true }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-text-engine = { path = "../../core/fission-text-engine", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.9.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.9.0" }
+fission-macros = { path = "../fission-macros", version = "0.9.0" }
+fission-icons = { path = "../fission-icons", version = "0.9.0" }
+fission-charts = { path = "../fission-charts", version = "0.9.0", optional = true }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.0" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.9.0", optional = true }
+fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.9.0", optional = true }
+fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.9.0", optional = true }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.8.0", optional = true }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.9.0", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.8.0", optional = true }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.9.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.8.0", optional = true }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.9.0", optional = true }

--- a/crates/authoring/fission/README.md
+++ b/crates/authoring/fission/README.md
@@ -15,7 +15,7 @@ This crate is the public facade. Application code should normally depend on `fis
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["desktop"] }
+fission = { version = "0.9.0", features = ["desktop"] }
 ```
 
 For the full developer workflow, install the Fission command:

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fission = { version = "0.7.0", default-features = false, features = ["desktop"] }
+//! fission = { version = "0.9.0", default-features = false, features = ["desktop"] }
 //! ```
 //!
 //! Then use via:

--- a/crates/core/fission-3d/Cargo.toml
+++ b/crates/core/fission-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-3d"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 license = "MIT"
@@ -10,8 +10,8 @@ documentation = "https://fission.rs"
 description = "3D scene primitives and rendering data types for Fission applications"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../fission-core", version = "0.8.0" }
-fission-ir = { path = "../fission-ir", version = "0.8.0" }
+fission-core = { path = "../fission-core", version = "0.9.0" }
+fission-ir = { path = "../fission-ir", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 wgpu = "26.0"
 bytemuck = { version = "1.18", features = ["derive"] }

--- a/crates/core/fission-3d/README.md
+++ b/crates/core/fission-3d/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["desktop", "three-d"] }
+fission = { version = "0.9.0", features = ["desktop", "three-d"] }
 ```
 
 Use this crate directly only when you are extending the framework's 3D model or renderer integration.

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,13 +10,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.8.0" }
-fission-layout = { path = "../fission-layout", version = "0.8.0" }
-fission-semantics = { path = "../fission-semantics", version = "0.8.0" }
-fission-theme = { path = "../fission-theme", version = "0.8.0" }
-fission-i18n = { path = "../fission-i18n", version = "0.8.0" }
-fission-text-engine = { path = "../fission-text-engine", version = "0.8.0" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.8.0" }
+fission-ir = { path = "../fission-ir", version = "0.9.0" }
+fission-layout = { path = "../fission-layout", version = "0.9.0" }
+fission-semantics = { path = "../fission-semantics", version = "0.9.0" }
+fission-theme = { path = "../fission-theme", version = "0.9.0" }
+fission-i18n = { path = "../fission-i18n", version = "0.9.0" }
+fission-text-engine = { path = "../fission-text-engine", version = "0.9.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -27,6 +27,6 @@ lazy_static = "1.4"
 blake3 = "1.5"
 unicode-segmentation = "1.10"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.8.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.0" }
 
 [dev-dependencies]

--- a/crates/core/fission-i18n/Cargo.toml
+++ b/crates/core/fission-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-i18n"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-ir/Cargo.toml
+++ b/crates/core/fission-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-ir"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-layout"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,9 +10,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.8.0" }
+fission-ir = { path = "../fission-ir", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.8.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.0" }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/Cargo.toml
+++ b/crates/core/fission-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-semantics"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,7 +10,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.8.0" }
+fission-ir = { path = "../fission-ir", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/core/fission-text-engine/Cargo.toml
+++ b/crates/core/fission-text-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-text-engine"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 license = "MIT"

--- a/crates/core/fission-theme/Cargo.toml
+++ b/crates/core/fission-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-theme"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -19,8 +19,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.8.0" }
+fission-ir = { path = "../fission-ir", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.8.0" }
+fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.9.0" }

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-vello"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,13 +10,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
+fission-render = { path = "../fission-render", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
 anyhow = "1.0"
 vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2", features = ["wgpu"] }
 parley = "0.7.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.8.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.0" }
 image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"

--- a/crates/rendering/fission-render-wgpu2d/Cargo.toml
+++ b/crates/rendering/fission-render-wgpu2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-wgpu2d"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -9,7 +9,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.8.0" }
+fission-render = { path = "../fission-render", version = "0.9.0" }
 anyhow = "1.0"
 bytemuck = { version = "1.16", features = ["derive"] }
 wgpu = { version = "26.0.1", default-features = false, features = ["std", "wgsl"] }

--- a/crates/rendering/fission-render/Cargo.toml
+++ b/crates/rendering/fission-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,8 +10,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-desktop"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 license = "MIT"
@@ -16,19 +16,19 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.8.0" }
-fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.8.0" }
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
+fission-shell = { path = "../fission-shell", version = "0.9.0" }
+fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.9.0" }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
 anyhow = "1.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.8.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.8.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.8.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.8.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-mobile"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,10 +15,10 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.8.0" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.8.0", default-features = false }
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
+fission-shell = { path = "../fission-shell", version = "0.9.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.9.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/shell/fission-shell-mobile/README.md
+++ b/crates/shell/fission-shell-mobile/README.md
@@ -8,9 +8,9 @@ Most application developers should use the public facade instead of depending on
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["android"] }
+fission = { version = "0.9.0", features = ["android"] }
 # or
-fission = { version = "0.8.0", features = ["ios"] }
+fission = { version = "0.9.0", features = ["ios"] }
 ```
 
 ## What it provides

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-server"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -23,12 +23,12 @@ axum = { version = "0.7", optional = true, default-features = false }
 base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-shell-site = { path = "../fission-shell-site", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-shell-site = { path = "../fission-shell-site", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
 getrandom = { version = "0.2", features = ["std"] }
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 moka = { version = "0.12", features = ["sync"] }
@@ -39,4 +39,4 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.8.0", default-features = false }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.0", default-features = false }

--- a/crates/shell/fission-shell-server/README.md
+++ b/crates/shell/fission-shell-server/README.md
@@ -14,7 +14,7 @@ Most applications should depend on the public `fission` facade with the
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["server"] }
+fission = { version = "0.9.0", features = ["server"] }
 ```
 
 Enable adapter features through the facade when you want to host the renderer
@@ -22,7 +22,7 @@ inside an existing HTTP stack:
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["server", "server-axum"] }
+fission = { version = "0.9.0", features = ["server", "server-axum"] }
 ```
 
 See the guides and reference at <https://fission.rs> for the server app model,

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-site"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -12,14 +12,14 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.8.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 
 [dev-dependencies]
-fission-i18n = { path = "../../core/fission-i18n", version = "0.8.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.9.0" }

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -6,7 +6,7 @@ Static site shell for Fission applications and documentation sites.
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["site"] }
+fission = { version = "0.9.0", features = ["site"] }
 ```
 
 ```sh

--- a/crates/shell/fission-shell-terminal/Cargo.toml
+++ b/crates/shell/fission-shell-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-terminal"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,9 +16,9 @@ crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["png"] }
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.8.0" }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.0" }
 base64 = "0.22"

--- a/crates/shell/fission-shell-terminal/README.md
+++ b/crates/shell/fission-shell-terminal/README.md
@@ -8,7 +8,7 @@ Application developers normally enable it through the facade crate:
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["terminal-shell"] }
+fission = { version = "0.9.0", features = ["terminal-shell"] }
 ```
 
 ## What it contains

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-web"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,9 +16,9 @@ video = ["fission-shell-winit/video"]
 
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
-fission-shell = { path = "../fission-shell", version = "0.8.0" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.8.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
+fission-shell = { path = "../fission-shell", version = "0.9.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.9.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-winit"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Shared winit shell runtime for desktop and mobile Fission hosts"
 
@@ -16,18 +16,18 @@ three-d = ["dep:fission-3d"]
 video = ["dep:gstreamer", "dep:gstreamer-video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.8.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.8.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.8.0" }
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
-fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.8.0" }
+fission-shell = { path = "../fission-shell", version = "0.9.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.0" }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
+fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.9.0" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.8.0" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.8.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.0" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.0" }
 image = "0.25"
 tiny-skia = "0.11.4"
 fontdue = "0.9.3"
@@ -92,6 +92,6 @@ dispatch = "0.2"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.8.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.8.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,9 +10,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.8.0" } # Corrected path
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.0" } # Corrected path
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/tools/cargo-fission/Cargo.toml
+++ b/crates/tools/cargo-fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fission"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -24,10 +24,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.8.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.8.0" }
-fission-command-release = { path = "../fission-command-release", version = "0.8.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.8.0" }
-fission-command-server = { path = "../fission-command-server", version = "0.8.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.8.0" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.8.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.9.0" }
+fission-command-release = { path = "../fission-command-release", version = "0.9.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.9.0" }
+fission-command-server = { path = "../fission-command-server", version = "0.9.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.9.0" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.9.0" }

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -1497,7 +1497,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fission = { version = "0.7.0", default-features = false, features = ["desktop"] }
+fission = { version = "0.9.0", default-features = false, features = ["desktop"] }
 "#,
         )
         .unwrap();
@@ -1524,7 +1524,7 @@ edition = "2021"
 anyhow = "1"
 
 [dependencies.fission]
-version = "0.7.0"
+version = "0.9.0"
 default-features = true
 features = ["desktop"]
 "#,

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-core/assets/AGENTS.md
+++ b/crates/tools/fission-command-core/assets/AGENTS.md
@@ -217,7 +217,7 @@ Outside the Fission source workspace, prefer the published crate pinned to the s
 
 ```toml
 [build-dependencies]
-fission-design-system-codegen = { version = "0.8.0" }
+fission-design-system-codegen = { version = "0.9.0" }
 ```
 
 Generate a typed design system from the copied DSP file in `build.rs`:

--- a/crates/tools/fission-command-package/Cargo.toml
+++ b/crates/tools/fission-command-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-package"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ aws-config = "1"
 aws-sdk-s3 = "1"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.8.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.8.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.8.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.9.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.9.0" }
 flate2 = "1.0"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-release/Cargo.toml
+++ b/crates/tools/fission-command-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-release"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -13,8 +13,8 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.8.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.8.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.9.0" }
 jsonwebtoken = "9"
 md-5 = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-run"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,10 +11,10 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-command-core = { path = "../fission-command-core", version = "0.8.0" }
-fission-command-server = { path = "../fission-command-server", version = "0.8.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.8.0" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.8.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.0" }
+fission-command-server = { path = "../fission-command-server", version = "0.9.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.9.0" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ureq = "2"

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-server"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-site"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,6 +11,6 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.8.0" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.9.0" }
 serde_json = "1"
 toml = "0.8"

--- a/crates/tools/fission-command-ui/Cargo.toml
+++ b/crates/tools/fission-command-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-ui"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,11 +11,11 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../authoring/fission", version = "0.8.0", default-features = false, features = ["desktop", "terminal-shell"] }
-fission-command-core = { path = "../fission-command-core", version = "0.8.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.8.0" }
-fission-command-release = { path = "../fission-command-release", version = "0.8.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.8.0" }
+fission = { path = "../../authoring/fission", version = "0.9.0", default-features = false, features = ["desktop", "terminal-shell"] }
+fission-command-core = { path = "../fission-command-core", version = "0.9.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.9.0" }
+fission-command-release = { path = "../fission-command-release", version = "0.9.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.9.0" }
 rfd = { version = "0.14.1", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 toml_edit = "0.23"

--- a/crates/tools/fission-design-system-codegen/Cargo.toml
+++ b/crates/tools/fission-design-system-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-design-system-codegen"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-diagnostics"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test-driver/Cargo.toml
+++ b/crates/tools/fission-test-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test-driver"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test/Cargo.toml
+++ b/crates/tools/fission-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,22 +10,22 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.8.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.8.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.8.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.8.0" }
-fission-shell = { path = "../../shell/fission-shell", version = "0.8.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.8.0" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.8.0" }
+fission-core = { path = "../../core/fission-core", version = "0.9.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.0" }
+fission-shell = { path = "../../shell/fission-shell", version = "0.9.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.9.0" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
-fission-macros = { path = "../../authoring/fission-macros", version = "0.8.0" }
-fission-diagnostics = { path = "../fission-diagnostics", version = "0.8.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.8.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.8.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.0" }
+fission-diagnostics = { path = "../fission-diagnostics", version = "0.9.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.0" }
 fontique = "0.7"
 serde_json = "1.0"
 
 [dev-dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.8.0" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.9.0" }

--- a/documentation/Cargo.toml
+++ b/documentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-documentation"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/documentation/content/blog/2026-07-19-fission-0-9-0-native-packaging-accessibility-and-desktop-polish.mdx
+++ b/documentation/content/blog/2026-07-19-fission-0-9-0-native-packaging-accessibility-and-desktop-polish.mdx
@@ -1,0 +1,102 @@
+---
+title: Fission 0.9.0: native packaging, accessibility, and desktop polish
+authors:
+  - fission
+tags:
+  - release
+  - packaging
+  - accessibility
+  - desktop
+  - testing
+categories:
+  - Releases
+---
+
+Fission 0.9.0 is a platform hardening release. It focuses on the parts of a real cross-platform app that fail late if the framework treats them as afterthoughts: native packaging, release signing, desktop interaction details, accessibility documentation, and deterministic test automation.
+
+The main theme is reducing hidden shell-specific behavior. Package builds now expose more of their native inputs through the project manifest, desktop interactions preserve the user's context more consistently, and the documentation now explains how to ship and test these features instead of leaving the behavior implicit.
+
+## Native packaging is more explicit
+
+The CLI can now describe package variants, native module Cargo products, desktop assets, platform scripts, and release-signing overlays from `fission.toml`. That gives app projects one manifest-backed place to define the native pieces that sit around a shared Fission core.
+
+This release improves the package path for:
+
+- Android and iOS generated targets with native modules;
+- macOS app bundles, signing inputs, provisioning profiles, entitlements, and notarization;
+- Windows native module builds and package resources;
+- Linux native Cargo products and custom run installers;
+- desktop project assets included in package artifacts.
+
+The important change is not only that more targets are supported. The package tool now resolves native Cargo products from Cargo metadata targets and normalizes project-relative paths before invoking scripts. That removes a class of failures where generated package scripts accidentally depended on a developer's local absolute paths.
+
+## macOS release signing is a first-class path
+
+macOS packaging now has an explicit release-signing overlay. Applications can configure the app identity, provisioning profile, entitlements, notarization credentials, package identity, and whether a native product should produce package artifacts.
+
+This is intentionally still app-owned: Fission does not invent credentials or store private signing material in `fission.toml`. The manifest describes what the package needs; secrets should come from local environment, CI secret stores, keychains, or provider-owned credential sources.
+
+## Desktop interactions are tighter
+
+Several desktop behaviors were made more production-grade:
+
+- tray applications can choose whether they appear in the Dock, taskbar, or app switcher;
+- tray-style apps are hidden from app switchers by default where the platform supports that behavior;
+- modal and barrier lifecycles capture and restore focus;
+- native notification response callbacks are delivered back into the app;
+- tooltip and flyout surfaces preserve intrinsic sizing instead of filling the window;
+- reducer-bound effect callbacks are retained long enough for delayed shell callbacks.
+
+The tray switcher default is the one behavior change to call out. If an app should stay visible in the Dock or task switcher after minimizing or closing to the tray, set the tray app switcher policy explicitly.
+
+## Drag, drop, selectable text, and context menus
+
+Fission now has a more complete drag-and-drop model. The runtime tracks drag sessions, external file drops, dropzone state, drag previews, accepted effects, copy/move behavior, and cancellation. The widget gallery includes demonstrations so developers can see what the interaction should feel like rather than reverse-engineering it from low-level pointer events.
+
+Text rendering also gained opt-in selection for `Text` and `RichText`, plus widget-backed context menus. That keeps the simple default cheap while letting apps expose familiar actions such as copy and select all. Context menus accept child widgets, so applications can localize menu labels through their normal i18n path and build richer menus where needed.
+
+## More reliable state and input behavior
+
+This release fixes several issues that only show up once an app has multiple routed screens, controlled inputs, and long-running effects:
+
+- stale scroll state is pruned when widgets unmount;
+- route and tab content state is isolated so slider and scroll positions do not leak between pages;
+- slider thumbs align with their tracks and click positions map to the expected values;
+- controlled text inputs reconcile pending edits against transformed model values;
+- oversized `ScrollIntoView` targets stay anchored at the leading edge for nearest alignment.
+
+These are small fixes individually, but they matter because they remove surprising state carry-over in real applications.
+
+## Accessibility docs are now part of the public contract
+
+Fission already exposes semantics through the runtime and native shell integrations, but the documentation was not explicit enough about what developers can rely on.
+
+0.9.0 adds:
+
+- a Learn page for accessible Fission app structure;
+- a Cookbook page for adding semantic metadata to widgets and regions;
+- a Reference page with platform support levels, expected assistive technology compatibility, and known gaps.
+
+The guidance is direct: give interactive widgets stable semantic identifiers, set labels and roles from the meaning of the action, mark disabled/read-only/checked states accurately, and test with the LiveTest semantic tree as well as platform assistive tools.
+
+## Documentation catches up with the CLI
+
+The build and package docs were expanded to match the current CLI surface. Platform pages now explain generated target files, package resources, native modules, signing inputs, and realistic manifest values instead of only showing isolated `fission.toml` fragments.
+
+The testing docs now cover unit, integration, and LiveTest workflows, including selector-driven `/cmd` commands. The reference includes a command API section so tests can target semantic identifiers, widget IDs, roles, labels, and scoped selectors without hard-coded coordinates.
+
+There is also a new Fission release checklist for maintainers. It documents the actual release process: scope confirmation, version bumping, changelog and blog updates, pre-release checks, crates.io publish order, GitHub tagging, website verification, and post-release smoke testing.
+
+## Migration notes
+
+Update Fission dependencies to 0.9.0:
+
+```toml
+fission = { version = "0.9.0", default-features = false, features = ["desktop"] }
+```
+
+If your app uses tray behavior and should remain visible in the Dock, taskbar, or app switcher, configure the tray app switcher policy explicitly. The default now follows tray-app conventions and hides the app from switchers where the platform supports it.
+
+If your app has custom package scripts or native package resources, move those declarations into `fission.toml` where possible. The CLI can now resolve native package variants and products from the manifest and Cargo metadata, which is more portable across local machines and CI.
+
+If you rely on generated app-agent guidance, regenerate or copy the updated `AGENTS.md` content so agents get the current rules for responsive UI, design tokens, i18n, semantics, shared multi-platform cores, and LiveTest screenshot QA.

--- a/documentation/content/docs/build-and-package/linux-packages.mdx
+++ b/documentation/content/docs/build-and-package/linux-packages.mdx
@@ -82,11 +82,11 @@ set -euo pipefail
 payload="$FISSION_LINUX_PAYLOAD_DIR"
 out="target/fission/release/linux/run/acme-notes.run"
 
-# Build your installer from "$payload" and write "$out".
-# The installer should own service/helper policy; Fission only stages inputs.
-
 printf '%s\n' "$out"
 ```
+
+Build your installer from `$payload` and write `$out`. The installer should own
+service/helper policy; Fission only stages inputs.
 
 Keep package scripts deterministic. They should not rebuild the app, discover random files outside the package root, or upload artifacts. Packaging creates artifacts; distribution uploads them.
 

--- a/documentation/content/docs/guides/design-system.mdx
+++ b/documentation/content/docs/guides/design-system.mdx
@@ -69,10 +69,10 @@ Add the generator as a build dependency:
 
 ```toml title="Cargo.toml"
 [dependencies]
-fission = { version = "0.8.0", default-features = false, features = ["desktop"] }
+fission = { version = "0.9.0", default-features = false, features = ["desktop"] }
 
 [build-dependencies]
-fission-design-system-codegen = "0.8.0"
+fission-design-system-codegen = "0.9.0"
 ```
 
 ## What you should have working

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -89,7 +89,7 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["server", "server-redis"] }
+fission = { version = "0.9.0", features = ["server", "server-redis"] }
 ```
 
 ## Invalidate cached pages after writes

--- a/documentation/content/docs/guides/server-site-security.mdx
+++ b/documentation/content/docs/guides/server-site-security.mdx
@@ -78,14 +78,14 @@ Hyper is available with the normal `server` feature:
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["server"] }
+fission = { version = "0.9.0", features = ["server"] }
 ```
 
 Axum and Actix adapters are feature-gated to avoid pulling those dependencies into projects that do not use them:
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["server", "server-axum"] }
+fission = { version = "0.9.0", features = ["server", "server-axum"] }
 tower = "0.5"
 ```
 

--- a/documentation/content/docs/guides/static-sites.mdx
+++ b/documentation/content/docs/guides/static-sites.mdx
@@ -221,7 +221,7 @@ Use front matter to describe each post:
 
 ```mdx
 ---
-title: Fission 0.8.0
+title: Fission 0.9.0
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -232,7 +232,7 @@ tags:
   - authoring
 ---
 
-# Fission 0.8.0
+# Fission 0.9.0
 
 Write the post body here.
 ```

--- a/documentation/content/docs/guides/terminal-user-interfaces.mdx
+++ b/documentation/content/docs/guides/terminal-user-interfaces.mdx
@@ -21,7 +21,7 @@ Use the Fission facade crate and enable the terminal shell feature for tools tha
 
 ```toml
 [dependencies]
-fission = { version = "0.8.0", features = ["terminal-shell"] }
+fission = { version = "0.9.0", features = ["terminal-shell"] }
 ```
 
 ## What you should have working

--- a/documentation/content/docs/learn/testing.mdx
+++ b/documentation/content/docs/learn/testing.mdx
@@ -128,7 +128,7 @@ client.wait_for_ready(15_000)?;
 Prefer semantic selectors over coordinates. Coordinates are still useful for low-level input bugs, but product tests should name the UI element they intend to use.
 
 ```rust
-client.fill_text_semantic_identifier("todo.title", "Publish 0.8.0")?;
+client.fill_text_semantic_identifier("todo.title", "Publish 0.9.0")?;
 client.tap_semantic_identifier("todo.add")?;
 client.wait_for_visible(
     SelectorQuery::semantic_identifier("todo.row.0"),

--- a/documentation/content/reference/cli/overview.mdx
+++ b/documentation/content/reference/cli/overview.mdx
@@ -405,16 +405,24 @@ Runs focused preflight checks for packages, distribution destinations, or full p
 ### `fission publish`
 
 ```sh
-# Guided local release cockpit. Defaults target/format from the provider.
 fission publish --provider <provider> [--target <target>] [--format <format>] [--track <track>] [--locale <locale>] [--app]
 
-# Direct artifact publish for scripts and CI.
 fission publish --provider <provider> --artifact <artifact-manifest.json> [--site <profile>] [--track <track>] [--dry-run] [--yes]
 ```
 
-Without `--artifact`, `fission publish` opens the guided local publish flow. It shows preflight checks, creates/uses `~/.fission/<app-name>/release.env`, helps select or generate signing/provider files, builds the artifact, runs a dry-run, and then asks for explicit confirmation before publishing. Add `--app` to open the same workflow as a native windowed Fission app with native file dialogs. `--app` is interactive, so do not combine it with `--guided`, `--dry-run`, `--yes`, `--json`, or `--overwrite-remote`.
+The first form is the guided local release cockpit and defaults target/format
+from the provider. Without `--artifact`, `fission publish` shows preflight
+checks, creates/uses `~/.fission/<app-name>/release.env`, helps select or
+generate signing/provider files, builds the artifact, runs a dry-run, and then
+asks for explicit confirmation before publishing. Add `--app` to open the same
+workflow as a native windowed Fission app with native file dialogs. `--app` is
+interactive, so do not combine it with `--guided`, `--dry-run`, `--yes`,
+`--json`, or `--overwrite-remote`.
 
-With `--artifact`, `fission publish` keeps the direct non-interactive behavior for scripts and CI. `fission distribute publish ...` is still available, but `publish` is the direct command developers should reach for in normal release workflows.
+The second form is direct artifact publishing for scripts and CI. With
+`--artifact`, `fission publish` keeps the direct non-interactive behavior.
+`fission distribute publish ...` is still available, but `publish` is the direct
+command developers should reach for in normal release workflows.
 
 ### `fission distribute`
 

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -418,7 +418,7 @@ Example:
 
 ```mdx
 ---
-title: Fission 0.8.0
+title: Fission 0.9.0
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -430,7 +430,7 @@ tags:
 show_adjacent_posts: true
 ---
 
-# Fission 0.8.0
+# Fission 0.9.0
 
 Write the post body here.
 ```

--- a/documentation/content/reference/project/fission-release-checklist.mdx
+++ b/documentation/content/reference/project/fission-release-checklist.mdx
@@ -71,7 +71,7 @@ is part of the same release:
 Useful search before and after the bump:
 
 ```sh
-OLD_VERSION=0.8.0
+OLD_VERSION="0.8.0" # replace with previous release version
 rg -n "${OLD_VERSION}|fission = \\{ version|fission-design-system-codegen" \
   README.md CHANGELOG.md crates documentation examples
 ```

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -147,7 +147,7 @@ fn footer_identity(_ctx: BuildCtxHandle<DocsState>, view: ViewHandle<DocsState>)
                     ..Default::default()
                 }
                 .into(),
-                Text::new("Fission 0.7.0")
+                Text::new("Fission 0.9.0")
                     .size(tokens.typography.font_size_sm)
                     .family(tokens.typography.font_family_mono.clone())
                     .color(tokens.colors.text_muted)

--- a/examples/animation-gallery/Cargo.toml
+++ b/examples/animation-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animation-gallery"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/chart-gallery/Cargo.toml
+++ b/examples/chart-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chart-gallery"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "counter"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-editor"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/embed-3d/Cargo.toml
+++ b/examples/embed-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-3d"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/examples/embed-video/Cargo.toml
+++ b/examples/embed-video/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-video"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/examples/embed-webview/Cargo.toml
+++ b/examples/embed-webview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-webview"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/Cargo.toml
+++ b/examples/field-inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-inspector"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/fission.toml
+++ b/examples/field-inspector/fission.toml
@@ -24,13 +24,13 @@ capabilities = [
 [app]
 name = "field-inspector"
 app_id = "com.fission.examples.fieldinspector"
-version = "0.7.0"
+version = "0.9.0"
 build = 1
 
 [package.android]
 package_name = "com.fission.examples.fieldinspector"
 version_code = 1
-version_name = "0.7.0"
+version_name = "0.9.0"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -41,13 +41,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.fission.examples.fieldinspector"
-marketing_version = "0.7.0"
+marketing_version = "0.9.0"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.fission.examples.fieldinspector"
 publisher = "CN=Fission Developer"
-version = "0.7.0"
+version = "0.9.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/icons_gallery/Cargo.toml
+++ b/examples/icons_gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icons_gallery"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/inbox/Cargo.toml
+++ b/examples/inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inbox"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/inbox/src/features/settings.rs
+++ b/examples/inbox/src/features/settings.rs
@@ -595,6 +595,7 @@ impl From<SettingsModal> for Widget {
                                         ))
                                         .unwrap(),
                                     }),
+                                    ..Default::default()
                                 }
                                 .into(),
                             }

--- a/examples/mobile-smoke/Cargo.toml
+++ b/examples/mobile-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-smoke"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/examples/motion-memory-repro/Cargo.toml
+++ b/examples/motion-memory-repro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion-memory-repro"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/pokemon-card-store/Cargo.toml
+++ b/examples/pokemon-card-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pokemon-card-store"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 publish = false
 

--- a/examples/pokemon-card-store/fission.toml
+++ b/examples/pokemon-card-store/fission.toml
@@ -19,7 +19,7 @@ preload = "route"
 
 [package.docker]
 port = 8080
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.7.0"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.9.0"]
 
 [distribution.docker_registry.production]
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.7.0"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.9.0"]

--- a/examples/product-browser/Cargo.toml
+++ b/examples/product-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product-browser"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/text-lab/Cargo.toml
+++ b/examples/text-lab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-lab"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/todo-design-system/Cargo.toml
+++ b/examples/todo-design-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-design-system"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/web-smoke/Cargo.toml
+++ b/examples/web-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-smoke"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/examples/web-smoke/fission.toml
+++ b/examples/web-smoke/fission.toml
@@ -10,13 +10,13 @@ targets = [
 [app]
 name = "web-smoke"
 app_id = "com.example.web_smoke"
-version = "0.7.0"
+version = "0.9.0"
 build = 1
 
 [package.android]
 package_name = "com.example.web_smoke"
 version_code = 1
-version_name = "0.7.0"
+version_name = "0.9.0"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -27,13 +27,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.example.web_smoke"
-marketing_version = "0.7.0"
+marketing_version = "0.9.0"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.example.web.smoke"
 publisher = "CN=Fission Developer"
-version = "0.7.0"
+version = "0.9.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "widget-gallery"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## What changed

- Bumps first-party Fission crates, examples, generated snippets, and docs metadata to `0.9.0`.
- Adds the 0.9.0 changelog entry and release blog post covering native packaging, accessibility docs, desktop polish, drag/drop, selectable text/context menus, and release workflow hardening.
- Keeps the release checklist, CLI docs, and generated app guidance aligned with the new version.
- Fixes validation fallout found during release checks: docs fenced-command comments and the inbox settings `Slider` initializer.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p fission-documentation --bin fission-documentation`
- `cargo test --workspace --jobs 4`
- `cargo test -p fission-command-package -p fission-command-release -p fission-command-ui -p fission-test-driver --jobs 4`
- `cargo run -p cargo-fission --bin fission -- site check --project-dir documentation --release`
- `cargo run -p cargo-fission --bin fission -- package --project-dir documentation --target site --format static --release`
