### PR TITLE
Harden desktop development and Store packaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,8 +2649,10 @@ version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
+ "plist",
  "serde",
  "serde_json",
+ "sha1 0.10.6",
  "toml 0.8.2",
  "toml_edit 0.23.10+spec-1.0.0",
 ]
@@ -3060,6 +3062,7 @@ dependencies = [
  "futures-core",
  "gstreamer",
  "gstreamer-video",
+ "gtk",
  "image 0.25.8",
  "jni 0.21.1",
  "js-sys",
@@ -6209,6 +6212,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.41.0",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6461,6 +6477,15 @@ checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -8931,7 +8956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -10063,7 +10088,7 @@ version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "zbus_names 4.3.2",
  "zvariant 5.12.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,8 +3202,7 @@ dependencies = [
 [[package]]
 name = "fission-winit"
 version = "0.30.13-fission.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee53e43ee2bd2a3b827d78df30d1519d08da0eee82cb5cd8ce3a8a6944acdc3"
+source = "git+https://github.com/worka-ai/winit.git?rev=699b7f82b10f1aa65f735e3dbbf33a9701050dea#699b7f82b10f1aa65f735e3dbbf33a9701050dea"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ panic = "abort"
 
 [patch.crates-io]
 android-activity = { path = "third_party/android-activity/android-activity" }
+fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "699b7f82b10f1aa65f735e3dbbf33a9701050dea" }

--- a/crates/authoring/fission-widgets/src/markdown.rs
+++ b/crates/authoring/fission-widgets/src/markdown.rs
@@ -280,7 +280,9 @@ impl<'a> MarkdownRenderer<'a> {
                     image_block = Some(MarkdownImageBlock {
                         node_ref: nested_ref,
                         image,
-                        link_destination: Some(link.destination_str(self.source).to_string()),
+                        link_destination: safe_link_destination(
+                            link.destination_str(self.source).as_ref(),
+                        ),
                     });
                 }
                 image_block
@@ -686,10 +688,15 @@ impl<'a> MarkdownRenderer<'a> {
         style: &InlineStyle,
         runs: &mut Vec<RichTextRun>,
     ) {
+        let Some(destination) = safe_link_destination(link.destination_str(self.source).as_ref())
+        else {
+            self.push_children_inline(node_ref, style, runs);
+            return;
+        };
         let mut link_style = style.clone();
         link_style.color = self.palette.text_link;
         link_style.underline = true;
-        link_style.link_destination = Some(link.destination_str(self.source).to_string());
+        link_style.link_destination = Some(destination);
         self.push_children_inline(node_ref, &link_style, runs);
     }
 
@@ -791,6 +798,21 @@ impl<'a> MarkdownRenderer<'a> {
                 }
             }
         }
+    }
+}
+
+fn safe_link_destination(destination: &str) -> Option<String> {
+    let destination = destination.trim();
+    if destination.is_empty() || destination.chars().any(char::is_control) {
+        return None;
+    }
+
+    let scheme = destination
+        .split_once(':')
+        .map(|(scheme, _)| scheme.to_ascii_lowercase());
+    match scheme.as_deref() {
+        None | Some("http" | "https" | "mailto") => Some(destination.to_string()),
+        Some(_) => None,
     }
 }
 

--- a/crates/authoring/fission-widgets/src/modal.rs
+++ b/crates/authoring/fission-widgets/src/modal.rs
@@ -359,18 +359,16 @@ impl From<Modal> for Widget {
             );
         }
 
-        let mut modal_card_builder = Container::new(VStack {
-            spacing: Some(16.0),
-            children: vec![
-                // Header
-                HStack {
-                    spacing: Some(8.0),
-                    children: header_children,
-                }
-                .into(),
-                // Content
-                this.content.clone(),
-                // Footer Actions
+        let mut card_children = vec![
+            HStack {
+                spacing: Some(8.0),
+                children: header_children,
+            }
+            .into(),
+            this.content.clone(),
+        ];
+        if !action_buttons.is_empty() {
+            card_children.push(
                 HStack {
                     spacing: Some(8.0),
                     children: vec![fission_core::ui::widgets::spacer::Spacer {
@@ -383,7 +381,12 @@ impl From<Modal> for Widget {
                     .collect(),
                 }
                 .into(),
-            ],
+            );
+        }
+
+        let mut modal_card_builder = Container::new(VStack {
+            spacing: Some(16.0),
+            children: card_children,
         })
         .bg_fill(
             container_style
@@ -400,11 +403,15 @@ impl From<Modal> for Widget {
             }
         }
 
-        let mut modal_card: Widget = modal_card_builder
-            .width(dialog_width)
-            .height_length(Length::fit_content(None))
-            .padding_all(24.0)
-            .into();
+        let mut modal_card: Widget = fission_core::ui::SemanticsRegion::new(
+            modal_card_builder
+                .width(dialog_width)
+                .height_length(Length::fit_content(None))
+                .padding_all(24.0),
+        )
+        .identifier("fission-modal-surface")
+        .role(fission_ir::Role::Generic)
+        .into();
         if let Some(plan) = &motion_plan {
             modal_card = Presence {
                 id: slot_id(this.id, SLOT_SURFACE),

--- a/crates/authoring/fission-widgets/tests/markdown_viewer_test.rs
+++ b/crates/authoring/fission-widgets/tests/markdown_viewer_test.rs
@@ -103,6 +103,65 @@ fn renders_common_markdown_blocks_to_fission_nodes() {
 }
 
 #[test]
+fn disables_unsafe_link_schemes_without_hiding_link_text() {
+    let node = build_markdown_content(
+        "[safe](https://example.com) [relative](./details) [unsafe](javascript:alert(1))\n",
+    );
+    let column = fission_core::internal::widget_as_column(&node)
+        .expect("expected MarkdownContent to render a Column");
+    let paragraph = fission_core::internal::widget_as_rich_text(&column.children[0])
+        .expect("expected paragraph to render as RichText");
+
+    let safe = paragraph
+        .runs
+        .iter()
+        .find(|run| run.text == "safe")
+        .expect("safe link text");
+    assert!(safe.style.underline);
+
+    let relative = paragraph
+        .runs
+        .iter()
+        .find(|run| run.text == "relative")
+        .expect("relative link text");
+    assert!(relative.style.underline);
+
+    let unsafe_link = paragraph
+        .runs
+        .iter()
+        .find(|run| run.text.contains("unsafe"))
+        .expect("unsafe link text remains visible");
+    assert!(!unsafe_link.style.underline);
+    assert!(unsafe_link.semantics_identifier.is_none());
+}
+
+#[test]
+fn disables_unsafe_link_wrappers_around_images() {
+    let node = build_markdown_content(
+        "[![Screenshot](https://cdn.example.com/image.png)](javascript:alert(1))\n",
+    );
+    let ir = fission_core::internal::lower_widget_to_ir(&node);
+
+    assert!(ir.nodes.values().any(|node| matches!(
+        &node.op,
+        Op::Paint(PaintOp::DrawImage { request, .. })
+            if matches!(
+                &request.source,
+                ImageSource::Network { url, .. }
+                    if url == "https://cdn.example.com/image.png"
+            )
+    )));
+    assert!(!ir.nodes.values().any(|node| matches!(
+        &node.op,
+        Op::Semantics(semantics)
+            if semantics
+                .identifier
+                .as_deref()
+                .is_some_and(|identifier| identifier.starts_with("markdown-link:javascript:"))
+    )));
+}
+
+#[test]
 fn renders_gfm_table_as_rows_and_cells() {
     let node = build_markdown("| Name | Value |\n| --- | --- |\n| A | 1 |\n");
     let content = scroll_content(node);

--- a/crates/core/fission-layout/src/lib.rs
+++ b/crates/core/fission-layout/src/lib.rs
@@ -3053,6 +3053,10 @@ impl LayoutEngine {
             LayoutOp::StyledBox { style, .. } => style.width.as_ref(),
             _ => None,
         };
+        let intrinsic_box_height = match &node.op {
+            LayoutOp::StyledBox { style, .. } => style.height.as_ref(),
+            _ => None,
+        };
 
         let mut content_size;
         let size = match layout_op {
@@ -3117,6 +3121,15 @@ impl LayoutEngine {
                 if matches!(intrinsic_box_width, Some(Length::MaxContent)) {
                     base_child_constraints.min_w = 0.0;
                     base_child_constraints.max_w = f32::INFINITY;
+                }
+                // `fit-content` must measure the child's natural block-axis
+                // extent before the result is clamped to the available box.
+                // Passing the finite viewport maximum into a column allows
+                // stretch-aware descendants to report the whole viewport,
+                // making short dialogs and popovers viewport-height.
+                if matches!(intrinsic_box_height, Some(Length::FitContent(_))) {
+                    base_child_constraints.min_h = 0.0;
+                    base_child_constraints.max_h = f32::INFINITY;
                 }
                 if box_alignment != fission_ir::op::BoxAlignment::Stretch {
                     base_child_constraints.min_w = 0.0;

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [features]
 default = []
-tray = ["dep:tray-icon"]
+tray = ["dep:tray-icon", "dep:gtk"]
 three-d = ["dep:fission-3d"]
 video = ["dep:gstreamer", "dep:gstreamer-video"]
 
@@ -67,6 +67,7 @@ windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Media_Media
 [target.'cfg(target_os = "linux")'.dependencies]
 gstreamer = { version = "0.25", optional = true }
 gstreamer-video = { version = "0.25", optional = true }
+gtk = { version = "0.18", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios", target_os = "macos"))'.dependencies]
 rxing = { version = "0.9", default-features = false, features = ["image", "image_formats", "decoders", "encoding_rs", "full_barcode_format_support", "multi_barcode_readers"] }

--- a/crates/shell/fission-shell-winit/src/compositor.rs
+++ b/crates/shell/fission-shell-winit/src/compositor.rs
@@ -272,6 +272,13 @@ impl TextureLayerCompositor {
     ) -> Result<CompositorFrameStats> {
         self.frame_index = self.frame_index.saturating_add(1);
         let live_keys = self.sync_plans(plans);
+        if force_full_redraw {
+            for layer in self.layers.values_mut() {
+                if layer.has_texture {
+                    layer.local_dirty = true;
+                }
+            }
+        }
         let (pruned_damage, removed_layers) = self.prune(&live_keys);
 
         let mut stats = CompositorFrameStats::default();

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -875,6 +875,25 @@ fn preferred_surface_alpha_mode(
         .unwrap_or(wgpu::CompositeAlphaMode::Opaque)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SurfaceAcquireRecovery {
+    Reconfigure,
+    Retry,
+    Exit,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn surface_acquire_recovery(error: &wgpu::SurfaceError) -> SurfaceAcquireRecovery {
+    match error {
+        wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated => {
+            SurfaceAcquireRecovery::Reconfigure
+        }
+        wgpu::SurfaceError::Timeout | wgpu::SurfaceError::Other => SurfaceAcquireRecovery::Retry,
+        wgpu::SurfaceError::OutOfMemory => SurfaceAcquireRecovery::Exit,
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 async fn create_webgpu_presenter(
     canvas: HtmlCanvasElement,
@@ -7470,11 +7489,52 @@ where
                                     {
                                         let render_state =
                                             render_state.as_mut().expect("render state");
-                                        let surface_texture = render_state
+                                        let surface_texture = match render_state
                                             .surface
                                             .surface
                                             .get_current_texture()
-                                            .expect("failed to get texture");
+                                        {
+                                            Ok(texture) => texture,
+                                            Err(error) => {
+                                                match surface_acquire_recovery(&error) {
+                                                    SurfaceAcquireRecovery::Reconfigure => {
+                                                        let device_handle = &render_cx.devices
+                                                            [render_state.surface.dev_id];
+                                                        render_state.surface.surface.configure(
+                                                            &device_handle.device,
+                                                            &render_state.surface.config,
+                                                        );
+                                                        eprintln!(
+                                                                "render surface became {error}; reconfigured and retrying"
+                                                            );
+                                                    }
+                                                    SurfaceAcquireRecovery::Retry => {
+                                                        eprintln!(
+                                                                "render surface acquisition was {error}; retrying"
+                                                            );
+                                                    }
+                                                    SurfaceAcquireRecovery::Exit => {
+                                                        eprintln!(
+                                                                "render surface ran out of memory; exiting"
+                                                            );
+                                                        elwt.exit();
+                                                        diag::end_frame(diag::FrameStats::default());
+                                                        return;
+                                                    }
+                                                }
+                                                request_redraw_logged(
+                                                    &window,
+                                                    elwt,
+                                                    &mut last_redraw_at,
+                                                    min_frame,
+                                                    &mut redraw_pending,
+                                                    &mut frame_trace,
+                                                    "surface_acquire_recovery",
+                                                );
+                                                diag::end_frame(diag::FrameStats::default());
+                                                return;
+                                            }
+                                        };
                                         let device_handle =
                                             &render_cx.devices[render_state.surface.dev_id];
 
@@ -8727,10 +8787,10 @@ mod tests {
         normalize_scale_factor, normalize_winit_scroll_delta, physical_position_to_layout_point,
         physical_size_to_layout_size, preferred_surface_alpha_mode,
         rect_visible_in_scroll_ancestors, repeating_animation_redraw_interval, resize_is_unsettled,
-        resolve_build_viewport, resolve_selector_record,
+        resolve_build_viewport, resolve_selector_record, surface_acquire_recovery,
         sync_tracked_target_texture_size_to_surface, texture_plans_fit_device_limits,
         visual_rect_for_node, window_insets_from_safe_area_frames, LiveResizeController,
-        WindowViewportState,
+        SurfaceAcquireRecovery, WindowViewportState,
     };
     use crate::pipeline::CompositorTexturePlan;
     use crate::InvalidationSet;
@@ -8768,6 +8828,32 @@ mod tests {
             PostMultiplied
         );
         assert_eq!(preferred_surface_alpha_mode(&[]), Opaque);
+    }
+
+    #[test]
+    fn recoverable_surface_acquisition_errors_never_crash_the_app() {
+        use super::wgpu::SurfaceError;
+
+        assert_eq!(
+            surface_acquire_recovery(&SurfaceError::Lost),
+            SurfaceAcquireRecovery::Reconfigure
+        );
+        assert_eq!(
+            surface_acquire_recovery(&SurfaceError::Outdated),
+            SurfaceAcquireRecovery::Reconfigure
+        );
+        assert_eq!(
+            surface_acquire_recovery(&SurfaceError::Timeout),
+            SurfaceAcquireRecovery::Retry
+        );
+        assert_eq!(
+            surface_acquire_recovery(&SurfaceError::Other),
+            SurfaceAcquireRecovery::Retry
+        );
+        assert_eq!(
+            surface_acquire_recovery(&SurfaceError::OutOfMemory),
+            SurfaceAcquireRecovery::Exit
+        );
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -7500,6 +7500,25 @@ where
                                                     SurfaceAcquireRecovery::Reconfigure => {
                                                         let device_handle = &render_cx.devices
                                                             [render_state.surface.dev_id];
+                                                        let physical_size = window.inner_size();
+                                                        if physical_size.width > 0
+                                                            && physical_size.height > 0
+                                                        {
+                                                            render_state.surface.config.width =
+                                                                physical_size.width;
+                                                            render_state.surface.config.height =
+                                                                physical_size.height;
+                                                        }
+                                                        let capabilities = render_state
+                                                            .surface
+                                                            .surface
+                                                            .get_capabilities(
+                                                                device_handle.adapter(),
+                                                            );
+                                                        render_state.surface.config.alpha_mode =
+                                                            preferred_surface_alpha_mode(
+                                                                &capabilities.alpha_modes,
+                                                            );
                                                         render_state.surface.surface.configure(
                                                             &device_handle.device,
                                                             &render_state.surface.config,

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -577,18 +577,7 @@ fn create_render_state<'w>(
         eprintln!("wgpu uncaptured error: {error}");
     }));
     let surface_caps = surface.surface.get_capabilities(device_handle.adapter());
-    surface.config.alpha_mode = surface_caps
-        .alpha_modes
-        .iter()
-        .copied()
-        .find(|mode| *mode == wgpu::CompositeAlphaMode::PostMultiplied)
-        .unwrap_or_else(|| {
-            surface_caps
-                .alpha_modes
-                .first()
-                .copied()
-                .unwrap_or(wgpu::CompositeAlphaMode::Opaque)
-        });
+    surface.config.alpha_mode = preferred_surface_alpha_mode(&surface_caps.alpha_modes);
     surface
         .surface
         .configure(&device_handle.device, &surface.config);
@@ -863,6 +852,29 @@ fn adapter_labels(adapter: &wgpu::Adapter) -> (Option<String>, Option<String>) {
     (backend, adapter)
 }
 
+fn preferred_surface_alpha_mode(
+    supported: &[wgpu::CompositeAlphaMode],
+) -> wgpu::CompositeAlphaMode {
+    supported
+        .iter()
+        .copied()
+        .find(|mode| *mode == wgpu::CompositeAlphaMode::PostMultiplied)
+        .or_else(|| {
+            supported
+                .iter()
+                .copied()
+                .find(|mode| *mode == wgpu::CompositeAlphaMode::PreMultiplied)
+        })
+        .or_else(|| {
+            supported
+                .iter()
+                .copied()
+                .find(|mode| *mode == wgpu::CompositeAlphaMode::Opaque)
+        })
+        .or_else(|| supported.first().copied())
+        .unwrap_or(wgpu::CompositeAlphaMode::Opaque)
+}
+
 #[cfg(target_arch = "wasm32")]
 async fn create_webgpu_presenter(
     canvas: HtmlCanvasElement,
@@ -888,18 +900,7 @@ async fn create_webgpu_presenter(
 
     let device_handle = &render_cx.devices[surface.dev_id];
     let surface_caps = surface.surface.get_capabilities(device_handle.adapter());
-    surface.config.alpha_mode = surface_caps
-        .alpha_modes
-        .iter()
-        .copied()
-        .find(|mode| *mode == wgpu::CompositeAlphaMode::PostMultiplied)
-        .unwrap_or_else(|| {
-            surface_caps
-                .alpha_modes
-                .first()
-                .copied()
-                .unwrap_or(wgpu::CompositeAlphaMode::Opaque)
-        });
+    surface.config.alpha_mode = preferred_surface_alpha_mode(&surface_caps.alpha_modes);
     surface
         .surface
         .configure(&device_handle.device, &surface.config);
@@ -6904,8 +6905,6 @@ where
                                     );
                                     let device_handle =
                                         &render_cx.devices[render_state.surface.dev_id];
-                                    render_state.surface.config.alpha_mode =
-                                        wgpu::CompositeAlphaMode::PostMultiplied;
                                     render_state.surface.surface.configure(
                                         &device_handle.device,
                                         &render_state.surface.config,
@@ -7219,12 +7218,6 @@ where
                                                     let device_handle =
                                                         &presenter.render_cx.devices
                                                             [presenter.render_state.surface.dev_id];
-                                                    presenter
-                                                        .render_state
-                                                        .surface
-                                                        .config
-                                                        .alpha_mode =
-                                                        wgpu::CompositeAlphaMode::PostMultiplied;
                                                     presenter
                                                         .render_state
                                                         .surface
@@ -8732,11 +8725,12 @@ mod tests {
         layout_size_to_image_dimensions, logical_viewport_to_physical_size,
         logical_viewport_to_render_target_size, native_window_size_for_logical_viewport,
         normalize_scale_factor, normalize_winit_scroll_delta, physical_position_to_layout_point,
-        physical_size_to_layout_size, rect_visible_in_scroll_ancestors,
-        repeating_animation_redraw_interval, resize_is_unsettled, resolve_build_viewport,
-        resolve_selector_record, sync_tracked_target_texture_size_to_surface,
-        texture_plans_fit_device_limits, visual_rect_for_node, window_insets_from_safe_area_frames,
-        LiveResizeController, WindowViewportState,
+        physical_size_to_layout_size, preferred_surface_alpha_mode,
+        rect_visible_in_scroll_ancestors, repeating_animation_redraw_interval, resize_is_unsettled,
+        resolve_build_viewport, resolve_selector_record,
+        sync_tracked_target_texture_size_to_surface, texture_plans_fit_device_limits,
+        visual_rect_for_node, window_insets_from_safe_area_frames, LiveResizeController,
+        WindowViewportState,
     };
     use crate::pipeline::CompositorTexturePlan;
     use crate::InvalidationSet;
@@ -8750,6 +8744,31 @@ mod tests {
     use winit::dpi::{PhysicalPosition, PhysicalSize};
     use winit::event::MouseScrollDelta;
     use winit::window::CursorIcon;
+
+    #[test]
+    fn surface_alpha_mode_always_comes_from_the_supported_set() {
+        use super::wgpu::CompositeAlphaMode::{Inherit, Opaque, PostMultiplied, PreMultiplied};
+
+        assert_eq!(
+            preferred_surface_alpha_mode(&[Opaque, Inherit]),
+            Opaque,
+            "opaque is the preferred portable fallback"
+        );
+        assert_eq!(
+            preferred_surface_alpha_mode(&[Inherit]),
+            Inherit,
+            "the first advertised mode is used when preferred modes are absent"
+        );
+        assert_eq!(
+            preferred_surface_alpha_mode(&[Opaque, PreMultiplied]),
+            PreMultiplied
+        );
+        assert_eq!(
+            preferred_surface_alpha_mode(&[Opaque, PostMultiplied]),
+            PostMultiplied
+        );
+        assert_eq!(preferred_surface_alpha_mode(&[]), Opaque);
+    }
 
     #[test]
     fn semantic_cursor_icons_map_to_winit_icons() {

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -7500,7 +7500,27 @@ where
                                                     SurfaceAcquireRecovery::Reconfigure => {
                                                         let device_handle = &render_cx.devices
                                                             [render_state.surface.dev_id];
-                                                        let physical_size = window.inner_size();
+                                                        // A failed frame must discard any synthetic
+                                                        // or otherwise stale pending viewport. If it
+                                                        // remains pending, the next frame immediately
+                                                        // configures the surface back to the rejected
+                                                        // dimensions and enters a retry loop.
+                                                        let recovered_viewport =
+                                                            WindowViewportState::from_window(
+                                                                window,
+                                                            );
+                                                        #[cfg(not(target_os = "android"))]
+                                                        {
+                                                            window_viewport = recovered_viewport;
+                                                        }
+                                                        #[cfg(target_os = "android")]
+                                                        {
+                                                            window_viewport =
+                                                                Some(recovered_viewport);
+                                                        }
+                                                        pending_resize = Some(recovered_viewport);
+                                                        let physical_size =
+                                                            recovered_viewport.physical_size;
                                                         if physical_size.width > 0
                                                             && physical_size.height > 0
                                                         {

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -734,8 +734,15 @@ fn create_native_main_renderer(
     height: u32,
     scale_factor: f64,
 ) -> anyhow::Result<(MainRenderer, RendererReport)> {
-    let (backend, adapter) = adapter_labels(device_handle.adapter());
-    if matches!(request, RendererRequest::NativeSoftware) {
+    let adapter_info = device_handle.adapter().get_info();
+    let (backend, adapter) = adapter_labels_from_info(&adapter_info);
+    let auto_software_adapter = should_auto_select_native_software(
+        request,
+        cfg!(target_os = "windows"),
+        adapter_info.device_type,
+        &adapter_info.name,
+    );
+    if matches!(request, RendererRequest::NativeSoftware) || auto_software_adapter {
         return Ok((
             MainRenderer::Software,
             RendererReport::new(
@@ -743,7 +750,14 @@ fn create_native_main_renderer(
                 request,
                 backend,
                 adapter,
-                Some("forced_by_renderer_request".to_string()),
+                Some(
+                    if auto_software_adapter {
+                        "windows_software_adapter"
+                    } else {
+                        "forced_by_renderer_request"
+                    }
+                    .to_string(),
+                ),
                 width,
                 height,
                 scale_factor,
@@ -845,10 +859,31 @@ fn create_vello_main_renderer(
     })
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn should_auto_select_native_software(
+    request: RendererRequest,
+    windows: bool,
+    device_type: wgpu::DeviceType,
+    adapter_name: &str,
+) -> bool {
+    if request != RendererRequest::Auto || !windows {
+        return false;
+    }
+    let adapter_name = adapter_name.trim().to_ascii_lowercase();
+    device_type == wgpu::DeviceType::Cpu
+        || adapter_name.contains("warp")
+        || adapter_name.contains("microsoft basic render driver")
+}
+
+#[cfg(target_arch = "wasm32")]
 fn adapter_labels(adapter: &wgpu::Adapter) -> (Option<String>, Option<String>) {
     let info = adapter.get_info();
+    adapter_labels_from_info(&info)
+}
+
+fn adapter_labels_from_info(info: &wgpu::AdapterInfo) -> (Option<String>, Option<String>) {
     let backend = Some(format!("{:?}", info.backend));
-    let adapter = (!info.name.trim().is_empty()).then_some(info.name);
+    let adapter = (!info.name.trim().is_empty()).then_some(info.name.clone());
     (backend, adapter)
 }
 
@@ -7198,19 +7233,23 @@ where
                                                     .expect(
                                                     "retained render scene missing before render",
                                                 );
-                                                let rgba = SoftwareRenderer::render(
-                                                    retained_scene,
-                                                    render_target_size.0,
-                                                    render_target_size.1,
-                                                    fission_render::Color {
-                                                        r: env.theme.tokens.colors.background.r,
-                                                        g: env.theme.tokens.colors.background.g,
-                                                        b: env.theme.tokens.colors.background.b,
-                                                        a: env.theme.tokens.colors.background.a,
-                                                    },
-                                                    scale_factor as f32,
-                                                )
-                                                .expect("failed to rasterize software web frame");
+                                                let rgba =
+                                                    SoftwareRenderer::render_with_text_measurer(
+                                                        retained_scene,
+                                                        render_target_size.0,
+                                                        render_target_size.1,
+                                                        fission_render::Color {
+                                                            r: env.theme.tokens.colors.background.r,
+                                                            g: env.theme.tokens.colors.background.g,
+                                                            b: env.theme.tokens.colors.background.b,
+                                                            a: env.theme.tokens.colors.background.a,
+                                                        },
+                                                        scale_factor as f32,
+                                                        measurer.clone(),
+                                                    )
+                                                    .expect(
+                                                        "failed to rasterize software web frame",
+                                                    );
 
                                                 if let Err(err) = presenter.present(
                                                     &rgba,
@@ -7718,19 +7757,21 @@ where
                                                     .expect(
                                                     "retained render scene missing before render",
                                                 );
-                                                let rgba = SoftwareRenderer::render(
-                                                    retained_scene,
-                                                    render_target_size.0,
-                                                    render_target_size.1,
-                                                    fission_render::Color {
-                                                        r: env.theme.tokens.colors.background.r,
-                                                        g: env.theme.tokens.colors.background.g,
-                                                        b: env.theme.tokens.colors.background.b,
-                                                        a: env.theme.tokens.colors.background.a,
-                                                    },
-                                                    scale_factor as f32,
-                                                )
-                                                .expect("failed to rasterize software frame");
+                                                let rgba =
+                                                    SoftwareRenderer::render_with_text_measurer(
+                                                        retained_scene,
+                                                        render_target_size.0,
+                                                        render_target_size.1,
+                                                        fission_render::Color {
+                                                            r: env.theme.tokens.colors.background.r,
+                                                            g: env.theme.tokens.colors.background.g,
+                                                            b: env.theme.tokens.colors.background.b,
+                                                            a: env.theme.tokens.colors.background.a,
+                                                        },
+                                                        scale_factor as f32,
+                                                        measurer.clone(),
+                                                    )
+                                                    .expect("failed to rasterize software frame");
                                                 device_handle.queue.write_texture(
                                                     wgpu::TexelCopyTextureInfo {
                                                         texture: &render_state
@@ -8832,12 +8873,13 @@ mod tests {
         normalize_scale_factor, normalize_winit_scroll_delta, physical_position_to_layout_point,
         physical_size_to_layout_size, preferred_surface_alpha_mode,
         rect_visible_in_scroll_ancestors, repeating_animation_redraw_interval, resize_is_unsettled,
-        resolve_build_viewport, resolve_selector_record, surface_acquire_recovery,
-        sync_tracked_target_texture_size_to_surface, texture_plans_fit_device_limits,
-        visual_rect_for_node, window_insets_from_safe_area_frames, LiveResizeController,
-        SurfaceAcquireRecovery, WindowViewportState,
+        resolve_build_viewport, resolve_selector_record, should_auto_select_native_software,
+        surface_acquire_recovery, sync_tracked_target_texture_size_to_surface,
+        texture_plans_fit_device_limits, visual_rect_for_node, window_insets_from_safe_area_frames,
+        LiveResizeController, SurfaceAcquireRecovery, WindowViewportState,
     };
     use crate::pipeline::CompositorTexturePlan;
+    use crate::renderer_diagnostics::RendererRequest;
     use crate::InvalidationSet;
     use fission_core::{ActiveMotion, MotionEasing, MotionStateMap, MotionValue, ScrollStateMap};
     use fission_core::{DeepLinkConfig, MotionPropertyId, WidgetId};
@@ -8873,6 +8915,66 @@ mod tests {
             PostMultiplied
         );
         assert_eq!(preferred_surface_alpha_mode(&[]), Opaque);
+    }
+
+    #[test]
+    fn windows_auto_uses_software_for_cpu_and_warp_adapters() {
+        use super::wgpu::DeviceType::{Cpu, IntegratedGpu};
+
+        assert!(should_auto_select_native_software(
+            RendererRequest::Auto,
+            true,
+            Cpu,
+            "Microsoft Basic Render Driver"
+        ));
+        assert!(should_auto_select_native_software(
+            RendererRequest::Auto,
+            true,
+            IntegratedGpu,
+            "Microsoft Direct3D12 (WARP)"
+        ));
+        assert!(should_auto_select_native_software(
+            RendererRequest::Auto,
+            true,
+            IntegratedGpu,
+            "Microsoft Basic Render Driver"
+        ));
+    }
+
+    #[test]
+    fn native_software_auto_selection_preserves_platform_hardware_and_explicit_choices() {
+        use super::wgpu::DeviceType::{Cpu, IntegratedGpu};
+
+        assert!(!should_auto_select_native_software(
+            RendererRequest::Auto,
+            false,
+            Cpu,
+            "Microsoft Basic Render Driver"
+        ));
+        assert!(!should_auto_select_native_software(
+            RendererRequest::Auto,
+            true,
+            IntegratedGpu,
+            "Qualcomm Adreno X1"
+        ));
+        assert!(!should_auto_select_native_software(
+            RendererRequest::NativeVelloGpu,
+            true,
+            Cpu,
+            "Microsoft Basic Render Driver"
+        ));
+        assert!(!should_auto_select_native_software(
+            RendererRequest::NativeVelloCpu,
+            true,
+            Cpu,
+            "Microsoft Basic Render Driver"
+        ));
+        assert!(!should_auto_select_native_software(
+            RendererRequest::NativeSoftware,
+            true,
+            Cpu,
+            "Microsoft Basic Render Driver"
+        ));
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -5568,6 +5568,10 @@ where
                             resize_needs_settled_frame,
                             live_resize.is_live(Instant::now()),
                         );
+                        // A capture reads the complete retained target texture. Force every
+                        // compositor layer to repaint so the image cannot contain only the
+                        // regions damaged by the preceding interaction.
+                        invalidations.mark_paint();
                         window.request_redraw();
                     }
                     TestEvent::CaptureScreenshot { response_tx } => {
@@ -5584,6 +5588,7 @@ where
                             resize_needs_settled_frame,
                             live_resize.is_live(Instant::now()),
                         );
+                        invalidations.mark_paint();
                         window.request_redraw();
                     }
                     TestEvent::PauseAnimations { response_tx } => {
@@ -5632,6 +5637,7 @@ where
                             resize_needs_settled_frame,
                             live_resize.is_live(Instant::now()),
                         );
+                        invalidations.mark_paint();
                         window.request_redraw();
                     }
                     TestEvent::MotionStatus { response_tx } => {

--- a/crates/shell/fission-shell-winit/src/software_renderer.rs
+++ b/crates/shell/fission-shell-winit/src/software_renderer.rs
@@ -1,10 +1,12 @@
 use anyhow::{anyhow, Result};
 use fission_ir::op::{HttpHeader, ImageAlignment, ImageRequest, ImageSource};
+use fission_layout::{LineMetric, TextMeasurer};
 use fission_render::{
     image_cache_store::ImageCacheStore, surface_placeholder_color, Color as RenderColor,
     DisplayList, DisplayOp, Fill, ImageFit, LineCap, LineJoin, RenderScene, Stroke, TextRun,
 };
 use fontdue::layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle as FontdueTextStyle};
+use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -439,6 +441,65 @@ fn wrap_max_width(bounds_width: f32, font_size: f32, wrap: bool) -> Option<f32> 
     Some(bounds_width.ceil() + font_size * 0.5)
 }
 
+fn pipeline_wrap_breaks(
+    measurer: Option<&dyn TextMeasurer>,
+    text: &str,
+    font_size: f32,
+    bounds_width: f32,
+    wrap: bool,
+) -> Option<Vec<usize>> {
+    if !wrap || bounds_width <= 0.0 {
+        return None;
+    }
+    let measurer = measurer?;
+    let lines = measurer.get_line_metrics(text, font_size, Some(bounds_width));
+    if lines.is_empty() {
+        return None;
+    }
+    Some(soft_wrap_breaks(text, &lines))
+}
+
+fn soft_wrap_breaks(text: &str, lines: &[LineMetric]) -> Vec<usize> {
+    lines
+        .windows(2)
+        .filter_map(|pair| {
+            let end = pair[0].end_index.min(text.len());
+            let next_start = pair[1].start_index.min(text.len());
+            if !text.is_char_boundary(end) || !text.is_char_boundary(next_start) {
+                return None;
+            }
+            let gap_start = end.min(next_start);
+            let gap_end = end.max(next_start);
+            let already_broken = text[..end].ends_with('\r')
+                || text[..end].ends_with('\n')
+                || text[end..].starts_with('\r')
+                || text[end..].starts_with('\n')
+                || text[gap_start..gap_end]
+                    .chars()
+                    .any(|character| matches!(character, '\r' | '\n'));
+            (!already_broken).then_some(end)
+        })
+        .collect()
+}
+
+fn insert_soft_wraps<'a>(text: &'a str, breaks: &[usize]) -> Cow<'a, str> {
+    if breaks.is_empty() {
+        return Cow::Borrowed(text);
+    }
+    let mut wrapped = String::with_capacity(text.len() + breaks.len());
+    let mut cursor = 0;
+    for &break_at in breaks {
+        if break_at < cursor || break_at > text.len() || !text.is_char_boundary(break_at) {
+            continue;
+        }
+        wrapped.push_str(&text[cursor..break_at]);
+        wrapped.push('\n');
+        cursor = break_at;
+    }
+    wrapped.push_str(&text[cursor..]);
+    Cow::Owned(wrapped)
+}
+
 fn cached_image(request: &ImageRequest) -> Option<Arc<Pixmap>> {
     let key = request.stable_cache_key();
     if let Some(entry) = image_cache().get(&key) {
@@ -641,6 +702,29 @@ mod image_tests {
     use std::net::TcpListener;
     use std::time::{Duration, Instant};
 
+    struct SingleLineMeasurer;
+
+    impl TextMeasurer for SingleLineMeasurer {
+        fn measure(&self, text: &str, font_size: f32, _available_width: Option<f32>) -> (f32, f32) {
+            (text.len() as f32 * font_size, font_size * 1.2)
+        }
+
+        fn get_line_metrics(
+            &self,
+            text: &str,
+            font_size: f32,
+            _available_width: Option<f32>,
+        ) -> Vec<LineMetric> {
+            vec![LineMetric {
+                start_index: 0,
+                end_index: text.len(),
+                baseline: font_size,
+                height: font_size * 1.2,
+                width: text.len() as f32 * font_size,
+            }]
+        }
+    }
+
     #[test]
     fn normalized_gradient_point_maps_to_painted_bounds() {
         let point = normalized_fill_point(
@@ -648,6 +732,179 @@ mod image_tests {
             (0.25, 0.75),
         );
         assert_eq!(point, Point::from_xy(70.0, 115.0));
+    }
+
+    #[test]
+    fn software_text_does_not_rewrap_pipeline_single_line_layouts() {
+        let bounds = fission_render::LayoutRect::new(0.0, 0.0, 24.0, 24.0);
+        let mut display_list =
+            DisplayList::new(fission_render::LayoutRect::new(0.0, 0.0, 260.0, 80.0));
+        display_list.push(DisplayOp::DrawText {
+            text: "Secure local storage required".into(),
+            position: bounds.origin,
+            size: 20.0,
+            color: RenderColor {
+                r: 20,
+                g: 40,
+                b: 60,
+                a: 255,
+            },
+            bounds,
+            node_id: None,
+            underline: false,
+            wrap: true,
+            caret_index: None,
+            caret_color: None,
+            caret_width: None,
+            caret_height: None,
+            caret_radius: None,
+            paragraph_style: None,
+        });
+
+        let pixels = SoftwareRenderer::render_with_text_measurer(
+            &RenderScene::from_display_list(display_list),
+            260,
+            80,
+            RenderColor {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0,
+            },
+            1.0,
+            Arc::new(SingleLineMeasurer),
+        )
+        .expect("render pipeline-shaped single line");
+        let row_has_ink = |y: usize| {
+            pixels[y * 260 * 4..(y + 1) * 260 * 4]
+                .chunks_exact(4)
+                .any(|pixel| pixel[3] > 0)
+        };
+
+        assert!(
+            (0..24).any(|y| row_has_ink(y)),
+            "the first line should be painted"
+        );
+        assert!(
+            !(30..80).any(|y| row_has_ink(y)),
+            "fontdue must not add lines below the pipeline's one-line bounds"
+        );
+    }
+
+    #[test]
+    fn software_rich_text_does_not_rewrap_pipeline_single_line_layouts() {
+        let bounds = fission_render::LayoutRect::new(0.0, 0.0, 24.0, 20.0);
+        let mut display_list =
+            DisplayList::new(fission_render::LayoutRect::new(0.0, 0.0, 220.0, 70.0));
+        display_list.push(DisplayOp::DrawRichText {
+            runs: vec![TextRun {
+                text: "Enable secure storage".into(),
+                style: fission_render::TextStyle {
+                    font_size: 14.0,
+                    color: RenderColor {
+                        r: 20,
+                        g: 40,
+                        b: 60,
+                        a: 255,
+                    },
+                    underline: false,
+                    font_family: None,
+                    locale: None,
+                    font_weight: 600,
+                    font_style: fission_ir::op::FontStyle::Normal,
+                    line_height: None,
+                    letter_spacing: 0.0,
+                    background_color: None,
+                },
+            }],
+            position: bounds.origin,
+            bounds,
+            node_id: None,
+            wrap: true,
+            caret_index: None,
+            caret_color: None,
+            caret_width: None,
+            caret_height: None,
+            caret_radius: None,
+            paragraph_style: None,
+            annotations: Vec::new(),
+        });
+
+        let pixels = SoftwareRenderer::render_with_text_measurer(
+            &RenderScene::from_display_list(display_list),
+            220,
+            70,
+            RenderColor {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0,
+            },
+            1.0,
+            Arc::new(SingleLineMeasurer),
+        )
+        .expect("render pipeline-shaped rich-text line");
+        let row_has_ink = |y: usize| {
+            pixels[y * 220 * 4..(y + 1) * 220 * 4]
+                .chunks_exact(4)
+                .any(|pixel| pixel[3] > 0)
+        };
+
+        assert!((0..20).any(|y| row_has_ink(y)));
+        assert!(
+            !(26..70).any(|y| row_has_ink(y)),
+            "fontdue must not rewrap a pipeline-shaped rich-text label"
+        );
+    }
+
+    #[test]
+    fn scaled_svg_keeps_its_display_list_origin() {
+        let bounds = fission_render::LayoutRect::new(10.0, 12.0, 20.0, 20.0);
+        let mut display_list =
+            DisplayList::new(fission_render::LayoutRect::new(0.0, 0.0, 64.0, 64.0));
+        display_list.push(DisplayOp::Save);
+        display_list.push(DisplayOp::Translate(fission_render::LayoutPoint::new(
+            5.0, 7.0,
+        )));
+        display_list.push(DisplayOp::DrawSvg {
+            content: r#"<svg viewBox="0 0 10 10"><rect x="0" y="0" width="10" height="10"/></svg>"#
+                .into(),
+            fill: Some(Fill::Solid(RenderColor {
+                r: 255,
+                g: 0,
+                b: 0,
+                a: 255,
+            })),
+            stroke: None,
+            bounds,
+            node_id: None,
+        });
+        display_list.push(DisplayOp::Restore);
+
+        let pixels = SoftwareRenderer::render(
+            &RenderScene::from_display_list(display_list),
+            64,
+            64,
+            RenderColor {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0,
+            },
+            1.0,
+        )
+        .expect("render translated and scaled SVG");
+        let pixel_at = |x: usize, y: usize| {
+            let offset = (y * 64 + x) * 4;
+            &pixels[offset..offset + 4]
+        };
+
+        assert_eq!(pixel_at(16, 20), &[255, 0, 0, 255]);
+        assert_eq!(
+            pixel_at(40, 45),
+            &[0, 0, 0, 0],
+            "the SVG origin must not be scaled a second time"
+        );
     }
 
     fn tiny_png() -> Vec<u8> {
@@ -1050,6 +1307,7 @@ pub struct SoftwareRenderer {
     width: u32,
     height: u32,
     scale_factor: f32,
+    text_measurer: Option<Arc<dyn TextMeasurer>>,
     surfaces: Vec<Pixmap>,
     states: Vec<DrawState>,
 }
@@ -1060,6 +1318,7 @@ impl SoftwareRenderer {
         height: u32,
         background: RenderColor,
         scale_factor: f32,
+        text_measurer: Option<Arc<dyn TextMeasurer>>,
     ) -> Result<Self> {
         let mut root = Pixmap::new(width.max(1), height.max(1))
             .ok_or_else(|| anyhow!("failed to allocate software render target"))?;
@@ -1068,6 +1327,7 @@ impl SoftwareRenderer {
             width: width.max(1),
             height: height.max(1),
             scale_factor: normalized_scale_factor(scale_factor),
+            text_measurer,
             surfaces: vec![root],
             states: vec![DrawState {
                 transform: Transform::identity(),
@@ -1085,8 +1345,49 @@ impl SoftwareRenderer {
         background: RenderColor,
         scale_factor: f32,
     ) -> Result<Vec<u8>> {
-        let mut renderer =
-            Self::new_with_scale(width.max(1), height.max(1), background, scale_factor)?;
+        Self::render_with_optional_text_measurer(
+            scene,
+            width,
+            height,
+            background,
+            scale_factor,
+            None,
+        )
+    }
+
+    pub fn render_with_text_measurer(
+        scene: &RenderScene,
+        width: u32,
+        height: u32,
+        background: RenderColor,
+        scale_factor: f32,
+        text_measurer: Arc<dyn TextMeasurer>,
+    ) -> Result<Vec<u8>> {
+        Self::render_with_optional_text_measurer(
+            scene,
+            width,
+            height,
+            background,
+            scale_factor,
+            Some(text_measurer),
+        )
+    }
+
+    fn render_with_optional_text_measurer(
+        scene: &RenderScene,
+        width: u32,
+        height: u32,
+        background: RenderColor,
+        scale_factor: f32,
+        text_measurer: Option<Arc<dyn TextMeasurer>>,
+    ) -> Result<Vec<u8>> {
+        let mut renderer = Self::new_with_scale(
+            width.max(1),
+            height.max(1),
+            background,
+            scale_factor,
+            text_measurer,
+        )?;
         let display_list = scene.flatten();
         renderer.render_ops(&display_list)?;
         Ok(renderer.finish())
@@ -1235,14 +1536,14 @@ impl SoftwareRenderer {
                 } => self.draw_backdrop_filter(*rect, *filter, *corner_radius)?,
                 DisplayOp::Translate(point) => {
                     let state = self.current_state_mut();
-                    state.transform = state.transform.post_translate(point.x, point.y);
+                    state.transform = state.transform.pre_translate(point.x, point.y);
                 }
                 DisplayOp::Transform(matrix) => {
                     let transform = Transform::from_row(
                         matrix[0], matrix[1], matrix[4], matrix[5], matrix[12], matrix[13],
                     );
                     let state = self.current_state_mut();
-                    state.transform = state.transform.post_concat(transform);
+                    state.transform = state.transform.pre_concat(transform);
                 }
                 DisplayOp::CachedScene { list, .. } => self.render_ops(list)?,
                 DisplayOp::DrawRect {
@@ -1442,14 +1743,29 @@ impl SoftwareRenderer {
     ) -> Result<()> {
         let font = default_font();
         let fonts = [font];
+        let pipeline_breaks = pipeline_wrap_breaks(
+            self.text_measurer.as_deref(),
+            text,
+            size,
+            bounds.width(),
+            wrap,
+        );
+        let layout_text = pipeline_breaks
+            .as_deref()
+            .map(|breaks| insert_soft_wraps(text, breaks))
+            .unwrap_or(Cow::Borrowed(text));
         let mut layout = Layout::new(CoordinateSystem::PositiveYDown);
         layout.reset(&LayoutSettings {
             x: position.x,
             y: position.y,
-            max_width: wrap_max_width(bounds.width(), size, wrap),
+            max_width: if pipeline_breaks.is_some() {
+                None
+            } else {
+                wrap_max_width(bounds.width(), size, wrap)
+            },
             ..LayoutSettings::default()
         });
-        layout.append(&fonts, &FontdueTextStyle::new(text, size, 0));
+        layout.append(&fonts, &FontdueTextStyle::new(&layout_text, size, 0));
         self.draw_glyphs(&layout, |_, _| color)?;
         if underline {
             self.draw_layout_underlines(&layout, color, size)?;
@@ -1481,22 +1797,51 @@ impl SoftwareRenderer {
                 None => default_font(),
             })
             .collect::<Vec<_>>();
+        let full_text = runs.iter().map(|run| run.text.as_str()).collect::<String>();
+        let base_size = runs.first().map(|run| run.style.font_size).unwrap_or(14.0);
+        let pipeline_breaks = pipeline_wrap_breaks(
+            self.text_measurer.as_deref(),
+            &full_text,
+            base_size,
+            bounds.width(),
+            wrap,
+        );
+        let mut break_cursor = 0;
+        let mut text_cursor = 0;
         let mut layout = Layout::new(CoordinateSystem::PositiveYDown);
         layout.reset(&LayoutSettings {
             x: position.x,
             y: position.y,
-            max_width: wrap_max_width(
-                bounds.width(),
-                runs.first().map(|run| run.style.font_size).unwrap_or(14.0),
-                wrap,
-            ),
+            max_width: if pipeline_breaks.is_some() {
+                None
+            } else {
+                wrap_max_width(bounds.width(), base_size, wrap)
+            },
             ..LayoutSettings::default()
         });
         for (font_index, run) in runs.iter().enumerate() {
+            let run_start = text_cursor;
+            let run_end = run_start + run.text.len();
+            let rendered_text = if let Some(breaks) = pipeline_breaks.as_deref() {
+                while break_cursor < breaks.len() && breaks[break_cursor] < run_start {
+                    break_cursor += 1;
+                }
+                let first_break = break_cursor;
+                while break_cursor < breaks.len() && breaks[break_cursor] <= run_end {
+                    break_cursor += 1;
+                }
+                let local_breaks = breaks[first_break..break_cursor]
+                    .iter()
+                    .map(|break_at| break_at - run_start)
+                    .collect::<Vec<_>>();
+                insert_soft_wraps(&run.text, &local_breaks)
+            } else {
+                Cow::Borrowed(run.text.as_str())
+            };
             layout.append(
                 &fonts,
                 &fontdue::layout::TextStyle::with_user_data(
-                    &run.text,
+                    &rendered_text,
                     run.style.font_size,
                     font_index,
                     (
@@ -1506,6 +1851,7 @@ impl SoftwareRenderer {
                     ),
                 ),
             );
+            text_cursor = run_end;
         }
         self.draw_glyphs(&layout, |glyph, (color, _underline, bg)| {
             if bg.is_some() {
@@ -1677,8 +2023,8 @@ impl SoftwareRenderer {
         let transform = self.device_transform(
             self.current_state()
                 .transform
-                .post_translate(dx, dy)
-                .post_scale(scale_x, scale_y),
+                .pre_translate(dx, dy)
+                .pre_scale(scale_x, scale_y),
         );
         self.with_temporary_clip_rect(rect, |this| {
             let clip = this.current_clip().cloned();
@@ -1715,7 +2061,7 @@ impl SoftwareRenderer {
         let transform = self.device_transform(
             self.current_state()
                 .transform
-                .post_translate(bounds.origin.x, bounds.origin.y),
+                .pre_translate(bounds.origin.x, bounds.origin.y),
         );
         let clip = self.current_clip().cloned();
         let surface = self.current_surface_mut();
@@ -1768,8 +2114,8 @@ impl SoftwareRenderer {
         let transform = self.device_transform(
             self.current_state()
                 .transform
-                .post_translate(dx, dy)
-                .post_scale(scale, scale),
+                .pre_translate(dx, dy)
+                .pre_scale(scale, scale),
         );
         let clip = self.current_clip().cloned();
         let surface = self.current_surface_mut();

--- a/crates/shell/fission-shell-winit/src/tray.rs
+++ b/crates/shell/fission-shell-winit/src/tray.rs
@@ -382,6 +382,7 @@ impl<S: GlobalState> ActiveTray<S> {
     }
 
     pub(crate) fn build(config: TrayConfig<S>) -> Result<Self> {
+        initialise_native_tray_runtime()?;
         let icon = load_icon(&config.icon)?;
         let tray_menu = fallback_tray_menu(&config);
         let (menu, actions_by_menu_id) = native_menu_from_tray_menu(&tray_menu)?;
@@ -465,6 +466,16 @@ impl<S: GlobalState> ActiveTray<S> {
             }
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn initialise_native_tray_runtime() -> Result<()> {
+    gtk::init().context("failed to initialise GTK for the Fission tray")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn initialise_native_tray_runtime() -> Result<()> {
+    Ok(())
 }
 
 pub(crate) fn install_event_forwarders(

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -12,7 +12,9 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+plist = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha1 = "0.10"
 toml = "0.8"
 toml_edit = "0.23"

--- a/crates/tools/fission-command-core/src/macos_signing.rs
+++ b/crates/tools/fission-command-core/src/macos_signing.rs
@@ -1,15 +1,21 @@
 use crate::NativeVariant;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
+#[cfg(any(target_os = "macos", test))]
+use sha1::{Digest as _, Sha1};
+#[cfg(any(target_os = "macos", test))]
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(any(target_os = "macos", test))]
+use std::time::SystemTime;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 pub struct MacosPackageConfig {
     pub bundle_id: Option<String>,
+    pub team_id: Option<String>,
     pub minimum_os: Option<String>,
     pub application_category: Option<String>,
     pub entitlements: Option<String>,
@@ -210,6 +216,7 @@ pub fn sign_macos_app_if_configured(
         );
     }
     if let Some(profile) = profile {
+        validate_macos_provisioning_profile(project_dir, macos, identity.expect("validated"))?;
         embed_macos_provisioning_profile(project_dir, app_bundle, profile)?;
     }
     remove_macos_bundle_extended_attributes(app_bundle)?;
@@ -235,6 +242,216 @@ pub fn sign_macos_app_if_configured(
         .context("failed to verify macOS code signature")?;
     if !verify.success() {
         bail!("codesign verification failed with {verify}");
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", test))]
+#[derive(Debug, Deserialize)]
+struct DecodedMacosProvisioningProfile {
+    #[serde(rename = "TeamIdentifier")]
+    team_identifiers: Vec<String>,
+    #[serde(rename = "DeveloperCertificates")]
+    developer_certificates: Vec<plist::Value>,
+    #[serde(rename = "ProvisionedDevices", default)]
+    provisioned_devices: Vec<String>,
+    #[serde(rename = "ExpirationDate")]
+    expiration_date: plist::Date,
+    #[serde(rename = "Entitlements")]
+    entitlements: BTreeMap<String, plist::Value>,
+}
+
+#[cfg(target_os = "macos")]
+fn validate_macos_provisioning_profile(
+    project_dir: &Path,
+    macos: &MacosPackageConfig,
+    signing_identity: &str,
+) -> Result<()> {
+    let profile = macos
+        .provisioning_profile
+        .as_deref()
+        .expect("profile validation is called only when configured");
+    let profile_path = resolve_project_path(project_dir, profile);
+    if !profile_path.is_file() {
+        bail!(
+            "macOS provisioning profile does not exist or is not a file: {}",
+            profile_path.display()
+        );
+    }
+    let decoded = Command::new("security")
+        .args(["cms", "-D", "-i"])
+        .arg(&profile_path)
+        .output()
+        .context("failed to decode the macOS provisioning profile with `security cms`")?;
+    if !decoded.status.success() {
+        bail!(
+            "macOS provisioning profile could not be verified by `security cms`: {}",
+            String::from_utf8_lossy(&decoded.stderr).trim()
+        );
+    }
+    let profile: DecodedMacosProvisioningProfile = plist::from_bytes(&decoded.stdout)
+        .context("failed to parse decoded provisioning profile")?;
+    let identity = resolve_codesigning_identity(signing_identity)?;
+    let host_udid = current_macos_provisioning_udid()?;
+    validate_macos_profile_bindings(&profile, macos, &identity, host_udid.as_deref())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn validate_macos_provisioning_profile(
+    _project_dir: &Path,
+    _macos: &MacosPackageConfig,
+    _signing_identity: &str,
+) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", test))]
+#[derive(Debug, Eq, PartialEq)]
+struct ResolvedCodesigningIdentity {
+    certificate_sha1: String,
+    display_name: String,
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_codesigning_identity(requested: &str) -> Result<ResolvedCodesigningIdentity> {
+    let output = Command::new("security")
+        .args(["find-identity", "-v", "-p", "codesigning"])
+        .output()
+        .context("failed to query macOS code-signing identities")?;
+    if !output.status.success() {
+        bail!("macOS code-signing identities could not be queried");
+    }
+    let mut matches = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(parse_codesigning_identity)
+        .filter(|identity| {
+            identity.certificate_sha1.eq_ignore_ascii_case(requested)
+                || identity.display_name == requested
+                || identity.display_name.contains(requested)
+        })
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        bail!(
+            "macOS signing identity `{requested}` resolved to {} valid identities; configure one unambiguous certificate name or SHA-1 fingerprint",
+            matches.len()
+        );
+    }
+    Ok(matches.remove(0))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn parse_codesigning_identity(line: &str) -> Option<ResolvedCodesigningIdentity> {
+    let trimmed = line.trim();
+    let (_, after_index) = trimmed.split_once(')')?;
+    let (fingerprint, quoted_name) = after_index.trim().split_once(' ')?;
+    let display_name = quoted_name.strip_prefix('"')?.strip_suffix('"')?;
+    if fingerprint.len() != 40
+        || !fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || display_name.is_empty()
+    {
+        return None;
+    }
+    Some(ResolvedCodesigningIdentity {
+        certificate_sha1: fingerprint.to_ascii_uppercase(),
+        display_name: display_name.to_owned(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn current_macos_provisioning_udid() -> Result<Option<String>> {
+    let output = Command::new("system_profiler")
+        .arg("SPHardwareDataType")
+        .output()
+        .context("failed to query this Mac's Provisioning UDID")?;
+    if !output.status.success() {
+        bail!("this Mac's Provisioning UDID could not be queried");
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Provisioning UDID:"))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn validate_macos_profile_bindings(
+    profile: &DecodedMacosProvisioningProfile,
+    macos: &MacosPackageConfig,
+    identity: &ResolvedCodesigningIdentity,
+    host_udid: Option<&str>,
+) -> Result<()> {
+    if SystemTime::from(profile.expiration_date) <= SystemTime::now() {
+        bail!("macOS provisioning profile has expired");
+    }
+    let bundle_id = macos
+        .bundle_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .context("macOS provisioning profile validation requires package.macos.bundle_id")?;
+    let profile_team = profile
+        .team_identifiers
+        .first()
+        .filter(|value| !value.trim().is_empty())
+        .context("macOS provisioning profile has no TeamIdentifier")?;
+    if profile
+        .team_identifiers
+        .iter()
+        .any(|team| team != profile_team)
+    {
+        bail!("macOS provisioning profile contains conflicting team identifiers");
+    }
+    if let Some(configured_team) = macos
+        .team_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        if configured_team != profile_team {
+            bail!(
+                "macOS provisioning profile team `{profile_team}` does not match configured team `{configured_team}`"
+            );
+        }
+    }
+    let application_identifier = profile
+        .entitlements
+        .get("com.apple.application-identifier")
+        .and_then(plist::Value::as_string)
+        .context("macOS provisioning profile has no application identifier entitlement")?;
+    let expected_application_identifier = format!("{profile_team}.{bundle_id}");
+    let application_matches = application_identifier == expected_application_identifier
+        || application_identifier
+            .strip_suffix('*')
+            .is_some_and(|prefix| expected_application_identifier.starts_with(prefix));
+    if !application_matches {
+        bail!(
+            "macOS provisioning profile application identifier `{application_identifier}` does not authorize `{expected_application_identifier}`"
+        );
+    }
+    let identity_in_profile = profile
+        .developer_certificates
+        .iter()
+        .filter_map(plist::Value::as_data)
+        .any(|certificate| format!("{:X}", Sha1::digest(certificate)) == identity.certificate_sha1);
+    if !identity_in_profile {
+        bail!(
+            "macOS provisioning profile does not include signing certificate `{}` ({})",
+            identity.display_name,
+            identity.certificate_sha1
+        );
+    }
+    if !profile.provisioned_devices.is_empty() {
+        let host_udid = host_udid.context(
+            "macOS development provisioning profile is device-bound but this Mac's Provisioning UDID is unavailable",
+        )?;
+        if !profile
+            .provisioned_devices
+            .iter()
+            .any(|device| device == host_udid)
+        {
+            bail!(
+                "macOS development provisioning profile does not include this Mac's Provisioning UDID `{host_udid}`"
+            );
+        }
     }
     Ok(())
 }
@@ -353,6 +570,7 @@ fn resolve_project_path(project_dir: &Path, path: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn parses_macos_package_signing_configuration() {
@@ -400,6 +618,109 @@ signing_identity = "-"
             Some("profiles/Developer-Local.provisionprofile")
         );
         assert_eq!(run.signing_identity.as_deref(), Some("-"));
+    }
+
+    #[test]
+    fn parses_codesigning_identity_output() {
+        assert_eq!(
+            parse_codesigning_identity(
+                r#"  1) A678CDF82B5E6D0031FB0690F74FD365C01FE43D "Apple Development: Example (TEAM123)""#,
+            ),
+            Some(ResolvedCodesigningIdentity {
+                certificate_sha1: "A678CDF82B5E6D0031FB0690F74FD365C01FE43D".into(),
+                display_name: "Apple Development: Example (TEAM123)".into(),
+            })
+        );
+        assert!(parse_codesigning_identity("0 valid identities found").is_none());
+    }
+
+    #[test]
+    fn provisioning_profile_parses_apple_certificate_data_values() {
+        let decoded: DecodedMacosProvisioningProfile = plist::from_bytes(
+            br#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>TeamIdentifier</key><array><string>TEAM123</string></array>
+<key>DeveloperCertificates</key><array><data>Y2VydGlmaWNhdGU=</data></array>
+<key>ExpirationDate</key><date>2030-01-01T00:00:00Z</date>
+<key>Entitlements</key><dict>
+<key>com.apple.application-identifier</key><string>TEAM123.com.example.app</string>
+</dict>
+</dict></plist>"#,
+        )
+        .expect("Apple profile data should deserialize");
+
+        assert_eq!(
+            decoded.developer_certificates[0].as_data(),
+            Some(b"certificate".as_slice())
+        );
+    }
+
+    #[test]
+    fn profile_bindings_require_bundle_team_certificate_and_device() {
+        let certificate = b"certificate-der".to_vec();
+        let identity = ResolvedCodesigningIdentity {
+            certificate_sha1: format!("{:X}", Sha1::digest(&certificate)),
+            display_name: "Apple Development: Example (TEAM123)".into(),
+        };
+        let mut profile = DecodedMacosProvisioningProfile {
+            team_identifiers: vec!["TEAM123".into()],
+            developer_certificates: vec![plist::Value::Data(certificate)],
+            provisioned_devices: vec!["MAC-UDID".into()],
+            expiration_date: (SystemTime::now() + Duration::from_secs(3_600)).into(),
+            entitlements: BTreeMap::from([(
+                "com.apple.application-identifier".into(),
+                plist::Value::String("TEAM123.com.example.app".into()),
+            )]),
+        };
+        let config = MacosPackageConfig {
+            bundle_id: Some("com.example.app".into()),
+            team_id: Some("TEAM123".into()),
+            ..Default::default()
+        };
+
+        validate_macos_profile_bindings(&profile, &config, &identity, Some("MAC-UDID")).unwrap();
+
+        let error =
+            validate_macos_profile_bindings(&profile, &config, &identity, Some("OTHER-MAC"))
+                .unwrap_err();
+        assert!(error.to_string().contains("Provisioning UDID"));
+
+        profile.entitlements.insert(
+            "com.apple.application-identifier".into(),
+            plist::Value::String("TEAM123.com.other.app".into()),
+        );
+        let error = validate_macos_profile_bindings(&profile, &config, &identity, Some("MAC-UDID"))
+            .unwrap_err();
+        assert!(error.to_string().contains("does not authorize"));
+    }
+
+    #[test]
+    fn profile_bindings_reject_a_certificate_not_embedded_in_the_profile() {
+        let profile = DecodedMacosProvisioningProfile {
+            team_identifiers: vec!["TEAM123".into()],
+            developer_certificates: vec![plist::Value::Data(b"different-certificate".to_vec())],
+            provisioned_devices: Vec::new(),
+            expiration_date: (SystemTime::now() + Duration::from_secs(3_600)).into(),
+            entitlements: BTreeMap::from([(
+                "com.apple.application-identifier".into(),
+                plist::Value::String("TEAM123.com.example.app".into()),
+            )]),
+        };
+        let identity = ResolvedCodesigningIdentity {
+            certificate_sha1: format!("{:X}", Sha1::digest(b"selected-certificate")),
+            display_name: "Apple Development: Example (TEAM123)".into(),
+        };
+        let config = MacosPackageConfig {
+            bundle_id: Some("com.example.app".into()),
+            team_id: Some("TEAM123".into()),
+            ..Default::default()
+        };
+
+        let error =
+            validate_macos_profile_bindings(&profile, &config, &identity, None).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("does not include signing certificate"));
     }
 
     #[test]

--- a/crates/tools/fission-command-core/src/macos_signing.rs
+++ b/crates/tools/fission-command-core/src/macos_signing.rs
@@ -3,7 +3,6 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 #[cfg(any(target_os = "macos", test))]
 use sha1::{Digest as _, Sha1};
-#[cfg(any(target_os = "macos", test))]
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
@@ -321,15 +320,8 @@ fn resolve_codesigning_identity(requested: &str) -> Result<ResolvedCodesigningId
     if !output.status.success() {
         bail!("macOS code-signing identities could not be queried");
     }
-    let mut matches = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(parse_codesigning_identity)
-        .filter(|identity| {
-            identity.certificate_sha1.eq_ignore_ascii_case(requested)
-                || identity.display_name == requested
-                || identity.display_name.contains(requested)
-        })
-        .collect::<Vec<_>>();
+    let mut matches =
+        matching_codesigning_identities(&String::from_utf8_lossy(&output.stdout), requested);
     if matches.len() != 1 {
         bail!(
             "macOS signing identity `{requested}` resolved to {} valid identities; configure one unambiguous certificate name or SHA-1 fingerprint",
@@ -355,6 +347,29 @@ fn parse_codesigning_identity(line: &str) -> Option<ResolvedCodesigningIdentity>
         certificate_sha1: fingerprint.to_ascii_uppercase(),
         display_name: display_name.to_owned(),
     })
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn matching_codesigning_identities(
+    output: &str,
+    requested: &str,
+) -> Vec<ResolvedCodesigningIdentity> {
+    let mut matches = Vec::new();
+    for identity in output.lines().filter_map(parse_codesigning_identity) {
+        let is_match = identity.certificate_sha1.eq_ignore_ascii_case(requested)
+            || identity.display_name == requested
+            || identity.display_name.contains(requested);
+        let certificate_already_matched =
+            matches.iter().any(|matched: &ResolvedCodesigningIdentity| {
+                matched
+                    .certificate_sha1
+                    .eq_ignore_ascii_case(&identity.certificate_sha1)
+            });
+        if is_match && !certificate_already_matched {
+            matches.push(identity);
+        }
+    }
+    matches
 }
 
 #[cfg(target_os = "macos")]
@@ -632,6 +647,24 @@ signing_identity = "-"
             })
         );
         assert!(parse_codesigning_identity("0 valid identities found").is_none());
+    }
+
+    #[test]
+    fn duplicate_keychain_results_are_one_codesigning_identity() {
+        let output = r#"
+  1) 00112233445566778899AABBCCDDEEFF00112233 "Developer ID Application: Example (TEAM123)"
+  2) 00112233445566778899AABBCCDDEEFF00112233 "Developer ID Application: Example Duplicate Label (TEAM123)"
+  3) FFEEDDCCBBAA99887766554433221100FFEEDDCC "Apple Development: Example (TEAM123)"
+     3 valid identities found
+"#;
+
+        assert_eq!(
+            matching_codesigning_identities(output, "00112233445566778899AABBCCDDEEFF00112233"),
+            vec![ResolvedCodesigningIdentity {
+                certificate_sha1: "00112233445566778899AABBCCDDEEFF00112233".into(),
+                display_name: "Developer ID Application: Example (TEAM123)".into(),
+            }]
+        );
     }
 
     #[test]

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -4,12 +4,12 @@ use anyhow::{bail, Context, Result};
 use fission_command_core::{
     build_linux_native_modules, build_windows_native_modules, cargo_package_name,
     embed_and_sign_macos_native_modules, ensure_native_variant_target, normalized_extension,
-    read_macos_package_config_for_profile_and_variant, read_project_config, resolve_app_icon,
-    sign_macos_app_if_configured, stage_linux_native_products, stage_project_assets,
-    stage_windows_runtime_products, sync_platform_config, variant_output_path,
-    BuiltLinuxNativeProduct, BuiltWindowsNativeProduct, FissionProject, MacosNativeBundleMode,
-    MacosPackageConfig, NativeLinuxProductKind, NativeWindowsProductKind, PlatformCapability,
-    Target,
+    read_desktop_cargo_options, read_macos_package_config_for_profile_and_variant,
+    read_project_config, resolve_app_icon, sign_macos_app_if_configured,
+    stage_linux_native_products, stage_project_assets, stage_windows_runtime_products,
+    sync_platform_config, variant_output_path, BuiltLinuxNativeProduct, BuiltWindowsNativeProduct,
+    DesktopCargoOptions, FissionProject, MacosNativeBundleMode, MacosPackageConfig,
+    NativeLinuxProductKind, NativeWindowsProductKind, PlatformCapability, Target,
 };
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -249,7 +249,7 @@ fn package_linux_run(options: &PackageOptions) -> Result<ArtifactManifest> {
     let staging_dir = clean_package_dir(options)?;
     let payload_dir = staging_dir.join("payload");
     fs::create_dir_all(&payload_dir)?;
-    let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
+    let binary = build_desktop_binary(options)?;
     let executable_name = binary
         .file_name()
         .and_then(OsStr::to_str)
@@ -330,7 +330,7 @@ fn package_terminal_run(options: &PackageOptions) -> Result<ArtifactManifest> {
     let staging_dir = clean_package_dir(options)?;
     let payload_dir = staging_dir.join("payload");
     fs::create_dir_all(&payload_dir)?;
-    let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
+    let binary = build_desktop_binary(options)?;
     let executable_name = binary
         .file_name()
         .and_then(OsStr::to_str)
@@ -451,7 +451,7 @@ fn package_windows_exe(options: &PackageOptions) -> Result<ArtifactManifest> {
     let project = read_project_config(&options.project_dir)?;
     let profile = profile_name(options.release);
     let staging_dir = clean_package_dir(options)?;
-    let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
+    let binary = build_desktop_binary(options)?;
     let native_products = build_windows_native_modules(
         &options.project_dir,
         &project,
@@ -572,7 +572,7 @@ fn package_with_project_script(
     }
     let mut environment = Vec::new();
     if target == Target::Windows {
-        let binary = build_desktop_binary(&options.project_dir, options.release, &[], false)?;
+        let binary = build_desktop_binary(options)?;
         let native_products = build_windows_native_modules(
             &options.project_dir,
             &project,
@@ -1526,7 +1526,25 @@ fn require_host_os(target: Target) -> Result<()> {
     }
 }
 
-fn build_desktop_binary(
+fn desktop_package_cargo_options(options: &PackageOptions) -> Result<DesktopCargoOptions> {
+    read_desktop_cargo_options(
+        &options.project_dir,
+        options.target,
+        options.variant.as_ref().map(NativeVariant::as_str),
+    )
+}
+
+fn build_desktop_binary(options: &PackageOptions) -> Result<PathBuf> {
+    let cargo_options = desktop_package_cargo_options(options)?;
+    build_desktop_binary_with_cargo_options(
+        &options.project_dir,
+        options.release,
+        &cargo_options.features,
+        cargo_options.no_default_features,
+    )
+}
+
+fn build_desktop_binary_with_cargo_options(
     project_dir: &Path,
     release: bool,
     cargo_features: &[String],
@@ -1627,7 +1645,7 @@ fn create_macos_app_bundle(
     staging_dir: &Path,
     macos: &MacosPackageConfig,
 ) -> Result<PathBuf> {
-    let binary = build_desktop_binary(
+    let binary = build_desktop_binary_with_cargo_options(
         &options.project_dir,
         options.release,
         &macos.cargo_features,

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -110,8 +110,7 @@ impl DockerPackageConfig {
 #[path = "package_validation.rs"]
 mod package_validation;
 use package_validation::{
-    ensure_macos_app_store_private_api_safe, manifest_validation_state, package_artifact_checks,
-    prepare_package_validation_inputs,
+    manifest_validation_state, package_artifact_checks, prepare_package_validation_inputs,
 };
 
 pub(super) fn package_artifact(options: &PackageOptions) -> Result<ArtifactManifest> {
@@ -378,7 +377,6 @@ fn package_macos_app(options: &PackageOptions) -> Result<ArtifactManifest> {
         MacosNativeBundleMode::Package,
         options.release,
     )?;
-    ensure_macos_app_store_private_api_safe(options, &app_bundle)?;
     sign_macos_app_if_configured(&options.project_dir, &app_bundle, &macos)?;
     notarize_macos_artifact_if_configured(&app_bundle, &macos)?;
     println!("{}", app_bundle.display());
@@ -407,7 +405,6 @@ fn package_macos_pkg(options: &PackageOptions) -> Result<ArtifactManifest> {
         MacosNativeBundleMode::Package,
         options.release,
     )?;
-    ensure_macos_app_store_private_api_safe(options, &app_bundle)?;
     sign_macos_app_if_configured(&options.project_dir, &app_bundle, &macos)?;
     notarize_macos_artifact_if_configured(&app_bundle, &macos)?;
     let version = resolved_package_version(&options.project_dir, options.target)?;

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -110,7 +110,8 @@ impl DockerPackageConfig {
 #[path = "package_validation.rs"]
 mod package_validation;
 use package_validation::{
-    manifest_validation_state, package_artifact_checks, prepare_package_validation_inputs,
+    ensure_macos_app_store_private_api_safe, manifest_validation_state, package_artifact_checks,
+    prepare_package_validation_inputs,
 };
 
 pub(super) fn package_artifact(options: &PackageOptions) -> Result<ArtifactManifest> {
@@ -377,6 +378,7 @@ fn package_macos_app(options: &PackageOptions) -> Result<ArtifactManifest> {
         MacosNativeBundleMode::Package,
         options.release,
     )?;
+    ensure_macos_app_store_private_api_safe(options, &app_bundle)?;
     sign_macos_app_if_configured(&options.project_dir, &app_bundle, &macos)?;
     notarize_macos_artifact_if_configured(&app_bundle, &macos)?;
     println!("{}", app_bundle.display());
@@ -405,6 +407,7 @@ fn package_macos_pkg(options: &PackageOptions) -> Result<ArtifactManifest> {
         MacosNativeBundleMode::Package,
         options.release,
     )?;
+    ensure_macos_app_store_private_api_safe(options, &app_bundle)?;
     sign_macos_app_if_configured(&options.project_dir, &app_bundle, &macos)?;
     notarize_macos_artifact_if_configured(&app_bundle, &macos)?;
     let version = resolved_package_version(&options.project_dir, options.target)?;

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -480,6 +480,75 @@ fn custom_packager_receives_selected_variant() {
 }
 
 #[test]
+fn desktop_package_builds_use_selected_variant_cargo_options() {
+    let root = std::env::temp_dir().join(format!(
+        "fission-package-desktop-cargo-variant-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("fission.toml"),
+        r#"
+[package.windows]
+cargo_features = ["windows-base"]
+
+[package.windows.variants.billing]
+cargo_features = ["shared", "billing", "shared"]
+cargo_no_default_features = true
+
+[package.linux]
+cargo_features = ["linux-base"]
+cargo_no_default_features = true
+
+[package.linux.variants.billing]
+cargo_features = ["linux-billing"]
+cargo_no_default_features = false
+"#,
+    )
+    .unwrap();
+    let billing: fission_command_core::NativeVariant = "billing".parse().unwrap();
+
+    let windows = desktop_package_cargo_options(&PackageOptions {
+        project_dir: root.clone(),
+        target: Target::Windows,
+        format: PackageFormat::Exe,
+        release: true,
+        variant: Some(billing.clone()),
+        json: false,
+    })
+    .unwrap();
+    assert_eq!(windows.features, ["billing", "shared"]);
+    assert!(windows.no_default_features);
+
+    let linux = desktop_package_cargo_options(&PackageOptions {
+        project_dir: root.clone(),
+        target: Target::Linux,
+        format: PackageFormat::Run,
+        release: true,
+        variant: Some(billing),
+        json: false,
+    })
+    .unwrap();
+    assert_eq!(linux.features, ["linux-billing"]);
+    assert!(!linux.no_default_features);
+
+    let windows_base = desktop_package_cargo_options(&PackageOptions {
+        project_dir: root.clone(),
+        target: Target::Windows,
+        format: PackageFormat::Exe,
+        release: true,
+        variant: None,
+        json: false,
+    })
+    .unwrap();
+    assert_eq!(windows_base.features, ["windows-base"]);
+    assert!(!windows_base.no_default_features);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn linux_native_manifest_records_staged_product_digest() {
     let root = std::env::temp_dir().join(format!(
         "fission-linux-native-manifest-{}",

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -1,5 +1,6 @@
 use super::package_validation::{
-    package_artifact_checks, package_install_smoke_check, prepare_package_validation_inputs,
+    ensure_macos_app_store_private_api_safe, package_artifact_checks, package_install_smoke_check,
+    prepare_package_validation_inputs,
 };
 use super::*;
 use fission_command_core::AppConfig;
@@ -40,6 +41,70 @@ fn macos_info_plist_includes_capability_usage_descriptions() {
     assert!(plist.contains("NSMicrophoneUsageDescription"));
     assert!(plist.contains("<key>CFBundleShortVersionString</key>\n  <string>1.2.3</string>"));
     assert!(plist.contains("<key>CFBundleVersion</key>\n  <string>42</string>"));
+}
+
+#[test]
+fn macos_app_store_preflight_checks_every_mach_o_for_private_apple_apis() {
+    let root = std::env::temp_dir().join(format!(
+        "fission-macos-private-api-preflight-{}",
+        std::process::id()
+    ));
+    let app = root.join("Demo.app");
+    let executable = app.join("Contents/MacOS/Demo");
+    let framework = app.join("Contents/Frameworks/Private.framework/Private");
+    let resources = app.join("Contents/Resources");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(executable.parent().unwrap()).unwrap();
+    fs::create_dir_all(framework.parent().unwrap()).unwrap();
+    fs::create_dir_all(&resources).unwrap();
+
+    let mut main_binary = vec![0xcf, 0xfa, 0xed, 0xfe];
+    main_binary.extend_from_slice(b"binary data _CGSMainConnectionID");
+    fs::write(&executable, main_binary).unwrap();
+    let mut framework_binary = vec![0xca, 0xfe, 0xba, 0xbe];
+    framework_binary.extend_from_slice(b"binary data _CGSSetWindowBackgroundBlurRadius");
+    fs::write(&framework, framework_binary).unwrap();
+    fs::write(
+        resources.join("readme.txt"),
+        b"_CGSMainConnectionID is harmless in a non-Mach-O resource",
+    )
+    .unwrap();
+
+    let default_options = PackageOptions {
+        project_dir: root.clone(),
+        target: Target::Macos,
+        format: PackageFormat::App,
+        release: true,
+        variant: None,
+        json: false,
+    };
+    ensure_macos_app_store_private_api_safe(&default_options, &app).unwrap();
+
+    let app_store_options = PackageOptions {
+        variant: Some("app-store".parse().unwrap()),
+        ..default_options
+    };
+    let error = ensure_macos_app_store_private_api_safe(&app_store_options, &app)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("_CGSMainConnectionID"));
+    assert!(error.contains(executable.to_string_lossy().as_ref()));
+    assert!(error.contains("_CGSSetWindowBackgroundBlurRadius"));
+    assert!(error.contains(framework.to_string_lossy().as_ref()));
+
+    fs::write(
+        &executable,
+        [vec![0xcf, 0xfa, 0xed, 0xfe], b"clean".to_vec()].concat(),
+    )
+    .unwrap();
+    fs::write(
+        &framework,
+        [vec![0xca, 0xfe, 0xba, 0xbe], b"clean".to_vec()].concat(),
+    )
+    .unwrap();
+    ensure_macos_app_store_private_api_safe(&app_store_options, &app).unwrap();
+
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -1,6 +1,5 @@
 use super::package_validation::{
-    ensure_macos_app_store_private_api_safe, package_artifact_checks, package_install_smoke_check,
-    prepare_package_validation_inputs,
+    package_artifact_checks, package_install_smoke_check, prepare_package_validation_inputs,
 };
 use super::*;
 use fission_command_core::AppConfig;
@@ -41,70 +40,6 @@ fn macos_info_plist_includes_capability_usage_descriptions() {
     assert!(plist.contains("NSMicrophoneUsageDescription"));
     assert!(plist.contains("<key>CFBundleShortVersionString</key>\n  <string>1.2.3</string>"));
     assert!(plist.contains("<key>CFBundleVersion</key>\n  <string>42</string>"));
-}
-
-#[test]
-fn macos_app_store_preflight_checks_every_mach_o_for_private_apple_apis() {
-    let root = std::env::temp_dir().join(format!(
-        "fission-macos-private-api-preflight-{}",
-        std::process::id()
-    ));
-    let app = root.join("Demo.app");
-    let executable = app.join("Contents/MacOS/Demo");
-    let framework = app.join("Contents/Frameworks/Private.framework/Private");
-    let resources = app.join("Contents/Resources");
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(executable.parent().unwrap()).unwrap();
-    fs::create_dir_all(framework.parent().unwrap()).unwrap();
-    fs::create_dir_all(&resources).unwrap();
-
-    let mut main_binary = vec![0xcf, 0xfa, 0xed, 0xfe];
-    main_binary.extend_from_slice(b"binary data _CGSMainConnectionID");
-    fs::write(&executable, main_binary).unwrap();
-    let mut framework_binary = vec![0xca, 0xfe, 0xba, 0xbe];
-    framework_binary.extend_from_slice(b"binary data _CGSSetWindowBackgroundBlurRadius");
-    fs::write(&framework, framework_binary).unwrap();
-    fs::write(
-        resources.join("readme.txt"),
-        b"_CGSMainConnectionID is harmless in a non-Mach-O resource",
-    )
-    .unwrap();
-
-    let default_options = PackageOptions {
-        project_dir: root.clone(),
-        target: Target::Macos,
-        format: PackageFormat::App,
-        release: true,
-        variant: None,
-        json: false,
-    };
-    ensure_macos_app_store_private_api_safe(&default_options, &app).unwrap();
-
-    let app_store_options = PackageOptions {
-        variant: Some("app-store".parse().unwrap()),
-        ..default_options
-    };
-    let error = ensure_macos_app_store_private_api_safe(&app_store_options, &app)
-        .unwrap_err()
-        .to_string();
-    assert!(error.contains("_CGSMainConnectionID"));
-    assert!(error.contains(executable.to_string_lossy().as_ref()));
-    assert!(error.contains("_CGSSetWindowBackgroundBlurRadius"));
-    assert!(error.contains(framework.to_string_lossy().as_ref()));
-
-    fs::write(
-        &executable,
-        [vec![0xcf, 0xfa, 0xed, 0xfe], b"clean".to_vec()].concat(),
-    )
-    .unwrap();
-    fs::write(
-        &framework,
-        [vec![0xca, 0xfe, 0xba, 0xbe], b"clean".to_vec()].concat(),
-    )
-    .unwrap();
-    ensure_macos_app_store_private_api_safe(&app_store_options, &app).unwrap();
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/tools/fission-command-package/src/package_validation.rs
+++ b/crates/tools/fission-command-package/src/package_validation.rs
@@ -1,5 +1,24 @@
 use super::*;
 use serde::{Deserialize, Serialize};
+use std::io::{ErrorKind, Read};
+
+const MACH_O_MAGICS: [[u8; 4]; 8] = [
+    [0xfe, 0xed, 0xfa, 0xce],
+    [0xce, 0xfa, 0xed, 0xfe],
+    [0xfe, 0xed, 0xfa, 0xcf],
+    [0xcf, 0xfa, 0xed, 0xfe],
+    [0xca, 0xfe, 0xba, 0xbe],
+    [0xbe, 0xba, 0xfe, 0xca],
+    [0xca, 0xfe, 0xba, 0xbf],
+    [0xbf, 0xba, 0xfe, 0xca],
+];
+const APP_STORE_FORBIDDEN_PRIVATE_APIS: [(&str, &[u8]); 2] = [
+    ("_CGSMainConnectionID", b"_CGSMainConnectionID"),
+    (
+        "_CGSSetWindowBackgroundBlurRadius",
+        b"_CGSSetWindowBackgroundBlurRadius",
+    ),
+];
 
 #[derive(Debug, Deserialize)]
 struct InstallSmokeReceipt {
@@ -13,6 +32,95 @@ struct InstallSmokeCheckOutcome {
     id: String,
     status: String,
     details: Option<String>,
+}
+
+pub(super) fn ensure_macos_app_store_private_api_safe(
+    options: &PackageOptions,
+    app_bundle: &Path,
+) -> Result<()> {
+    if options.target != Target::Macos
+        || options.variant.as_ref().map(NativeVariant::as_str) != Some("app-store")
+    {
+        return Ok(());
+    }
+
+    let mut mach_o_count = 0;
+    let mut violations = Vec::new();
+    inspect_mach_o_private_apis(app_bundle, &mut mach_o_count, &mut violations)?;
+    if !violations.is_empty() {
+        bail!(
+            "macOS App Store preflight rejected private Apple API references in {}: {}. Remove the references (including any dependency feature that enables private Apple APIs) before signing or upload.",
+            app_bundle.display(),
+            violations.join(", ")
+        );
+    }
+    if mach_o_count == 0 {
+        bail!(
+            "macOS App Store preflight found no Mach-O files in {}; the app bundle is incomplete",
+            app_bundle.display()
+        );
+    }
+    Ok(())
+}
+
+fn inspect_mach_o_private_apis(
+    path: &Path,
+    mach_o_count: &mut usize,
+    violations: &mut Vec<String>,
+) -> Result<()> {
+    for entry in fs::read_dir(path)
+        .with_context(|| format!("failed to inspect macOS app bundle {}", path.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("failed to inspect entry under {}", path.display()))?;
+        let file_type = entry.file_type().with_context(|| {
+            format!(
+                "failed to inspect macOS app bundle entry {}",
+                entry.path().display()
+            )
+        })?;
+        if file_type.is_dir() {
+            inspect_mach_o_private_apis(&entry.path(), mach_o_count, violations)?;
+        } else if file_type.is_file() {
+            inspect_mach_o_file(&entry.path(), mach_o_count, violations)?;
+        }
+    }
+    Ok(())
+}
+
+fn inspect_mach_o_file(
+    path: &Path,
+    mach_o_count: &mut usize,
+    violations: &mut Vec<String>,
+) -> Result<()> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("failed to inspect packaged file {}", path.display()))?;
+    let mut magic = [0_u8; 4];
+    match file.read_exact(&mut magic) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::UnexpectedEof => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read packaged file {}", path.display()))
+        }
+    }
+    if !MACH_O_MAGICS.contains(&magic) {
+        return Ok(());
+    }
+
+    *mach_o_count += 1;
+    let mut contents = magic.to_vec();
+    file.read_to_end(&mut contents)
+        .with_context(|| format!("failed to read Mach-O file {}", path.display()))?;
+    for (name, symbol) in APP_STORE_FORBIDDEN_PRIVATE_APIS {
+        if contents
+            .windows(symbol.len())
+            .any(|candidate| candidate == symbol)
+        {
+            violations.push(format!("{} ({name})", path.display()));
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn prepare_package_validation_inputs(

--- a/crates/tools/fission-command-package/src/package_validation.rs
+++ b/crates/tools/fission-command-package/src/package_validation.rs
@@ -527,6 +527,16 @@ fn package_signature_checks(
             "Android AAB jar signature verifies",
             "Configure Android upload signing and regenerate the AAB.",
         )],
+        PackageFormat::Msix if env_flag("WINDOWS_SKIP_SIGNING") => vec![check(
+            "release.package.signature.windows_msix",
+            CheckSeverity::Warning,
+            CheckStatus::Skipped,
+            "Windows MSIX signature verification is intentionally skipped",
+            Some("WINDOWS_SKIP_SIGNING=1; Microsoft Store will sign the package after certification".to_string()),
+            vec![
+                "Use unsigned MSIX output only for Microsoft Store submission; sign packages distributed through other channels.",
+            ],
+        )],
         PackageFormat::Msix => vec![verify_with_tool(
             "release.package.signature.windows_msix",
             "signtool",
@@ -694,6 +704,17 @@ fn package_static_load_smoke_check(
             "Re-run static packaging and inspect index.html if the static load-smoke check fails.",
         ],
     )
+}
+
+fn env_flag(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        })
+        .unwrap_or(false)
 }
 
 fn verify_with_tool(

--- a/crates/tools/fission-command-package/src/package_validation.rs
+++ b/crates/tools/fission-command-package/src/package_validation.rs
@@ -1,24 +1,5 @@
 use super::*;
 use serde::{Deserialize, Serialize};
-use std::io::{ErrorKind, Read};
-
-const MACH_O_MAGICS: [[u8; 4]; 8] = [
-    [0xfe, 0xed, 0xfa, 0xce],
-    [0xce, 0xfa, 0xed, 0xfe],
-    [0xfe, 0xed, 0xfa, 0xcf],
-    [0xcf, 0xfa, 0xed, 0xfe],
-    [0xca, 0xfe, 0xba, 0xbe],
-    [0xbe, 0xba, 0xfe, 0xca],
-    [0xca, 0xfe, 0xba, 0xbf],
-    [0xbf, 0xba, 0xfe, 0xca],
-];
-const APP_STORE_FORBIDDEN_PRIVATE_APIS: [(&str, &[u8]); 2] = [
-    ("_CGSMainConnectionID", b"_CGSMainConnectionID"),
-    (
-        "_CGSSetWindowBackgroundBlurRadius",
-        b"_CGSSetWindowBackgroundBlurRadius",
-    ),
-];
 
 #[derive(Debug, Deserialize)]
 struct InstallSmokeReceipt {
@@ -32,95 +13,6 @@ struct InstallSmokeCheckOutcome {
     id: String,
     status: String,
     details: Option<String>,
-}
-
-pub(super) fn ensure_macos_app_store_private_api_safe(
-    options: &PackageOptions,
-    app_bundle: &Path,
-) -> Result<()> {
-    if options.target != Target::Macos
-        || options.variant.as_ref().map(NativeVariant::as_str) != Some("app-store")
-    {
-        return Ok(());
-    }
-
-    let mut mach_o_count = 0;
-    let mut violations = Vec::new();
-    inspect_mach_o_private_apis(app_bundle, &mut mach_o_count, &mut violations)?;
-    if !violations.is_empty() {
-        bail!(
-            "macOS App Store preflight rejected private Apple API references in {}: {}. Remove the references (including any dependency feature that enables private Apple APIs) before signing or upload.",
-            app_bundle.display(),
-            violations.join(", ")
-        );
-    }
-    if mach_o_count == 0 {
-        bail!(
-            "macOS App Store preflight found no Mach-O files in {}; the app bundle is incomplete",
-            app_bundle.display()
-        );
-    }
-    Ok(())
-}
-
-fn inspect_mach_o_private_apis(
-    path: &Path,
-    mach_o_count: &mut usize,
-    violations: &mut Vec<String>,
-) -> Result<()> {
-    for entry in fs::read_dir(path)
-        .with_context(|| format!("failed to inspect macOS app bundle {}", path.display()))?
-    {
-        let entry =
-            entry.with_context(|| format!("failed to inspect entry under {}", path.display()))?;
-        let file_type = entry.file_type().with_context(|| {
-            format!(
-                "failed to inspect macOS app bundle entry {}",
-                entry.path().display()
-            )
-        })?;
-        if file_type.is_dir() {
-            inspect_mach_o_private_apis(&entry.path(), mach_o_count, violations)?;
-        } else if file_type.is_file() {
-            inspect_mach_o_file(&entry.path(), mach_o_count, violations)?;
-        }
-    }
-    Ok(())
-}
-
-fn inspect_mach_o_file(
-    path: &Path,
-    mach_o_count: &mut usize,
-    violations: &mut Vec<String>,
-) -> Result<()> {
-    let mut file = fs::File::open(path)
-        .with_context(|| format!("failed to inspect packaged file {}", path.display()))?;
-    let mut magic = [0_u8; 4];
-    match file.read_exact(&mut magic) {
-        Ok(()) => {}
-        Err(error) if error.kind() == ErrorKind::UnexpectedEof => return Ok(()),
-        Err(error) => {
-            return Err(error)
-                .with_context(|| format!("failed to read packaged file {}", path.display()))
-        }
-    }
-    if !MACH_O_MAGICS.contains(&magic) {
-        return Ok(());
-    }
-
-    *mach_o_count += 1;
-    let mut contents = magic.to_vec();
-    file.read_to_end(&mut contents)
-        .with_context(|| format!("failed to read Mach-O file {}", path.display()))?;
-    for (name, symbol) in APP_STORE_FORBIDDEN_PRIVATE_APIS {
-        if contents
-            .windows(symbol.len())
-            .any(|candidate| candidate == symbol)
-        {
-            violations.push(format!("{} ({name})", path.display()));
-        }
-    }
-    Ok(())
 }
 
 pub(super) fn prepare_package_validation_inputs(

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -12,8 +12,10 @@ use fission_command_core::{
     MacosPackageConfig, NativeVariant, PlatformCapability, Target,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
 use std::env;
 use std::fs::{self, File, OpenOptions};
+use std::hash::{Hash, Hasher};
 use std::io::{self, IsTerminal, Read, Seek, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
@@ -1357,7 +1359,7 @@ fn package_macos_run_app(
     let profile = if release { "release" } else { "debug" };
     let app_name = macos_display_name(&project.app.name);
     let app_bundle = variant_output_path(
-        project_dir.join(".fission/run/macos").join(profile),
+        macos_run_staging_root(&project_dir, project, profile),
         variant,
     )
     .join(format!("{app_name}.app"));
@@ -1412,6 +1414,23 @@ fn package_macos_run_app(
     sign_macos_app_if_configured(&project_dir, &app_bundle, &macos)?;
 
     Ok(MacosRunApp { bundle: app_bundle })
+}
+
+fn macos_run_staging_root(project_dir: &Path, project: &FissionProject, profile: &str) -> PathBuf {
+    let mut project_hash = DefaultHasher::new();
+    project_dir.hash(&mut project_hash);
+    let project_key = format!(
+        "{}-{:016x}",
+        sanitize_file_stem(&project.app.app_id),
+        project_hash.finish()
+    );
+
+    env::temp_dir()
+        .join("fission")
+        .join("run")
+        .join("macos")
+        .join(project_key)
+        .join(profile)
 }
 
 fn package_linux_run_app(
@@ -2254,6 +2273,20 @@ mod tests {
 
         assert!(plist.contains("<string>com.example.packaged</string>"));
         assert!(plist.contains("<key>LSMinimumSystemVersion</key>\n  <string>14.0</string>"));
+    }
+
+    #[test]
+    fn macos_run_bundle_is_staged_outside_the_project_volume() {
+        let project_dir = Path::new("/Volumes/My Shared Files/projects/example");
+
+        let staging = macos_run_staging_root(project_dir, &project(), "debug");
+
+        assert!(staging.starts_with(env::temp_dir()));
+        assert!(!staging.starts_with(project_dir));
+        assert!(staging.ends_with("debug"));
+        assert!(staging
+            .to_string_lossy()
+            .contains("com.fission.examples.fieldinspector"));
     }
 
     #[test]

--- a/crates/tools/fission-test/tests/interaction_and_layout_regressions.rs
+++ b/crates/tools/fission-test/tests/interaction_and_layout_regressions.rs
@@ -1,5 +1,5 @@
 use fission_core::ui::{Container, SemanticsRegion, Text, Widget};
-use fission_core::{GlobalState, ReducerContext, Role, reduce_with};
+use fission_core::{reduce_with, GlobalState, ReducerContext, Role};
 use fission_test::TestHarness;
 use fission_widgets::{NumberInput, SplitDirection, SplitView};
 
@@ -309,26 +309,38 @@ fn test_modal_content_keeps_its_intrinsic_height() {
 
     let ir = harness.last_ir.as_ref().unwrap();
     let snapshot = harness.last_snapshot.as_ref().unwrap();
-    let content_id = ir
-        .nodes
-        .iter()
-        .find_map(|(id, node)| match &node.op {
-            fission_ir::Op::Semantics(semantics)
-                if semantics.identifier.as_deref() == Some("intrinsic-modal-content") =>
-            {
-                Some(*id)
-            }
-            _ => None,
-        })
-        .expect("modal content semantics were not rendered");
+    let (content_id, surface_id) =
+        ir.nodes
+            .iter()
+            .fold((None, None), |(content, surface), (id, node)| {
+                let fission_ir::Op::Semantics(semantics) = &node.op else {
+                    return (content, surface);
+                };
+                match semantics.identifier.as_deref() {
+                    Some("intrinsic-modal-content") => (Some(*id), surface),
+                    Some("fission-modal-surface") => (content, Some(*id)),
+                    _ => (content, surface),
+                }
+            });
+    let content_id = content_id.expect("modal content semantics were not rendered");
+    let surface_id = surface_id.expect("modal surface semantics were not rendered");
     let content = snapshot
         .get_node_rect(content_id)
         .expect("modal content was not laid out");
+    let surface = snapshot
+        .get_node_rect(surface_id)
+        .expect("modal surface was not laid out");
 
     assert!(
         content.height() < VIEWPORT_HEIGHT / 2.0,
         "short modal content should keep an intrinsic height, got {} in a {}px viewport",
         content.height(),
+        VIEWPORT_HEIGHT,
+    );
+    assert!(
+        surface.height() < VIEWPORT_HEIGHT / 2.0,
+        "short modal surface should keep an intrinsic height, got {} in a {}px viewport",
+        surface.height(),
         VIEWPORT_HEIGHT,
     );
 }


### PR DESCRIPTION
## Summary
- stage macOS development app bundles on a local temporary volume so launchd can launch projects stored on shared/network filesystems
- validate macOS provisioning profile team, bundle ID, signing certificate, expiry, and development-device UDID before signing
- compile macOS signing configuration on non-macOS hosts used for cross-platform release orchestration
- initialize GTK before constructing Linux tray menus
- permit explicitly unsigned Microsoft Store MSIX validation when `WINDOWS_SKIP_SIGNING=1`
- automatically select the native software renderer on Windows when Auto detects a CPU, WARP, or Microsoft Basic Render Driver adapter
- preserve explicit renderer choices and hardware-backed Windows adapters
- align software-renderer transform order, SVG placement, and text wrapping with the retained display pipeline

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p fission-shell-winit --lib software -- --nocapture` (15 passed)
- `cargo test -p fission-shell-winit --lib -- --nocapture` (112 passed)
- selector regressions cover Windows Auto fallback plus explicit-choice and hardware-adapter preservation
- rendering regressions cover scaled/translated SVG placement and plain/rich text pipeline wrapping
- `cargo test -p fission-command-core macos_signing`
- `cargo test -p fission-command-core provisioning_profile_parses_apple_certificate_data_values`
- `cargo test -p fission-command-run macos_run_bundle_is_staged_outside_the_project_volume`
- real macOS development run validates the Developer Defence profile and stages under `$TMPDIR/fission/run/macos`
- real Linux Developer Defence run reproduced the pre-fix GTK tray panic; pinned consumer validation is in progress

The commits intentionally exclude unrelated dirty example/showcase work.