### PR TITLE
fix(cli): reserve stack for command dispatcher

### DIFF
--- a/crates/tools/cargo-fission/src/bin/cargo-fission.rs
+++ b/crates/tools/cargo-fission/src/bin/cargo-fission.rs
@@ -1,3 +1,3 @@
 fn main() -> anyhow::Result<()> {
-    fission_cli::run(std::env::args())
+    fission_cli::run_from_env()
 }

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -1,6 +1,6 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
-use std::path::Path;
+use std::{ffi::OsString, path::Path, thread};
 
 mod cli;
 
@@ -9,16 +9,36 @@ use fission_command_core::{read_project_config, Target};
 
 use cli::{Cli, Command, ServerCommand, SiteCommand};
 
+const CLI_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
+
+/// Runs the CLI dispatcher on a thread with a consistent cross-platform stack.
+///
+/// Some platform ABIs, notably Windows on ARM64, provide a smaller main-thread
+/// stack than the command graph needs while parsing and dispatching packaging
+/// operations. The reserve is virtual address space and is committed on demand.
+pub fn run_from_env() -> Result<()> {
+    let args = std::env::args_os().collect::<Vec<_>>();
+    let worker = thread::Builder::new()
+        .name("fission-cli".into())
+        .stack_size(CLI_THREAD_STACK_BYTES)
+        .spawn(move || run(args))
+        .context("failed to start the Fission CLI worker")?;
+
+    worker
+        .join()
+        .map_err(|_| anyhow::anyhow!("the Fission CLI worker terminated unexpectedly"))?
+}
+
 pub fn run<I, S>(args: I) -> Result<()>
 where
     I: IntoIterator<Item = S>,
-    S: Into<std::ffi::OsString> + Clone,
+    S: Into<OsString> + Clone,
 {
-    let mut argv: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+    let mut argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
     if let Some(bin) = argv.first() {
         if let Some(name) = Path::new(bin).file_name().and_then(|value| value.to_str()) {
             if name == "cargo-fission" {
-                argv[0] = std::ffi::OsString::from("fission");
+                argv[0] = OsString::from("fission");
                 if argv.get(1).and_then(|value| value.to_str()) == Some("fission") {
                     argv.remove(1);
                 }

--- a/crates/tools/cargo-fission/src/main.rs
+++ b/crates/tools/cargo-fission/src/main.rs
@@ -1,3 +1,3 @@
 fn main() -> anyhow::Result<()> {
-    fission_cli::run(std::env::args())
+    fission_cli::run_from_env()
 }


### PR DESCRIPTION
## Summary
- run both Fission CLI entrypoints on a named thread with a 16 MiB virtual stack reserve
- preserve the existing public `run` API and command behavior
- collect `args_os` before crossing the thread boundary

## Why
The native Windows ARM64 CLI reaches `fission package` and then terminates with `thread main has overflowed its stack`. The same command graph succeeds on x86_64. Windows commits the requested thread stack on demand, so this provides a consistent CLI execution boundary without increasing steady-state memory by the full reserve.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p cargo-fission --bins`

A downstream Windows ARM64 package job will pin this commit and exercise the complete NSIS packaging path.