### PR TITLE
chore(release): prepare Fission 0.9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ test_output.txt
 # Static site output
 **/dist/site/
 /documentation/dist/
+/documentation/target/
 
 # Separate publications repository
 publications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-07-24
+
+### Added
+
+- **Anchored spotlight layout** - Added a first-class `Spotlight` widget for product tours and guided onboarding. Native, Web, Static site, and SSR output share the same five-region geometry contract, including browser-side repositioning after resize and scroll.
+- **Mac App Store delivery** - Added signed PKG packaging, App Store Connect upload and processing checks, macOS build lookup, review submission, App Store screenshot preparation, and cookbook tutorials for Apple signing, notarized direct distribution, and Mac App Store releases.
+
+### Changed
+
+- **Responsive examples are retained and production-shaped** - Reworked the animation gallery, chart gallery, editor, field inspector, inbox, product examples, text lab, widget gallery, and smoke examples around concrete responsive widget components, stable identities, design tokens, semantic LiveTest selectors, and compact layouts that keep controls reachable.
+- **Desktop variants use one effective Cargo configuration** - `fission run` and desktop builds now honor variant `cargo_features` and `cargo_no_default_features` with the same overlay semantics used by packaging.
+- **Release capture uses the public LiveTest protocol** - Screenshot scenarios now serialize public selector types, honor scenario timeouts, stop failed capture applications, flatten App Store PNG alpha, and validate explicit screenshot display-type directories.
+- **Responsive and visual-fidelity documentation is broader** - Expanded Learn, Develop, Cookbook, Test and Debug, Release and Distribute, and Reference coverage for responsive layout, typed lengths, grid, containers, pressables, fonts, golden tests, package metadata, and release screenshots.
+
+### Fixed
+
+- **GPU renderer memory scales with visible work** - Vello caller buffers are sized from encoded visible content instead of retained offscreen document text, rich text is culled against active scroll clips before glyph encoding, packaged software fonts load lazily, and native/WASM image caches share a bounded 50 MB policy.
+- **Layout and slider geometry** - Wrapped and aligned controls preserve intrinsic dimensions, stretch retains explicit cross-axis sizing, flyouts clamp using rendered descendant bounds, and slider visuals, hit testing, and semantic values agree at both fixed and typed widths.
+- **Retained custom input identity** - Custom render widgets preserve stable identities across rebuilds, and timer/startup state changes schedule the rebuilds needed by editor, terminal, chart, and other interactive examples.
+- **App Store Connect mutations** - Existing localization updates omit immutable locale fields, generated artifact paths resolve without duplicated project roots, IPA and PKG flows select the correct Apple platform, and readiness checks use the matching iOS or macOS build number.
+- **Desktop package output discovery** - Desktop packaging honors Cargo target overrides, generated browser artifacts are discovered from Cargo compiler output, and macOS notifications avoid native notification APIs when an app is not running from a valid bundle.
+- **Responsive LiveTest selection** - Selector resolution prefers the responsive branch that participates in layout when hidden duplicate branches share one semantic identifier.
+
+### Migration notes
+
+- Update Fission dependencies to `0.9.2`:
+
+```toml
+fission = { version = "0.9.2", default-features = false, features = ["desktop"] }
+```
+
+- Desktop package variants should declare their complete effective `cargo_features` list. A variant list replaces the base list, matching existing package-overlay behavior, and `cargo_no_default_features` can be overridden per variant.
+- Mac App Store releases use a macOS package variant, PKG format, and `distribution.app_store.platform = "macos"`. Follow the Apple signing and Mac App Store cookbook pages for the complete setup.
+- `Spotlight` is additive and requires no application migration. Terminal applications should use a terminal-specific guided-attention treatment because cell-grid output intentionally rejects spotlight overlays.
+
 ## [0.9.1] - 2026-07-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "animation-gallery"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fission"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1635,7 +1635,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chart-gallery"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "counter"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "embed-3d"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "embed-video"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "embed-webview"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "field-inspector"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2578,7 +2578,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fission"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "fission-3d",
  "fission-charts",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "fission-3d"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "fission-charts"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "fission-core",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-package"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-release"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-run"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-command-core",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "toml 0.8.2",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-site"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-shell-site",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-ui"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "fission-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "fission-design-system-codegen"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "fission-diagnostics"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bitflags 2.13.0",
  "once_cell",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "fission-documentation"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "fission-editor"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -2818,14 +2818,14 @@ dependencies = [
 
 [[package]]
 name = "fission-i18n"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fission-icons"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "heck 0.4.1",
  "serde_json",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "fission-ir"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "serde",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "fission-layout"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "fission-macros"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-ir",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render-vello"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "fission-semantics"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "fission-ir",
  "serde",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-desktop"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-mobile"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-site"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-terminal"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-web"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-winit"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test-driver"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3123,14 +3123,14 @@ dependencies = [
 
 [[package]]
 name = "fission-text-engine"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "fission-theme"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "fission-design-system-codegen",
  "fission-ir",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "fission-widgets"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "icons_gallery"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -4562,7 +4562,7 @@ checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "inbox"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-smoke"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "motion-memory-repro"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -6237,7 +6237,7 @@ dependencies = [
 
 [[package]]
 name = "pokemon-card-store"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "product-browser"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -8046,7 +8046,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "text-lab"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -8238,7 +8238,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todo-design-system"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",
@@ -8950,7 +8950,7 @@ dependencies = [
 
 [[package]]
 name = "web-smoke"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "widget-gallery"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "fission",

--- a/crates/authoring/fission-charts/Cargo.toml
+++ b/crates/authoring/fission-charts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-charts"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 license = "MIT"
@@ -11,9 +11,9 @@ description = "Native chart widgets and data visualization primitives for Fissio
 readme = "README.md"
 [dependencies]
 chrono = "0.4.44"
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-widgets = { path = "../fission-widgets", version = "0.9.1" }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-widgets = { path = "../fission-widgets", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/authoring/fission-charts/README.md
+++ b/crates/authoring/fission-charts/README.md
@@ -6,7 +6,7 @@ Chart widgets and data-visualization primitives for Fission applications.
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["desktop", "charts"] }
+fission = { version = "0.9.2", features = ["desktop", "charts"] }
 ```
 
 Most application code should import from `fission::prelude::*` and `fission::charts::*` rather than depending on this crate directly. Depend on `fission-charts` only when you are extending the chart layer itself.

--- a/crates/authoring/fission-icons/Cargo.toml
+++ b/crates/authoring/fission-icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-icons"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-macros/Cargo.toml
+++ b/crates/authoring/fission-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-macros"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-widgets"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -19,22 +19,22 @@ terminal = [
 ]
 
 [dependencies]
-fission-macros = { path = "../fission-macros", version = "0.9.1" }
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
-fission-icons = { path = "../fission-icons", version = "0.9.1" }
+fission-macros = { path = "../fission-macros", version = "0.9.2" }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
+fission-icons = { path = "../fission-icons", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.2" }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 
 [dev-dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -45,30 +45,30 @@ video = [
 web = ["dep:fission-shell-web"]
 
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-3d = { path = "../../core/fission-3d", version = "0.9.1", optional = true }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-text-engine = { path = "../../core/fission-text-engine", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.9.1" }
-fission-widgets = { path = "../fission-widgets", version = "0.9.1" }
-fission-macros = { path = "../fission-macros", version = "0.9.1" }
-fission-icons = { path = "../fission-icons", version = "0.9.1" }
-fission-charts = { path = "../fission-charts", version = "0.9.1", optional = true }
-fission-render = { path = "../../rendering/fission-render", version = "0.9.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.1" }
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.9.1", optional = true }
-fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.9.1", optional = true }
-fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.9.1", optional = true }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.1", optional = true }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-3d = { path = "../../core/fission-3d", version = "0.9.2", optional = true }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-text-engine = { path = "../../core/fission-text-engine", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.9.2" }
+fission-widgets = { path = "../fission-widgets", version = "0.9.2" }
+fission-macros = { path = "../fission-macros", version = "0.9.2" }
+fission-icons = { path = "../fission-icons", version = "0.9.2" }
+fission-charts = { path = "../fission-charts", version = "0.9.2", optional = true }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.2" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.2" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.9.2", optional = true }
+fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.9.2", optional = true }
+fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.9.2", optional = true }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.9.1", optional = true }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.9.2", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.9.1", optional = true }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.9.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.9.1", optional = true }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.9.2", optional = true }

--- a/crates/authoring/fission/README.md
+++ b/crates/authoring/fission/README.md
@@ -15,7 +15,7 @@ This crate is the public facade. Application code should normally depend on `fis
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["desktop"] }
+fission = { version = "0.9.2", features = ["desktop"] }
 ```
 
 For the full developer workflow, install the Fission command:

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fission = { version = "0.9.1", default-features = false, features = ["desktop"] }
+//! fission = { version = "0.9.2", default-features = false, features = ["desktop"] }
 //! ```
 //!
 //! Then use via:

--- a/crates/core/fission-3d/Cargo.toml
+++ b/crates/core/fission-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-3d"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 license = "MIT"
@@ -10,8 +10,8 @@ documentation = "https://fission.rs"
 description = "3D scene primitives and rendering data types for Fission applications"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../fission-core", version = "0.9.1" }
-fission-ir = { path = "../fission-ir", version = "0.9.1" }
+fission-core = { path = "../fission-core", version = "0.9.2" }
+fission-ir = { path = "../fission-ir", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 wgpu = "26.0"
 bytemuck = { version = "1.18", features = ["derive"] }

--- a/crates/core/fission-3d/README.md
+++ b/crates/core/fission-3d/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["desktop", "three-d"] }
+fission = { version = "0.9.2", features = ["desktop", "three-d"] }
 ```
 
 Use this crate directly only when you are extending the framework's 3D model or renderer integration.

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-core"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,13 +10,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.9.1" }
-fission-layout = { path = "../fission-layout", version = "0.9.1" }
-fission-semantics = { path = "../fission-semantics", version = "0.9.1" }
-fission-theme = { path = "../fission-theme", version = "0.9.1" }
-fission-i18n = { path = "../fission-i18n", version = "0.9.1" }
-fission-text-engine = { path = "../fission-text-engine", version = "0.9.1" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.9.1" }
+fission-ir = { path = "../fission-ir", version = "0.9.2" }
+fission-layout = { path = "../fission-layout", version = "0.9.2" }
+fission-semantics = { path = "../fission-semantics", version = "0.9.2" }
+fission-theme = { path = "../fission-theme", version = "0.9.2" }
+fission-i18n = { path = "../fission-i18n", version = "0.9.2" }
+fission-text-engine = { path = "../fission-text-engine", version = "0.9.2" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -27,6 +27,6 @@ lazy_static = "1.4"
 blake3 = "1.5"
 unicode-segmentation = "1.10"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.2" }
 
 [dev-dependencies]

--- a/crates/core/fission-i18n/Cargo.toml
+++ b/crates/core/fission-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-i18n"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-ir/Cargo.toml
+++ b/crates/core/fission-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-ir"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-layout"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,9 +10,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.9.1" }
+fission-ir = { path = "../fission-ir", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.2" }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/Cargo.toml
+++ b/crates/core/fission-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-semantics"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,7 +10,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.9.1" }
+fission-ir = { path = "../fission-ir", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/core/fission-text-engine/Cargo.toml
+++ b/crates/core/fission-text-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-text-engine"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 license = "MIT"

--- a/crates/core/fission-theme/Cargo.toml
+++ b/crates/core/fission-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-theme"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -22,8 +22,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.9.1" }
+fission-ir = { path = "../fission-ir", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.9.1" }
+fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.9.2" }

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-vello"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,13 +10,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
+fission-render = { path = "../fission-render", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
 anyhow = "1.0"
 vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2", features = ["wgpu"] }
 parley = "0.7.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.2" }
 image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"

--- a/crates/rendering/fission-render-wgpu2d/Cargo.toml
+++ b/crates/rendering/fission-render-wgpu2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-wgpu2d"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -9,7 +9,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.9.1" }
+fission-render = { path = "../fission-render", version = "0.9.2" }
 anyhow = "1.0"
 bytemuck = { version = "1.16", features = ["derive"] }
 wgpu = { version = "26.0.1", default-features = false, features = ["std", "wgsl"] }

--- a/crates/rendering/fission-render/Cargo.toml
+++ b/crates/rendering/fission-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,8 +10,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-desktop"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 license = "MIT"
@@ -16,19 +16,19 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.9.1" }
-fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.9.1" }
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
+fission-shell = { path = "../fission-shell", version = "0.9.2" }
+fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.9.2" }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
 anyhow = "1.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.9.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.9.1" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.2" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.2" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.2" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.2" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-mobile"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,10 +15,10 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.9.1" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.9.1", default-features = false }
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
+fission-shell = { path = "../fission-shell", version = "0.9.2" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.9.2", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/shell/fission-shell-mobile/README.md
+++ b/crates/shell/fission-shell-mobile/README.md
@@ -8,9 +8,9 @@ Most application developers should use the public facade instead of depending on
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["android"] }
+fission = { version = "0.9.2", features = ["android"] }
 # or
-fission = { version = "0.9.1", features = ["ios"] }
+fission = { version = "0.9.2", features = ["ios"] }
 ```
 
 ## What it provides

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-server"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -23,12 +23,12 @@ axum = { version = "0.7", optional = true, default-features = false }
 base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-shell-site = { path = "../fission-shell-site", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-shell-site = { path = "../fission-shell-site", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
 getrandom = { version = "0.2", features = ["std"] }
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 moka = { version = "0.12", features = ["sync"] }
@@ -39,4 +39,4 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.1", default-features = false }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.2", default-features = false }

--- a/crates/shell/fission-shell-server/README.md
+++ b/crates/shell/fission-shell-server/README.md
@@ -14,7 +14,7 @@ Most applications should depend on the public `fission` facade with the
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["server"] }
+fission = { version = "0.9.2", features = ["server"] }
 ```
 
 Enable adapter features through the facade when you want to host the renderer
@@ -22,7 +22,7 @@ inside an existing HTTP stack:
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["server", "server-axum"] }
+fission = { version = "0.9.2", features = ["server", "server-axum"] }
 ```
 
 See the guides and reference at <https://fission.rs> for the server app model,

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-site"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -12,14 +12,14 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.1", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 
 [dev-dependencies]
-fission-i18n = { path = "../../core/fission-i18n", version = "0.9.1" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.9.2" }

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -6,7 +6,7 @@ Static site shell for Fission applications and documentation sites.
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["site"] }
+fission = { version = "0.9.2", features = ["site"] }
 ```
 
 ```sh

--- a/crates/shell/fission-shell-terminal/Cargo.toml
+++ b/crates/shell/fission-shell-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-terminal"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,9 +16,9 @@ crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["png"] }
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.1" }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.2" }
 base64 = "0.22"

--- a/crates/shell/fission-shell-terminal/README.md
+++ b/crates/shell/fission-shell-terminal/README.md
@@ -8,7 +8,7 @@ Application developers normally enable it through the facade crate:
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["terminal-shell"] }
+fission = { version = "0.9.2", features = ["terminal-shell"] }
 ```
 
 ## What it contains

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-web"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,9 +16,9 @@ video = ["fission-shell-winit/video"]
 
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
-fission-shell = { path = "../fission-shell", version = "0.9.1" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.9.1", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
+fission-shell = { path = "../fission-shell", version = "0.9.2" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.9.2", default-features = false }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-winit"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 description = "Shared winit shell runtime for desktop and mobile Fission hosts"
 
@@ -16,18 +16,18 @@ three-d = ["dep:fission-3d"]
 video = ["dep:gstreamer", "dep:gstreamer-video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.9.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.9.1" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.1" }
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
-fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.9.1" }
+fission-shell = { path = "../fission-shell", version = "0.9.2" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.2" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.2" }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
+fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.9.2" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.1" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.9.2" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.9.2" }
 image = "0.25"
 tiny-skia = "0.11.4"
 fontdue = "0.9.3"
@@ -92,6 +92,6 @@ dispatch = "0.2"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.9.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.1" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.2" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.2" }
 lazy_static = "1"

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,9 +10,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.9.1" } # Corrected path
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.2" } # Corrected path
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/tools/cargo-fission/Cargo.toml
+++ b/crates/tools/cargo-fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fission"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -24,10 +24,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.9.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.9.1" }
-fission-command-release = { path = "../fission-command-release", version = "0.9.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.9.1" }
-fission-command-server = { path = "../fission-command-server", version = "0.9.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.9.1" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.9.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.2" }
+fission-command-package = { path = "../fission-command-package", version = "0.9.2" }
+fission-command-release = { path = "../fission-command-release", version = "0.9.2" }
+fission-command-run = { path = "../fission-command-run", version = "0.9.2" }
+fission-command-server = { path = "../fission-command-server", version = "0.9.2" }
+fission-command-site = { path = "../fission-command-site", version = "0.9.2" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.9.2" }

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -1517,7 +1517,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fission = { version = "0.9.1", default-features = false, features = ["desktop"] }
+fission = { version = "0.9.2", default-features = false, features = ["desktop"] }
 "#,
         )
         .unwrap();
@@ -1544,7 +1544,7 @@ edition = "2021"
 anyhow = "1"
 
 [dependencies.fission]
-version = "0.9.1"
+version = "0.9.2"
 default-features = true
 features = ["desktop"]
 "#,

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-core"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-core/assets/AGENTS.md
+++ b/crates/tools/fission-command-core/assets/AGENTS.md
@@ -217,7 +217,7 @@ Outside the Fission source workspace, prefer the published crate pinned to the s
 
 ```toml
 [build-dependencies]
-fission-design-system-codegen = { version = "0.9.1" }
+fission-design-system-codegen = { version = "0.9.2" }
 ```
 
 Generate a typed design system from the copied DSP file in `build.rs`:

--- a/crates/tools/fission-command-package/Cargo.toml
+++ b/crates/tools/fission-command-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-package"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ aws-config = "1"
 aws-sdk-s3 = "1"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.9.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.9.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.9.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.2" }
+fission-command-run = { path = "../fission-command-run", version = "0.9.2" }
+fission-command-site = { path = "../fission-command-site", version = "0.9.2" }
 flate2 = "1.0"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-release/Cargo.toml
+++ b/crates/tools/fission-command-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-release"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -13,9 +13,9 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.9.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.9.1" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.9.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.2" }
+fission-command-package = { path = "../fission-command-package", version = "0.9.2" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.9.2" }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 jsonwebtoken = "9"
 md-5 = "0.10"

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-run"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,10 +11,10 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-command-core = { path = "../fission-command-core", version = "0.9.1" }
-fission-command-server = { path = "../fission-command-server", version = "0.9.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.9.1" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.9.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.9.2" }
+fission-command-server = { path = "../fission-command-server", version = "0.9.2" }
+fission-command-site = { path = "../fission-command-site", version = "0.9.2" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.9.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ureq = "2"

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-server"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-site"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,6 +11,6 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.9.1" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.9.2" }
 serde_json = "1"
 toml = "0.8"

--- a/crates/tools/fission-command-ui/Cargo.toml
+++ b/crates/tools/fission-command-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-ui"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -11,11 +11,11 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../authoring/fission", version = "0.9.1", default-features = false, features = ["desktop", "terminal-shell"] }
-fission-command-core = { path = "../fission-command-core", version = "0.9.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.9.1" }
-fission-command-release = { path = "../fission-command-release", version = "0.9.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.9.1" }
+fission = { path = "../../authoring/fission", version = "0.9.2", default-features = false, features = ["desktop", "terminal-shell"] }
+fission-command-core = { path = "../fission-command-core", version = "0.9.2" }
+fission-command-package = { path = "../fission-command-package", version = "0.9.2" }
+fission-command-release = { path = "../fission-command-release", version = "0.9.2" }
+fission-command-run = { path = "../fission-command-run", version = "0.9.2" }
 rfd = { version = "0.14.1", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 toml_edit = "0.23"

--- a/crates/tools/fission-design-system-codegen/Cargo.toml
+++ b/crates/tools/fission-design-system-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-design-system-codegen"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-diagnostics"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test-driver/Cargo.toml
+++ b/crates/tools/fission-test-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test-driver"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test/Cargo.toml
+++ b/crates/tools/fission-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -10,23 +10,23 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.9.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.9.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.9.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.9.1" }
-fission-shell = { path = "../../shell/fission-shell", version = "0.9.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.1" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.9.1" }
+fission-core = { path = "../../core/fission-core", version = "0.9.2" }
+fission-ir = { path = "../../core/fission-ir", version = "0.9.2" }
+fission-layout = { path = "../../core/fission-layout", version = "0.9.2" }
+fission-render = { path = "../../rendering/fission-render", version = "0.9.2" }
+fission-shell = { path = "../../shell/fission-shell", version = "0.9.2" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.9.2" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.9.2" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
-fission-macros = { path = "../../authoring/fission-macros", version = "0.9.1" }
-fission-diagnostics = { path = "../fission-diagnostics", version = "0.9.1" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.9.1" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.9.2" }
+fission-diagnostics = { path = "../fission-diagnostics", version = "0.9.2" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.9.2" }
+fission-theme = { path = "../../core/fission-theme", version = "0.9.2" }
 fontique = "0.7"
 read-fonts = "0.35"
 serde_json = "1.0"
 
 [dev-dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.9.1" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.9.2" }

--- a/documentation/Cargo.toml
+++ b/documentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-documentation"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/documentation/content/blog/2026-07-24-fission-0-9-2-responsive-memory-and-macos-delivery.mdx
+++ b/documentation/content/blog/2026-07-24-fission-0-9-2-responsive-memory-and-macos-delivery.mdx
@@ -1,0 +1,117 @@
+---
+title: Fission 0.9.2: responsive apps, bounded rendering, and Mac App Store delivery
+authors:
+  - fission
+tags:
+  - release
+  - responsive-design
+  - performance
+  - macos
+  - app-store
+  - testing
+categories:
+  - Releases
+---
+
+Fission 0.9.2 closes the gap between having a capable API and proving that the whole framework uses it well. The release rebuilds the examples around retained responsive components, fixes the renderer and layout issues those examples exposed, adds anchored spotlight layouts, and completes the path from a Fission macOS project to a submitted Mac App Store build.
+
+The examples were important to this work. They are not decorative screenshots; they are applications developers read, run, test, and copy. When the editor, inbox, galleries, and product demos were exercised across desktop and compact viewports, they exposed unreachable controls, duplicated responsive state, incorrect intrinsic sizing, unstable custom input identity, and memory use that did not correspond to the visible scene. 0.9.2 fixes those causes rather than hiding them behind reduced functionality.
+
+## Responsive examples that model real Fission applications
+
+The animation gallery, chart gallery, editor, field inspector, inbox, product examples, text lab, widget gallery, and smoke examples now use concrete widget structs, retained component boundaries, stable identities, design-system values, and explicit responsive branches.
+
+That means compact layouts are designed rather than merely compressed. Product filters and detail views remain reachable, chart plots and legends adapt to the available width, gallery controls remain usable on narrow screens, and stateful controls are not duplicated across simultaneously lowered responsive branches.
+
+The documentation grew with the examples. Learn, Develop, Cookbook, Test and Debug, Release and Distribute, and Reference now cover the responsive and visual-fidelity APIs in context: typed `Length`, responsive variants, `Grid`, `Container`, `Pressable`, packaged fonts, golden image checks, package metadata, and release screenshots.
+
+The result is a more useful source tree. Applications can still choose declarative responsive composition or make an imperative viewport decision where that is genuinely clearer, but the examples no longer mix the two styles accidentally or hide reusable widget trees behind `fn -> Widget` factories.
+
+## Memory now follows visible rendering work
+
+The manual QA pass found a more serious problem than layout polish. GPU examples that should have remained modest in memory were retaining substantially more than their visible content justified.
+
+Profiling narrowed that to two concrete causes. Packaged fonts were eagerly parsed for the software renderer even when the application was using Vello, retaining roughly 57 MB that the active renderer did not need. Large documents also used retained document glyph counts to size Vello caller buffers, even when most of those glyphs were outside the current scroll clip. A large `Cargo.lock` could request an 805 MB line buffer despite only a small portion of the document being visible.
+
+0.9.2 parses packaged software fonts only when software rendering needs them, culls rich text against active scroll clips before glyph encoding, and sizes Vello workloads from the encoded visible scene. Native Moka and WASM-safe LRU image caches now share the same bounded 50 MB policy as well.
+
+The measured macOS physical footprint changed materially:
+
+| Example | Viewport | Before | After |
+| --- | ---: | ---: | ---: |
+| Inbox | 800 x 600 | 122 MB | 52 MB |
+| Inbox | 1280 x 800 | 158 MB | 90 MB |
+| Inbox | compact/mobile | 148 MB | 53 MB |
+| Editor | 800 x 600 | 79 MB | 66-67 MB |
+| Editor | 1280 x 800 | 110 MB | 80 MB |
+| Editor | compact/mobile | 98 MB | 56 MB |
+
+A large `Cargo.lock` now renders without the GPU buffer overflow at roughly 127 MB. Whole-document Parley shaping remains the next large-document cost, but Vello is no longer allocating buffers from offscreen work it will not encode.
+
+## Layout, input, and retained identity fixes
+
+The same QA pass fixed several smaller problems that shared one theme: the rendered geometry, hit geometry, semantics, and retained identity must describe the same control.
+
+Wrapped and aligned controls now preserve their intrinsic dimensions. Stretch alignment retains an explicit cross-axis size instead of silently replacing it. Sliders align their thumb with the track and map pointer positions to the value implied by the point that was clicked. Flyouts now clamp using the bounds of their rendered descendants, which prevents a tooltip or other intrinsic popup from escaping the viewport because its root box understated the visible content.
+
+Custom render widgets also receive stable identities across rebuilds. This matters for editor, terminal, chart, and other input-heavy surfaces where a rebuild should not create a new logical input target. Timer resources and startup reducers now schedule the required rebuild after state changes instead of mutating state without refreshing the visible tree.
+
+LiveTest selector resolution has been tightened for responsive trees too. When inactive and active branches share a semantic identifier and hidden nodes are included, Fission prefers the branch that actually participates in layout. Tests can keep using stable semantic selectors instead of calculating coordinates or knowing which responsive implementation is active.
+
+## Anchored spotlight layouts
+
+`Spotlight` is a new low-level widget for product tours and contextual onboarding. It receives an existing anchor `WidgetId`, reveal padding, and five children: four shaded regions around the target and one focus-ring region over it.
+
+```rust
+Spotlight {
+    anchor: WidgetId::explicit("onboarding.primary_action"),
+    padding: tokens.spacing.s,
+    children: spotlight_regions,
+}
+.into()
+```
+
+The geometry is part of Fission's normal lowering and layout pipeline on native targets. Web, Static site, and SSR output emit the same contract and update the regions after resize, scroll, or observed anchor changes. If the anchor is unavailable, the overlay closes the hole rather than revealing an arbitrary part of the application.
+
+`Spotlight` deliberately does not invent a tour state machine, user-facing copy, focus policy, or accessibility announcement. Applications keep those responsibilities in a named component, with localized text and semantic actions that can be exercised through LiveTest. Terminal output rejects the layout because a terminal cell grid cannot preserve the same overlay geometry.
+
+## Mac App Store delivery
+
+Fission's macOS release path now covers both notarized direct distribution and the Mac App Store instead of treating every App Store Connect build as an iOS IPA.
+
+The CLI can build a signed Mac App Store PKG with the selected macOS package variant, upload it, follow processing state, resolve the corresponding macOS build, synchronize version metadata, and submit the build for review. Readiness selects iOS or macOS from the requested IPA or PKG format before an artifact exists, then checks the correct target build number.
+
+Several issues found during a real submission are fixed in the same path:
+
+- existing App Store localizations no longer send Apple's immutable locale field during updates;
+- generated artifact paths no longer prepend the project root twice;
+- PKG uploads and build queries use the macOS App Store platform;
+- App Store screenshots can be organized by explicit display type and rendered without an alpha channel;
+- failed screenshot capture scenarios stop their application, honor their configured timeout, and use the public LiveTest selector protocol.
+
+Three cookbook tutorials now take maintainers through Apple certificate, provisioning-profile, and API-key setup; notarized direct macOS distribution; and Mac App Store metadata, screenshots, packaging, upload, and submission.
+
+Desktop package variants also use one effective Cargo configuration across development and release. `fission run` and desktop builds honor the same variant `cargo_features` and `cargo_no_default_features` overlay that packaging uses, so a Store-specific feature set is tested before it is packaged.
+
+## Validation
+
+The responsive and renderer work was manually exercised across 19 example and browser paths with more than 322 LiveTest `/cmd` actions. All 13 colour-picker variants were checked at desktop and mobile sizes, and 49 ignored end-to-end LiveTests were run alongside the core, layout, Vello, Winit, server, WebGPU, Static site, and SSR suites.
+
+The Mac App Store and Spotlight changes add focused package, release, layout, widget, native-shell, browser-renderer, Android, iOS, Web/WASM, and CLI platform coverage.
+
+## Migration notes
+
+Update Fission dependencies to 0.9.2:
+
+```toml
+fission = { version = "0.9.2", default-features = false, features = ["desktop"] }
+```
+
+Ordinary applications do not need a code migration. Desktop variants should list their complete effective Cargo feature set because a variant feature list replaces the base list, matching the package overlay model. Mac App Store projects should use a macOS package variant, PKG format, and `distribution.app_store.platform = "macos"`.
+
+Relevant pull requests:
+
+- [#141: responsive examples and renderer memory hardening](https://github.com/fission-ui/fission/pull/141)
+- [#143: desktop packaging with Cargo target overrides](https://github.com/fission-ui/fission/pull/143)
+- [#146: macOS App Store release workflows](https://github.com/fission-ui/fission/pull/146)
+- [#145: Spotlight, release capture, and variant readiness](https://github.com/fission-ui/fission/pull/145)

--- a/documentation/content/docs/guides/design-system.mdx
+++ b/documentation/content/docs/guides/design-system.mdx
@@ -69,10 +69,10 @@ Add the generator as a build dependency:
 
 ```toml title="Cargo.toml"
 [dependencies]
-fission = { version = "0.9.1", default-features = false, features = ["desktop"] }
+fission = { version = "0.9.2", default-features = false, features = ["desktop"] }
 
 [build-dependencies]
-fission-design-system-codegen = "0.9.1"
+fission-design-system-codegen = "0.9.2"
 ```
 
 ## What you should have working

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -89,7 +89,7 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["server", "server-redis"] }
+fission = { version = "0.9.2", features = ["server", "server-redis"] }
 ```
 
 ## Invalidate cached pages after writes

--- a/documentation/content/docs/guides/server-site-security.mdx
+++ b/documentation/content/docs/guides/server-site-security.mdx
@@ -78,14 +78,14 @@ Hyper is available with the normal `server` feature:
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["server"] }
+fission = { version = "0.9.2", features = ["server"] }
 ```
 
 Axum and Actix adapters are feature-gated to avoid pulling those dependencies into projects that do not use them:
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["server", "server-axum"] }
+fission = { version = "0.9.2", features = ["server", "server-axum"] }
 tower = "0.5"
 ```
 

--- a/documentation/content/docs/guides/static-sites.mdx
+++ b/documentation/content/docs/guides/static-sites.mdx
@@ -221,7 +221,7 @@ Use front matter to describe each post:
 
 ```mdx
 ---
-title: Fission 0.9.1
+title: Fission 0.9.2
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -232,7 +232,7 @@ tags:
   - authoring
 ---
 
-# Fission 0.9.1
+# Fission 0.9.2
 
 Write the post body here.
 ```

--- a/documentation/content/docs/guides/terminal-user-interfaces.mdx
+++ b/documentation/content/docs/guides/terminal-user-interfaces.mdx
@@ -21,7 +21,7 @@ Use the Fission facade crate and enable the terminal shell feature for tools tha
 
 ```toml
 [dependencies]
-fission = { version = "0.9.1", features = ["terminal-shell"] }
+fission = { version = "0.9.2", features = ["terminal-shell"] }
 ```
 
 ## What you should have working

--- a/documentation/content/docs/learn/testing.mdx
+++ b/documentation/content/docs/learn/testing.mdx
@@ -128,7 +128,7 @@ client.wait_for_ready(15_000)?;
 Prefer semantic selectors over coordinates. Coordinates are still useful for low-level input bugs, but product tests should name the UI element they intend to use.
 
 ```rust
-client.fill_text_semantic_identifier("todo.title", "Publish 0.9.1")?;
+client.fill_text_semantic_identifier("todo.title", "Publish 0.9.2")?;
 client.tap_semantic_identifier("todo.add")?;
 client.wait_for_visible(
     SelectorQuery::semantic_identifier("todo.row.0"),

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -418,7 +418,7 @@ Example:
 
 ```mdx
 ---
-title: Fission 0.9.1
+title: Fission 0.9.2
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -430,7 +430,7 @@ tags:
 show_adjacent_posts: true
 ---
 
-# Fission 0.9.1
+# Fission 0.9.2
 
 Write the post body here.
 ```

--- a/documentation/content/reference/widgets/widget-pages/video.mdx
+++ b/documentation/content/reference/widgets/widget-pages/video.mdx
@@ -118,7 +118,7 @@ In the winit shell path, macOS and iOS use AVFoundation player layers, Windows u
 Native Linux video is behind the `video` Cargo feature so ordinary desktop apps do not need GStreamer development packages unless they use embedded video:
 
 ```toml
-fission = { version = "0.9.1", default-features = false, features = ["desktop", "video"] }
+fission = { version = "0.9.2", default-features = false, features = ["desktop", "video"] }
 ```
 
 On Debian or Ubuntu, enabling that feature requires:

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -153,7 +153,7 @@ impl From<FooterIdentity> for Widget {
                     ..Default::default()
                 }
                 .into(),
-                Text::new("Fission 0.9.1")
+                Text::new("Fission 0.9.2")
                     .size(tokens.typography.font_size_sm)
                     .family(tokens.typography.font_family_mono.clone())
                     .color(tokens.colors.text_muted)

--- a/examples/animation-gallery/Cargo.toml
+++ b/examples/animation-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animation-gallery"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/chart-gallery/Cargo.toml
+++ b/examples/chart-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chart-gallery"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "counter"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-editor"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/embed-3d/Cargo.toml
+++ b/examples/embed-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-3d"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/examples/embed-video/Cargo.toml
+++ b/examples/embed-video/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-video"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/examples/embed-webview/Cargo.toml
+++ b/examples/embed-webview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-webview"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/Cargo.toml
+++ b/examples/field-inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-inspector"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/fission.toml
+++ b/examples/field-inspector/fission.toml
@@ -24,13 +24,13 @@ capabilities = [
 [app]
 name = "field-inspector"
 app_id = "com.fission.examples.fieldinspector"
-version = "0.9.1"
+version = "0.9.2"
 build = 1
 
 [package.android]
 package_name = "com.fission.examples.fieldinspector"
 version_code = 1
-version_name = "0.9.1"
+version_name = "0.9.2"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -41,13 +41,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.fission.examples.fieldinspector"
-marketing_version = "0.9.1"
+marketing_version = "0.9.2"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.fission.examples.fieldinspector"
 publisher = "CN=Fission Developer"
-version = "0.9.1"
+version = "0.9.2"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/icons_gallery/Cargo.toml
+++ b/examples/icons_gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icons_gallery"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/inbox/Cargo.toml
+++ b/examples/inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inbox"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/mobile-smoke/Cargo.toml
+++ b/examples/mobile-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-smoke"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/examples/motion-memory-repro/Cargo.toml
+++ b/examples/motion-memory-repro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion-memory-repro"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/pokemon-card-store/Cargo.toml
+++ b/examples/pokemon-card-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pokemon-card-store"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 publish = false
 

--- a/examples/pokemon-card-store/fission.toml
+++ b/examples/pokemon-card-store/fission.toml
@@ -19,7 +19,7 @@ preload = "route"
 
 [package.docker]
 port = 8080
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.9.1"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.9.2"]
 
 [distribution.docker_registry.production]
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.9.1"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.9.2"]

--- a/examples/product-browser/Cargo.toml
+++ b/examples/product-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product-browser"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/text-lab/Cargo.toml
+++ b/examples/text-lab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-lab"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/todo-design-system/Cargo.toml
+++ b/examples/todo-design-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-design-system"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/examples/web-smoke/Cargo.toml
+++ b/examples/web-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-smoke"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/examples/web-smoke/fission.toml
+++ b/examples/web-smoke/fission.toml
@@ -10,13 +10,13 @@ targets = [
 [app]
 name = "web-smoke"
 app_id = "com.example.web_smoke"
-version = "0.9.1"
+version = "0.9.2"
 build = 1
 
 [package.android]
 package_name = "com.example.web_smoke"
 version_code = 1
-version_name = "0.9.1"
+version_name = "0.9.2"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -27,13 +27,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.example.web_smoke"
-marketing_version = "0.9.1"
+marketing_version = "0.9.2"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.example.web.smoke"
 publisher = "CN=Fission Developer"
-version = "0.9.1"
+version = "0.9.2"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "widget-gallery"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## What this release contains

Fission 0.9.2 consolidates the responsive/example hardening, renderer memory fixes, desktop packaging corrections, anchored Spotlight widget, and complete macOS App Store delivery work now on `main`.

### Responsive examples and documentation

- rebuilds the animation gallery, chart gallery, editor, field inspector, inbox, product examples, text lab, widget gallery, and smoke examples around retained responsive components;
- keeps compact controls and routed content reachable without duplicating retained state across responsive branches;
- uses stable widget identities, design-system values, and semantic LiveTest selectors;
- expands Learn, Develop, Cookbook, Test and Debug, Release and Distribute, and Reference coverage for typed lengths, responsive variants, grid, containers, pressables, packaged fonts, golden checks, package metadata, and release screenshots.

### Renderer, layout, and runtime correctness

- sizes Vello caller buffers from encoded visible work rather than retained offscreen document content;
- culls rich text against active scroll clips before glyph encoding;
- lazily loads software-renderer fonts and applies the same bounded 50 MB image-cache policy on native and WASM;
- aligns slider rendering, pointer mapping, and semantic values;
- preserves intrinsic dimensions through wrapping/alignment and clamps flyouts by rendered descendant bounds;
- retains stable custom-input identity across rebuilds and schedules rebuilds after timer/startup state changes;
- resolves duplicate responsive semantic selectors to the branch participating in layout.

Measured macOS physical-footprint changes include Inbox at 800x600 from 122 MB to 52 MB and Editor at 1280x800 from 110 MB to 80 MB. A large `Cargo.lock` now renders without the previous GPU buffer overflow at roughly 127 MB; whole-document Parley shaping remains the main large-document cost.

### Spotlight and browser parity

- adds a concrete first-class `Spotlight` widget with anchored five-region geometry;
- shares the geometry contract across native, Web, Static site, and SSR;
- keeps browser overlays anchored through resize, scroll, and anchor changes;
- documents the intentional Terminal limitation.

### macOS App Store and release workflows

- packages signed Mac App Store PKGs and supports upload, processing status, build lookup, metadata synchronization, and review submission;
- resolves App Store readiness against iOS or macOS from the selected IPA/PKG format;
- fixes immutable locale updates, generated artifact paths, PNG alpha preparation, screenshot scenario cleanup/timeouts, and public LiveTest selector serialization;
- makes `fission run`, desktop build, and packaging use the same effective variant Cargo feature configuration;
- adds Apple signing, notarized direct distribution, and Mac App Store cookbook tutorials.

## Release metadata

- bumps every first-party crate and internal dependency requirement to `0.9.2`;
- updates generated project guidance, README snippets, docs snippets, examples, lockfile, and site version chrome;
- adds the 0.9.2 changelog entry and release blog post;
- leaves the independently versioned Vello, Winit, and AccessKit forks unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test -p fission-command-package -p fission-command-release -p fission-command-ui -p fission-test-driver`
- `cargo run -p cargo-fission --bin fission -- site check --project-dir documentation --release` (827 routes)
- `cargo run -p cargo-fission --bin fission -- package --project-dir documentation --target site --format static --release`
- static package load-smoke validation passed and the 0.9.2 blog route is present
- `git diff --check`
- crate package assembly was exercised for the full first-party publish order; leaf dry-runs passed, and dependency-bearing dry-runs will be repeated immediately before each publish after the preceding 0.9.2 crates are indexed

## Included work

- #141
- #143
- #145
- #146
