### PR TITLE
Expose host system appearance through Env

### DIFF
--- a/crates/core/fission-core/src/env.rs
+++ b/crates/core/fission-core/src/env.rs
@@ -7,7 +7,7 @@ use fission_ir::semantics::MouseCursor;
 use fission_ir::WidgetId;
 use fission_layout::{LayoutPoint, LayoutSize};
 use fission_text_engine::{EditTransaction, TextBuffer, TextEdit};
-use fission_theme::Theme;
+use fission_theme::{DesignMode, Theme};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -101,6 +101,11 @@ impl RouteLocation {
 #[derive(Clone)]
 pub struct Env {
     pub theme: Theme,
+    /// Current light/dark appearance reported by the host platform.
+    ///
+    /// Applications that offer a "System" preference can select their generated
+    /// design-system theme from this value during environment synchronization.
+    pub system_theme_mode: DesignMode,
     pub i18n: I18nRegistry,
     pub locale: Locale,
     pub window: WindowEnv,
@@ -114,6 +119,7 @@ impl Default for Env {
     fn default() -> Self {
         Self {
             theme: Theme::default(),
+            system_theme_mode: DesignMode::Light,
             i18n: I18nRegistry::new(),
             locale: Locale::default(),
             window: WindowEnv::default(),
@@ -129,6 +135,7 @@ impl std::fmt::Debug for Env {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Env")
             .field("theme", &self.theme)
+            .field("system_theme_mode", &self.system_theme_mode)
             .field("locale", &self.locale)
             .field("window", &self.window)
             .field("current_route", &self.current_route)
@@ -142,6 +149,7 @@ impl Env {
     pub fn new(measurer: Arc<dyn fission_layout::TextMeasurer>) -> Self {
         Self {
             theme: Theme::default(),
+            system_theme_mode: DesignMode::Light,
             i18n: I18nRegistry::new(),
             locale: Locale::default(),
             window: WindowEnv::default(),
@@ -842,4 +850,14 @@ pub enum VideoStatus {
     Buffering,
     Ended,
     Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn environment_exposes_a_safe_light_system_theme_default() {
+        assert_eq!(Env::default().system_theme_mode, DesignMode::Light);
+    }
 }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -31,7 +31,7 @@ use winit::{
     event_loop::{
         ActiveEventLoop as EventLoopWindowTarget, ControlFlow, EventLoop, EventLoopProxy,
     },
-    window::{CursorIcon, Window, WindowAttributes, WindowId},
+    window::{CursorIcon, Theme as WindowTheme, Window, WindowAttributes, WindowId},
 };
 
 use fission_core::env::{VideoStatus, WindowInsets};
@@ -6617,6 +6617,16 @@ where
                                 "scale_factor_changed",
                             );
                         }
+                        WindowEvent::ThemeChanged(theme) => {
+                            env.system_theme_mode = match theme {
+                                WindowTheme::Light => fission_theme::DesignMode::Light,
+                                WindowTheme::Dark => fission_theme::DesignMode::Dark,
+                            };
+                            invalidations.mark_build();
+                            frame_trace.note_redraw_reason("system_theme_changed");
+                            window.request_redraw();
+                            redraw_pending = true;
+                        }
                         WindowEvent::RedrawRequested => {
                             if debug_android_events {
                                 eprintln!("[android-events] redraw_requested");
@@ -6942,6 +6952,10 @@ where
                             env.viewport_size = build_viewport;
                             env.window_insets =
                                 window_safe_area_insets(window, viewport_state.scale_factor);
+                            env.system_theme_mode = match window.theme() {
+                                Some(WindowTheme::Dark) => fission_theme::DesignMode::Dark,
+                                Some(WindowTheme::Light) | None => fission_theme::DesignMode::Light,
+                            };
 
                             if let Some(sync) = &self.sync_env {
                                 let state = runtime.get_global_state::<S>().unwrap();


### PR DESCRIPTION
## Summary

- add a host `system_appearance` value to the Fission environment
- update it from the winit shell using the window theme
- preserve the application-selected theme while making the operating-system preference observable

## Motivation

Desktop applications need to offer a System theme choice in addition to explicit Light and Dark choices. Exposing the host preference separately lets app state retain the user choice while environment synchronization resolves System to the current host appearance.