### PR TITLE
Fix desktop packaging with Cargo target overrides

### DIFF
--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -1531,13 +1531,30 @@ fn build_desktop_binary(project_dir: &Path, release: bool) -> Result<PathBuf> {
     } else {
         name
     };
-    let path = target_directory
-        .join(profile_name(release))
-        .join(executable);
+    let cargo_build_target = env::var_os("CARGO_BUILD_TARGET").filter(|value| !value.is_empty());
+    let path = desktop_binary_output_path(
+        &target_directory,
+        profile_name(release),
+        &executable,
+        cargo_build_target.as_deref(),
+    );
     if !path.exists() {
         bail!("expected built binary at {}", path.display());
     }
     Ok(path)
+}
+
+fn desktop_binary_output_path(
+    target_directory: &Path,
+    profile: &str,
+    executable: &str,
+    cargo_build_target: Option<&OsStr>,
+) -> PathBuf {
+    let mut path = target_directory.to_path_buf();
+    if let Some(target) = cargo_build_target {
+        path.push(target);
+    }
+    path.join(profile).join(executable)
 }
 
 #[derive(Deserialize)]

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -4,6 +4,7 @@ use super::package_validation::{
 use super::*;
 use fission_command_core::AppConfig;
 use std::collections::BTreeSet;
+use std::ffi::OsStr;
 use std::process::Command;
 
 #[test]
@@ -39,6 +40,25 @@ fn macos_info_plist_includes_capability_usage_descriptions() {
     assert!(plist.contains("NSMicrophoneUsageDescription"));
     assert!(plist.contains("<key>CFBundleShortVersionString</key>\n  <string>1.2.3</string>"));
     assert!(plist.contains("<key>CFBundleVersion</key>\n  <string>42</string>"));
+}
+
+#[test]
+fn desktop_binary_output_path_honours_cargo_build_target() {
+    let target_directory = Path::new("/workspace/target");
+
+    assert_eq!(
+        desktop_binary_output_path(target_directory, "release", "demo", None),
+        target_directory.join("release/demo")
+    );
+    assert_eq!(
+        desktop_binary_output_path(
+            target_directory,
+            "release",
+            "demo",
+            Some(OsStr::new("x86_64-apple-darwin")),
+        ),
+        target_directory.join("x86_64-apple-darwin/release/demo")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- honour Cargo's standard `CARGO_BUILD_TARGET` output layout when resolving desktop binaries
- preserve the existing host-target path when no override is set
- cover both path layouts with a focused unit test

This enables architecture-specific desktop packaging such as `CARGO_BUILD_TARGET=x86_64-apple-darwin fission package --target macos ...` without bypassing Fission.

## Validation

- `cargo test -p fission-command-package desktop_binary_output_path_honours_cargo_build_target --locked`
- `cargo fmt`
- `git diff --check`