### PR TITLE
Support macOS App Store packaging and distribution

### DIFF
--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -32,7 +32,8 @@ pub use macos_native::{
     NativeMacosProductKind, NativeMacosProductSigningConfig,
 };
 pub use macos_signing::{
-    read_macos_package_config, read_macos_package_config_for_profile, read_macos_run_config,
+    read_macos_package_config, read_macos_package_config_for_profile,
+    read_macos_package_config_for_profile_and_variant, read_macos_run_config,
     read_macos_run_config_for_profile, sign_macos_app_if_configured, MacosPackageConfig,
 };
 pub use native_variant::{ensure_native_variant_target, variant_output_path, NativeVariant};

--- a/crates/tools/fission-command-core/src/macos_signing.rs
+++ b/crates/tools/fission-command-core/src/macos_signing.rs
@@ -16,6 +16,10 @@ pub struct MacosPackageConfig {
     pub signing_identity: Option<String>,
     pub installer_identity: Option<String>,
     pub notarize: Option<bool>,
+    #[serde(default)]
+    pub cargo_features: Vec<String>,
+    #[serde(default)]
+    pub cargo_no_default_features: bool,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -57,6 +61,8 @@ struct MacosPackageOverlay {
     signing_identity: Option<String>,
     installer_identity: Option<String>,
     notarize: Option<bool>,
+    cargo_features: Option<Vec<String>>,
+    cargo_no_default_features: Option<bool>,
 }
 
 impl MacosPackageManifest {
@@ -94,6 +100,12 @@ impl MacosPackageOverlay {
         }
         if self.notarize.is_some() {
             config.notarize = self.notarize;
+        }
+        if let Some(features) = &self.cargo_features {
+            config.cargo_features.clone_from(features);
+        }
+        if let Some(no_default_features) = self.cargo_no_default_features {
+            config.cargo_no_default_features = no_default_features;
         }
     }
 }
@@ -305,6 +317,7 @@ signing_identity = "-"
                 signing_identity: Some("Apple Development".into()),
                 installer_identity: Some("Developer ID Installer".into()),
                 notarize: Some(true),
+                ..Default::default()
             }
         );
         let run = manifest.run.as_ref().unwrap().macos.as_ref().unwrap();
@@ -396,6 +409,8 @@ provisioning_profile = "profiles/AppStore.provisionprofile"
 signing_identity = "Apple Distribution: Example Ltd"
 installer_identity = "3rd Party Mac Developer Installer: Example Ltd"
 notarize = false
+cargo_features = ["macos-app-store"]
+cargo_no_default_features = true
 "#,
         )
         .unwrap();
@@ -420,6 +435,8 @@ notarize = false
             Some("3rd Party Mac Developer Installer: Example Ltd")
         );
         assert_eq!(config.notarize, Some(false));
+        assert_eq!(config.cargo_features, ["macos-app-store"]);
+        assert!(config.cargo_no_default_features);
     }
 
     #[test]

--- a/crates/tools/fission-command-core/src/macos_signing.rs
+++ b/crates/tools/fission-command-core/src/macos_signing.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 pub struct MacosPackageConfig {
     pub bundle_id: Option<String>,
     pub minimum_os: Option<String>,
+    pub application_category: Option<String>,
     pub entitlements: Option<String>,
     pub provisioning_profile: Option<String>,
     pub signing_identity: Option<String>,
@@ -57,6 +58,7 @@ struct MacosPackageManifest {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 struct MacosPackageOverlay {
+    application_category: Option<String>,
     entitlements: Option<String>,
     provisioning_profile: Option<String>,
     signing_identity: Option<String>,
@@ -84,6 +86,11 @@ impl MacosPackageManifest {
 
 impl MacosPackageOverlay {
     fn apply_to(&self, config: &mut MacosPackageConfig) {
+        if self.application_category.is_some() {
+            config
+                .application_category
+                .clone_from(&self.application_category);
+        }
         if self.entitlements.is_some() {
             config.entitlements.clone_from(&self.entitlements);
         }
@@ -205,6 +212,7 @@ pub fn sign_macos_app_if_configured(
     if let Some(profile) = profile {
         embed_macos_provisioning_profile(project_dir, app_bundle, profile)?;
     }
+    make_macos_bundle_world_readable(app_bundle)?;
 
     let Some(identity) = identity else {
         return Ok(());
@@ -254,6 +262,45 @@ fn embed_macos_provisioning_profile(
     Ok(())
 }
 
+fn make_macos_bundle_world_readable(app_bundle: &Path) -> Result<()> {
+    let mut pending = vec![app_bundle.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("failed to inspect macOS bundle path {}", path.display()))?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            for entry in fs::read_dir(&path)
+                .with_context(|| format!("failed to read macOS bundle path {}", path.display()))?
+            {
+                pending.push(entry?.path());
+            }
+        }
+        make_world_readable(&path, metadata.permissions())?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_world_readable(path: &Path, mut permissions: fs::Permissions) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let readable = if path.is_dir() { 0o0555 } else { 0o0444 };
+    permissions.set_mode(permissions.mode() | readable);
+    fs::set_permissions(path, permissions).with_context(|| {
+        format!(
+            "failed to make macOS bundle path readable: {}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn make_world_readable(_path: &Path, _permissions: fs::Permissions) -> Result<()> {
+    Ok(())
+}
+
 fn codesign_arguments(
     project_dir: &Path,
     identity: &str,
@@ -298,6 +345,7 @@ mod tests {
 [package.macos]
 bundle_id = "com.example.app"
 minimum_os = "14.0"
+application_category = "public.app-category.developer-tools"
 entitlements = "platforms/macos/App.entitlements"
 provisioning_profile = "profiles/Developer.provisionprofile"
 signing_identity = "Apple Development"
@@ -317,6 +365,7 @@ signing_identity = "-"
             MacosPackageConfig {
                 bundle_id: Some("com.example.app".into()),
                 minimum_os: Some("14.0".into()),
+                application_category: Some("public.app-category.developer-tools".into()),
                 entitlements: Some("platforms/macos/App.entitlements".into()),
                 provisioning_profile: Some("profiles/Developer.provisionprofile".into()),
                 signing_identity: Some("Apple Development".into()),
@@ -348,6 +397,7 @@ entitlements = "platforms/macos/Development.entitlements"
 signing_identity = "-"
 
 [package.macos.release]
+application_category = "public.app-category.utilities"
 entitlements = "platforms/macos/Release.entitlements"
 provisioning_profile = "profiles/Distribution.provisionprofile"
 signing_identity = "Developer ID Application: Example Ltd"
@@ -371,6 +421,10 @@ notarize = true
         assert_eq!(
             release.entitlements.as_deref(),
             Some("platforms/macos/Release.entitlements")
+        );
+        assert_eq!(
+            release.application_category.as_deref(),
+            Some("public.app-category.utilities")
         );
         assert_eq!(
             release.provisioning_profile.as_deref(),
@@ -540,6 +594,39 @@ signing_identity = "-"
         assert_eq!(
             fs::read(app.join("Contents/embedded.provisionprofile")).unwrap(),
             b"profile-data"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn macos_bundle_resources_are_readable_by_non_root_users() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "fission-macos-readable-bundle-{}",
+            std::process::id()
+        ));
+        let app = root.join("Demo.app");
+        let resource = app.join("Contents/Resources/private.dat");
+        fs::remove_dir_all(&root).ok();
+        fs::create_dir_all(resource.parent().unwrap()).unwrap();
+        fs::write(&resource, b"resource").unwrap();
+        fs::set_permissions(&resource, fs::Permissions::from_mode(0o600)).unwrap();
+
+        make_macos_bundle_world_readable(&app).unwrap();
+
+        assert_eq!(
+            fs::metadata(&resource).unwrap().permissions().mode() & 0o004,
+            0o004
+        );
+        assert_eq!(
+            fs::metadata(resource.parent().unwrap())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o001,
+            0o001
         );
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/tools/fission-command-core/src/macos_signing.rs
+++ b/crates/tools/fission-command-core/src/macos_signing.rs
@@ -212,6 +212,7 @@ pub fn sign_macos_app_if_configured(
     if let Some(profile) = profile {
         embed_macos_provisioning_profile(project_dir, app_bundle, profile)?;
     }
+    remove_macos_bundle_extended_attributes(app_bundle)?;
     make_macos_bundle_world_readable(app_bundle)?;
 
     let Some(identity) = identity else {
@@ -259,6 +260,21 @@ fn embed_macos_provisioning_profile(
             destination.display()
         )
     })?;
+    Ok(())
+}
+
+fn remove_macos_bundle_extended_attributes(_app_bundle: &Path) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let status = Command::new("xattr")
+            .args(["-c", "-r"])
+            .arg(_app_bundle)
+            .status()
+            .context("failed to remove extended attributes from macOS app bundle")?;
+        if !status.success() {
+            bail!("xattr failed with {status}");
+        }
+    }
     Ok(())
 }
 
@@ -628,6 +644,34 @@ signing_identity = "-"
                 & 0o001,
             0o001
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_bundle_extended_attributes_are_removed_before_signing() {
+        let root =
+            std::env::temp_dir().join(format!("fission-macos-clean-bundle-{}", std::process::id()));
+        let app = root.join("Demo.app");
+        let resource = app.join("Contents/Resources/downloaded.dat");
+        fs::remove_dir_all(&root).ok();
+        fs::create_dir_all(resource.parent().unwrap()).unwrap();
+        fs::write(&resource, b"resource").unwrap();
+        let status = Command::new("xattr")
+            .args(["-w", "com.apple.quarantine", "0081;test;Fission;"])
+            .arg(&resource)
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        remove_macos_bundle_extended_attributes(&app).unwrap();
+
+        let status = Command::new("xattr")
+            .args(["-p", "com.apple.quarantine"])
+            .arg(&resource)
+            .status()
+            .unwrap();
+        assert!(!status.success());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/tools/fission-command-core/src/macos_signing.rs
+++ b/crates/tools/fission-command-core/src/macos_signing.rs
@@ -1,5 +1,7 @@
+use crate::NativeVariant;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -43,11 +45,13 @@ struct MacosRunConfig {
 struct MacosPackageManifest {
     #[serde(flatten)]
     base: MacosPackageConfig,
-    release: Option<MacosReleasePackageConfig>,
+    release: Option<MacosPackageOverlay>,
+    #[serde(default)]
+    variants: BTreeMap<NativeVariant, MacosPackageOverlay>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
-struct MacosReleasePackageConfig {
+struct MacosPackageOverlay {
     entitlements: Option<String>,
     provisioning_profile: Option<String>,
     signing_identity: Option<String>,
@@ -56,18 +60,21 @@ struct MacosReleasePackageConfig {
 }
 
 impl MacosPackageManifest {
-    fn effective(&self, release: bool) -> MacosPackageConfig {
+    fn effective(&self, release: bool, variant: Option<&NativeVariant>) -> MacosPackageConfig {
         let mut config = self.base.clone();
         if release {
             if let Some(overlay) = &self.release {
                 overlay.apply_to(&mut config);
             }
         }
+        if let Some(overlay) = variant.and_then(|variant| self.variants.get(variant)) {
+            overlay.apply_to(&mut config);
+        }
         config
     }
 }
 
-impl MacosReleasePackageConfig {
+impl MacosPackageOverlay {
     fn apply_to(&self, config: &mut MacosPackageConfig) {
         if self.entitlements.is_some() {
             config.entitlements.clone_from(&self.entitlements);
@@ -99,8 +106,16 @@ pub fn read_macos_package_config_for_profile(
     project_dir: &Path,
     release: bool,
 ) -> Result<MacosPackageConfig> {
+    read_macos_package_config_for_profile_and_variant(project_dir, release, None)
+}
+
+pub fn read_macos_package_config_for_profile_and_variant(
+    project_dir: &Path,
+    release: bool,
+    variant: Option<&NativeVariant>,
+) -> Result<MacosPackageConfig> {
     let manifest = read_manifest(project_dir)?;
-    Ok(package_config(manifest.package.as_ref(), release))
+    Ok(package_config(manifest.package.as_ref(), release, variant))
 }
 
 pub fn read_macos_run_config(project_dir: &Path) -> Result<MacosPackageConfig> {
@@ -116,7 +131,7 @@ pub fn read_macos_run_config_for_profile(
 
 fn run_config(manifest: &PackageManifest, release: bool) -> MacosPackageConfig {
     let run = manifest.run.as_ref().and_then(|run| run.macos.as_ref());
-    let mut config = package_config(manifest.package.as_ref(), release);
+    let mut config = package_config(manifest.package.as_ref(), release, None);
     if let Some(run) = run {
         if run.entitlements.is_some() {
             config.entitlements.clone_from(&run.entitlements);
@@ -140,10 +155,14 @@ fn read_manifest(project_dir: &Path) -> Result<PackageManifest> {
     toml::from_str(&data).with_context(|| format!("failed to parse {}", path.display()))
 }
 
-fn package_config(package: Option<&PackageRoot>, release: bool) -> MacosPackageConfig {
+fn package_config(
+    package: Option<&PackageRoot>,
+    release: bool,
+    variant: Option<&NativeVariant>,
+) -> MacosPackageConfig {
     package
         .and_then(|package| package.macos.as_ref())
-        .map(|macos| macos.effective(release))
+        .map(|macos| macos.effective(release, variant))
         .unwrap_or_default()
 }
 
@@ -277,7 +296,7 @@ signing_identity = "-"
         .unwrap();
 
         assert_eq!(
-            package_config(manifest.package.as_ref(), false),
+            package_config(manifest.package.as_ref(), false, None),
             MacosPackageConfig {
                 bundle_id: Some("com.example.app".into()),
                 minimum_os: Some("14.0".into()),
@@ -320,7 +339,7 @@ notarize = true
         )
         .unwrap();
 
-        let debug = package_config(manifest.package.as_ref(), false);
+        let debug = package_config(manifest.package.as_ref(), false, None);
         assert_eq!(
             debug.entitlements.as_deref(),
             Some("platforms/macos/Development.entitlements")
@@ -330,7 +349,7 @@ notarize = true
         assert_eq!(debug.installer_identity, None);
         assert_eq!(debug.notarize, None);
 
-        let release = package_config(manifest.package.as_ref(), true);
+        let release = package_config(manifest.package.as_ref(), true, None);
         assert_eq!(
             release.entitlements.as_deref(),
             Some("platforms/macos/Release.entitlements")
@@ -354,6 +373,53 @@ notarize = true
             release_run.signing_identity.as_deref(),
             Some("Developer ID Application: Example Ltd")
         );
+    }
+
+    #[test]
+    fn selected_variant_overrides_effective_release_signing() {
+        let manifest: PackageManifest = toml::from_str(
+            r#"
+[package.macos]
+bundle_id = "com.example.app"
+signing_identity = "-"
+
+[package.macos.release]
+entitlements = "platforms/macos/DeveloperId.entitlements"
+provisioning_profile = "profiles/DeveloperId.provisionprofile"
+signing_identity = "Developer ID Application: Example Ltd"
+installer_identity = "Developer ID Installer: Example Ltd"
+notarize = true
+
+[package.macos.variants.app-store]
+entitlements = "platforms/macos/AppStore.entitlements"
+provisioning_profile = "profiles/AppStore.provisionprofile"
+signing_identity = "Apple Distribution: Example Ltd"
+installer_identity = "3rd Party Mac Developer Installer: Example Ltd"
+notarize = false
+"#,
+        )
+        .unwrap();
+        let variant: NativeVariant = "app-store".parse().unwrap();
+
+        let config = package_config(manifest.package.as_ref(), true, Some(&variant));
+
+        assert_eq!(
+            config.entitlements.as_deref(),
+            Some("platforms/macos/AppStore.entitlements")
+        );
+        assert_eq!(
+            config.provisioning_profile.as_deref(),
+            Some("profiles/AppStore.provisionprofile")
+        );
+        assert_eq!(
+            config.signing_identity.as_deref(),
+            Some("Apple Distribution: Example Ltd")
+        );
+        assert_eq!(
+            config.installer_identity.as_deref(),
+            Some("3rd Party Mac Developer Installer: Example Ltd")
+        );
+        assert_eq!(config.notarize, Some(false));
     }
 
     #[test]

--- a/crates/tools/fission-command-core/src/macos_signing.rs
+++ b/crates/tools/fission-command-core/src/macos_signing.rs
@@ -16,6 +16,7 @@ pub struct MacosPackageConfig {
     pub signing_identity: Option<String>,
     pub installer_identity: Option<String>,
     pub notarize: Option<bool>,
+    pub pkg_builder: Option<String>,
     #[serde(default)]
     pub cargo_features: Vec<String>,
     #[serde(default)]
@@ -61,6 +62,7 @@ struct MacosPackageOverlay {
     signing_identity: Option<String>,
     installer_identity: Option<String>,
     notarize: Option<bool>,
+    pkg_builder: Option<String>,
     cargo_features: Option<Vec<String>>,
     cargo_no_default_features: Option<bool>,
 }
@@ -100,6 +102,9 @@ impl MacosPackageOverlay {
         }
         if self.notarize.is_some() {
             config.notarize = self.notarize;
+        }
+        if self.pkg_builder.is_some() {
+            config.pkg_builder.clone_from(&self.pkg_builder);
         }
         if let Some(features) = &self.cargo_features {
             config.cargo_features.clone_from(features);
@@ -409,6 +414,7 @@ provisioning_profile = "profiles/AppStore.provisionprofile"
 signing_identity = "Apple Distribution: Example Ltd"
 installer_identity = "3rd Party Mac Developer Installer: Example Ltd"
 notarize = false
+pkg_builder = "productbuild"
 cargo_features = ["macos-app-store"]
 cargo_no_default_features = true
 "#,
@@ -435,6 +441,7 @@ cargo_no_default_features = true
             Some("3rd Party Mac Developer Installer: Example Ltd")
         );
         assert_eq!(config.notarize, Some(false));
+        assert_eq!(config.pkg_builder.as_deref(), Some("productbuild"));
         assert_eq!(config.cargo_features, ["macos-app-store"]);
         assert!(config.cargo_no_default_features);
     }

--- a/crates/tools/fission-command-package/src/artifact.rs
+++ b/crates/tools/fission-command-package/src/artifact.rs
@@ -105,6 +105,7 @@ pub(super) fn package_signing_context(
     target: Target,
     format: PackageFormat,
     release: bool,
+    variant: Option<&NativeVariant>,
     checks: &[ReadinessCheck],
 ) -> Result<Option<ArtifactSigning>> {
     if !package_format_requires_signing(format) {
@@ -131,7 +132,7 @@ pub(super) fn package_signing_context(
     };
     Ok(Some(ArtifactSigning {
         state: state.to_string(),
-        identity: package_signing_identity(project_dir, target, format, release)?,
+        identity: package_signing_identity(project_dir, target, format, release, variant)?,
         certificate_sha256: None,
     }))
 }
@@ -140,6 +141,7 @@ pub(super) fn package_notarization_context(
     project_dir: &Path,
     target: Target,
     release: bool,
+    variant: Option<&NativeVariant>,
 ) -> Result<Option<Value>> {
     if target != Target::Macos {
         return Ok(None);
@@ -147,7 +149,11 @@ pub(super) fn package_notarization_context(
     if !project_dir.join("fission.toml").exists() {
         return Ok(None);
     }
-    let macos = fission_command_core::read_macos_package_config_for_profile(project_dir, release)?;
+    let macos = fission_command_core::read_macos_package_config_for_profile_and_variant(
+        project_dir,
+        release,
+        variant,
+    )?;
     if macos.notarize.unwrap_or(false) {
         Ok(Some(json!({
             "state": "configured",
@@ -177,13 +183,17 @@ pub(super) fn package_signing_identity(
     target: Target,
     format: PackageFormat,
     release: bool,
+    variant: Option<&NativeVariant>,
 ) -> Result<Option<String>> {
     if target == Target::Macos {
         if !project_dir.join("fission.toml").exists() {
             return Ok(None);
         }
-        let macos =
-            fission_command_core::read_macos_package_config_for_profile(project_dir, release)?;
+        let macos = fission_command_core::read_macos_package_config_for_profile_and_variant(
+            project_dir,
+            release,
+            variant,
+        )?;
         return Ok(match format {
             PackageFormat::Pkg => macos.installer_identity.or(macos.signing_identity),
             PackageFormat::App => macos.signing_identity,

--- a/crates/tools/fission-command-package/src/lib.rs
+++ b/crates/tools/fission-command-package/src/lib.rs
@@ -411,6 +411,7 @@ struct PlayStoreConfig {
 struct AppStoreConfig {
     app_id: Option<String>,
     bundle_id: Option<String>,
+    platform: Option<String>,
     issuer_id: Option<String>,
     key_id: Option<String>,
     default_track: Option<String>,

--- a/crates/tools/fission-command-package/src/lib_tests.rs
+++ b/crates/tools/fission-command-package/src/lib_tests.rs
@@ -396,6 +396,7 @@ fn app_store_status_prefers_review_submission_state_over_build_processing() {
                 "attributes": { "state": "WAITING_FOR_REVIEW" }
             }]
         }),
+        &json!({ "data": [] }),
     );
     assert_eq!(status, "waiting_for_review");
 }
@@ -407,6 +408,35 @@ fn app_store_status_queries_the_sortable_global_builds_endpoint() {
     assert!(url.contains("/v1/builds?filter[app]=6794005791"));
     assert!(url.contains("sort=-uploadedDate"));
     assert!(!url.contains("/v1/apps/6794005791/builds"));
+}
+
+#[test]
+fn app_store_status_reports_build_upload_failures_before_a_build_exists() {
+    let status = stores::app_store_observed_status(
+        &json!({ "data": [] }),
+        &json!({ "data": [] }),
+        &json!({
+            "data": [{
+                "attributes": {
+                    "state": {
+                        "state": "FAILED",
+                        "errors": [{ "code": "91109" }]
+                    }
+                }
+            }]
+        }),
+    );
+
+    assert_eq!(status, "failed");
+}
+
+#[test]
+fn app_store_build_upload_status_uses_the_app_relationship_endpoint() {
+    let url = stores::app_store_build_uploads_status_url("6794005791");
+
+    assert!(url.contains("/v1/apps/6794005791/buildUploads"));
+    assert!(url.contains("sort=-uploadedDate"));
+    assert!(url.contains("fields[buildUploads]"));
 }
 
 #[test]

--- a/crates/tools/fission-command-package/src/lib_tests.rs
+++ b/crates/tools/fission-command-package/src/lib_tests.rs
@@ -282,6 +282,7 @@ keystore_alias = "upload"
         Target::Android,
         PackageFormat::Aab,
         false,
+        None,
         &[ReadinessCheck {
             id: "release.package.signature.android_aab".to_string(),
             severity: CheckSeverity::Warning,
@@ -318,23 +319,27 @@ notarize = true
     .unwrap();
 
     assert_eq!(
-        package_signing_identity(&dir, Target::Macos, PackageFormat::App, false).unwrap(),
+        package_signing_identity(&dir, Target::Macos, PackageFormat::App, false, None).unwrap(),
         None
     );
     assert_eq!(
-        package_signing_identity(&dir, Target::Macos, PackageFormat::App, true).unwrap(),
+        package_signing_identity(&dir, Target::Macos, PackageFormat::App, true, None).unwrap(),
         Some("Developer ID Application: Example Ltd".to_string())
     );
     assert_eq!(
-        package_signing_identity(&dir, Target::Macos, PackageFormat::Pkg, true).unwrap(),
+        package_signing_identity(&dir, Target::Macos, PackageFormat::Pkg, true, None).unwrap(),
         Some("Developer ID Installer: Example Ltd".to_string())
     );
-    assert!(package_notarization_context(&dir, Target::Macos, false)
-        .unwrap()
-        .is_none());
-    assert!(package_notarization_context(&dir, Target::Macos, true)
-        .unwrap()
-        .is_some());
+    assert!(
+        package_notarization_context(&dir, Target::Macos, false, None)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        package_notarization_context(&dir, Target::Macos, true, None)
+            .unwrap()
+            .is_some()
+    );
     fs::remove_dir_all(dir).unwrap();
 }
 

--- a/crates/tools/fission-command-package/src/lib_tests.rs
+++ b/crates/tools/fission-command-package/src/lib_tests.rs
@@ -344,6 +344,33 @@ notarize = true
 }
 
 #[test]
+fn macos_app_store_package_uses_productbuild_component_archive() {
+    let app = Path::new("/tmp/Developer Defence.app");
+    let pkg = Path::new("/tmp/Developer-Defence.pkg");
+    let config = fission_command_core::MacosPackageConfig {
+        installer_identity: Some("3rd Party Mac Developer Installer: Example Ltd".to_string()),
+        pkg_builder: Some("productbuild".to_string()),
+        ..Default::default()
+    };
+
+    let (builder, arguments) = package::macos_pkg_builder_command(app, pkg, &config).unwrap();
+
+    assert_eq!(builder, "productbuild");
+    assert_eq!(
+        arguments,
+        [
+            "--sign",
+            "3rd Party Mac Developer Installer: Example Ltd",
+            "--component",
+            "/tmp/Developer Defence.app",
+            "/Applications",
+            "/tmp/Developer-Defence.pkg",
+        ]
+        .map(std::ffi::OsString::from)
+    );
+}
+
+#[test]
 fn app_store_status_prefers_review_submission_state_over_build_processing() {
     let status = stores::app_store_observed_status(
         &json!({

--- a/crates/tools/fission-command-package/src/lib_tests.rs
+++ b/crates/tools/fission-command-package/src/lib_tests.rs
@@ -371,6 +371,19 @@ fn macos_app_store_package_uses_productbuild_component_archive() {
 }
 
 #[test]
+fn macos_info_plist_includes_configured_application_category() {
+    let config = fission_command_core::MacosPackageConfig {
+        application_category: Some("public.app-category.developer-tools".to_string()),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        package::render_macos_application_category_entry(&config),
+        "  <key>LSApplicationCategoryType</key>\n  <string>public.app-category.developer-tools</string>"
+    );
+}
+
+#[test]
 fn app_store_status_prefers_review_submission_state_over_build_processing() {
     let status = stores::app_store_observed_status(
         &json!({

--- a/crates/tools/fission-command-package/src/lib_tests.rs
+++ b/crates/tools/fission-command-package/src/lib_tests.rs
@@ -401,6 +401,15 @@ fn app_store_status_prefers_review_submission_state_over_build_processing() {
 }
 
 #[test]
+fn app_store_status_queries_the_sortable_global_builds_endpoint() {
+    let url = stores::app_store_builds_status_url("6794005791");
+
+    assert!(url.contains("/v1/builds?filter[app]=6794005791"));
+    assert!(url.contains("sort=-uploadedDate"));
+    assert!(!url.contains("/v1/apps/6794005791/builds"));
+}
+
+#[test]
 fn app_store_upload_follow_up_points_to_review_submission_command() {
     let msg = stores::app_store_upload_follow_up(
         "app-store-review",

--- a/crates/tools/fission-command-package/src/lib_tests.rs
+++ b/crates/tools/fission-command-package/src/lib_tests.rs
@@ -353,7 +353,7 @@ fn macos_app_store_package_uses_productbuild_component_archive() {
         ..Default::default()
     };
 
-    let (builder, arguments) = package::macos_pkg_builder_command(app, pkg, &config).unwrap();
+    let (builder, arguments) = package::macos_pkg_builder_command(app, pkg, None, &config).unwrap();
 
     assert_eq!(builder, "productbuild");
     assert_eq!(
@@ -368,6 +368,54 @@ fn macos_app_store_package_uses_productbuild_component_archive() {
         ]
         .map(std::ffi::OsString::from)
     );
+}
+
+#[test]
+fn macos_developer_id_package_uses_a_non_relocatable_component_root() {
+    let app = Path::new("/tmp/app-staging/Developer Defence.app");
+    let pkg = Path::new("/tmp/Developer-Defence.pkg");
+    let component_plist = Path::new("/tmp/components.plist");
+    let config = fission_command_core::MacosPackageConfig {
+        installer_identity: Some("Developer ID Installer: Example Ltd".to_string()),
+        ..Default::default()
+    };
+
+    let (builder, arguments) =
+        package::macos_pkg_builder_command(app, pkg, Some(component_plist), &config).unwrap();
+
+    assert_eq!(builder, "pkgbuild");
+    assert_eq!(
+        arguments,
+        [
+            "--root",
+            "/tmp/app-staging",
+            "--install-location",
+            "/Applications",
+            "--component-plist",
+            "/tmp/components.plist",
+            "--sign",
+            "Developer ID Installer: Example Ltd",
+            "/tmp/Developer-Defence.pkg",
+        ]
+        .map(std::ffi::OsString::from)
+    );
+}
+
+#[test]
+fn macos_component_plist_disables_bundle_relocation() {
+    let dir = unique_dir("macos-component-plist");
+    let app = dir.join("app-staging/Developer & Defence.app");
+    fs::create_dir_all(&app).unwrap();
+
+    let component_plist = package::write_macos_component_plist(&dir, &app).unwrap();
+    let contents = fs::read_to_string(component_plist).unwrap();
+
+    assert!(contents.contains("<string>Developer &amp; Defence.app</string>"));
+    assert!(contents.contains("<key>BundleIsRelocatable</key>\n    <false/>"));
+    assert!(contents.contains("<key>BundleIsVersionChecked</key>\n    <false/>"));
+    assert!(contents.contains("<key>BundleHasStrictIdentifier</key>\n    <true/>"));
+    assert!(contents.contains("<key>BundleOverwriteAction</key>\n    <string>upgrade</string>"));
+    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -1715,6 +1715,7 @@ fn render_info_plist(
   <key>LSMinimumSystemVersion</key>
   <string>{}</string>
 {}
+{}
 </dict>
 </plist>
 "#,
@@ -1725,8 +1726,23 @@ fn render_info_plist(
         escape_xml(version),
         escape_xml(build),
         escape_xml(minimum_os),
+        render_macos_application_category_entry(macos),
         render_macos_info_plist_capability_entries(project)
     )
+}
+
+pub(super) fn render_macos_application_category_entry(macos: &MacosPackageConfig) -> String {
+    macos
+        .application_category
+        .as_deref()
+        .filter(|category| !category.trim().is_empty())
+        .map(|category| {
+            format!(
+                "  <key>LSApplicationCategoryType</key>\n  <string>{}</string>",
+                escape_xml(category)
+            )
+        })
+        .unwrap_or_default()
 }
 
 fn render_macos_info_plist_capability_entries(project: &FissionProject) -> String {

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -413,7 +413,13 @@ fn package_macos_pkg(options: &PackageOptions) -> Result<ArtifactManifest> {
         sanitize_file_stem(&project.app.name),
         version
     ));
-    let (pkg_builder, pkg_arguments) = macos_pkg_builder_command(&app_bundle, &pkg_path, &macos)?;
+    let component_plist = if macos.pkg_builder.as_deref().unwrap_or("pkgbuild") == "pkgbuild" {
+        Some(write_macos_component_plist(&staging_dir, &app_bundle)?)
+    } else {
+        None
+    };
+    let (pkg_builder, pkg_arguments) =
+        macos_pkg_builder_command(&app_bundle, &pkg_path, component_plist.as_deref(), &macos)?;
     if find_in_path(pkg_builder).is_none() {
         bail!(
             "{pkg_builder} was not found; install Xcode command line tools to create macOS .pkg packages"
@@ -425,6 +431,14 @@ fn package_macos_pkg(options: &PackageOptions) -> Result<ArtifactManifest> {
         .with_context(|| format!("failed to run {pkg_builder}"))?;
     if !status.success() {
         bail!("{pkg_builder} failed with {status}");
+    }
+    if let Some(component_plist) = component_plist {
+        fs::remove_file(&component_plist).with_context(|| {
+            format!(
+                "failed to remove macOS component property list {}",
+                component_plist.display()
+            )
+        })?;
     }
     notarize_macos_artifact_if_configured(&pkg_path, &macos)?;
     fs::remove_dir_all(&app_staging).ok();
@@ -1796,15 +1810,23 @@ fn pkgbuild_signing_args(macos: &MacosPackageConfig) -> Vec<String> {
 pub(super) fn macos_pkg_builder_command(
     app_bundle: &Path,
     pkg_path: &Path,
+    component_plist: Option<&Path>,
     macos: &MacosPackageConfig,
 ) -> Result<(&'static str, Vec<OsString>)> {
     match macos.pkg_builder.as_deref().unwrap_or("pkgbuild") {
         "pkgbuild" => {
+            let component_root = app_bundle
+                .parent()
+                .context("macOS app bundle must have a component root")?;
+            let component_plist =
+                component_plist.context("pkgbuild requires a macOS component property list")?;
             let mut args = vec![
-                OsString::from("--component"),
-                app_bundle.as_os_str().to_owned(),
+                OsString::from("--root"),
+                component_root.as_os_str().to_owned(),
                 OsString::from("--install-location"),
                 OsString::from("/Applications"),
+                OsString::from("--component-plist"),
+                component_plist.as_os_str().to_owned(),
             ];
             args.extend(pkgbuild_signing_args(macos).into_iter().map(OsString::from));
             args.push(pkg_path.as_os_str().to_owned());
@@ -1828,6 +1850,46 @@ pub(super) fn macos_pkg_builder_command(
             bail!("package.macos pkg_builder must be `pkgbuild` or `productbuild`, got `{other}`")
         }
     }
+}
+
+pub(super) fn write_macos_component_plist(
+    staging_dir: &Path,
+    app_bundle: &Path,
+) -> Result<PathBuf> {
+    let bundle_name = app_bundle
+        .file_name()
+        .and_then(OsStr::to_str)
+        .context("macOS app bundle name must be valid UTF-8")?;
+    let component_plist = staging_dir.join("components.plist");
+    let contents = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+  <dict>
+    <key>RootRelativeBundlePath</key>
+    <string>{}</string>
+    <key>BundleIsRelocatable</key>
+    <false/>
+    <key>BundleIsVersionChecked</key>
+    <false/>
+    <key>BundleHasStrictIdentifier</key>
+    <true/>
+    <key>BundleOverwriteAction</key>
+    <string>upgrade</string>
+  </dict>
+</array>
+</plist>
+"#,
+        escape_xml(bundle_name)
+    );
+    fs::write(&component_plist, contents).with_context(|| {
+        format!(
+            "failed to write macOS component property list {}",
+            component_plist.display()
+        )
+    })?;
+    Ok(component_plist)
 }
 
 fn write_linux_run(

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
 use fission_command_core::{
     build_linux_native_modules, build_windows_native_modules, cargo_package_name,
     embed_and_sign_macos_native_modules, ensure_native_variant_target, normalized_extension,
-    read_macos_package_config_for_profile, read_project_config, resolve_app_icon,
+    read_macos_package_config_for_profile_and_variant, read_project_config, resolve_app_icon,
     sign_macos_app_if_configured, stage_linux_native_products, stage_project_assets,
     stage_windows_runtime_products, sync_platform_config, variant_output_path,
     BuiltLinuxNativeProduct, BuiltWindowsNativeProduct, FissionProject, MacosNativeBundleMode,
@@ -362,7 +362,11 @@ fn package_macos_app(options: &PackageOptions) -> Result<ArtifactManifest> {
     let project = read_project_config(&options.project_dir)?;
     let profile = profile_name(options.release);
     let staging_dir = clean_package_dir(options)?;
-    let macos = read_macos_package_config_for_profile(&options.project_dir, options.release)?;
+    let macos = read_macos_package_config_for_profile_and_variant(
+        &options.project_dir,
+        options.release,
+        options.variant.as_ref(),
+    )?;
     let app_bundle = create_macos_app_bundle(options, &project, &staging_dir, &macos)?;
     embed_and_sign_macos_native_modules(
         &options.project_dir,
@@ -386,7 +390,11 @@ fn package_macos_pkg(options: &PackageOptions) -> Result<ArtifactManifest> {
     let profile = profile_name(options.release);
     let staging_dir = clean_package_dir(options)?;
     let app_staging = staging_dir.join("app-staging");
-    let macos = read_macos_package_config_for_profile(&options.project_dir, options.release)?;
+    let macos = read_macos_package_config_for_profile_and_variant(
+        &options.project_dir,
+        options.release,
+        options.variant.as_ref(),
+    )?;
     let app_bundle = create_macos_app_bundle(options, &project, &app_staging, &macos)?;
     embed_and_sign_macos_native_modules(
         &options.project_dir,
@@ -617,10 +625,15 @@ fn finish_artifact_manifest(
         options.target,
         options.format,
         options.release,
+        options.variant.as_ref(),
         &manifest.validation.checks,
     )?;
-    manifest.notarization =
-        package_notarization_context(&options.project_dir, options.target, options.release)?;
+    manifest.notarization = package_notarization_context(
+        &options.project_dir,
+        options.target,
+        options.release,
+        options.variant.as_ref(),
+    )?;
     let manifest_path = staging_dir.join(ARTIFACT_MANIFEST);
     fs::write(&manifest_path, serde_json::to_vec_pretty(&manifest)?).with_context(|| {
         format!(

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -249,7 +249,7 @@ fn package_linux_run(options: &PackageOptions) -> Result<ArtifactManifest> {
     let staging_dir = clean_package_dir(options)?;
     let payload_dir = staging_dir.join("payload");
     fs::create_dir_all(&payload_dir)?;
-    let binary = build_desktop_binary(&options.project_dir, options.release)?;
+    let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
     let executable_name = binary
         .file_name()
         .and_then(OsStr::to_str)
@@ -330,7 +330,7 @@ fn package_terminal_run(options: &PackageOptions) -> Result<ArtifactManifest> {
     let staging_dir = clean_package_dir(options)?;
     let payload_dir = staging_dir.join("payload");
     fs::create_dir_all(&payload_dir)?;
-    let binary = build_desktop_binary(&options.project_dir, options.release)?;
+    let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
     let executable_name = binary
         .file_name()
         .and_then(OsStr::to_str)
@@ -439,7 +439,7 @@ fn package_windows_exe(options: &PackageOptions) -> Result<ArtifactManifest> {
     let project = read_project_config(&options.project_dir)?;
     let profile = profile_name(options.release);
     let staging_dir = clean_package_dir(options)?;
-    let binary = build_desktop_binary(&options.project_dir, options.release)?;
+    let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
     let native_products = build_windows_native_modules(
         &options.project_dir,
         &project,
@@ -560,7 +560,7 @@ fn package_with_project_script(
     }
     let mut environment = Vec::new();
     if target == Target::Windows {
-        let binary = build_desktop_binary(&options.project_dir, options.release)?;
+        let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
         let native_products = build_windows_native_modules(
             &options.project_dir,
             &project,
@@ -1514,7 +1514,12 @@ fn require_host_os(target: Target) -> Result<()> {
     }
 }
 
-fn build_desktop_binary(project_dir: &Path, release: bool) -> Result<PathBuf> {
+fn build_desktop_binary(
+    project_dir: &Path,
+    release: bool,
+    cargo_features: &[String],
+    cargo_no_default_features: bool,
+) -> Result<PathBuf> {
     let project_dir = fs::canonicalize(project_dir).with_context(|| {
         format!(
             "failed to resolve project directory {}",
@@ -1533,6 +1538,12 @@ fn build_desktop_binary(project_dir: &Path, release: bool) -> Result<PathBuf> {
         .current_dir(&project_dir);
     if release {
         command.arg("--release");
+    }
+    if cargo_no_default_features {
+        command.arg("--no-default-features");
+    }
+    if !cargo_features.is_empty() {
+        command.arg("--features").arg(cargo_features.join(","));
     }
     let status = command.status().context("failed to run cargo build")?;
     if !status.success() {
@@ -1604,7 +1615,12 @@ fn create_macos_app_bundle(
     staging_dir: &Path,
     macos: &MacosPackageConfig,
 ) -> Result<PathBuf> {
-    let binary = build_desktop_binary(&options.project_dir, options.release)?;
+    let binary = build_desktop_binary(
+        &options.project_dir,
+        options.release,
+        &macos.cargo_features,
+        macos.cargo_no_default_features,
+    )?;
     let executable = binary
         .file_name()
         .and_then(OsStr::to_str)

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -413,20 +413,18 @@ fn package_macos_pkg(options: &PackageOptions) -> Result<ArtifactManifest> {
         sanitize_file_stem(&project.app.name),
         version
     ));
-    if find_in_path("pkgbuild").is_none() {
-        bail!("pkgbuild was not found; install Xcode command line tools to create macOS .pkg packages");
+    let (pkg_builder, pkg_arguments) = macos_pkg_builder_command(&app_bundle, &pkg_path, &macos)?;
+    if find_in_path(pkg_builder).is_none() {
+        bail!(
+            "{pkg_builder} was not found; install Xcode command line tools to create macOS .pkg packages"
+        );
     }
-    let status = Command::new("pkgbuild")
-        .arg("--component")
-        .arg(&app_bundle)
-        .arg("--install-location")
-        .arg("/Applications")
-        .args(pkgbuild_signing_args(&macos))
-        .arg(&pkg_path)
+    let status = Command::new(pkg_builder)
+        .args(pkg_arguments)
         .status()
-        .context("failed to run pkgbuild")?;
+        .with_context(|| format!("failed to run {pkg_builder}"))?;
     if !status.success() {
-        bail!("pkgbuild failed with {status}");
+        bail!("{pkg_builder} failed with {status}");
     }
     notarize_macos_artifact_if_configured(&pkg_path, &macos)?;
     fs::remove_dir_all(&app_staging).ok();
@@ -1777,6 +1775,43 @@ fn pkgbuild_signing_args(macos: &MacosPackageConfig) -> Vec<String> {
         .filter(|value| !value.trim().is_empty())
         .map(|identity| vec!["--sign".to_string(), identity.to_string()])
         .unwrap_or_default()
+}
+
+pub(super) fn macos_pkg_builder_command(
+    app_bundle: &Path,
+    pkg_path: &Path,
+    macos: &MacosPackageConfig,
+) -> Result<(&'static str, Vec<OsString>)> {
+    match macos.pkg_builder.as_deref().unwrap_or("pkgbuild") {
+        "pkgbuild" => {
+            let mut args = vec![
+                OsString::from("--component"),
+                app_bundle.as_os_str().to_owned(),
+                OsString::from("--install-location"),
+                OsString::from("/Applications"),
+            ];
+            args.extend(pkgbuild_signing_args(macos).into_iter().map(OsString::from));
+            args.push(pkg_path.as_os_str().to_owned());
+            Ok(("pkgbuild", args))
+        }
+        "productbuild" => {
+            let mut args = Vec::new();
+            if let Some(identity) = macos.installer_identity.as_deref() {
+                args.push(OsString::from("--sign"));
+                args.push(OsString::from(identity));
+            }
+            args.extend([
+                OsString::from("--component"),
+                app_bundle.as_os_str().to_owned(),
+                OsString::from("/Applications"),
+                pkg_path.as_os_str().to_owned(),
+            ]);
+            Ok(("productbuild", args))
+        }
+        other => {
+            bail!("package.macos pkg_builder must be `pkgbuild` or `productbuild`, got `{other}`")
+        }
+    }
 }
 
 fn write_linux_run(

--- a/crates/tools/fission-command-package/src/readiness.rs
+++ b/crates/tools/fission-command-package/src/readiness.rs
@@ -1290,10 +1290,10 @@ fn artifact_manifest_hashes_check(manifest: &ArtifactManifest) -> ReadinessCheck
 
 fn artifact_file_path(manifest: &ArtifactManifest, artifact: &ArtifactFile) -> PathBuf {
     let path = PathBuf::from(&artifact.path);
-    if path.is_absolute() {
+    if path.is_absolute() || path.is_file() {
         path
     } else {
-        Path::new(&manifest.root_dir).join(path)
+        Path::new(&manifest.root_dir).join(&artifact.relative_path)
     }
 }
 

--- a/crates/tools/fission-command-package/src/stores.rs
+++ b/crates/tools/fission-command-package/src/stores.rs
@@ -415,6 +415,16 @@ pub(super) fn app_store_status(
         .send()
         .context("failed to query App Store Connect build status")?;
     let builds = json_response(builds_response, "App Store Connect build status")?;
+    let build_uploads_url = app_store_build_uploads_status_url(&app_id);
+    let build_uploads_response = client
+        .get(build_uploads_url)
+        .bearer_auth(&token)
+        .send()
+        .context("failed to query App Store Connect build upload status")?;
+    let build_uploads = json_response(
+        build_uploads_response,
+        "App Store Connect build upload status",
+    )?;
     let review_submissions_url = format!(
         "{APP_STORE_API}/v1/apps/{app_id}/reviewSubmissions?limit=10&fields[reviewSubmissions]=state,platform&include=items&fields[reviewSubmissionItems]=state,appStoreVersion"
     );
@@ -433,10 +443,11 @@ pub(super) fn app_store_status(
         .send()
         .context("failed to query App Store TestFlight beta group status")?;
     let beta_groups = json_response(beta_groups_response, "App Store beta groups status")?;
-    let status = app_store_observed_status(&builds, &review_submissions);
+    let status = app_store_observed_status(&builds, &review_submissions, &build_uploads);
     let stdout = json!({
         "app_id": app_id,
         "builds": builds,
+        "build_uploads": build_uploads,
         "review_submissions": review_submissions,
         "beta_groups": beta_groups,
     });
@@ -461,6 +472,12 @@ pub(super) fn app_store_status(
 pub(super) fn app_store_builds_status_url(app_id: &str) -> String {
     format!(
         "{APP_STORE_API}/v1/builds?filter[app]={app_id}&limit=10&sort=-uploadedDate&fields[builds]=version,uploadedDate,processingState,expired,minOsVersion,usesNonExemptEncryption"
+    )
+}
+
+pub(super) fn app_store_build_uploads_status_url(app_id: &str) -> String {
+    format!(
+        "{APP_STORE_API}/v1/apps/{app_id}/buildUploads?limit=10&sort=-uploadedDate&fields[buildUploads]=cfBundleShortVersionString,cfBundleVersion,createdDate,state,platform,uploadedDate,build"
     )
 }
 
@@ -792,9 +809,31 @@ pub(super) fn microsoft_store_status(
     })
 }
 
-pub(super) fn app_store_observed_status(builds: &Value, review_submissions: &Value) -> String {
+pub(super) fn app_store_observed_status(
+    builds: &Value,
+    review_submissions: &Value,
+    build_uploads: &Value,
+) -> String {
     app_store_latest_review_submission_status(review_submissions)
-        .unwrap_or_else(|| app_store_latest_build_status(builds))
+        .or_else(|| {
+            let status = app_store_latest_build_status(builds);
+            (status != "no-builds").then_some(status)
+        })
+        .or_else(|| app_store_latest_build_upload_status(build_uploads))
+        .unwrap_or_else(|| "no-builds".to_string())
+}
+
+fn app_store_latest_build_upload_status(value: &Value) -> Option<String> {
+    let state = value
+        .get("data")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .and_then(|item| item.get("attributes"))
+        .and_then(|attributes| attributes.get("state"))?;
+    state
+        .as_str()
+        .or_else(|| state.get("state").and_then(Value::as_str))
+        .map(|state| state.to_ascii_lowercase())
 }
 
 fn app_store_latest_review_submission_status(value: &Value) -> Option<String> {

--- a/crates/tools/fission-command-package/src/stores.rs
+++ b/crates/tools/fission-command-package/src/stores.rs
@@ -1258,11 +1258,31 @@ pub(super) fn readiness_app_store(
     ));
     if let Some(path) = artifact.filter(|path| path.exists()) {
         let manifest = read_artifact_manifest(path)?;
-        checks.push(artifact_format_check(
+        let platform = app_store_platform_for_manifest(&cfg, &manifest);
+        checks.push(check(
             "release.app_store.artifact_format",
-            &manifest,
-            &["ipa"],
-            "App Store Connect binary upload requires an IPA artifact.",
+            CheckSeverity::Error,
+            if platform.is_ok() {
+                CheckStatus::Passed
+            } else {
+                CheckStatus::Failed
+            },
+            "artifact is an iOS .ipa or macOS .pkg",
+            Some(
+                platform
+                    .map(|platform| {
+                        format!(
+                            "target={} format={} platform={}",
+                            manifest.target,
+                            manifest.format,
+                            platform.target()
+                        )
+                    })
+                    .unwrap_or_else(|error| error.to_string()),
+            ),
+            vec![
+                "Build an iOS .ipa or macOS .pkg and configure distribution.app_store.platform to match.",
+            ],
         ));
         checks.push(app_store_build_number_state_check(
             project_dir,

--- a/crates/tools/fission-command-package/src/stores.rs
+++ b/crates/tools/fission-command-package/src/stores.rs
@@ -271,7 +271,8 @@ pub(super) fn publish_app_store(
     let key_id = env_value("APP_STORE_CONNECT_KEY_ID")
         .or(cfg.key_id.clone())
         .context("distribution.app_store.key_id or APP_STORE_CONNECT_KEY_ID is required")?;
-    let ipa = primary_artifact_with_extensions(manifest, &["ipa"])?;
+    let platform = app_store_platform_for_manifest(&cfg, manifest)?;
+    let upload = primary_artifact_with_extensions(manifest, &[platform.artifact_extension()])?;
     let track = options
         .track
         .as_deref()
@@ -287,7 +288,7 @@ pub(super) fn publish_app_store(
             Some("https://appstoreconnect.apple.com/apps".to_string()),
             vec![format!(
                 "Would upload {} to App Store Connect with API key {key_id} for track {track}.",
-                ipa.display()
+                upload.display()
             )],
         ));
     }
@@ -306,9 +307,9 @@ pub(super) fn publish_app_store(
             "altool",
             "--upload-app",
             "-f",
-            ipa.to_string_lossy().as_ref(),
+            upload.to_string_lossy().as_ref(),
             "-t",
-            "ios",
+            platform.altool_type(),
             "--apiKey",
             &key_id,
             "--apiIssuer",

--- a/crates/tools/fission-command-package/src/stores.rs
+++ b/crates/tools/fission-command-package/src/stores.rs
@@ -408,9 +408,7 @@ pub(super) fn app_store_status(
     let client = http_client()?;
     let token = app_store_access_token(&cfg)?;
     let app_id = app_store_app_id(&cfg, &client, &token)?;
-    let builds_url = format!(
-        "{APP_STORE_API}/v1/apps/{app_id}/builds?limit=10&sort=-uploadedDate&fields[builds]=version,uploadedDate,processingState,expired,minOsVersion,usesNonExemptEncryption"
-    );
+    let builds_url = app_store_builds_status_url(&app_id);
     let builds_response = client
         .get(builds_url)
         .bearer_auth(&token)
@@ -458,6 +456,12 @@ pub(super) fn app_store_status(
         stderr: None,
         manual_follow_up: Vec::new(),
     })
+}
+
+pub(super) fn app_store_builds_status_url(app_id: &str) -> String {
+    format!(
+        "{APP_STORE_API}/v1/builds?filter[app]={app_id}&limit=10&sort=-uploadedDate&fields[builds]=version,uploadedDate,processingState,expired,minOsVersion,usesNonExemptEncryption"
+    )
 }
 
 pub(super) fn app_store_lifecycle(

--- a/crates/tools/fission-command-package/src/stores.rs
+++ b/crates/tools/fission-command-package/src/stores.rs
@@ -327,11 +327,13 @@ pub(super) fn publish_app_store(
         .context("failed to run xcrun altool; install Xcode and App Store Connect upload tools")?;
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    if !output.status.success() {
+    if !output.status.success() || app_store_upload_reported_error(&stdout, &stderr).is_some() {
+        let reported_error = app_store_upload_reported_error(&stdout, &stderr)
+            .unwrap_or_else(|| stderr.trim().to_string());
         bail!(
             "App Store Connect upload failed with {}: {}",
             output.status,
-            stderr.trim()
+            reported_error
         );
     }
 
@@ -351,6 +353,35 @@ pub(super) fn publish_app_store(
         stderr: (!stderr.trim().is_empty()).then_some(stderr),
         manual_follow_up: vec![app_store_upload_follow_up(track, artifact_path)],
     })
+}
+
+pub(super) fn app_store_upload_reported_error(stdout: &str, stderr: &str) -> Option<String> {
+    if let Ok(value) = serde_json::from_str::<Value>(stdout) {
+        if app_store_json_has_errors(&value) {
+            return Some(stdout.trim().to_string());
+        }
+    }
+    stderr.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let uppercase = trimmed.to_ascii_uppercase();
+        (uppercase.starts_with("ERROR:") || uppercase.contains(" ERROR:"))
+            .then(|| trimmed.to_string())
+    })
+}
+
+fn app_store_json_has_errors(value: &Value) -> bool {
+    match value {
+        Value::Object(fields) => fields.iter().any(|(key, value)| {
+            let error_field = key.to_ascii_lowercase().ends_with("errors");
+            error_field
+                && !matches!(value, Value::Null)
+                && !matches!(value, Value::Array(items) if items.is_empty())
+                && !matches!(value, Value::Object(fields) if fields.is_empty())
+                || app_store_json_has_errors(value)
+        }),
+        Value::Array(values) => values.iter().any(app_store_json_has_errors),
+        _ => false,
+    }
 }
 
 pub(super) fn app_store_upload_follow_up(track: &str, artifact_path: &Path) -> String {

--- a/crates/tools/fission-command-package/src/stores/app_store_review.rs
+++ b/crates/tools/fission-command-package/src/stores/app_store_review.rs
@@ -32,6 +32,7 @@ pub(super) fn lifecycle(
         .as_deref()
         .context("App Store App Review submission requires --artifact <artifact-manifest.json>")?;
     let manifest = read_artifact_manifest(artifact_path)?;
+    let platform = app_store_platform_for_manifest(&cfg, &manifest)?;
     let version = manifest
         .project
         .version
@@ -47,10 +48,10 @@ pub(super) fn lifecycle(
     let client = http_client()?;
     let token = app_store_access_token(&cfg)?;
     let app_id = app_store_app_id(&cfg, &client, &token)?;
-    let version_id = resolve_app_store_version_id(&client, &token, &app_id, version)?;
+    let version_id = resolve_app_store_version_id(&client, &token, &app_id, version, platform)?;
     let build = resolve_app_store_review_build(&client, &token, &app_id, &build_number)?;
     let attach_payload = app_store_version_build_payload(&version_id, &build.id);
-    let create_payload = app_store_review_submission_create_payload(&app_id, "IOS");
+    let create_payload = app_store_review_submission_create_payload(&app_id, platform.api_value());
 
     if options.dry_run {
         let stdout = serde_json::to_string_pretty(&json!({
@@ -158,10 +159,12 @@ fn resolve_app_store_version_id(
     token: &str,
     app_id: &str,
     version: &str,
+    platform: AppStorePlatform,
 ) -> Result<String> {
     let url = format!(
-        "{APP_STORE_API}/v1/apps/{app_id}/appStoreVersions?filter[versionString]={}&filter[platform]=IOS&limit=1&fields[appStoreVersions]=versionString,appStoreState,platform",
-        encode_query_component(version)
+        "{APP_STORE_API}/v1/apps/{app_id}/appStoreVersions?filter[versionString]={}&filter[platform]={}&limit=1&fields[appStoreVersions]=versionString,appStoreState,platform",
+        encode_query_component(version),
+        platform.api_value()
     );
     let response = client
         .get(url)
@@ -361,6 +364,12 @@ mod app_store_review_tests {
                     "relationships": { "app": { "data": { "type": "apps", "id": "app-1" } } }
                 }
             })
+        );
+        assert_eq!(
+            app_store_review_submission_create_payload("app-1", "MAC_OS")
+                .pointer("/data/attributes/platform")
+                .and_then(Value::as_str),
+            Some("MAC_OS")
         );
         assert_eq!(
             app_store_review_submission_item_payload("submission-1", "version-1"),

--- a/crates/tools/fission-command-package/src/stores/app_store_review.rs
+++ b/crates/tools/fission-command-package/src/stores/app_store_review.rs
@@ -189,7 +189,7 @@ fn resolve_app_store_review_build(
     build_number: &str,
 ) -> Result<AppStoreReviewBuild> {
     let url = format!(
-        "{APP_STORE_API}/v1/apps/{app_id}/builds?filter[version]={}&limit=1&fields[builds]=version,processingState,uploadedDate,expired",
+        "{APP_STORE_API}/v1/builds?filter[app]={app_id}&filter[version]={}&limit=1&fields[builds]=version,processingState,uploadedDate,expired",
         encode_query_component(build_number)
     );
     let response = client

--- a/crates/tools/fission-command-package/src/stores/shared.rs
+++ b/crates/tools/fission-command-package/src/stores/shared.rs
@@ -767,7 +767,7 @@ pub(super) fn ensure_app_store_build_number_unused(
     build_number: &str,
 ) -> Result<()> {
     let url = format!(
-        "{APP_STORE_API}/v1/apps/{app_id}/builds?filter[version]={build_number}&limit=1&fields[builds]=version,processingState,uploadedDate"
+        "{APP_STORE_API}/v1/builds?filter[app]={app_id}&filter[version]={build_number}&limit=1&fields[builds]=version,processingState,uploadedDate"
     );
     let response = client
         .get(url)

--- a/crates/tools/fission-command-package/src/stores/shared.rs
+++ b/crates/tools/fission-command-package/src/stores/shared.rs
@@ -1,5 +1,78 @@
 use super::*;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AppStorePlatform {
+    Ios,
+    Macos,
+}
+
+impl AppStorePlatform {
+    pub(super) fn api_value(self) -> &'static str {
+        match self {
+            Self::Ios => "IOS",
+            Self::Macos => "MAC_OS",
+        }
+    }
+
+    pub(super) fn altool_type(self) -> &'static str {
+        match self {
+            Self::Ios => "ios",
+            Self::Macos => "macos",
+        }
+    }
+
+    pub(super) fn artifact_extension(self) -> &'static str {
+        match self {
+            Self::Ios => "ipa",
+            Self::Macos => "pkg",
+        }
+    }
+
+    pub(super) fn target(self) -> &'static str {
+        match self {
+            Self::Ios => "ios",
+            Self::Macos => "macos",
+        }
+    }
+}
+
+pub(super) fn app_store_platform(cfg: &AppStoreConfig) -> Result<AppStorePlatform> {
+    parse_app_store_platform(cfg.platform.as_deref().unwrap_or("ios"))
+}
+
+pub(super) fn app_store_platform_for_manifest(
+    cfg: &AppStoreConfig,
+    manifest: &ArtifactManifest,
+) -> Result<AppStorePlatform> {
+    let inferred = match (manifest.target.as_str(), manifest.format.as_str()) {
+        ("ios", "ipa") => AppStorePlatform::Ios,
+        ("macos", "pkg") => AppStorePlatform::Macos,
+        (target, format) => bail!(
+            "App Store upload requires an iOS .ipa or macOS .pkg artifact, got target `{target}` format `{format}`"
+        ),
+    };
+    if cfg.platform.is_none() {
+        return Ok(inferred);
+    }
+    let configured = app_store_platform(cfg)?;
+    if configured != inferred {
+        bail!(
+            "distribution.app_store.platform `{}` does not match artifact target `{}`",
+            configured.target(),
+            manifest.target
+        );
+    }
+    Ok(configured)
+}
+
+fn parse_app_store_platform(value: &str) -> Result<AppStorePlatform> {
+    match value.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+        "ios" => Ok(AppStorePlatform::Ios),
+        "macos" | "mac-os" => Ok(AppStorePlatform::Macos),
+        other => bail!("distribution.app_store.platform must be `ios` or `macos`, got `{other}`"),
+    }
+}
+
 pub(super) fn create_play_edit(client: &Client, token: &str, package_name: &str) -> Result<String> {
     let url = format!("{PLAY_API}/androidpublisher/v3/applications/{package_name}/edits");
     let response = client

--- a/crates/tools/fission-command-package/src/stores_tests.rs
+++ b/crates/tools/fission-command-package/src/stores_tests.rs
@@ -71,6 +71,59 @@ fn store_credentials_honor_configured_env_names() {
 }
 
 #[test]
+fn app_store_platform_matches_ios_and_macos_artifacts() {
+    let config = AppStoreConfig::default();
+    let ios = store_artifact_manifest("ios", "ipa");
+    let macos = store_artifact_manifest("macos", "pkg");
+
+    assert_eq!(
+        app_store_platform_for_manifest(&config, &ios).unwrap(),
+        AppStorePlatform::Ios
+    );
+    assert_eq!(
+        app_store_platform_for_manifest(&config, &macos).unwrap(),
+        AppStorePlatform::Macos
+    );
+
+    let configured = AppStoreConfig {
+        platform: Some("macos".to_string()),
+        ..Default::default()
+    };
+    assert!(app_store_platform_for_manifest(&configured, &ios).is_err());
+    assert_eq!(
+        app_store_platform_for_manifest(&configured, &macos).unwrap(),
+        AppStorePlatform::Macos
+    );
+}
+
+fn store_artifact_manifest(target: &str, format: &str) -> ArtifactManifest {
+    ArtifactManifest {
+        schema_version: 1,
+        created_at_unix_seconds: 0,
+        project: ArtifactProject {
+            app_id: "com.example.demo".to_string(),
+            name: "Demo".to_string(),
+            build: Some(1),
+            version: Some("1.0.0".to_string()),
+        },
+        target: target.to_string(),
+        format: format.to_string(),
+        profile: "release".to_string(),
+        variant: None,
+        root_dir: "/tmp/fission-store-artifact".to_string(),
+        source_config: Vec::new(),
+        artifacts: Vec::new(),
+        icon_manifest: None,
+        signing: None,
+        notarization: None,
+        validation: ArtifactValidation {
+            state: "passed".to_string(),
+            checks: Vec::new(),
+        },
+    }
+}
+
+#[test]
 fn play_internal_sharing_upload_urls_use_media_endpoints() {
     assert_eq!(
         play_internal_sharing_upload_url("com.example.app", "apk").unwrap(),

--- a/crates/tools/fission-command-package/src/stores_tests.rs
+++ b/crates/tools/fission-command-package/src/stores_tests.rs
@@ -96,6 +96,25 @@ fn app_store_platform_matches_ios_and_macos_artifacts() {
     );
 }
 
+#[test]
+fn app_store_upload_detects_altool_errors_even_with_a_success_exit() {
+    let stderr = "Running altool...\n2026-07-24 00:05:54 ERROR: package is invalid (-43)";
+    assert_eq!(
+        app_store_upload_reported_error("", stderr).as_deref(),
+        Some("2026-07-24 00:05:54 ERROR: package is invalid (-43)")
+    );
+    assert!(app_store_upload_reported_error(
+        r#"{"product-errors":[{"message":"invalid package"}]}"#,
+        ""
+    )
+    .is_some());
+    assert!(app_store_upload_reported_error(
+        r#"{"product-errors":[],"success-message":"No errors uploading"}"#,
+        "Running altool..."
+    )
+    .is_none());
+}
+
 fn store_artifact_manifest(target: &str, format: &str) -> ArtifactManifest {
     ArtifactManifest {
         schema_version: 1,

--- a/crates/tools/fission-command-release/src/publish_workflow.rs
+++ b/crates/tools/fission-command-release/src/publish_workflow.rs
@@ -1432,6 +1432,21 @@ fn build_release_plan(
     artifact: Option<&Path>,
 ) -> Result<ReleasePlanReport> {
     let mut requirements = Vec::new();
+    let signing_variant = artifact
+        .filter(|path| path.exists())
+        .map(read_json_file)
+        .transpose()?
+        .and_then(|manifest| {
+            manifest
+                .get("variant")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .map(|variant| variant.parse::<fission_command_core::NativeVariant>())
+        .transpose()
+        .map_err(|error| {
+            anyhow::anyhow!("artifact manifest contains an invalid native variant: {error}")
+        })?;
     if let Some(target) = options.target {
         requirements.extend(
             package_cmd::package_readiness_checks_for_profile(
@@ -1445,9 +1460,13 @@ fn build_release_plan(
         );
         if release_target_requires_signing(target) {
             requirements.extend(
-                signing_ops::status_checks(&options.project_dir, target)
-                    .into_iter()
-                    .map(|check| lifecycle_requirement(check, RequirementLevel::ProviderRequired)),
+                signing_ops::status_checks_for_variant(
+                    &options.project_dir,
+                    target,
+                    signing_variant.as_ref(),
+                )
+                .into_iter()
+                .map(|check| lifecycle_requirement(check, RequirementLevel::ProviderRequired)),
             );
         }
     }

--- a/crates/tools/fission-command-release/src/signing_ops.rs
+++ b/crates/tools/fission-command-release/src/signing_ops.rs
@@ -57,17 +57,21 @@ struct WindowsPackageToml {
 
 pub(super) fn status(project_dir: &Path, target: Target, json: bool) -> Result<()> {
     print_report(
-        build_status_report("signing.status", project_dir, target),
+        build_status_report("signing.status", project_dir, target, None),
         json,
     )
 }
 
-pub(super) fn status_checks(project_dir: &Path, target: Target) -> Vec<LifecycleCheck> {
-    build_status_report("signing.status", project_dir, target).checks
+pub(super) fn status_checks_for_variant(
+    project_dir: &Path,
+    target: Target,
+    variant: Option<&fission_command_core::NativeVariant>,
+) -> Vec<LifecycleCheck> {
+    build_status_report("signing.status", project_dir, target, variant).checks
 }
 
 pub(super) fn sync(project_dir: &Path, target: Target, readonly: bool, json: bool) -> Result<()> {
-    let mut report = build_status_report("signing.sync", project_dir, target);
+    let mut report = build_status_report("signing.sync", project_dir, target, None);
     report.checks.push(ok_check(
         "signing.sync.mode",
         if readonly {
@@ -187,7 +191,12 @@ fn import_android(
     Ok(())
 }
 
-fn build_status_report(area: &str, project_dir: &Path, target: Target) -> LifecycleReport {
+fn build_status_report(
+    area: &str,
+    project_dir: &Path,
+    target: Target,
+    variant: Option<&fission_command_core::NativeVariant>,
+) -> LifecycleReport {
     let mut report = base_report(area, None, Some(target));
     let config_path = project_dir.join("fission.toml");
     report.checks.push(path_check(
@@ -207,7 +216,11 @@ fn build_status_report(area: &str, project_dir: &Path, target: Target) -> Lifecy
         }
         Target::Macos => {
             let cfg = config.package.and_then(|p| p.macos);
-            match fission_command_core::read_macos_package_config_for_profile(project_dir, true) {
+            match fission_command_core::read_macos_package_config_for_profile_and_variant(
+                project_dir,
+                true,
+                variant,
+            ) {
                 Ok(signing) => macos_checks(project_dir, cfg, &signing, &mut report),
                 Err(error) => {
                     report.checks.push(failed_check(
@@ -814,10 +827,16 @@ entitlements = "platforms/macos/Release.entitlements"
 signing_identity = "Developer ID Application: Example Ltd"
 installer_identity = "Developer ID Installer: Example Ltd"
 notarize = true
+
+[package.macos.variants.app-store]
+entitlements = "platforms/macos/AppStore.entitlements"
+signing_identity = "Apple Distribution: Example Ltd"
+installer_identity = "3rd Party Mac Developer Installer: Example Ltd"
+notarize = false
 "#,
         )
         .unwrap();
-        let report = build_status_report("test", &dir, Target::Macos);
+        let report = build_status_report("test", &dir, Target::Macos, None);
         let check = |id: &str| report.checks.iter().find(|check| check.id == id).unwrap();
 
         assert_eq!(check("signing.macos.identity").status, "passed");
@@ -833,6 +852,22 @@ notarize = true
             .checks
             .iter()
             .all(|check| check.id != "signing.macos.config"));
+
+        let variant = "app-store".parse().unwrap();
+        let report = build_status_report("test", &dir, Target::Macos, Some(&variant));
+        let identity = report
+            .checks
+            .iter()
+            .find(|check| check.id == "signing.macos.identity")
+            .unwrap();
+        assert_eq!(
+            identity.details.as_deref(),
+            Some("Apple Distribution: Example Ltd")
+        );
+        assert!(report
+            .checks
+            .iter()
+            .all(|check| !check.id.starts_with("signing.apple.notary_")));
         fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/crates/tools/fission-command-release/src/store_ops.rs
+++ b/crates/tools/fission-command-release/src/store_ops.rs
@@ -1177,7 +1177,7 @@ fn resolve_app_store_beta_build(
 
 fn app_store_builds_url(app_id: &str, build_number: Option<&str>) -> String {
     let mut url = format!(
-        "{APP_STORE_API}/v1/apps/{app_id}/builds?limit=10&sort=-uploadedDate&fields[builds]=version,uploadedDate,processingState,expired,minOsVersion,usesNonExemptEncryption"
+        "{APP_STORE_API}/v1/builds?filter[app]={app_id}&limit=10&sort=-uploadedDate&fields[builds]=version,uploadedDate,processingState,expired,minOsVersion,usesNonExemptEncryption"
     );
     if let Some(build_number) = build_number.filter(|value| !value.trim().is_empty()) {
         url.push_str("&filter[version]=");
@@ -1889,7 +1889,7 @@ groups = ["qa@example.com"]
     #[test]
     fn app_store_build_lookup_filters_artifact_build() {
         let url = app_store_builds_url("app-123", Some("42"));
-        assert!(url.contains("/v1/apps/app-123/builds?"));
+        assert!(url.contains("/v1/builds?filter[app]=app-123"));
         assert!(url.contains("filter[version]=42"));
         assert!(url.contains("sort=-uploadedDate"));
     }

--- a/crates/tools/fission-command-release/src/store_ops.rs
+++ b/crates/tools/fission-command-release/src/store_ops.rs
@@ -161,6 +161,7 @@ struct PlayStoreConfig {
 struct AppStoreConfig {
     app_id: Option<String>,
     bundle_id: Option<String>,
+    platform: Option<String>,
     issuer_id: Option<String>,
     key_id: Option<String>,
     access_token_env: Option<String>,
@@ -169,6 +170,22 @@ struct AppStoreConfig {
     api_key_env: Option<String>,
     api_key_base64_env: Option<String>,
     api_key_path_env: Option<String>,
+}
+
+fn app_store_platform_api_value(cfg: &AppStoreConfig) -> Result<&'static str> {
+    match cfg
+        .platform
+        .as_deref()
+        .unwrap_or("ios")
+        .trim()
+        .to_ascii_lowercase()
+        .replace('_', "-")
+        .as_str()
+    {
+        "ios" => Ok("IOS"),
+        "macos" | "mac-os" => Ok("MAC_OS"),
+        other => bail!("distribution.app_store.platform must be `ios` or `macos`, got `{other}`"),
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1650,6 +1667,27 @@ fn set_private_file_permissions(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn app_store_platform_supports_ios_and_macos() {
+        assert_eq!(
+            app_store_platform_api_value(&AppStoreConfig::default()).unwrap(),
+            "IOS"
+        );
+        assert_eq!(
+            app_store_platform_api_value(&AppStoreConfig {
+                platform: Some("macos".to_string()),
+                ..Default::default()
+            })
+            .unwrap(),
+            "MAC_OS"
+        );
+        assert!(app_store_platform_api_value(&AppStoreConfig {
+            platform: Some("windows".to_string()),
+            ..Default::default()
+        })
+        .is_err());
+    }
 
     #[test]
     fn latest_user_comment_uses_newest_user_comment() {

--- a/crates/tools/fission-command-release/src/store_ops/release_config_ops.rs
+++ b/crates/tools/fission-command-release/src/store_ops/release_config_ops.rs
@@ -550,9 +550,16 @@ pub(super) fn app_store_version_id(
                 .and_then(|id| id.split('+').next())
         })
         .context("active [[releases]].version is required for App Store metadata sync")?;
+    let cfg = root
+        .distribution
+        .as_ref()
+        .and_then(|distribution| distribution.app_store.as_ref())
+        .cloned()
+        .unwrap_or_default();
+    let platform = app_store_platform_api_value(&cfg)?;
     let response = client
         .get(format!(
-            "{APP_STORE_API}/v1/apps/{app_id}/appStoreVersions?filter[versionString]={version}&limit=1"
+            "{APP_STORE_API}/v1/apps/{app_id}/appStoreVersions?filter[versionString]={version}&filter[platform]={platform}&limit=1"
         ))
         .bearer_auth(token)
         .send()

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -1582,6 +1582,7 @@ fn render_macos_run_info_plist(
   <key>NSHighResolutionCapable</key>
   <true/>
 {}
+{}
 </dict>
 </plist>
 "#,
@@ -1592,8 +1593,23 @@ fn render_macos_run_info_plist(
         escape_xml(&binary.version),
         escape_xml(&binary.version),
         escape_xml(minimum_os),
+        render_macos_run_application_category_entry(macos),
         render_macos_run_capability_plist_entries(project)
     )
+}
+
+fn render_macos_run_application_category_entry(macos: &MacosPackageConfig) -> String {
+    macos
+        .application_category
+        .as_deref()
+        .filter(|category| !category.trim().is_empty())
+        .map(|category| {
+            format!(
+                "  <key>LSApplicationCategoryType</key>\n  <string>{}</string>",
+                escape_xml(category)
+            )
+        })
+        .unwrap_or_default()
 }
 
 fn render_macos_run_capability_plist_entries(project: &FissionProject) -> String {

--- a/documentation/content/docs/build-and-package/macos-packages.mdx
+++ b/documentation/content/docs/build-and-package/macos-packages.mdx
@@ -36,6 +36,7 @@ marketing_version = "1.4.0"
 build_number = "37"
 team_id = "ABCDE12345"
 minimum_os = "13.0"
+application_category = "public.app-category.developer-tools"
 entitlements = "platforms/macos/AcmeNotes.entitlements"
 provisioning_profile = "profiles/macos/AcmeNotes.provisionprofile"
 signing_identity = "Developer ID Application: Acme Software Ltd (ABCDE12345)"
@@ -58,6 +59,7 @@ The values are deliberately duplicated where the platform needs them:
 | `build_number` | The macOS `CFBundleVersion`, usually monotonically increasing for release artifacts. |
 | `team_id` | Used by signing, provisioning, notarization readiness, and review diagnostics. |
 | `minimum_os` | Documents and propagates the intended minimum macOS version. |
+| `application_category` | Writes the Mac App Store category UTI into `Info.plist`. |
 | `entitlements` | The app-level entitlements used when signing the containing `.app`. |
 | `provisioning_profile` | Embedded at `Contents/embedded.provisionprofile` before signing when profile-backed entitlements are required. |
 | `signing_identity` | The application signing identity passed to `codesign`. |

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -740,6 +740,7 @@ installer_script = "platforms/linux/package-run.sh"
 | `build_number` | string | No | macOS `CFBundleVersion`. If omitted, Fission falls back to the resolved release/app build number. |
 | `team_id` | string | No | Apple Developer Team ID used by signing/notarization readiness checks. |
 | `minimum_os` | string | No | Records the intended minimum macOS version for package metadata. |
+| `application_category` | string | No | Writes the `LSApplicationCategoryType` UTI required for Mac App Store submission, such as `public.app-category.developer-tools`. |
 | `entitlements` | string | No | Base project-relative entitlements plist passed to `codesign` when signing. |
 | `provisioning_profile` | string | No | Base project-relative provisioning profile embedded at `Contents/embedded.provisionprofile` before signing. |
 | `signing_identity` | string | No | Base application signing identity. Flat signing fields apply to debug and release packaging for backward compatibility. |
@@ -761,6 +762,7 @@ production credentials.
 
 | Field | Type | Required | Meaning |
 | --- | --- | --- | --- |
+| `application_category` | string | No | Overrides the base `LSApplicationCategoryType` UTI for release packaging. |
 | `entitlements` | string | No | Project-relative release entitlements plist. |
 | `provisioning_profile` | string | No | Project-relative release provisioning profile embedded before signing. |
 | `signing_identity` | string | No | Developer ID Application identity used to sign release `.app` bundles. |
@@ -786,6 +788,7 @@ editing configuration between packages.
 
 ```toml
 [package.macos.variants.app-store]
+application_category = "public.app-category.developer-tools"
 entitlements = "platforms/macos/AppStore.entitlements"
 provisioning_profile = ".fission/signing/macos/AppStore.provisionprofile"
 signing_identity = "Apple Distribution: Example Ltd"
@@ -795,9 +798,10 @@ pkg_builder = "productbuild"
 cargo_features = ["macos-app-store"]
 ```
 
-The variant accepts the same `entitlements`, `provisioning_profile`,
-`signing_identity`, `installer_identity`, `notarize`, `pkg_builder`,
-`cargo_features`, and `cargo_no_default_features` fields as the release overlay.
+The variant accepts the same `application_category`, `entitlements`,
+`provisioning_profile`, `signing_identity`, `installer_identity`, `notarize`,
+`pkg_builder`, `cargo_features`, and `cargo_no_default_features` fields as the
+release overlay.
 Package it with `fission package --target macos --format pkg --release --variant
 app-store`.
 

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -745,6 +745,7 @@ installer_script = "platforms/linux/package-run.sh"
 | `signing_identity` | string | No | Base application signing identity. Flat signing fields apply to debug and release packaging for backward compatibility. |
 | `installer_identity` | string | No | Base installer identity passed to `pkgbuild` for `.pkg` output. |
 | `notarize` | boolean | No | Base notarization setting. Prefer the release overlay below for production notarization. |
+| `pkg_builder` | string | No | `.pkg` construction tool: `pkgbuild` (default) or `productbuild`. Mac App Store submissions use `productbuild`. |
 | `cargo_features` | array of strings | No | Cargo features enabled while building the packaged desktop binary. |
 | `cargo_no_default_features` | boolean | No | Passes `--no-default-features` while building the packaged desktop binary. |
 
@@ -765,6 +766,7 @@ production credentials.
 | `signing_identity` | string | No | Developer ID Application identity used to sign release `.app` bundles. |
 | `installer_identity` | string | No | Developer ID Installer identity passed to `pkgbuild` for release `.pkg` output. |
 | `notarize` | boolean | No | When `true`, notarizes the signed `.app` and, for `.pkg` output, the signed installer. Requires `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, and key material from `APP_STORE_CONNECT_API_KEY_PATH`, `APP_STORE_CONNECT_API_KEY`, or `APP_STORE_CONNECT_API_KEY_BASE64`. |
+| `pkg_builder` | string | No | Overrides the base `.pkg` construction tool for release packaging. |
 | `cargo_features` | array of strings | No | Replaces the base Cargo feature list for release packaging. |
 | `cargo_no_default_features` | boolean | No | Overrides the base `--no-default-features` setting for release packaging. |
 
@@ -789,13 +791,15 @@ provisioning_profile = ".fission/signing/macos/AppStore.provisionprofile"
 signing_identity = "Apple Distribution: Example Ltd"
 installer_identity = "3rd Party Mac Developer Installer: Example Ltd"
 notarize = false
+pkg_builder = "productbuild"
 cargo_features = ["macos-app-store"]
 ```
 
 The variant accepts the same `entitlements`, `provisioning_profile`,
-`signing_identity`, `installer_identity`, `notarize`, `cargo_features`, and
-`cargo_no_default_features` fields as the release overlay. Package it with
-`fission package --target macos --format pkg --release --variant app-store`.
+`signing_identity`, `installer_identity`, `notarize`, `pkg_builder`,
+`cargo_features`, and `cargo_no_default_features` fields as the release overlay.
+Package it with `fission package --target macos --format pkg --release --variant
+app-store`.
 
 ### `[run.macos]`
 

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -745,6 +745,8 @@ installer_script = "platforms/linux/package-run.sh"
 | `signing_identity` | string | No | Base application signing identity. Flat signing fields apply to debug and release packaging for backward compatibility. |
 | `installer_identity` | string | No | Base installer identity passed to `pkgbuild` for `.pkg` output. |
 | `notarize` | boolean | No | Base notarization setting. Prefer the release overlay below for production notarization. |
+| `cargo_features` | array of strings | No | Cargo features enabled while building the packaged desktop binary. |
+| `cargo_no_default_features` | boolean | No | Passes `--no-default-features` while building the packaged desktop binary. |
 
 ### `[package.macos.release]`
 
@@ -763,6 +765,8 @@ production credentials.
 | `signing_identity` | string | No | Developer ID Application identity used to sign release `.app` bundles. |
 | `installer_identity` | string | No | Developer ID Installer identity passed to `pkgbuild` for release `.pkg` output. |
 | `notarize` | boolean | No | When `true`, notarizes the signed `.app` and, for `.pkg` output, the signed installer. Requires `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, and key material from `APP_STORE_CONNECT_API_KEY_PATH`, `APP_STORE_CONNECT_API_KEY`, or `APP_STORE_CONNECT_API_KEY_BASE64`. |
+| `cargo_features` | array of strings | No | Replaces the base Cargo feature list for release packaging. |
+| `cargo_no_default_features` | boolean | No | Overrides the base `--no-default-features` setting for release packaging. |
 
 Fission submits an app bundle through a private temporary ZIP created with
 `ditto --keepParent`, then staples and validates the original `.app`. The ZIP
@@ -785,12 +789,13 @@ provisioning_profile = ".fission/signing/macos/AppStore.provisionprofile"
 signing_identity = "Apple Distribution: Example Ltd"
 installer_identity = "3rd Party Mac Developer Installer: Example Ltd"
 notarize = false
+cargo_features = ["macos-app-store"]
 ```
 
 The variant accepts the same `entitlements`, `provisioning_profile`,
-`signing_identity`, `installer_identity`, and `notarize` fields as the release
-overlay. Package it with `fission package --target macos --format pkg --release
---variant app-store`.
+`signing_identity`, `installer_identity`, `notarize`, `cargo_features`, and
+`cargo_no_default_features` fields as the release overlay. Package it with
+`fission package --target macos --format pkg --release --variant app-store`.
 
 ### `[run.macos]`
 

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -770,6 +770,28 @@ and any API key material decoded from environment values are removed after the
 operation. `.pkg` notarization continues to submit, staple, and validate the
 signed installer itself.
 
+### `[package.macos.variants.<name>]`
+
+A selected desktop `--variant` may override the effective macOS package signing
+configuration. Fission applies `[package.macos]`, then
+`[package.macos.release]` for release packaging, then the selected variant.
+This keeps Developer ID and Mac App Store identities in one project without
+editing configuration between packages.
+
+```toml
+[package.macos.variants.app-store]
+entitlements = "platforms/macos/AppStore.entitlements"
+provisioning_profile = ".fission/signing/macos/AppStore.provisionprofile"
+signing_identity = "Apple Distribution: Example Ltd"
+installer_identity = "3rd Party Mac Developer Installer: Example Ltd"
+notarize = false
+```
+
+The variant accepts the same `entitlements`, `provisioning_profile`,
+`signing_identity`, `installer_identity`, and `notarize` fields as the release
+overlay. Package it with `fission package --target macos --format pkg --release
+--variant app-store`.
+
 ### `[run.macos]`
 
 `fission run --target macos` builds a development `.app` and signs it before
@@ -982,6 +1004,7 @@ Credentials come from the configured environment-variable names. Do not put serv
 | --- | --- | --- | --- | --- |
 | `app_id` | string | Required unless `bundle_id` can resolve the app through the provider API | none | App Store Connect app id. |
 | `bundle_id` | string | Required when `app_id` is omitted | none | Bundle id used to look up the app. |
+| `platform` | string | No | inferred from the upload artifact, otherwise `ios` | App Store platform. Accepted values are `ios` and `macos`. |
 | `issuer_id` | string | Required unless the configured issuer env var is set | none | App Store Connect issuer id. |
 | `key_id` | string | Required unless the configured key-id env var is set | none | App Store Connect API key id. |
 | `default_track` | string | No | command/provider default | Default release/beta track label for commands that accept tracks. |
@@ -993,6 +1016,10 @@ Credentials come from the configured environment-variable names. Do not put serv
 | `api_key_path_env` | string | No | `APP_STORE_CONNECT_API_KEY_PATH` | Environment variable containing a local private-key path outside the repo. |
 
 API key material comes from the configured environment-variable names. Use the path variable only for local files outside the repo; use base64 CI secrets for automation.
+
+App Store distribution accepts an iOS `.ipa` or a macOS `.pkg`. Fission
+validates the artifact target against `platform`, passes the matching type to
+Apple's upload tool, and uses `IOS` or `MAC_OS` for App Review operations.
 
 ### `[distribution.microsoft_store]`
 
@@ -1351,6 +1378,7 @@ service_account_json_base64_env = "PLAY_STORE_SERVICE_ACCOUNT_JSON_BASE64"
 
 [distribution.app_store]
 bundle_id = "com.example.app"
+platform = "ios"
 issuer_id = "00000000-0000-0000-0000-000000000000"
 key_id = "ABC123DEFG"
 api_key_env = "APP_STORE_CONNECT_API_KEY"


### PR DESCRIPTION
## Summary

- add named macOS package signing overlays selected by `--variant`, allowing Developer ID and Mac App Store identities in one project
- upload macOS `.pkg` artifacts through App Store Connect with the correct `macos` platform type
- use `MAC_OS` for App Store version lookup and App Review submissions
- document macOS App Store configuration and packaging

## Validation

- `cargo fmt --all`
- `cargo test -p fission-command-core macos_signing` (8 passed)
- App Store package tests passed before the final release-client platform lookup test was added; the rerun was blocked by the shared build volume reaching 100% capacity before compiling the test target