### PR TITLE
Fix release checklist add-target smoke command

### DIFF
--- a/documentation/content/reference/project/fission-release-checklist.mdx
+++ b/documentation/content/reference/project/fission-release-checklist.mdx
@@ -316,7 +316,7 @@ Create or update a small app and verify the public happy path:
 ```sh
 fission init /tmp/fission-release-smoke --name release-smoke
 cd /tmp/fission-release-smoke
-fission add target macos
+fission add-target macos
 fission readiness package --target macos --format app --json
 ```
 


### PR DESCRIPTION
## What changed

- Fixes the release checklist smoke-test command to use the actual CLI subcommand, `fission add-target macos`.

## Validation

- `git diff --check`
- Verified during post-release CLI smoke: `fission --version` reports `0.9.0`; the previous checklist command failed because `fission add` is not a command.
