### PR TITLE
Add configurable minimize-to-tray behavior

### DIFF
--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -326,6 +326,7 @@ pub use fission_shell_desktop::{
 pub use fission_shell_desktop::{
     TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
     TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
+    WindowMinimizeBehavior,
 };
 #[cfg(all(
     any(
@@ -520,7 +521,7 @@ pub mod prelude {
     pub use fission_shell_desktop::{
         TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
         TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem,
-        WindowCloseBehavior,
+        WindowCloseBehavior, WindowMinimizeBehavior,
     };
 
     // Layout

--- a/crates/authoring/fission/tests/desktop_tray_api.rs
+++ b/crates/authoring/fission/tests/desktop_tray_api.rs
@@ -6,7 +6,7 @@
 use fission::prelude::*;
 use fission::{
     DesktopApp, TrayActivateBehavior, TrayConfig, TrayHostAction, TrayIconSource, TrayMenu,
-    TrayMenuAction, TrayMenuBuilder, WindowCloseBehavior,
+    TrayMenuAction, TrayMenuBuilder, WindowCloseBehavior, WindowMinimizeBehavior,
 };
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -55,6 +55,7 @@ fn facade_exports_desktop_tray_api() {
     let tray = TrayConfig::<FacadeTrayState>::new(TrayIconSource::rgba(vec![0, 0, 0, 255], 1, 1))
         .tooltip("Facade tray")
         .close_behavior(WindowCloseBehavior::HideToTray)
+        .minimize_behavior(WindowMinimizeBehavior::HideToTray)
         .activate_behavior(TrayActivateBehavior::ShowMainWindow)
         .menu(FacadeTrayMenu);
 

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -21,6 +21,7 @@ pub use fission_shell_winit::{
 pub use fission_shell_winit::{
     TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
     TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
+    WindowMinimizeBehavior,
 };
 
 pub struct DesktopApp<S: GlobalState, W>

--- a/crates/shell/fission-shell-desktop/tests/tray_api.rs
+++ b/crates/shell/fission-shell-desktop/tests/tray_api.rs
@@ -4,7 +4,7 @@ use fission_core::ui::{Button, Column, Text, Widget};
 use fission_core::{reduce_with, BuildCtxHandle, GlobalState, ViewHandle};
 use fission_shell_desktop::{
     DesktopApp, TrayActivateBehavior, TrayConfig, TrayHostAction, TrayIconSource, TrayMenu,
-    TrayMenuAction, TrayMenuBuilder, WindowCloseBehavior,
+    TrayMenuAction, TrayMenuBuilder, WindowCloseBehavior, WindowMinimizeBehavior,
 };
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -62,6 +62,7 @@ fn desktop_app_accepts_tray_config_with_menu_widget() {
         TrayConfig::<TrayApiState>::new(TrayIconSource::rgba(vec![255, 255, 255, 255], 1, 1))
             .tooltip("Tray API smoke")
             .close_behavior(WindowCloseBehavior::HideToTray)
+            .minimize_behavior(WindowMinimizeBehavior::HideToTray)
             .activate_behavior(TrayActivateBehavior::ToggleMainWindow)
             .menu(TrayMenuModel);
 

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -131,6 +131,7 @@ pub mod tray;
 pub use tray::{
     TrayActivateBehavior, TrayAppSwitcherPolicy, TrayConfig, TrayHostAction, TrayIconSource,
     TrayMenu, TrayMenuAction, TrayMenuBuilder, TrayMenuEntry, TrayMenuItem, WindowCloseBehavior,
+    WindowMinimizeBehavior,
 };
 pub mod test_control;
 mod wifi;
@@ -5827,6 +5828,15 @@ where
                         elwt.set_control_flow(ControlFlow::Wait);
                         return;
                     };
+                    #[cfg(feature = "tray")]
+                    if let Some(tray) = active_tray.as_ref() {
+                        if tray.minimize_behavior() == tray::WindowMinimizeBehavior::HideToTray
+                            && window.is_visible().unwrap_or(true)
+                            && window.is_minimized() == Some(true)
+                        {
+                            tray::hide_window_to_tray(window, tray.app_switcher_policy());
+                        }
+                    }
                     #[cfg(target_os = "android")]
                     drain_pending_test_events();
                     #[cfg(feature = "tray")]

--- a/crates/shell/fission-shell-winit/src/tray.rs
+++ b/crates/shell/fission-shell-winit/src/tray.rs
@@ -30,6 +30,21 @@ impl Default for WindowCloseBehavior {
     }
 }
 
+/// What the desktop shell should do when the main window is minimised.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WindowMinimizeBehavior {
+    /// Keep the window minimised using the platform's normal window behavior.
+    Minimize,
+    /// Hide the main window while keeping the app and tray icon alive.
+    HideToTray,
+}
+
+impl Default for WindowMinimizeBehavior {
+    fn default() -> Self {
+        Self::Minimize
+    }
+}
+
 /// What the desktop shell should do when the tray icon itself is activated.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TrayActivateBehavior {
@@ -230,6 +245,7 @@ pub struct TrayConfig<S: GlobalState> {
     pub title: Option<String>,
     pub icon_is_template: bool,
     pub close_behavior: WindowCloseBehavior,
+    pub minimize_behavior: WindowMinimizeBehavior,
     pub activate_behavior: TrayActivateBehavior,
     pub app_switcher_policy: TrayAppSwitcherPolicy,
     pub menu_on_left_click: bool,
@@ -246,6 +262,7 @@ impl<S: GlobalState> Clone for TrayConfig<S> {
             title: self.title.clone(),
             icon_is_template: self.icon_is_template,
             close_behavior: self.close_behavior,
+            minimize_behavior: self.minimize_behavior,
             activate_behavior: self.activate_behavior,
             app_switcher_policy: self.app_switcher_policy,
             menu_on_left_click: self.menu_on_left_click,
@@ -264,6 +281,7 @@ impl<S: GlobalState> TrayConfig<S> {
             title: None,
             icon_is_template: false,
             close_behavior: WindowCloseBehavior::Exit,
+            minimize_behavior: WindowMinimizeBehavior::Minimize,
             activate_behavior: TrayActivateBehavior::ToggleMainWindow,
             app_switcher_policy: TrayAppSwitcherPolicy::Hidden,
             menu_on_left_click: false,
@@ -290,6 +308,11 @@ impl<S: GlobalState> TrayConfig<S> {
 
     pub fn close_behavior(mut self, behavior: WindowCloseBehavior) -> Self {
         self.close_behavior = behavior;
+        self
+    }
+
+    pub fn minimize_behavior(mut self, behavior: WindowMinimizeBehavior) -> Self {
+        self.minimize_behavior = behavior;
         self
     }
 
@@ -348,6 +371,10 @@ pub(crate) struct ActiveTray<S: GlobalState> {
 impl<S: GlobalState> ActiveTray<S> {
     pub(crate) fn close_behavior(&self) -> WindowCloseBehavior {
         self.config.close_behavior
+    }
+
+    pub(crate) fn minimize_behavior(&self) -> WindowMinimizeBehavior {
+        self.config.minimize_behavior
     }
 
     pub(crate) fn app_switcher_policy(&self) -> TrayAppSwitcherPolicy {
@@ -756,6 +783,7 @@ mod tests {
             TrayConfig::<TrayTestState>::new(TrayIconSource::rgba(vec![255, 255, 255, 255], 1, 1));
 
         assert_eq!(config.app_switcher_policy, TrayAppSwitcherPolicy::Hidden);
+        assert_eq!(config.minimize_behavior, WindowMinimizeBehavior::Minimize);
     }
 
     #[test]
@@ -766,6 +794,7 @@ mod tests {
                 .title("Running")
                 .icon_template(true)
                 .close_behavior(WindowCloseBehavior::HideToTray)
+                .minimize_behavior(WindowMinimizeBehavior::HideToTray)
                 .activate_behavior(TrayActivateBehavior::ShowMainWindow)
                 .app_switcher_policy(TrayAppSwitcherPolicy::Visible)
                 .menu_on_left_click(true)
@@ -776,6 +805,7 @@ mod tests {
         assert_eq!(config.title.as_deref(), Some("Running"));
         assert!(config.icon_is_template);
         assert_eq!(config.close_behavior, WindowCloseBehavior::HideToTray);
+        assert_eq!(config.minimize_behavior, WindowMinimizeBehavior::HideToTray);
         assert_eq!(
             config.activate_behavior,
             TrayActivateBehavior::ShowMainWindow


### PR DESCRIPTION
## Summary
- add an opt-in `WindowMinimizeBehavior` to desktop tray configuration
- hide a minimized main window when `HideToTray` is selected
- preserve native minimize behavior by default
- expose and test the API through desktop shell and authoring facades

## Validation
- `cargo fmt --all`
- `git diff --check`
- focused Cargo tests are queued behind the configured shared target lock and will be reported when complete