### PR TITLE
Add non-scrolling Markdown content widget

### DIFF
--- a/crates/authoring/fission-widgets/src/lib.rs
+++ b/crates/authoring/fission-widgets/src/lib.rs
@@ -214,7 +214,7 @@ pub mod link;
 pub use link::Link;
 
 pub mod markdown;
-pub use markdown::MarkdownViewer;
+pub use markdown::{MarkdownContent, MarkdownViewer};
 
 pub mod pagination;
 pub use pagination::Pagination;

--- a/crates/authoring/fission-widgets/src/markdown.rs
+++ b/crates/authoring/fission-widgets/src/markdown.rs
@@ -26,6 +26,31 @@ pub struct MarkdownViewer {
     pub show_scrollbar: bool,
 }
 
+/// Parses Markdown into ordinary Fission content without creating a scroll
+/// viewport.
+///
+/// Use this when the surrounding page already owns scrolling. It renders the
+/// same safe native Markdown nodes as [`MarkdownViewer`] while allowing the
+/// document to participate in the parent's intrinsic layout.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MarkdownContent {
+    pub markdown: String,
+}
+
+impl MarkdownContent {
+    pub fn new(markdown: impl Into<String>) -> Self {
+        Self {
+            markdown: markdown.into(),
+        }
+    }
+}
+
+impl From<MarkdownContent> for Widget {
+    fn from(component: MarkdownContent) -> Self {
+        render_markdown_content(&component.markdown)
+    }
+}
+
 impl Default for MarkdownViewer {
     fn default() -> Self {
         Self {
@@ -46,19 +71,10 @@ impl MarkdownViewer {
 
 impl From<MarkdownViewer> for Widget {
     fn from(component: MarkdownViewer) -> Self {
-        let (_, view) = fission_core::build::current::<()>();
         let this = &component;
 
-        let parser = Parser::with_extensions(
-            parser::Options::default(),
-            parser::gfm(parser::GfmOptions::default()),
-        );
-        let mut reader = BasicReader::new(&this.markdown);
-        let (arena, document_ref) = parser.parse(&mut reader);
-        let renderer = MarkdownRenderer::new(&this.markdown, &arena, view);
-
         Scroll {
-            child: Some(renderer.document(document_ref)),
+            child: Some(render_markdown_content(&this.markdown)),
             direction: FlexDirection::Column,
             show_scrollbar: this.show_scrollbar,
             flex_grow: 1.0,
@@ -66,6 +82,17 @@ impl From<MarkdownViewer> for Widget {
         }
         .into()
     }
+}
+
+fn render_markdown_content(markdown: &str) -> Widget {
+    let (_, view) = fission_core::build::current::<()>();
+    let parser = Parser::with_extensions(
+        parser::Options::default(),
+        parser::gfm(parser::GfmOptions::default()),
+    );
+    let mut reader = BasicReader::new(markdown);
+    let (arena, document_ref) = parser.parse(&mut reader);
+    MarkdownRenderer::new(markdown, &arena, view).document(document_ref)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/authoring/fission-widgets/src/markdown.rs
+++ b/crates/authoring/fission-widgets/src/markdown.rs
@@ -47,7 +47,14 @@ impl MarkdownContent {
 
 impl From<MarkdownContent> for Widget {
     fn from(component: MarkdownContent) -> Self {
-        render_markdown_content(&component.markdown)
+        let (_, view) = fission_core::build::current::<()>();
+        let parser = Parser::with_extensions(
+            parser::Options::default(),
+            parser::gfm(parser::GfmOptions::default()),
+        );
+        let mut reader = BasicReader::new(&component.markdown);
+        let (arena, document_ref) = parser.parse(&mut reader);
+        MarkdownRenderer::new(&component.markdown, &arena, view).document(document_ref)
     }
 }
 
@@ -74,7 +81,7 @@ impl From<MarkdownViewer> for Widget {
         let this = &component;
 
         Scroll {
-            child: Some(render_markdown_content(&this.markdown)),
+            child: Some(MarkdownContent::new(this.markdown.clone()).into()),
             direction: FlexDirection::Column,
             show_scrollbar: this.show_scrollbar,
             flex_grow: 1.0,
@@ -82,17 +89,6 @@ impl From<MarkdownViewer> for Widget {
         }
         .into()
     }
-}
-
-fn render_markdown_content(markdown: &str) -> Widget {
-    let (_, view) = fission_core::build::current::<()>();
-    let parser = Parser::with_extensions(
-        parser::Options::default(),
-        parser::gfm(parser::GfmOptions::default()),
-    );
-    let mut reader = BasicReader::new(markdown);
-    let (arena, document_ref) = parser.parse(&mut reader);
-    MarkdownRenderer::new(markdown, &arena, view).document(document_ref)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/authoring/fission-widgets/tests/markdown_viewer_test.rs
+++ b/crates/authoring/fission-widgets/tests/markdown_viewer_test.rs
@@ -2,7 +2,7 @@ use fission_core::internal::BuildCtx;
 use fission_core::{build, Env, GlobalState, RuntimeState, View, Widget};
 use fission_ir::op::{ImageSource, PaintOp};
 use fission_ir::Op;
-use fission_widgets::MarkdownViewer;
+use fission_widgets::{MarkdownContent, MarkdownViewer};
 
 #[derive(Default, Debug, Clone)]
 struct State;
@@ -26,6 +26,28 @@ fn scroll_content(node: Widget) -> Widget {
         .as_ref()
         .expect("MarkdownViewer scroll content")
         .clone()
+}
+
+fn build_markdown_content(markdown: &str) -> Widget {
+    let env = Env::default();
+    let runtime = RuntimeState::default();
+    let state = State;
+    let view = View::new(&state, &runtime, &env, None);
+    let mut ctx = BuildCtx::<State>::new();
+
+    build::enter(&mut ctx, &view, || MarkdownContent::new(markdown).into())
+}
+
+#[test]
+fn markdown_content_participates_in_parent_scrolling_without_nested_scroll() {
+    let content = build_markdown_content("# Title\n\nBody\n");
+    assert!(
+        fission_core::internal::widget_as_scroll(&content).is_none(),
+        "MarkdownContent must not create an independent scroll viewport"
+    );
+    let column = fission_core::internal::widget_as_column(&content)
+        .expect("MarkdownContent should render its document column directly");
+    assert_eq!(column.children.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- separate Markdown content rendering from the scrollable viewer wrapper
- expose a non-scrolling `MarkdownContent` widget for embedding in an existing scroll region
- retain `MarkdownViewer` as the convenient scrollable composition
- add coverage for both rendering modes

## Motivation

Applications that place rendered Markdown inside a larger detail panel currently receive nested scroll regions and double scrollbars. This gives callers a content-only widget while preserving the existing viewer API.