### PR TITLE
Keep modal surfaces intrinsically sized

### DIFF
--- a/crates/authoring/fission-widgets/src/modal.rs
+++ b/crates/authoring/fission-widgets/src/modal.rs
@@ -5,7 +5,7 @@ use crate::motion_support::{
 use crate::stack::{HStack, VStack};
 use crate::Icon;
 use fission_core::motion::{MotionTrack, Presence};
-use fission_core::op::Color;
+use fission_core::op::{Color, Length};
 use fission_core::ui::{
     Align, Button, ButtonVariant, Container, GestureDetector, Text, Widget, ZStack,
 };
@@ -335,31 +335,37 @@ impl From<Modal> for Widget {
             );
         }
 
+        let mut header_children = vec![
+            Text::new(this.title.clone()).size(20.0).into(),
+            fission_core::ui::widgets::spacer::Spacer {
+                flex_grow: 1.0,
+                ..Default::default()
+            }
+            .into(),
+        ];
+        if let Some(on_dismiss) = this.on_dismiss.clone() {
+            header_children.push(
+                Button {
+                    variant: ButtonVariant::Ghost,
+                    child: Some(
+                        Icon::svg(fission_icons::material::navigation::close::regular())
+                            .size(20.0)
+                            .into(),
+                    ),
+                    on_press: Some(on_dismiss),
+                    ..Default::default()
+                }
+                .into(),
+            );
+        }
+
         let mut modal_card_builder = Container::new(VStack {
             spacing: Some(16.0),
             children: vec![
                 // Header
                 HStack {
                     spacing: Some(8.0),
-                    children: vec![
-                        Text::new(this.title.clone()).size(20.0).into(),
-                        fission_core::ui::widgets::spacer::Spacer {
-                            flex_grow: 1.0,
-                            ..Default::default()
-                        }
-                        .into(),
-                        Button {
-                            variant: ButtonVariant::Ghost,
-                            child: Some(
-                                Icon::svg(fission_icons::material::navigation::close::regular())
-                                    .size(20.0)
-                                    .into(),
-                            ),
-                            on_press: this.on_dismiss.clone(),
-                            ..Default::default()
-                        }
-                        .into(),
-                    ],
+                    children: header_children,
                 }
                 .into(),
                 // Content
@@ -396,6 +402,7 @@ impl From<Modal> for Widget {
 
         let mut modal_card: Widget = modal_card_builder
             .width(dialog_width)
+            .height_length(Length::fit_content(None))
             .padding_all(24.0)
             .into();
         if let Some(plan) = &motion_plan {

--- a/crates/tools/fission-test/tests/interaction_and_layout_regressions.rs
+++ b/crates/tools/fission-test/tests/interaction_and_layout_regressions.rs
@@ -1,5 +1,5 @@
-use fission_core::ui::{Container, Text, Widget};
-use fission_core::{reduce_with, GlobalState, ReducerContext};
+use fission_core::ui::{Container, SemanticsRegion, Text, Widget};
+use fission_core::{GlobalState, ReducerContext, Role, reduce_with};
 use fission_test::TestHarness;
 use fission_widgets::{NumberInput, SplitDirection, SplitView};
 
@@ -274,4 +274,61 @@ fn test_modal_close_button_dismiss() {
 
     let state = h.runtime.get_app_state::<State>().unwrap();
     assert!(!state.modal_open, "Modal should be closed via close button");
+}
+
+#[test]
+fn test_modal_content_keeps_its_intrinsic_height() {
+    use fission_widgets::Modal;
+
+    const VIEWPORT_HEIGHT: f32 = 600.0;
+
+    #[derive(Clone)]
+    struct IntrinsicModalTest;
+
+    impl From<IntrinsicModalTest> for Widget {
+        fn from(_component: IntrinsicModalTest) -> Self {
+            Modal {
+                id: fission_core::WidgetId::explicit("intrinsic_modal"),
+                title: "Required action".into(),
+                content: SemanticsRegion::new(Text::new("A short explanation"))
+                    .identifier("intrinsic-modal-content")
+                    .role(Role::Dialog)
+                    .into(),
+                is_open: true,
+                on_dismiss: None,
+                actions: vec![],
+                width: Some(420.0),
+                motion: None,
+            }
+            .into()
+        }
+    }
+
+    let mut harness = TestHarness::new(State::default()).with_root_widget(IntrinsicModalTest);
+    harness.pump().unwrap();
+
+    let ir = harness.last_ir.as_ref().unwrap();
+    let snapshot = harness.last_snapshot.as_ref().unwrap();
+    let content_id = ir
+        .nodes
+        .iter()
+        .find_map(|(id, node)| match &node.op {
+            fission_ir::Op::Semantics(semantics)
+                if semantics.identifier.as_deref() == Some("intrinsic-modal-content") =>
+            {
+                Some(*id)
+            }
+            _ => None,
+        })
+        .expect("modal content semantics were not rendered");
+    let content = snapshot
+        .get_node_rect(content_id)
+        .expect("modal content was not laid out");
+
+    assert!(
+        content.height() < VIEWPORT_HEIGHT / 2.0,
+        "short modal content should keep an intrinsic height, got {} in a {}px viewport",
+        content.height(),
+        VIEWPORT_HEIGHT,
+    );
 }


### PR DESCRIPTION
## Summary

- make modal surfaces explicitly use fit-content height
- omit the close control when a modal has no dismiss action
- add a layout regression for short intrinsic modal content

## Motivation

A short required-action dialog could stretch to the full viewport height, and a non-dismissible modal still rendered a misleading close affordance. Required startup and recovery dialogs need a compact content-sized surface without an inoperative escape control.

## Validation

`cargo test -p fission-test --test interaction_and_layout_regressions test_modal_content_keeps_its_intrinsic_height -- --nocapture`