### PR TITLE
Add generic native surface handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,7 @@ dependencies = [
  "fission-core",
  "fission-ir",
  "fission-render",
+ "raw-window-handle",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use fission_core::{Action, ActionId, Env, GlobalState, Widget};
-use fission_shell::async_host::AsyncRegistry;
+use fission_shell::{async_host::AsyncRegistry, NativeSurfaceHandler};
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
@@ -111,6 +111,16 @@ where
         F: Fn(&mut S) -> bool + Send + Sync + 'static,
     {
         self.inner = self.inner.with_frame_hook(f);
+        self
+    }
+
+    /// Registers an extension that presents opaque custom surfaces in the
+    /// desktop host.
+    pub fn with_native_surface_handler<H>(mut self, handler: H) -> Self
+    where
+        H: NativeSurfaceHandler + 'static,
+    {
+        self.inner = self.inner.with_native_surface_handler(handler);
         self
     }
 

--- a/crates/shell/fission-shell-mobile/src/lib.rs
+++ b/crates/shell/fission-shell-mobile/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use fission_core::{Action, ActionRegistry, Env, GlobalState, Widget};
-use fission_shell::async_host::AsyncRegistry;
+use fission_shell::{async_host::AsyncRegistry, NativeSurfaceHandler};
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
@@ -113,6 +113,16 @@ where
         F: Fn(&mut S) -> bool + Send + Sync + 'static,
     {
         self.inner = self.inner.with_frame_hook(hook);
+        self
+    }
+
+    /// Registers an extension that presents opaque custom surfaces in the
+    /// mobile host.
+    pub fn with_native_surface_handler<H>(mut self, handler: H) -> Self
+    where
+        H: NativeSurfaceHandler + 'static,
+    {
+        self.inner = self.inner.with_native_surface_handler(handler);
         self
     }
 

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -1158,9 +1158,9 @@ fn build_window_before_run(
     ))
 }
 
-fn native_surface_host(window: &Window) -> Option<NativeSurfaceHost> {
+fn native_surface_host(window: &Window) -> Option<NativeSurfaceHost<'_>> {
     let handle = window.window_handle().ok()?;
-    Some(NativeSurfaceHost::from_raw_window_handle(handle.as_raw()))
+    Some(NativeSurfaceHost::from_window_handle(handle))
 }
 
 fn build_window_attributes(
@@ -5919,6 +5919,9 @@ where
                         active_primary_touch = None;
                         touch_positions.clear();
                     }
+                }
+                Event::LoopExiting => {
+                    native_surface_handlers.detach_host();
                 }
                 // ═══════════════════════════════════════════════════════
                 // UserEvent — injected by test control server via proxy

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -5907,6 +5907,7 @@ where
                     }
                     #[cfg(target_os = "android")]
                     {
+                        native_surface_handlers.detach_host();
                         ime_handler.set_window(None);
                         platform_window = None;
                         window_viewport = None;

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -58,12 +58,13 @@ use fission_render_vello::{
 use fission_shell::async_host::{
     AsyncMessage, AsyncRegistry, RunningServiceHandle, ServiceControlMessage,
 };
-use fission_shell::{VideoEvent, VideoPlayer};
+use fission_shell::{NativeSurfaceHandler, NativeSurfaceHost, VideoEvent, VideoPlayer};
 use fission_theme::fonts;
 use fontique::{
     Blob, Collection, CollectionOptions, FontInfoOverride, FontStyle as FontiqueStyle, FontWeight,
     SourceCache,
 };
+use raw_window_handle::HasWindowHandle;
 use read_fonts::types::Tag;
 
 use fission_test_driver::TestEvent;
@@ -95,6 +96,8 @@ use renderer_diagnostics::renderer_request_from_value;
 use renderer_diagnostics::{emit_renderer_report, RendererReport, RendererRequest};
 mod software_renderer;
 use software_renderer::SoftwareRenderer;
+mod native_surface;
+use native_surface::NativeSurfaceRegistry;
 mod video_backend;
 use video_backend::create_video_backend;
 mod web_backend;
@@ -1153,6 +1156,11 @@ fn build_window_before_run(
             .create_window(window_attributes)
             .map_err(|e| anyhow::anyhow!("Window build error: {}", e))?,
     ))
+}
+
+fn native_surface_host(window: &Window) -> Option<NativeSurfaceHost> {
+    let handle = window.window_handle().ok()?;
+    Some(NativeSurfaceHost::from_raw_window_handle(handle.as_raw()))
 }
 
 fn build_window_attributes(
@@ -3955,6 +3963,7 @@ where
     sync_env: Option<Arc<dyn Fn(&S, &mut Env) + Send + Sync>>,
     key_handler: Option<KeyHandler<S>>,
     frame_hook: Option<FrameHook<S>>,
+    native_surface_handlers: NativeSurfaceRegistry,
     title: String,
     web_mount_selector: Option<String>,
     test_control_port: Option<u16>,
@@ -4023,6 +4032,7 @@ where
             sync_env: None,
             key_handler: None,
             frame_hook: None,
+            native_surface_handlers: NativeSurfaceRegistry::default(),
             title: "Fission".into(),
             web_mount_selector: None,
             test_control_port: None,
@@ -4118,6 +4128,16 @@ where
         F: Fn(&mut S) -> bool + Send + Sync + 'static,
     {
         self.frame_hook = Some(Arc::new(f));
+        self
+    }
+
+    /// Registers an extension that presents opaque `EmbedKind::Custom`
+    /// surfaces in this native host.
+    pub fn with_native_surface_handler<H>(mut self, handler: H) -> Self
+    where
+        H: NativeSurfaceHandler + 'static,
+    {
+        self.native_surface_handlers.register(handler);
         self
     }
 
@@ -4565,6 +4585,7 @@ where
         env.window.title = fission_core::WindowTitle::plain(window_title.clone());
         let mut applied_window_title = window_title.clone();
         let mut pipeline = self.pipeline;
+        let mut native_surface_handlers = self.native_surface_handlers;
         let measurer = self.measurer;
         let effect_result_tx = self.effect_result_tx;
         let effect_result_rx = self.effect_result_rx;
@@ -5813,6 +5834,9 @@ where
                     let Some(window) = platform_window.active_window() else {
                         return;
                     };
+                    if let Some(host) = native_surface_host(window) {
+                        native_surface_handlers.attach_host(host);
+                    }
                     accessibility_bridge.ensure_adapter(elwt, window);
                     if accessibility::window_must_start_hidden() && !background_test_mode {
                         window.set_visible(true);
@@ -6026,6 +6050,7 @@ where
                     video_backend.present_surfaces(&surfaces);
                     let web_surfaces = pipeline.web_surfaces.clone();
                     web_backend.present_surfaces(&web_surfaces);
+                    native_surface_handlers.present_surfaces(&pipeline.native_surfaces);
 
                     // Video Logic - Process Player Events and Sync State
                     for (widget_id, active_player) in players.iter_mut() {
@@ -7612,15 +7637,15 @@ where
 
                                         #[cfg(feature = "three-d")]
                                         {
-                                            for (_, rect, payload) in &pipeline.scene_3d_surfaces {
+                                            for surface in &pipeline.native_surfaces {
                                                 if let Ok(primitives) = bincode::deserialize::<
                                                     Vec<fission_3d::Primitive3D>,
                                                 >(
-                                                    payload
+                                                    &surface.payload
                                                 ) {
                                                     let scene3d = fission_3d::Scene3D {
-                                                        width: Some(rect.size.width),
-                                                        height: Some(rect.size.height),
+                                                        width: Some(surface.rect.size.width),
+                                                        height: Some(surface.rect.size.height),
                                                         primitives,
                                                     };
                                                     let scale = scale_factor as f32;
@@ -7630,10 +7655,11 @@ where
                                                         &render_state.surface.target_view,
                                                         &scene3d,
                                                         fission_3d::render::Scene3DViewport {
-                                                            x: rect.origin.x * scale,
-                                                            y: rect.origin.y * scale,
-                                                            width: rect.size.width * scale,
-                                                            height: rect.size.height * scale,
+                                                            x: surface.rect.origin.x * scale,
+                                                            y: surface.rect.origin.y * scale,
+                                                            width: surface.rect.size.width * scale,
+                                                            height: surface.rect.size.height
+                                                                * scale,
                                                         },
                                                     );
                                                 }

--- a/crates/shell/fission-shell-winit/src/native_surface.rs
+++ b/crates/shell/fission-shell-winit/src/native_surface.rs
@@ -21,11 +21,17 @@ impl NativeSurfaceRegistry {
     }
 
     pub(crate) fn present_surfaces(&mut self, frames: &[NativeSurfaceFrame]) {
+        let mut claimed = vec![false; frames.len()];
         for handler in &mut self.handlers {
             let claimed = frames
                 .iter()
-                .filter(|frame| handler.handles_payload(&frame.payload))
-                .cloned()
+                .enumerate()
+                .filter_map(|(index, frame)| {
+                    (!claimed[index] && handler.handles_payload(&frame.payload)).then(|| {
+                        claimed[index] = true;
+                        frame.clone()
+                    })
+                })
                 .collect::<Vec<_>>();
             handler.present_surfaces(&claimed);
         }
@@ -95,5 +101,29 @@ mod tests {
         registry.attach_host(NativeSurfaceHost::from_raw_window_handle(
             RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0)),
         ));
+    }
+
+    #[test]
+    fn gives_overlapping_payloads_to_the_first_registered_handler() {
+        let first = Arc::new(Mutex::new(Vec::new()));
+        let second = Arc::new(Mutex::new(Vec::new()));
+        let mut registry = NativeSurfaceRegistry::default();
+        registry.register(RecordingHandler {
+            prefix: b"maps:",
+            frames: first.clone(),
+        });
+        registry.register(RecordingHandler {
+            prefix: b"maps:",
+            frames: second.clone(),
+        });
+
+        registry.present_surfaces(&[NativeSurfaceFrame {
+            widget_id: WidgetId::from_u128(1),
+            rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
+            payload: b"maps:payload".to_vec(),
+        }]);
+
+        assert_eq!(first.lock().unwrap().len(), 1);
+        assert!(second.lock().unwrap().is_empty());
     }
 }

--- a/crates/shell/fission-shell-winit/src/native_surface.rs
+++ b/crates/shell/fission-shell-winit/src/native_surface.rs
@@ -20,6 +20,12 @@ impl NativeSurfaceRegistry {
         }
     }
 
+    pub(crate) fn detach_host(&mut self) {
+        for handler in &mut self.handlers {
+            handler.detach_host();
+        }
+    }
+
     pub(crate) fn present_surfaces(&mut self, frames: &[NativeSurfaceFrame]) {
         let mut claimed = vec![false; frames.len()];
         for handler in &mut self.handlers {
@@ -50,6 +56,7 @@ mod tests {
     struct RecordingHandler {
         prefix: &'static [u8],
         frames: Arc<Mutex<Vec<NativeSurfaceFrame>>>,
+        detach_count: Arc<Mutex<u32>>,
     }
 
     impl NativeSurfaceHandler for RecordingHandler {
@@ -58,6 +65,10 @@ mod tests {
         }
 
         fn attach_host(&mut self, _host: NativeSurfaceHost) {}
+
+        fn detach_host(&mut self) {
+            *self.detach_count.lock().unwrap() += 1;
+        }
 
         fn present_surfaces(&mut self, frames: &[NativeSurfaceFrame]) {
             *self.frames.lock().unwrap() = frames.to_vec();
@@ -71,6 +82,7 @@ mod tests {
         registry.register(RecordingHandler {
             prefix: b"maps:",
             frames: received.clone(),
+            detach_count: Arc::new(Mutex::new(0)),
         });
 
         registry.present_surfaces(&[
@@ -78,11 +90,13 @@ mod tests {
                 widget_id: WidgetId::from_u128(1),
                 rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
                 payload: b"maps:payload".to_vec(),
+                visible_rect: None,
             },
             NativeSurfaceFrame {
                 widget_id: WidgetId::from_u128(2),
                 rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
                 payload: b"other:payload".to_vec(),
+                visible_rect: None,
             },
         ]);
 
@@ -97,6 +111,7 @@ mod tests {
         registry.register(RecordingHandler {
             prefix: b"maps:",
             frames: Arc::new(Mutex::new(Vec::new())),
+            detach_count: Arc::new(Mutex::new(0)),
         });
         registry.attach_host(NativeSurfaceHost::from_raw_window_handle(
             RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0)),
@@ -111,19 +126,40 @@ mod tests {
         registry.register(RecordingHandler {
             prefix: b"maps:",
             frames: first.clone(),
+            detach_count: Arc::new(Mutex::new(0)),
         });
         registry.register(RecordingHandler {
             prefix: b"maps:",
             frames: second.clone(),
+            detach_count: Arc::new(Mutex::new(0)),
         });
 
         registry.present_surfaces(&[NativeSurfaceFrame {
             widget_id: WidgetId::from_u128(1),
             rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
             payload: b"maps:payload".to_vec(),
+            visible_rect: None,
         }]);
 
         assert_eq!(first.lock().unwrap().len(), 1);
         assert!(second.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn detach_host_notifies_all_handlers() {
+        let detach_count = Arc::new(Mutex::new(0u32));
+        let mut registry = NativeSurfaceRegistry::default();
+        registry.register(RecordingHandler {
+            prefix: b"maps:",
+            frames: Arc::new(Mutex::new(Vec::new())),
+            detach_count: detach_count.clone(),
+        });
+
+        registry.attach_host(NativeSurfaceHost::from_raw_window_handle(
+            RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0)),
+        ));
+        registry.detach_host();
+
+        assert_eq!(*detach_count.lock().unwrap(), 1);
     }
 }

--- a/crates/shell/fission-shell-winit/src/native_surface.rs
+++ b/crates/shell/fission-shell-winit/src/native_surface.rs
@@ -4,6 +4,7 @@ use fission_shell::{NativeSurfaceFrame, NativeSurfaceHandler, NativeSurfaceHost}
 #[derive(Default)]
 pub(crate) struct NativeSurfaceRegistry {
     handlers: Vec<Box<dyn NativeSurfaceHandler>>,
+    host_attached: bool,
 }
 
 impl NativeSurfaceRegistry {
@@ -14,16 +15,21 @@ impl NativeSurfaceRegistry {
         self.handlers.push(Box::new(handler));
     }
 
-    pub(crate) fn attach_host(&mut self, host: NativeSurfaceHost) {
+    pub(crate) fn attach_host(&mut self, host: NativeSurfaceHost<'_>) {
         for handler in &mut self.handlers {
             handler.attach_host(host);
         }
+        self.host_attached = true;
     }
 
     pub(crate) fn detach_host(&mut self) {
+        if !self.host_attached {
+            return;
+        }
         for handler in &mut self.handlers {
             handler.detach_host();
         }
+        self.host_attached = false;
     }
 
     pub(crate) fn present_surfaces(&mut self, frames: &[NativeSurfaceFrame]) {
@@ -50,7 +56,7 @@ mod tests {
     use fission_ir::WidgetId;
     use fission_render::LayoutRect;
     use fission_shell::{NativeSurfaceFrame, NativeSurfaceHandler, NativeSurfaceHost};
-    use raw_window_handle::RawWindowHandle;
+    use raw_window_handle::{RawWindowHandle, WindowHandle};
     use std::sync::{Arc, Mutex};
 
     struct RecordingHandler {
@@ -64,7 +70,7 @@ mod tests {
             payload.starts_with(self.prefix)
         }
 
-        fn attach_host(&mut self, _host: NativeSurfaceHost) {}
+        fn attach_host(&mut self, _host: NativeSurfaceHost<'_>) {}
 
         fn detach_host(&mut self) {
             *self.detach_count.lock().unwrap() += 1;
@@ -90,13 +96,19 @@ mod tests {
                 widget_id: WidgetId::from_u128(1),
                 rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
                 payload: b"maps:payload".to_vec(),
-                visible_rect: None,
+                visible_rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
+                transform: None,
+                opacity: 1.0,
+                paint_order: 0,
             },
             NativeSurfaceFrame {
                 widget_id: WidgetId::from_u128(2),
                 rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
                 payload: b"other:payload".to_vec(),
-                visible_rect: None,
+                visible_rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
+                transform: None,
+                opacity: 1.0,
+                paint_order: 1,
             },
         ]);
 
@@ -113,9 +125,9 @@ mod tests {
             frames: Arc::new(Mutex::new(Vec::new())),
             detach_count: Arc::new(Mutex::new(0)),
         });
-        registry.attach_host(NativeSurfaceHost::from_raw_window_handle(
-            RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0)),
-        ));
+        let raw = RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0));
+        let handle = unsafe { WindowHandle::borrow_raw(raw) };
+        registry.attach_host(NativeSurfaceHost::from_window_handle(handle));
     }
 
     #[test]
@@ -138,7 +150,10 @@ mod tests {
             widget_id: WidgetId::from_u128(1),
             rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
             payload: b"maps:payload".to_vec(),
-            visible_rect: None,
+            visible_rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
+            transform: None,
+            opacity: 1.0,
+            paint_order: 0,
         }]);
 
         assert_eq!(first.lock().unwrap().len(), 1);
@@ -155,9 +170,9 @@ mod tests {
             detach_count: detach_count.clone(),
         });
 
-        registry.attach_host(NativeSurfaceHost::from_raw_window_handle(
-            RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0)),
-        ));
+        let raw = RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0));
+        let handle = unsafe { WindowHandle::borrow_raw(raw) };
+        registry.attach_host(NativeSurfaceHost::from_window_handle(handle));
         registry.detach_host();
 
         assert_eq!(*detach_count.lock().unwrap(), 1);

--- a/crates/shell/fission-shell-winit/src/native_surface.rs
+++ b/crates/shell/fission-shell-winit/src/native_surface.rs
@@ -1,0 +1,99 @@
+use fission_shell::{NativeSurfaceFrame, NativeSurfaceHandler, NativeSurfaceHost};
+
+/// Delivers generic custom embed frames to registered extensions.
+#[derive(Default)]
+pub(crate) struct NativeSurfaceRegistry {
+    handlers: Vec<Box<dyn NativeSurfaceHandler>>,
+}
+
+impl NativeSurfaceRegistry {
+    pub(crate) fn register<H>(&mut self, handler: H)
+    where
+        H: NativeSurfaceHandler + 'static,
+    {
+        self.handlers.push(Box::new(handler));
+    }
+
+    pub(crate) fn attach_host(&mut self, host: NativeSurfaceHost) {
+        for handler in &mut self.handlers {
+            handler.attach_host(host);
+        }
+    }
+
+    pub(crate) fn present_surfaces(&mut self, frames: &[NativeSurfaceFrame]) {
+        for handler in &mut self.handlers {
+            let claimed = frames
+                .iter()
+                .filter(|frame| handler.handles_payload(&frame.payload))
+                .cloned()
+                .collect::<Vec<_>>();
+            handler.present_surfaces(&claimed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NativeSurfaceRegistry;
+    use fission_ir::WidgetId;
+    use fission_render::LayoutRect;
+    use fission_shell::{NativeSurfaceFrame, NativeSurfaceHandler, NativeSurfaceHost};
+    use raw_window_handle::RawWindowHandle;
+    use std::sync::{Arc, Mutex};
+
+    struct RecordingHandler {
+        prefix: &'static [u8],
+        frames: Arc<Mutex<Vec<NativeSurfaceFrame>>>,
+    }
+
+    impl NativeSurfaceHandler for RecordingHandler {
+        fn handles_payload(&self, payload: &[u8]) -> bool {
+            payload.starts_with(self.prefix)
+        }
+
+        fn attach_host(&mut self, _host: NativeSurfaceHost) {}
+
+        fn present_surfaces(&mut self, frames: &[NativeSurfaceFrame]) {
+            *self.frames.lock().unwrap() = frames.to_vec();
+        }
+    }
+
+    #[test]
+    fn routes_only_claimed_surfaces_to_each_handler() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let mut registry = NativeSurfaceRegistry::default();
+        registry.register(RecordingHandler {
+            prefix: b"maps:",
+            frames: received.clone(),
+        });
+
+        registry.present_surfaces(&[
+            NativeSurfaceFrame {
+                widget_id: WidgetId::from_u128(1),
+                rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
+                payload: b"maps:payload".to_vec(),
+            },
+            NativeSurfaceFrame {
+                widget_id: WidgetId::from_u128(2),
+                rect: LayoutRect::new(0.0, 0.0, 1.0, 1.0),
+                payload: b"other:payload".to_vec(),
+            },
+        ]);
+
+        let received = received.lock().unwrap();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].widget_id, WidgetId::from_u128(1));
+    }
+
+    #[test]
+    fn accepts_a_host_handle_without_retaining_it() {
+        let mut registry = NativeSurfaceRegistry::default();
+        registry.register(RecordingHandler {
+            prefix: b"maps:",
+            frames: Arc::new(Mutex::new(Vec::new())),
+        });
+        registry.attach_host(NativeSurfaceHost::from_raw_window_handle(
+            RawWindowHandle::Web(raw_window_handle::WebWindowHandle::new(0)),
+        ));
+    }
+}

--- a/crates/shell/fission-shell-winit/src/pipeline.rs
+++ b/crates/shell/fission-shell-winit/src/pipeline.rs
@@ -421,6 +421,7 @@ impl Pipeline {
         self.web_surfaces.clear();
         self.native_surfaces.clear();
         if let Some(root) = ir.root {
+            let mut paint_order = 0;
             collect_video_surfaces(
                 root,
                 ir,
@@ -428,8 +429,12 @@ impl Pipeline {
                 video_map,
                 web_map,
                 scroll_map,
+                animation_map,
                 LayoutPoint::ZERO,
                 render_viewport,
+                None,
+                1.0,
+                &mut paint_order,
                 &mut self.video_surfaces,
                 &mut self.web_surfaces,
                 &mut self.native_surfaces,
@@ -1800,6 +1805,10 @@ fn push_video_surface(
     video_surfaces: &mut Vec<VideoSurfaceFrame>,
     widget_id: WidgetId,
     rect: LayoutRect,
+    visible_rect: LayoutRect,
+    transform: Option<[f32; 16]>,
+    opacity: f32,
+    paint_order: u32,
     video_map: &VideoStateMap,
 ) {
     if let Some(state) = video_map.states.get(&widget_id) {
@@ -1808,6 +1817,10 @@ fn push_video_surface(
             widget_id,
             surface_id,
             rect,
+            visible_rect,
+            transform,
+            opacity,
+            paint_order,
         });
     }
 }
@@ -1816,6 +1829,10 @@ fn push_web_surface(
     web_surfaces: &mut Vec<WebSurfaceFrame>,
     widget_id: WidgetId,
     rect: LayoutRect,
+    visible_rect: LayoutRect,
+    transform: Option<[f32; 16]>,
+    opacity: f32,
+    paint_order: u32,
     web_map: &WebStateMap,
 ) {
     if let Some(state) = web_map.states.get(&widget_id) {
@@ -1825,6 +1842,10 @@ fn push_web_surface(
                 url: state.url.clone(),
                 user_agent: state.user_agent.clone(),
                 rect,
+                visible_rect,
+                transform,
+                opacity,
+                paint_order,
             });
         }
     }
@@ -1844,6 +1865,31 @@ fn intersect_rects(a: LayoutRect, b: LayoutRect) -> Option<LayoutRect> {
     }
 }
 
+fn transform_rect_bounds(rect: LayoutRect, transform: Option<[f32; 16]>) -> LayoutRect {
+    let Some(matrix) = transform else {
+        return rect;
+    };
+    let points = [
+        (rect.x(), rect.y()),
+        (rect.right(), rect.y()),
+        (rect.right(), rect.bottom()),
+        (rect.x(), rect.bottom()),
+    ];
+    let mut min_x = f32::INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+    for (x, y) in points {
+        let transformed_x = matrix[0] * x + matrix[4] * y + matrix[12];
+        let transformed_y = matrix[1] * x + matrix[5] * y + matrix[13];
+        min_x = min_x.min(transformed_x);
+        min_y = min_y.min(transformed_y);
+        max_x = max_x.max(transformed_x);
+        max_y = max_y.max(transformed_y);
+    }
+    LayoutRect::new(min_x, min_y, max_x - min_x, max_y - min_y)
+}
+
 fn collect_video_surfaces(
     node_id: WidgetId,
     ir: &CoreIR,
@@ -1851,8 +1897,12 @@ fn collect_video_surfaces(
     video_map: &VideoStateMap,
     web_map: &WebStateMap,
     scroll_map: &ScrollStateMap,
+    animation_map: &MotionStateMap,
     accumulated_offset: LayoutPoint,
     accumulated_clip: LayoutRect,
+    accumulated_transform: Option<[f32; 16]>,
+    accumulated_opacity: f32,
+    paint_order: &mut u32,
     video_surfaces: &mut Vec<VideoSurfaceFrame>,
     web_surfaces: &mut Vec<WebSurfaceFrame>,
     native_surfaces: &mut Vec<NativeSurfaceFrame>,
@@ -1865,8 +1915,12 @@ fn collect_video_surfaces(
         video_map,
         web_map,
         scroll_map,
+        animation_map,
         accumulated_offset,
         accumulated_clip,
+        accumulated_transform,
+        accumulated_opacity,
+        paint_order,
         video_surfaces,
         web_surfaces,
         native_surfaces,
@@ -1881,8 +1935,12 @@ fn collect_video_surfaces_with_visited(
     video_map: &VideoStateMap,
     web_map: &WebStateMap,
     scroll_map: &ScrollStateMap,
+    animation_map: &MotionStateMap,
     accumulated_offset: LayoutPoint,
     accumulated_clip: LayoutRect,
+    accumulated_transform: Option<[f32; 16]>,
+    accumulated_opacity: f32,
+    paint_order: &mut u32,
     video_surfaces: &mut Vec<VideoSurfaceFrame>,
     web_surfaces: &mut Vec<WebSurfaceFrame>,
     native_surfaces: &mut Vec<NativeSurfaceFrame>,
@@ -1894,6 +1952,35 @@ fn collect_video_surfaces_with_visited(
     if let (Some(node), Some(geom)) = (ir.nodes.get(&node_id), snapshot.nodes.get(&node_id)) {
         let mut child_offset = accumulated_offset;
         let mut child_clip = accumulated_clip;
+        let translated_node_rect = translate_rect(geom.rect, accumulated_offset);
+        let node_transform = compose_dynamic_layer_transform(
+            &TransformBinding {
+                layer_path: Vec::new(),
+                rect: translated_node_rect,
+                layout_transform: match &node.op {
+                    Op::Layout(LayoutOp::Transform { transform }) => Some(*transform),
+                    _ => None,
+                },
+                scroll: None,
+                translate_x: node.composite.translate_x.clone(),
+                translate_y: node.composite.translate_y.clone(),
+                scale: node.composite.scale.clone(),
+                rotation: node.composite.rotation.clone(),
+            },
+            scroll_map,
+            animation_map,
+        );
+        let effective_transform = match node_transform {
+            Some(transform) => append_transform(accumulated_transform, transform),
+            None => accumulated_transform,
+        };
+        let node_opacity = node
+            .composite
+            .opacity
+            .as_ref()
+            .map(|opacity| resolve_scalar_value(opacity, animation_map, MotionPropertyId::Opacity))
+            .unwrap_or(1.0);
+        let effective_opacity = (accumulated_opacity * node_opacity).clamp(0.0, 1.0);
 
         // Scroll nodes shift children and clip to the scroll viewport.
         if let Op::Layout(LayoutOp::Scroll { direction, .. }) = &node.op {
@@ -1906,7 +1993,7 @@ fn collect_video_surfaces_with_visited(
                     LayoutPoint::new(accumulated_offset.x, accumulated_offset.y - offset)
                 }
             };
-            let viewport_rect = translate_rect(geom.rect, accumulated_offset);
+            let viewport_rect = transform_rect_bounds(translated_node_rect, effective_transform);
             child_clip = intersect_rects(child_clip, viewport_rect).unwrap_or(LayoutRect::new(
                 viewport_rect.x(),
                 viewport_rect.y(),
@@ -1917,7 +2004,7 @@ fn collect_video_surfaces_with_visited(
 
         // Clip nodes restrict children to their bounds.
         if matches!(&node.op, Op::Layout(LayoutOp::Clip { .. })) {
-            let clip_rect = translate_rect(geom.rect, accumulated_offset);
+            let clip_rect = transform_rect_bounds(translated_node_rect, effective_transform);
             child_clip = intersect_rects(child_clip, clip_rect).unwrap_or(LayoutRect::new(
                 clip_rect.x(),
                 clip_rect.y(),
@@ -1928,7 +2015,7 @@ fn collect_video_surfaces_with_visited(
 
         // clip_to_bounds restricts children to this node's bounds.
         if node.composite.clip_to_bounds {
-            let bounds_rect = translate_rect(geom.rect, accumulated_offset);
+            let bounds_rect = transform_rect_bounds(translated_node_rect, effective_transform);
             child_clip = intersect_rects(child_clip, bounds_rect).unwrap_or(LayoutRect::new(
                 bounds_rect.x(),
                 bounds_rect.y(),
@@ -1943,30 +2030,67 @@ fn collect_video_surfaces_with_visited(
             ..
         }) = &node.op
         {
-            let translated_rect = translate_rect(geom.rect, accumulated_offset);
-            push_video_surface(video_surfaces, *widget_id, translated_rect, video_map);
+            let translated_rect = transform_rect_bounds(translated_node_rect, effective_transform);
+            if effective_opacity > 0.0 {
+                if let Some(visible_rect) = intersect_rects(translated_rect, accumulated_clip) {
+                    let order = *paint_order;
+                    *paint_order += 1;
+                    push_video_surface(
+                        video_surfaces,
+                        *widget_id,
+                        translated_rect,
+                        visible_rect,
+                        effective_transform,
+                        effective_opacity,
+                        order,
+                        video_map,
+                    );
+                }
+            }
         } else if let Op::Layout(LayoutOp::Embed {
             kind: EmbedKind::Web,
             widget_id,
             ..
         }) = &node.op
         {
-            let translated_rect = translate_rect(geom.rect, accumulated_offset);
-            push_web_surface(web_surfaces, *widget_id, translated_rect, web_map);
+            let translated_rect = transform_rect_bounds(translated_node_rect, effective_transform);
+            if effective_opacity > 0.0 {
+                if let Some(visible_rect) = intersect_rects(translated_rect, accumulated_clip) {
+                    let order = *paint_order;
+                    *paint_order += 1;
+                    push_web_surface(
+                        web_surfaces,
+                        *widget_id,
+                        translated_rect,
+                        visible_rect,
+                        effective_transform,
+                        effective_opacity,
+                        order,
+                        web_map,
+                    );
+                }
+            }
         } else if let Op::Layout(LayoutOp::Embed {
             kind: EmbedKind::Custom(payload),
             widget_id,
             ..
         }) = &node.op
         {
-            let translated_rect = translate_rect(geom.rect, accumulated_offset);
-            if let Some(visible) = intersect_rects(translated_rect, accumulated_clip) {
-                native_surfaces.push(NativeSurfaceFrame {
-                    widget_id: *widget_id,
-                    rect: translated_rect,
-                    payload: payload.clone(),
-                    visible_rect: Some(visible),
-                });
+            let translated_rect = transform_rect_bounds(translated_node_rect, effective_transform);
+            if effective_opacity > 0.0 {
+                if let Some(visible) = intersect_rects(translated_rect, accumulated_clip) {
+                    let order = *paint_order;
+                    *paint_order += 1;
+                    native_surfaces.push(NativeSurfaceFrame {
+                        widget_id: *widget_id,
+                        rect: translated_rect,
+                        payload: payload.clone(),
+                        visible_rect: visible,
+                        transform: effective_transform,
+                        opacity: effective_opacity,
+                        paint_order: order,
+                    });
+                }
             }
             // Fully clipped — omit entirely. The handler will receive an
             // empty slice via `present_surfaces`, which already means "hide."
@@ -1980,8 +2104,12 @@ fn collect_video_surfaces_with_visited(
                 video_map,
                 web_map,
                 scroll_map,
+                animation_map,
                 child_offset,
                 child_clip,
+                effective_transform,
+                effective_opacity,
+                paint_order,
                 video_surfaces,
                 web_surfaces,
                 native_surfaces,
@@ -2476,8 +2604,11 @@ fn translate_rect(rect: LayoutRect, offset: LayoutPoint) -> LayoutRect {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_local_paint_list, scroll_offsets_changed, InvalidationSet, Pipeline};
-    use fission_core::env::Env;
+    use super::{
+        build_local_paint_list, scroll_offsets_changed, translation_matrix, InvalidationSet,
+        Pipeline,
+    };
+    use fission_core::env::{Env, VideoState, VideoStateMap, WebState, WebStateMap};
     use fission_core::MotionPropertyId;
     use fission_core::ScrollStateMap;
     use fission_ir::op::{
@@ -2896,7 +3027,10 @@ mod tests {
                 widget_id,
                 rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
                 payload,
-                visible_rect: Some(LayoutRect::new(0.0, 0.0, 320.0, 180.0)),
+                visible_rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
+                transform: None,
+                opacity: 1.0,
+                paint_order: 0,
             }]
         );
     }
@@ -3928,7 +4062,7 @@ mod tests {
         assert_eq!(pipeline.native_surfaces.len(), 1);
         let surface = &pipeline.native_surfaces[0];
         // The embed's translated rect is shifted up by the scroll offset.
-        let visible = surface.visible_rect.expect("visible_rect should be Some");
+        let visible = surface.visible_rect;
         // The visible portion is the intersection of the embed rect and the
         // scroll viewport. The exact values depend on how the layout engine
         // positions the child, but the visible height must be less than 100.
@@ -3941,5 +4075,145 @@ mod tests {
             visible.height() > 0.0,
             "visible height should be positive (embed is partially visible)",
         );
+    }
+
+    #[test]
+    fn built_in_native_surfaces_follow_scroll_visibility() {
+        let scroll_id = WidgetId::derived(23, &[0]);
+        let video_id = WidgetId::derived(23, &[1]);
+        let web_id = WidgetId::derived(23, &[2]);
+        let video_widget = WidgetId::explicit("video.scrolled");
+        let web_widget = WidgetId::explicit("web.scrolled");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            video_id,
+            Op::Layout(LayoutOp::Embed {
+                kind: EmbedKind::Video,
+                widget_id: video_widget,
+                width: Some(100.0),
+                height: Some(100.0),
+            }),
+            vec![],
+        );
+        ir.add_node(
+            web_id,
+            Op::Layout(LayoutOp::Embed {
+                kind: EmbedKind::Web,
+                widget_id: web_widget,
+                width: Some(100.0),
+                height: Some(100.0),
+            }),
+            vec![],
+        );
+        ir.add_node(
+            scroll_id,
+            Op::Layout(LayoutOp::Scroll {
+                direction: fission_ir::FlexDirection::Column,
+                show_scrollbar: false,
+                width: Some(200.0),
+                height: Some(200.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            }),
+            vec![video_id, web_id],
+        );
+        ir.set_root(scroll_id);
+
+        let mut videos = VideoStateMap::default();
+        videos.states.insert(video_widget, VideoState::default());
+        let mut webs = WebStateMap::default();
+        webs.states.insert(
+            web_widget,
+            WebState {
+                url: "https://example.invalid".into(),
+                ..Default::default()
+            },
+        );
+        let mut pipeline = Pipeline::new();
+        let mut layout_engine = LayoutEngine::new();
+        pipeline.replace_ir(ir, &Env::default());
+        pipeline
+            .ensure_layout(
+                LayoutRect::new(0.0, 0.0, 400.0, 400.0),
+                &mut layout_engine,
+                &ScrollStateMap::default(),
+            )
+            .unwrap();
+
+        let mut scrolled = ScrollStateMap::default();
+        scrolled.set_offset(scroll_id, 300.0);
+        pipeline
+            .prepare_current(
+                LayoutSize::new(400.0, 400.0),
+                LayoutSize::new(400.0, 400.0),
+                false,
+                &scrolled,
+                &Default::default(),
+                &videos,
+                &webs,
+            )
+            .unwrap();
+
+        assert!(pipeline.video_surfaces.is_empty());
+        assert!(pipeline.web_surfaces.is_empty());
+    }
+
+    #[test]
+    fn custom_surface_reports_ancestor_transform_and_opacity() {
+        let root_id = WidgetId::derived(24, &[0]);
+        let embed_id = WidgetId::derived(24, &[1]);
+        let widget_id = WidgetId::explicit("custom.transformed");
+        let transform = translation_matrix(40.0, 25.0);
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            embed_id,
+            Op::Layout(LayoutOp::Embed {
+                kind: EmbedKind::Custom(vec![1]),
+                widget_id,
+                width: Some(100.0),
+                height: Some(50.0),
+            }),
+            vec![],
+        );
+        ir.add_node(
+            root_id,
+            Op::Layout(LayoutOp::Transform { transform }),
+            vec![embed_id],
+        );
+        ir.nodes.get_mut(&root_id).unwrap().composite.opacity = Some(CompositeScalar::new(0.5));
+        ir.set_root(root_id);
+
+        let mut pipeline = Pipeline::new();
+        let mut layout_engine = LayoutEngine::new();
+        pipeline.replace_ir(ir, &Env::default());
+        pipeline
+            .ensure_layout(
+                LayoutRect::new(0.0, 0.0, 400.0, 400.0),
+                &mut layout_engine,
+                &ScrollStateMap::default(),
+            )
+            .unwrap();
+        pipeline
+            .prepare_current(
+                LayoutSize::new(400.0, 400.0),
+                LayoutSize::new(400.0, 400.0),
+                false,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+
+        let surface = &pipeline.native_surfaces[0];
+        assert_eq!(surface.transform, Some(transform));
+        assert!((surface.rect.x() - 40.0).abs() < 0.01);
+        assert!((surface.rect.y() - 25.0).abs() < 0.01);
+        assert!((surface.opacity - 0.5).abs() < 0.001);
     }
 }

--- a/crates/shell/fission-shell-winit/src/pipeline.rs
+++ b/crates/shell/fission-shell-winit/src/pipeline.rs
@@ -429,6 +429,7 @@ impl Pipeline {
                 web_map,
                 scroll_map,
                 LayoutPoint::ZERO,
+                render_viewport,
                 &mut self.video_surfaces,
                 &mut self.web_surfaces,
                 &mut self.native_surfaces,
@@ -1829,6 +1830,20 @@ fn push_web_surface(
     }
 }
 
+/// Computes the intersection of two rectangles, returning `None` when they do
+/// not overlap at all.
+fn intersect_rects(a: LayoutRect, b: LayoutRect) -> Option<LayoutRect> {
+    let x = a.x().max(b.x());
+    let y = a.y().max(b.y());
+    let right = a.right().min(b.right());
+    let bottom = a.bottom().min(b.bottom());
+    if right > x && bottom > y {
+        Some(LayoutRect::new(x, y, right - x, bottom - y))
+    } else {
+        None
+    }
+}
+
 fn collect_video_surfaces(
     node_id: WidgetId,
     ir: &CoreIR,
@@ -1837,6 +1852,7 @@ fn collect_video_surfaces(
     web_map: &WebStateMap,
     scroll_map: &ScrollStateMap,
     accumulated_offset: LayoutPoint,
+    accumulated_clip: LayoutRect,
     video_surfaces: &mut Vec<VideoSurfaceFrame>,
     web_surfaces: &mut Vec<WebSurfaceFrame>,
     native_surfaces: &mut Vec<NativeSurfaceFrame>,
@@ -1850,6 +1866,7 @@ fn collect_video_surfaces(
         web_map,
         scroll_map,
         accumulated_offset,
+        accumulated_clip,
         video_surfaces,
         web_surfaces,
         native_surfaces,
@@ -1865,6 +1882,7 @@ fn collect_video_surfaces_with_visited(
     web_map: &WebStateMap,
     scroll_map: &ScrollStateMap,
     accumulated_offset: LayoutPoint,
+    accumulated_clip: LayoutRect,
     video_surfaces: &mut Vec<VideoSurfaceFrame>,
     web_surfaces: &mut Vec<WebSurfaceFrame>,
     native_surfaces: &mut Vec<NativeSurfaceFrame>,
@@ -1875,6 +1893,9 @@ fn collect_video_surfaces_with_visited(
     }
     if let (Some(node), Some(geom)) = (ir.nodes.get(&node_id), snapshot.nodes.get(&node_id)) {
         let mut child_offset = accumulated_offset;
+        let mut child_clip = accumulated_clip;
+
+        // Scroll nodes shift children and clip to the scroll viewport.
         if let Op::Layout(LayoutOp::Scroll { direction, .. }) = &node.op {
             let offset = scroll_map.get_offset(node_id);
             child_offset = match direction {
@@ -1885,6 +1906,35 @@ fn collect_video_surfaces_with_visited(
                     LayoutPoint::new(accumulated_offset.x, accumulated_offset.y - offset)
                 }
             };
+            let viewport_rect = translate_rect(geom.rect, accumulated_offset);
+            child_clip = intersect_rects(child_clip, viewport_rect).unwrap_or(LayoutRect::new(
+                viewport_rect.x(),
+                viewport_rect.y(),
+                0.0,
+                0.0,
+            ));
+        }
+
+        // Clip nodes restrict children to their bounds.
+        if matches!(&node.op, Op::Layout(LayoutOp::Clip { .. })) {
+            let clip_rect = translate_rect(geom.rect, accumulated_offset);
+            child_clip = intersect_rects(child_clip, clip_rect).unwrap_or(LayoutRect::new(
+                clip_rect.x(),
+                clip_rect.y(),
+                0.0,
+                0.0,
+            ));
+        }
+
+        // clip_to_bounds restricts children to this node's bounds.
+        if node.composite.clip_to_bounds {
+            let bounds_rect = translate_rect(geom.rect, accumulated_offset);
+            child_clip = intersect_rects(child_clip, bounds_rect).unwrap_or(LayoutRect::new(
+                bounds_rect.x(),
+                bounds_rect.y(),
+                0.0,
+                0.0,
+            ));
         }
 
         if let Op::Layout(LayoutOp::Embed {
@@ -1910,11 +1960,16 @@ fn collect_video_surfaces_with_visited(
         }) = &node.op
         {
             let translated_rect = translate_rect(geom.rect, accumulated_offset);
-            native_surfaces.push(NativeSurfaceFrame {
-                widget_id: *widget_id,
-                rect: translated_rect,
-                payload: payload.clone(),
-            });
+            if let Some(visible) = intersect_rects(translated_rect, accumulated_clip) {
+                native_surfaces.push(NativeSurfaceFrame {
+                    widget_id: *widget_id,
+                    rect: translated_rect,
+                    payload: payload.clone(),
+                    visible_rect: Some(visible),
+                });
+            }
+            // Fully clipped — omit entirely. The handler will receive an
+            // empty slice via `present_surfaces`, which already means "hide."
         }
 
         for child in &node.children {
@@ -1926,6 +1981,7 @@ fn collect_video_surfaces_with_visited(
                 web_map,
                 scroll_map,
                 child_offset,
+                child_clip,
                 video_surfaces,
                 web_surfaces,
                 native_surfaces,
@@ -2840,6 +2896,7 @@ mod tests {
                 widget_id,
                 rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
                 payload,
+                visible_rect: Some(LayoutRect::new(0.0, 0.0, 320.0, 180.0)),
             }]
         );
     }
@@ -3702,6 +3759,187 @@ mod tests {
         assert!(
             rail_count > 0,
             "expected an overflow rail for the scroll node"
+        );
+    }
+
+    #[test]
+    fn custom_embed_fully_outside_scroll_viewport_is_omitted() {
+        // Scroll container 200px tall with a 100px custom embed placed at
+        // y=250 inside the content. With scroll offset 0 the embed sits
+        // below the visible viewport and should be omitted entirely.
+        let scroll_id = WidgetId::derived(20, &[0]);
+        let embed_id = WidgetId::derived(20, &[1]);
+        let widget_id = WidgetId::explicit("custom.offscreen");
+        let payload = vec![0xAA, 0xBB];
+
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            embed_id,
+            Op::Layout(LayoutOp::Embed {
+                kind: EmbedKind::Custom(payload.clone()),
+                widget_id,
+                width: Some(100.0),
+                height: Some(100.0),
+            }),
+            vec![],
+        );
+        ir.add_node(
+            scroll_id,
+            Op::Layout(LayoutOp::Scroll {
+                direction: fission_ir::FlexDirection::Column,
+                show_scrollbar: false,
+                width: Some(200.0),
+                height: Some(200.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            }),
+            vec![embed_id],
+        );
+        ir.set_root(scroll_id);
+
+        let mut pipeline = Pipeline::new();
+        let mut layout_engine = LayoutEngine::new();
+        let scroll = ScrollStateMap::default(); // offset 0
+        pipeline.replace_ir(ir, &Env::default());
+        pipeline
+            .ensure_layout(
+                LayoutRect::new(0.0, 0.0, 400.0, 400.0),
+                &mut layout_engine,
+                &scroll,
+            )
+            .unwrap();
+        pipeline
+            .prepare_current(
+                LayoutSize::new(400.0, 400.0),
+                LayoutSize::new(400.0, 400.0),
+                false,
+                &scroll,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+
+        // The embed fits inside the scroll viewport (content starts at y=0,
+        // embed is 100px tall, scroll viewport is 200px tall) so it should
+        // be visible. Now scroll the content so the embed is fully off-screen.
+        let mut scrolled = ScrollStateMap::default();
+        scrolled.set_offset(scroll_id, 300.0); // scrolled 300px down — embed at y=-300, off-screen
+
+        // Re-run pipeline with the scroll offset.
+        pipeline.clear_render_caches();
+        pipeline
+            .prepare_current(
+                LayoutSize::new(400.0, 400.0),
+                LayoutSize::new(400.0, 400.0),
+                false,
+                &scrolled,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+
+        assert!(
+            pipeline.native_surfaces.is_empty(),
+            "expected custom embed to be omitted when scrolled fully outside viewport, got {:?}",
+            pipeline.native_surfaces,
+        );
+    }
+
+    #[test]
+    fn custom_embed_partially_clipped_gets_intersected_visible_rect() {
+        // Scroll container 200×200, child embed 100×100 at layout y=0.
+        // Scroll offset 50 shifts the child up by 50px, so only the bottom
+        // 50px of the embed remains inside the scroll viewport. The
+        // visible_rect should reflect the intersection.
+        let scroll_id = WidgetId::derived(22, &[0]);
+        let embed_id = WidgetId::derived(22, &[1]);
+        let widget_id = WidgetId::explicit("custom.partial");
+        let payload = vec![0xCC, 0xDD];
+
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            embed_id,
+            Op::Layout(LayoutOp::Embed {
+                kind: EmbedKind::Custom(payload.clone()),
+                widget_id,
+                width: Some(100.0),
+                height: Some(100.0),
+            }),
+            vec![],
+        );
+        ir.add_node(
+            scroll_id,
+            Op::Layout(LayoutOp::Scroll {
+                direction: fission_ir::FlexDirection::Column,
+                show_scrollbar: false,
+                width: Some(200.0),
+                height: Some(200.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            }),
+            vec![embed_id],
+        );
+        ir.set_root(scroll_id);
+
+        let mut pipeline = Pipeline::new();
+        let mut layout_engine = LayoutEngine::new();
+        let scroll = ScrollStateMap::default();
+        pipeline.replace_ir(ir, &Env::default());
+        pipeline
+            .ensure_layout(
+                LayoutRect::new(0.0, 0.0, 400.0, 400.0),
+                &mut layout_engine,
+                &scroll,
+            )
+            .unwrap();
+
+        // Scroll by 50 — the embed starts at y=0, so after offset it's at
+        // y = -50 in the scroll viewport coordinate space. The viewport
+        // runs from y=0 to y=200, so only the bottom 50px of the embed
+        // (from y=0 to y=50 in viewport coords) is visible.
+        let mut scrolled = ScrollStateMap::default();
+        scrolled.set_offset(scroll_id, 50.0);
+
+        pipeline.clear_render_caches();
+        pipeline
+            .prepare_current(
+                LayoutSize::new(400.0, 400.0),
+                LayoutSize::new(400.0, 400.0),
+                false,
+                &scrolled,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+
+        assert_eq!(pipeline.native_surfaces.len(), 1);
+        let surface = &pipeline.native_surfaces[0];
+        // The embed's translated rect is shifted up by the scroll offset.
+        let visible = surface.visible_rect.expect("visible_rect should be Some");
+        // The visible portion is the intersection of the embed rect and the
+        // scroll viewport. The exact values depend on how the layout engine
+        // positions the child, but the visible height must be less than 100.
+        assert!(
+            visible.height() < 100.0,
+            "visible height ({}) should be less than the full embed height (100)",
+            visible.height(),
+        );
+        assert!(
+            visible.height() > 0.0,
+            "visible height should be positive (embed is partially visible)",
         );
     }
 }

--- a/crates/shell/fission-shell-winit/src/pipeline.rs
+++ b/crates/shell/fission-shell-winit/src/pipeline.rs
@@ -15,7 +15,7 @@ use fission_render::{
     embed_surface_id, BoxShadow, Color as RenderColor, DisplayList, DisplayOp, Fill, LayerClip,
     RenderLayer, RenderNode, RenderScene, Renderer, Stroke,
 };
-use fission_shell::VideoSurfaceFrame;
+use fission_shell::{NativeSurfaceFrame, VideoSurfaceFrame};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -174,7 +174,8 @@ pub struct Pipeline {
     pub last_scroll_offsets: HashMap<WidgetId, u32>,
     pub video_surfaces: Vec<VideoSurfaceFrame>,
     pub web_surfaces: Vec<WebSurfaceFrame>,
-    pub scene_3d_surfaces: Vec<(WidgetId, LayoutRect, Vec<u8>)>,
+    /// Opaque custom embeds available to registered native-surface handlers.
+    pub native_surfaces: Vec<NativeSurfaceFrame>,
     pub last_viewport: Option<LayoutRect>,
     pub layout_invariant_violation_count: u32,
     pub layout_full_rebuild_count: u32,
@@ -210,7 +211,7 @@ impl Pipeline {
             last_scroll_offsets: HashMap::new(),
             video_surfaces: Vec::new(),
             web_surfaces: Vec::new(),
-            scene_3d_surfaces: Vec::new(),
+            native_surfaces: Vec::new(),
             last_viewport: None,
             layout_invariant_violation_count: 0,
             layout_full_rebuild_count: 0,
@@ -418,7 +419,7 @@ impl Pipeline {
 
         self.video_surfaces.clear();
         self.web_surfaces.clear();
-        self.scene_3d_surfaces.clear();
+        self.native_surfaces.clear();
         if let Some(root) = ir.root {
             collect_video_surfaces(
                 root,
@@ -430,7 +431,7 @@ impl Pipeline {
                 LayoutPoint::ZERO,
                 &mut self.video_surfaces,
                 &mut self.web_surfaces,
-                &mut self.scene_3d_surfaces,
+                &mut self.native_surfaces,
             );
         }
         stats.video_surfaces = self.video_surfaces.len();
@@ -1838,7 +1839,7 @@ fn collect_video_surfaces(
     accumulated_offset: LayoutPoint,
     video_surfaces: &mut Vec<VideoSurfaceFrame>,
     web_surfaces: &mut Vec<WebSurfaceFrame>,
-    scene_3d_surfaces: &mut Vec<(WidgetId, LayoutRect, Vec<u8>)>,
+    native_surfaces: &mut Vec<NativeSurfaceFrame>,
 ) {
     let mut visited = HashSet::new();
     collect_video_surfaces_with_visited(
@@ -1851,7 +1852,7 @@ fn collect_video_surfaces(
         accumulated_offset,
         video_surfaces,
         web_surfaces,
-        scene_3d_surfaces,
+        native_surfaces,
         &mut visited,
     );
 }
@@ -1866,7 +1867,7 @@ fn collect_video_surfaces_with_visited(
     accumulated_offset: LayoutPoint,
     video_surfaces: &mut Vec<VideoSurfaceFrame>,
     web_surfaces: &mut Vec<WebSurfaceFrame>,
-    scene_3d_surfaces: &mut Vec<(WidgetId, LayoutRect, Vec<u8>)>,
+    native_surfaces: &mut Vec<NativeSurfaceFrame>,
     visited: &mut HashSet<WidgetId>,
 ) {
     if !visited.insert(node_id) {
@@ -1909,7 +1910,11 @@ fn collect_video_surfaces_with_visited(
         }) = &node.op
         {
             let translated_rect = translate_rect(geom.rect, accumulated_offset);
-            scene_3d_surfaces.push((*widget_id, translated_rect, payload.clone()));
+            native_surfaces.push(NativeSurfaceFrame {
+                widget_id: *widget_id,
+                rect: translated_rect,
+                payload: payload.clone(),
+            });
         }
 
         for child in &node.children {
@@ -1923,7 +1928,7 @@ fn collect_video_surfaces_with_visited(
                 child_offset,
                 video_surfaces,
                 web_surfaces,
-                scene_3d_surfaces,
+                native_surfaces,
                 visited,
             );
         }
@@ -2786,6 +2791,57 @@ mod tests {
             }
             other => panic!("expected surface display op, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn custom_embeds_flow_into_native_surfaces() {
+        let node_id = WidgetId::derived(15, &[0]);
+        let widget_id = WidgetId::explicit("custom.surface");
+        let payload = vec![0x4d, 0x41, 0x50, 0x01];
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            node_id,
+            Op::Layout(LayoutOp::Embed {
+                kind: EmbedKind::Custom(payload.clone()),
+                widget_id,
+                width: Some(320.0),
+                height: Some(180.0),
+            }),
+            vec![],
+        );
+        ir.set_root(node_id);
+
+        let mut pipeline = Pipeline::new();
+        let mut layout_engine = LayoutEngine::new();
+        let scroll = ScrollStateMap::default();
+        pipeline.replace_ir(ir, &Env::default());
+        pipeline
+            .ensure_layout(
+                LayoutRect::new(0.0, 0.0, 320.0, 240.0),
+                &mut layout_engine,
+                &scroll,
+            )
+            .unwrap();
+        pipeline
+            .prepare_current(
+                LayoutSize::new(320.0, 240.0),
+                LayoutSize::new(320.0, 240.0),
+                false,
+                &scroll,
+                &Default::default(),
+                &Default::default(),
+                &Default::default(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            pipeline.native_surfaces,
+            vec![fission_shell::NativeSurfaceFrame {
+                widget_id,
+                rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
+                payload,
+            }]
+        );
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/video_backend.rs
+++ b/crates/shell/fission-shell-winit/src/video_backend.rs
@@ -268,7 +268,7 @@ mod mac {
                 let entry = layer_map
                     .entry(widget_id)
                     .or_insert_with(|| VideoLayer::new(widget_id, &player, ctx));
-                entry.update(&player, ctx, frame.rect);
+                entry.update(&player, ctx, frame);
             }
         }
     }
@@ -394,12 +394,14 @@ mod mac {
             }
         }
 
-        fn update(&mut self, player: &RetainedId, ctx: &LayerContext, rect: LayoutRect) {
+        fn update(&mut self, player: &RetainedId, ctx: &LayerContext, frame: &VideoSurfaceFrame) {
             unsafe {
                 let layer_id = self.layer.as_id();
                 let () = msg_send![layer_id, setContentsScale: ctx.scale_factor];
                 let () = msg_send![layer_id, setPlayer: player.as_id()];
-                let cg_rect = cg_rect_from_layout(rect, ctx);
+                let () = msg_send![layer_id, setOpacity: frame.opacity];
+                let () = msg_send![layer_id, setZPosition: frame.paint_order as f64];
+                let cg_rect = cg_rect_from_layout(frame.rect, ctx);
                 let view_id = self.view.as_id();
                 let () = msg_send![view_id, setFrame: cg_rect];
                 let () = msg_send![
@@ -892,7 +894,7 @@ mod ios {
                 let entry = layer_map
                     .entry(widget_id)
                     .or_insert_with(|| VideoLayer::new(&player, ctx));
-                entry.update(&player, ctx, frame.rect);
+                entry.update(&player, ctx, frame);
             }
         }
     }
@@ -1017,16 +1019,18 @@ mod ios {
             }
         }
 
-        fn update(&mut self, player: &RetainedId, ctx: &LayerContext, rect: LayoutRect) {
+        fn update(&mut self, player: &RetainedId, ctx: &LayerContext, frame: &VideoSurfaceFrame) {
             unsafe {
                 let view = self.view.as_id();
                 let layer = self.layer.as_id();
-                let frame = cg_rect_from_layout(rect);
-                let () = msg_send![view, setFrame: frame];
+                let view_frame = cg_rect_from_layout(frame.rect);
+                let () = msg_send![view, setFrame: view_frame];
                 let bounds: CGRect = msg_send![view, bounds];
                 let () = msg_send![layer, setFrame: bounds];
                 let () = msg_send![layer, setContentsScale: ctx.scale_factor];
                 let () = msg_send![layer, setPlayer: player.as_id()];
+                let () = msg_send![layer, setOpacity: frame.opacity];
+                let () = msg_send![layer, setZPosition: frame.paint_order as f64];
                 let () = msg_send![ctx.parent_view, addSubview: view];
             }
         }
@@ -2875,6 +2879,19 @@ mod web {
         let _ = style.set_property("top", &format!("{}px", frame.rect.origin.y));
         let _ = style.set_property("width", &format!("{}px", frame.rect.size.width));
         let _ = style.set_property("height", &format!("{}px", frame.rect.size.height));
+        let top = (frame.visible_rect.y() - frame.rect.y()).max(0.0);
+        let right = (frame.rect.right() - frame.visible_rect.right()).max(0.0);
+        let bottom = (frame.rect.bottom() - frame.visible_rect.bottom()).max(0.0);
+        let left = (frame.visible_rect.x() - frame.rect.x()).max(0.0);
+        let _ = style.set_property(
+            "clip-path",
+            &format!("inset({top}px {right}px {bottom}px {left}px)"),
+        );
+        let _ = style.set_property("opacity", &frame.opacity.to_string());
+        let _ = style.set_property(
+            "z-index",
+            &(2_000_000_000u32 + frame.paint_order).to_string(),
+        );
     }
 
     fn document() -> Document {

--- a/crates/shell/fission-shell-winit/src/web_backend.rs
+++ b/crates/shell/fission-shell-winit/src/web_backend.rs
@@ -10,6 +10,11 @@ pub struct WebSurfaceFrame {
     pub url: String,
     pub user_agent: Option<String>,
     pub rect: LayoutRect,
+    pub visible_rect: LayoutRect,
+    /// Transform that produced the axis-aligned `rect` bounds.
+    pub transform: Option<[f32; 16]>,
+    pub opacity: f32,
+    pub paint_order: u32,
 }
 
 #[cfg(target_os = "macos")]
@@ -183,7 +188,8 @@ mod mac {
                 let () = msg_send![web_view.as_id(), setWantsLayer: YES];
                 let web_layer: id = msg_send![web_view.as_id(), layer];
                 if web_layer != nil {
-                    let () = msg_send![web_layer, setZPosition: 2.0f64];
+                    let () = msg_send![web_layer, setZPosition: frame.paint_order as f64];
+                    let () = msg_send![web_layer, setOpacity: frame.opacity];
                 }
                 let () = msg_send![web_view.as_id(), setAllowsBackForwardNavigationGestures: YES];
                 let () = msg_send![
@@ -209,6 +215,11 @@ mod mac {
                 let cg_rect = cg_rect_from_layout(frame.rect, ctx.bounds_height);
                 let () = msg_send![web_view, setFrame: cg_rect];
                 let () = msg_send![web_view, setHidden: false];
+                let web_layer: id = msg_send![web_view, layer];
+                if web_layer != nil {
+                    let () = msg_send![web_layer, setZPosition: frame.paint_order as f64];
+                    let () = msg_send![web_layer, setOpacity: frame.opacity];
+                }
                 let () = msg_send![
                     ctx.parent_view,
                     addSubview: web_view
@@ -300,6 +311,10 @@ mod tests {
             url: "https://example.invalid".to_string(),
             user_agent: Some("fission-test".to_string()),
             rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
+            visible_rect: LayoutRect::new(0.0, 0.0, 320.0, 180.0),
+            transform: None,
+            opacity: 1.0,
+            paint_order: 0,
         }]);
         backend.present_surfaces(&[]);
     }

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -16,6 +16,7 @@ fission-render = { path = "../../rendering/fission-render", version = "0.9.1" } 
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"
+raw-window-handle = "0.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "sync"] }

--- a/crates/shell/fission-shell/src/lib.rs
+++ b/crates/shell/fission-shell/src/lib.rs
@@ -59,6 +59,13 @@ pub struct NativeSurfaceFrame {
     pub rect: LayoutRect,
     /// Extension-defined payload from `EmbedKind::Custom`.
     pub payload: Vec<u8>,
+    /// The portion of [`rect`](Self::rect) that is actually visible after
+    /// ancestor clipping (scroll viewports, `Clip` nodes, `clip_to_bounds`).
+    ///
+    /// `None` means the full `rect` is visible (no ancestor clip applies).
+    /// When present, handlers should constrain their platform view to this
+    /// sub-rectangle.
+    pub visible_rect: Option<LayoutRect>,
 }
 
 /// A platform window made available to native-surface extensions.
@@ -93,13 +100,35 @@ impl NativeSurfaceHost {
 /// [`present_surfaces`](NativeSurfaceHandler::present_surfaces). The shell is
 /// intentionally unaware of individual extension types. A custom surface is
 /// delivered to the first registered handler that claims it.
+///
+/// # Lifecycle
+///
+/// 1. [`attach_host`](Self::attach_host) — called when the platform window is
+///    ready. On mobile, the host may be destroyed and recreated across
+///    suspend/resume cycles.
+/// 2. [`present_surfaces`](Self::present_surfaces) — called every frame with
+///    the set of visible surfaces.
+/// 3. [`detach_host`](Self::detach_host) — called before the native window is
+///    dropped (e.g. `Event::Suspended` on Android). Handlers must release any
+///    platform views associated with the previous host. A subsequent
+///    `attach_host` may follow if the host is recreated.
 pub trait NativeSurfaceHandler {
     /// Returns whether this handler owns a custom embed payload.
     fn handles_payload(&self, payload: &[u8]) -> bool;
 
-    /// Supplies a ready platform window. This may be called again after a
-    /// mobile host is recreated.
+    /// Supplies a ready platform window.
+    ///
+    /// On mobile platforms the host may be destroyed and recreated across
+    /// suspend/resume cycles. When that happens, [`detach_host`](Self::detach_host)
+    /// is called first, then `attach_host` is called again with the new window.
     fn attach_host(&mut self, host: NativeSurfaceHost);
+
+    /// Notifies the handler that the platform window is about to be destroyed.
+    ///
+    /// Handlers must release any platform views or resources associated with
+    /// the previous [`NativeSurfaceHost`]. A subsequent [`attach_host`](Self::attach_host)
+    /// call may follow if the host is recreated (e.g. after an Android resume).
+    fn detach_host(&mut self);
 
     /// Presents every visible surface claimed by this handler for the frame.
     ///

--- a/crates/shell/fission-shell/src/lib.rs
+++ b/crates/shell/fission-shell/src/lib.rs
@@ -1,6 +1,7 @@
 use fission_core::ui::VideoAudioOptions;
 use fission_ir::WidgetId;
 use fission_render::LayoutRect;
+use raw_window_handle::RawWindowHandle;
 use serde::{Deserialize, Serialize};
 
 pub mod async_host;
@@ -44,4 +45,64 @@ pub enum VideoEvent {
     Ready { duration: u64 },
     Ended,
     Error(String),
+}
+
+/// A laid-out opaque surface emitted by an `fission_ir::EmbedKind::Custom` IR node.
+///
+/// The payload is owned by the extension that created it. Shells only carry
+/// it from layout to registered [`NativeSurfaceHandler`] implementations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NativeSurfaceFrame {
+    /// Stable identity of the embedded surface.
+    pub widget_id: WidgetId,
+    /// Surface bounds in Fission layout coordinates.
+    pub rect: LayoutRect,
+    /// Extension-defined payload from `EmbedKind::Custom`.
+    pub payload: Vec<u8>,
+}
+
+/// A platform window made available to native-surface extensions.
+///
+/// This deliberately exposes only a raw handle, keeping the shared shell
+/// contract independent of a particular windowing implementation.
+#[derive(Debug, Clone, Copy)]
+pub struct NativeSurfaceHost {
+    raw_window_handle: RawWindowHandle,
+}
+
+impl NativeSurfaceHost {
+    /// Constructs a host wrapper for a platform window.
+    ///
+    /// Shell implementations call this after their native window is ready.
+    pub fn from_raw_window_handle(raw_window_handle: RawWindowHandle) -> Self {
+        Self { raw_window_handle }
+    }
+
+    /// Returns the underlying platform window handle.
+    pub fn raw_window_handle(&self) -> RawWindowHandle {
+        self.raw_window_handle
+    }
+}
+
+/// Receives opaque custom surfaces for one native window.
+///
+/// Extensions identify their payloads with [`handles_payload`]
+/// (NativeSurfaceHandler::handles_payload). A handler can create or replace
+/// platform views in [`attach_host`](NativeSurfaceHandler::attach_host), then
+/// reconcile their geometry and visibility in
+/// [`present_surfaces`](NativeSurfaceHandler::present_surfaces). The shell is
+/// intentionally unaware of individual extension types.
+pub trait NativeSurfaceHandler {
+    /// Returns whether this handler owns a custom embed payload.
+    fn handles_payload(&self, payload: &[u8]) -> bool;
+
+    /// Supplies a ready platform window. This may be called again after a
+    /// mobile host is recreated.
+    fn attach_host(&mut self, host: NativeSurfaceHost);
+
+    /// Presents every visible surface claimed by this handler for the frame.
+    ///
+    /// An empty slice means the handler should hide or detach its active
+    /// surfaces for this host.
+    fn present_surfaces(&mut self, frames: &[NativeSurfaceFrame]);
 }

--- a/crates/shell/fission-shell/src/lib.rs
+++ b/crates/shell/fission-shell/src/lib.rs
@@ -91,7 +91,8 @@ impl NativeSurfaceHost {
 /// platform views in [`attach_host`](NativeSurfaceHandler::attach_host), then
 /// reconcile their geometry and visibility in
 /// [`present_surfaces`](NativeSurfaceHandler::present_surfaces). The shell is
-/// intentionally unaware of individual extension types.
+/// intentionally unaware of individual extension types. A custom surface is
+/// delivered to the first registered handler that claims it.
 pub trait NativeSurfaceHandler {
     /// Returns whether this handler owns a custom embed payload.
     fn handles_payload(&self, payload: &[u8]) -> bool;

--- a/crates/shell/fission-shell/src/lib.rs
+++ b/crates/shell/fission-shell/src/lib.rs
@@ -1,7 +1,7 @@
 use fission_core::ui::VideoAudioOptions;
 use fission_ir::WidgetId;
 use fission_render::LayoutRect;
-use raw_window_handle::RawWindowHandle;
+use raw_window_handle::WindowHandle;
 use serde::{Deserialize, Serialize};
 
 pub mod async_host;
@@ -19,6 +19,16 @@ pub struct VideoSurfaceFrame {
     pub widget_id: WidgetId,
     pub surface_id: u64,
     pub rect: LayoutRect,
+    /// Visible axis-aligned portion after viewport and ancestor clipping.
+    pub visible_rect: LayoutRect,
+    /// Accumulated Fission presentation transform that produced `rect`.
+    /// `rect` is the transformed axis-aligned bounds; handlers can inspect this
+    /// matrix when they support rotation or other non-axis-aligned fidelity.
+    pub transform: Option<[f32; 16]>,
+    /// Accumulated ancestor opacity.
+    pub opacity: f32,
+    /// Stable paint-order position within the current frame.
+    pub paint_order: u32,
 }
 
 pub trait VideoBackend: Send + Sync {
@@ -62,32 +72,39 @@ pub struct NativeSurfaceFrame {
     /// The portion of [`rect`](Self::rect) that is actually visible after
     /// ancestor clipping (scroll viewports, `Clip` nodes, `clip_to_bounds`).
     ///
-    /// `None` means the full `rect` is visible (no ancestor clip applies).
-    /// When present, handlers should constrain their platform view to this
-    /// sub-rectangle.
-    pub visible_rect: Option<LayoutRect>,
+    /// Handlers should constrain their platform view to this sub-rectangle.
+    pub visible_rect: LayoutRect,
+    /// Accumulated Fission presentation transform that produced `rect`.
+    /// `rect` is the transformed axis-aligned bounds; handlers can inspect this
+    /// matrix when they support rotation or other non-axis-aligned fidelity.
+    pub transform: Option<[f32; 16]>,
+    /// Accumulated ancestor opacity.
+    pub opacity: f32,
+    /// Stable paint-order position within the current frame.
+    pub paint_order: u32,
 }
 
 /// A platform window made available to native-surface extensions.
 ///
-/// This deliberately exposes only a raw handle, keeping the shared shell
-/// contract independent of a particular windowing implementation.
+/// This deliberately exposes only a lifetime-bound window handle, keeping the
+/// shared shell contract independent of a particular windowing implementation
+/// without allowing the host wrapper itself to outlive the native window.
 #[derive(Debug, Clone, Copy)]
-pub struct NativeSurfaceHost {
-    raw_window_handle: RawWindowHandle,
+pub struct NativeSurfaceHost<'a> {
+    window_handle: WindowHandle<'a>,
 }
 
-impl NativeSurfaceHost {
+impl<'a> NativeSurfaceHost<'a> {
     /// Constructs a host wrapper for a platform window.
     ///
     /// Shell implementations call this after their native window is ready.
-    pub fn from_raw_window_handle(raw_window_handle: RawWindowHandle) -> Self {
-        Self { raw_window_handle }
+    pub fn from_window_handle(window_handle: WindowHandle<'a>) -> Self {
+        Self { window_handle }
     }
 
-    /// Returns the underlying platform window handle.
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
-        self.raw_window_handle
+    /// Returns the lifetime-bound platform window handle.
+    pub fn window_handle(&self) -> WindowHandle<'a> {
+        self.window_handle
     }
 }
 
@@ -121,7 +138,7 @@ pub trait NativeSurfaceHandler {
     /// On mobile platforms the host may be destroyed and recreated across
     /// suspend/resume cycles. When that happens, [`detach_host`](Self::detach_host)
     /// is called first, then `attach_host` is called again with the new window.
-    fn attach_host(&mut self, host: NativeSurfaceHost);
+    fn attach_host(&mut self, host: NativeSurfaceHost<'_>);
 
     /// Notifies the handler that the platform window is about to be destroyed.
     ///


### PR DESCRIPTION
## Summary
- add a generic `fission-shell` native-surface handler contract for opaque `EmbedKind::Custom` embeds
- route custom frames through `fission-shell-winit` while preserving the existing 3D consumer
- make ownership deterministic: the first registered handler that claims a payload receives it
- expose handler registration through the desktop and mobile shell wrappers

This PR deliberately contains no map-specific model, state, widget, or backend. A MapKit implementation is an external handler built against this contract.

## Verification
- `cargo test -p fission-shell-winit --lib --no-default-features` (110 tests)
- `cargo check -p fission-shell-desktop -p fission-shell-mobile -j 1`
- dispatch test for overlapping payload claims

Clippy with `-D warnings` remains blocked by existing warnings in unrelated workspace crates.