### PR TITLE
fix(site): preserve responsive semantic HTML and theme parity

### DIFF
--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -12,7 +12,7 @@ use fission_core::{
 };
 use fission_i18n::{I18nRegistry, Locale, TranslationBundle};
 use fission_layout::LayoutSize;
-use fission_theme::Theme;
+use fission_theme::{DesignMode, Theme};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU16, Ordering};
@@ -164,6 +164,10 @@ pub struct FissionServerApp {
     pub(crate) project_dir: std::path::PathBuf,
     pub(crate) theme: Theme,
     pub(crate) env: Env,
+    pub(crate) light_theme: Option<Theme>,
+    pub(crate) dark_theme: Option<Theme>,
+    pub(crate) default_theme_mode: Option<DesignMode>,
+    pub(crate) theme_switching: bool,
     pub(crate) request_env_sync: Option<Arc<RequestEnvSync>>,
     pub(crate) locale_resolver: Option<Arc<RequestLocaleResolver>>,
     pub(crate) default_locale: Locale,
@@ -182,6 +186,10 @@ impl FissionServerApp {
             project_dir: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             theme: Theme::default(),
             env: Env::default(),
+            light_theme: None,
+            dark_theme: None,
+            default_theme_mode: None,
+            theme_switching: false,
             request_env_sync: None,
             locale_resolver: None,
             default_locale: Locale::from("en"),
@@ -208,6 +216,29 @@ impl FissionServerApp {
     pub fn with_env(mut self, env: Env) -> Self {
         self.env = env;
         self.env.theme = self.theme.clone();
+        self
+    }
+
+    /// Configures light and dark themes for browser-side theme switching.
+    ///
+    /// SSR renders the selected default mode initially, emits both theme
+    /// variable sets in `/site.css`, and lets the standard Fission site
+    /// enhancement script persist user changes in local storage.
+    pub fn light_dark_themes(
+        mut self,
+        light: Theme,
+        dark: Theme,
+        default_mode: DesignMode,
+    ) -> Self {
+        self.theme = match default_mode {
+            DesignMode::Light => light.clone(),
+            DesignMode::Dark => dark.clone(),
+        };
+        self.env.theme = self.theme.clone();
+        self.light_theme = Some(light);
+        self.dark_theme = Some(dark);
+        self.default_theme_mode = Some(default_mode);
+        self.theme_switching = true;
         self
     }
 

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -1499,10 +1499,10 @@ mod tests {
         CacheError, CacheTag, InvalidationReport, MokaCache, ProgressiveWorker, RevalidationPolicy,
         WasmIsland, WebRouteMode,
     };
-    use fission_core::ui::{Button, Text, TextContent};
+    use fission_core::ui::{Button, SemanticsRegion, Text, TextContent};
     use fission_core::{
         Action, ActionId, GlobalState, Handler, JobRef, JobResource, JobSpec, ReducerContext,
-        ResourceKey, Widget, WidgetId,
+        ResourceKey, Role, Widget, WidgetId,
     };
     use fission_i18n::TranslationBundle;
     use serde::{Deserialize, Serialize};
@@ -1530,6 +1530,20 @@ mod tests {
         fn from(component: TestPage) -> Self {
             let (_ctx, _view) = fission_core::build::current::<TestState>();
             Text::new(component.0).into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct ThemeTogglePage;
+
+    impl From<ThemeTogglePage> for Widget {
+        fn from(_: ThemeTogglePage) -> Self {
+            let (_ctx, _view) = fission_core::build::current::<TestState>();
+            SemanticsRegion::new(Text::new("Cambiar tema"))
+                .identifier("site-theme-toggle")
+                .label("Cambiar el tema de color")
+                .role(Role::Button)
+                .into()
         }
     }
 
@@ -2602,6 +2616,26 @@ same_site = "none"
         assert!(html.contains(r#"<html lang="en" data-theme="dark">"#));
         assert!(html.contains("var k='fission-site-theme'"));
         assert!(html.contains("[data-fission-theme-toggle]"));
+    }
+
+    #[test]
+    fn server_renderer_uses_the_theme_toggle_semantics_label() {
+        let renderer = ServerRenderer::new(
+            FissionServerApp::new("Test")
+                .light_dark_themes(
+                    fission_theme::Theme::default(),
+                    fission_theme::Theme::dark(),
+                    DesignMode::Light,
+                )
+                .server_route_widget::<TestState, _>("/", "Home", None, ThemeTogglePage),
+        );
+
+        let html = renderer
+            .handle(ServerRequest::get("/"))
+            .unwrap()
+            .body_string();
+
+        assert!(html.contains(r#"aria-label="Cambiar el tema de color""#));
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -21,6 +21,7 @@ use fission_shell_site::{
     render_ir_to_html_with_styles, site_base_css, site_enhancement_js, theme_variables_css,
     CssVariableMap, HtmlRenderOptions, StyleRegistry,
 };
+use fission_theme::DesignMode;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -543,6 +544,8 @@ impl ServerRenderer {
             stylesheet_href: "/site.css".to_string(),
             current_route_path: route_path.clone(),
             css_variables: CssVariableMap::from_theme(&env.theme),
+            default_theme_mode: self.app.default_theme_mode,
+            theme_switching: self.app.theme_switching,
             server_action_post_path: Some("/__fission/action".to_string()),
             server_action_tokens: action_tokens,
             structured_data: route.route.structured_data.clone(),
@@ -598,7 +601,21 @@ impl ServerRenderer {
             "\n.fission-browser-action{cursor:pointer;user-select:none;display:inline-flex;align-items:center;justify-content:center;}\n.fission-browser-action:focus-visible{outline:3px solid rgba(96,165,250,.85);outline-offset:3px;}\n",
         );
         css.push('\n');
-        css.push_str(&theme_variables_css(":root", &self.app.theme));
+        if self.app.theme_switching {
+            let default_selector = match self.app.default_theme_mode.unwrap_or(DesignMode::Light) {
+                DesignMode::Light => ":root,[data-theme=\"light\"]",
+                DesignMode::Dark => ":root,[data-theme=\"dark\"]",
+            };
+            css.push_str(&theme_variables_css(default_selector, &self.app.theme));
+            if let Some(light) = &self.app.light_theme {
+                css.push_str(&theme_variables_css("[data-theme=\"light\"]", light));
+            }
+            if let Some(dark) = &self.app.dark_theme {
+                css.push_str(&theme_variables_css("[data-theme=\"dark\"]", dark));
+            }
+        } else {
+            css.push_str(&theme_variables_css(":root", &self.app.theme));
+        }
         let styles = self
             .style_cache
             .read()
@@ -2543,6 +2560,48 @@ same_site = "none"
         let runtime = runtime.body_string();
         assert!(runtime.contains("fission_bridge_alloc"));
         assert!(runtime.contains("fission-site-text-run"));
+    }
+
+    #[test]
+    fn server_renderer_emits_switchable_light_dark_theme_css() {
+        let light = fission_theme::Theme::default();
+        let dark = fission_theme::Theme::dark();
+        let renderer = ServerRenderer::new(
+            FissionServerApp::new("Test")
+                .light_dark_themes(light.clone(), dark.clone(), DesignMode::Dark)
+                .server_route_widget::<TestState, _>("/", "Home", None, TestPage("Theme page")),
+        );
+
+        let css = renderer
+            .handle(ServerRequest::get("/site.css"))
+            .unwrap()
+            .body_string();
+
+        assert!(css.contains(&theme_variables_css(":root,[data-theme=\"dark\"]", &dark)));
+        assert!(css.contains(&theme_variables_css("[data-theme=\"light\"]", &light)));
+        assert!(css.contains(&theme_variables_css("[data-theme=\"dark\"]", &dark)));
+    }
+
+    #[test]
+    fn server_renderer_enables_theme_switching_document_contract() {
+        let renderer = ServerRenderer::new(
+            FissionServerApp::new("Test")
+                .light_dark_themes(
+                    fission_theme::Theme::default(),
+                    fission_theme::Theme::dark(),
+                    DesignMode::Dark,
+                )
+                .server_route_widget::<TestState, _>("/", "Home", None, TestPage("Theme page")),
+        );
+
+        let html = renderer
+            .handle(ServerRequest::get("/"))
+            .unwrap()
+            .body_string();
+
+        assert!(html.contains(r#"<html lang="en" data-theme="dark">"#));
+        assert!(html.contains("var k='fission-site-theme'"));
+        assert!(html.contains("[data-fission-theme-toggle]"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -26,6 +26,25 @@ fission site build --project-dir documentation --release
 
 This is a shell, not a separate website framework. Custom pages are written as normal Fission widgets. Content pages are rendered through Fission templates. The static shell visits the resulting Fission node tree and emits semantic HTML instead of opening an OS window or canvas.
 
+Site-specific semantic regions can select native HTML landmarks and anchors
+without changing how the same widget tree renders in native shells:
+
+| Semantics identifier | Site-shell output |
+| --- | --- |
+| `site-header` | `<header>` |
+| `site-main` | `<main>` |
+| `site-navigation` | `<nav>` |
+| `site-footer` | `<footer>` |
+| `site-aside` | `<aside>` |
+| `site-link:#details` | An ordinary `<a href="#details">` |
+| `site-section:features` | `<section id="features">` |
+| `site-anchor:details` | `<div id="details">` |
+| `site-heading-1:top` through `site-heading-6:*` | The matching heading with an `id` |
+
+Use these identifiers on `SemanticsRegion` widgets only when the region has
+the corresponding document meaning. Other shells continue to consume the
+ordinary Fission semantics and layout nodes.
+
 ## Documentation
 
 See the static site guide at [fission.rs](https://fission.rs/docs/guides/static-sites/). The source for the live documentation site is in the repository `documentation` project.

--- a/crates/shell/fission-shell-site/assets/site.css
+++ b/crates/shell/fission-shell-site/assets/site.css
@@ -12,8 +12,30 @@ a:hover { text-decoration: underline; }
 img, svg { max-width: 100%; }
 .fission-site-root { min-height: 100vh; }
 .fission-site-node { min-width: 0; }
+/* Browsers ignore `justify-content: stretch` on a row flexbox. Native Fission
+   stretches a Container child only while its width and max-width are automatic,
+   so the renderer emits this class solely for that same lowering shape. */
+.fission-site-box-stretch-auto-width > .fission-site-node {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
+}
+figure.fission-site-semantics {
+  margin: 0;
+}
+h1.fission-site-semantics,
+h2.fission-site-semantics,
+h3.fission-site-semantics,
+h4.fission-site-semantics,
+h5.fission-site-semantics,
+h6.fission-site-semantics {
+  margin: 0;
+  font: inherit;
+  color: inherit;
+}
 .fission-site-route-link,
-.fission-site-heading-link {
+.fission-site-heading-link,
+.fission-site-general-link {
   display: inline-flex;
   max-width: 100%;
   color: inherit;
@@ -23,11 +45,13 @@ img, svg { max-width: 100%; }
   cursor: pointer;
 }
 .fission-site-route-link:hover,
-.fission-site-heading-link:hover {
+.fission-site-heading-link:hover,
+.fission-site-general-link:hover {
   text-decoration: none;
 }
 .fission-site-route-link > .fission-site-node,
-.fission-site-heading-link > .fission-site-node {
+.fission-site-heading-link > .fission-site-node,
+.fission-site-general-link > .fission-site-node {
   flex: 1 1 auto;
 }
 .fission-site-positioned > .fission-site-node,

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -906,6 +906,52 @@ impl HtmlRenderer<'_> {
         ))
     }
 
+    fn stretches_auto_width_content_child(&self, node: &CoreNode) -> bool {
+        if self.parent_uses_intrinsic_inline_sizing(node) {
+            return false;
+        }
+
+        let mut content_children = node
+            .children
+            .iter()
+            .filter_map(|child_id| self.ir.nodes.get(child_id))
+            .filter(|child| !is_coalesced_paint_child(child));
+        let Some(child) = content_children.next() else {
+            return false;
+        };
+
+        content_children.next().is_none() && !site_node_has_explicit_width(child)
+    }
+
+    fn parent_uses_intrinsic_inline_sizing(&self, node: &CoreNode) -> bool {
+        let Some(parent) = node
+            .parent
+            .and_then(|parent_id| self.ir.nodes.get(&parent_id))
+        else {
+            return false;
+        };
+        let Op::Semantics(semantics) = &parent.op else {
+            return false;
+        };
+
+        matches!(semantics.role, Role::Button | Role::Link | Role::MenuItem)
+            || semantics
+                .actions
+                .entries
+                .iter()
+                .any(|entry| entry.trigger == ActionTrigger::Default)
+            || semantics.identifier.as_deref().is_some_and(|identifier| {
+                identifier.starts_with("site-link:")
+                    || identifier.starts_with("site-route:")
+                    || identifier.starts_with("site-heading:")
+                    || identifier.starts_with("markdown-link:")
+                    || matches!(
+                        identifier,
+                        "site-theme-toggle" | "site-search-trigger" | "site-sidebar-toggle"
+                    )
+            })
+    }
+
     fn class_name(&mut self, base: &str, style: Vec<String>) -> String {
         if let Some(generated) = self.styles.class_for(style) {
             format!("{base} {generated}")
@@ -1338,7 +1384,15 @@ impl HtmlRenderer<'_> {
                     push_grid_placement(&mut style, "grid-column-end", grid.col_end);
                 }
                 push_flex_item(&mut style, *flex_grow, *flex_shrink);
-                self.render_element("div", node, "fission-site-node fission-site-box", style)
+                let stretches_auto_width_child = box_style.alignment
+                    == fission_ir::op::BoxAlignment::Stretch
+                    && self.stretches_auto_width_content_child(node);
+                let class_name = if stretches_auto_width_child {
+                    "fission-site-node fission-site-box fission-site-box-stretch-auto-width"
+                } else {
+                    "fission-site-node fission-site-box"
+                };
+                self.render_element("div", node, class_name, style)
             }
             LayoutOp::Flex {
                 direction,
@@ -1470,7 +1524,7 @@ impl HtmlRenderer<'_> {
                     }
                 };
                 Ok(format!(
-                    "<div class=\"fission-site-node {root_class}\"{container_style} data-fission-node=\"{}\">{children}</div>",
+                    "<div class=\"fission-site-node fission-site-responsive {root_class}\"{container_style} data-fission-node=\"{}\">{children}</div>",
                     node.id
                 ))
             }
@@ -1882,6 +1936,14 @@ impl HtmlRenderer<'_> {
                     target,
                     semantics.label.as_deref(),
                     "fission-site-route-link",
+                );
+            }
+            if let Some(target) = identifier.strip_prefix("site-link:") {
+                return self.render_semantic_link(
+                    node,
+                    target,
+                    semantics.label.as_deref(),
+                    "fission-site-general-link",
                 );
             }
             if let Some(anchor) = identifier.strip_prefix("site-heading:") {
@@ -2344,11 +2406,15 @@ impl HtmlRenderer<'_> {
         if let Some(label) = label {
             attrs.push_str(&format!(" aria-label=\"{}\"", escape_attr(label)));
         }
+        let (tag, anchor) = site_semantic_element(identifier);
+        if let Some(anchor) = anchor {
+            attrs.push_str(&format!(" id=\"{}\"", escape_attr(anchor)));
+        }
         attrs.push_str(&site_semantic_data_attrs(identifier));
         let children = self.render_children(&node.children, &HashSet::new())?;
         Ok(format!(
-            "<div class=\"fission-site-node fission-site-semantics {class_name}\"{attrs} data-fission-node=\"{}\">{children}</div>",
-            node.id
+            "<{tag} class=\"fission-site-node fission-site-semantics {class_name}\"{attrs} data-fission-node=\"{}\">{children}</{tag}>",
+            node.id,
         ))
     }
 
@@ -2445,24 +2511,28 @@ impl HtmlRenderer<'_> {
             let Some(child) = self.ir.nodes.get(child_id) else {
                 continue;
             };
-            if let Op::Paint(PaintOp::DrawRect {
+            if !is_coalesced_paint_child(child) {
+                continue;
+            }
+            let Op::Paint(PaintOp::DrawRect {
                 fill,
                 stroke,
                 corner_radius,
                 shadow,
             }) = &child.op
-            {
-                if let Some(shadow) = shadow {
-                    shadows.push(self.box_shadow_css(shadow));
-                }
-                style.extend(self.draw_rect_style(
-                    fill.as_ref(),
-                    stroke.as_ref(),
-                    *corner_radius,
-                    None,
-                ));
-                skip.insert(*child_id);
+            else {
+                unreachable!("coalesced site paint children are rectangles");
+            };
+            if let Some(shadow) = shadow {
+                shadows.push(self.box_shadow_css(shadow));
             }
+            style.extend(self.draw_rect_style(
+                fill.as_ref(),
+                stroke.as_ref(),
+                *corner_radius,
+                None,
+            ));
+            skip.insert(*child_id);
         }
         if !shadows.is_empty() {
             style.push(format!("box-shadow:{}", shadows.join(",")));
@@ -2711,6 +2781,65 @@ fn site_semantic_class(identifier: &str) -> String {
         })
         .collect::<String>();
     format!("fission-{suffix}")
+}
+
+fn site_semantic_element(identifier: &str) -> (&'static str, Option<&str>) {
+    match identifier {
+        "site-header" => return ("header", None),
+        "site-main" => return ("main", None),
+        "site-navigation" => return ("nav", None),
+        "site-footer" => return ("footer", None),
+        "site-aside" => return ("aside", None),
+        _ => {}
+    }
+    if let Some(anchor) = identifier
+        .strip_prefix("site-section:")
+        .filter(|anchor| !anchor.is_empty())
+    {
+        return ("section", Some(anchor));
+    }
+    if let Some(anchor) = identifier
+        .strip_prefix("site-anchor:")
+        .filter(|anchor| !anchor.is_empty())
+    {
+        return ("div", Some(anchor));
+    }
+    for (prefix, tag) in [
+        ("site-heading-1:", "h1"),
+        ("site-heading-2:", "h2"),
+        ("site-heading-3:", "h3"),
+        ("site-heading-4:", "h4"),
+        ("site-heading-5:", "h5"),
+        ("site-heading-6:", "h6"),
+    ] {
+        if let Some(anchor) = identifier
+            .strip_prefix(prefix)
+            .filter(|anchor| !anchor.is_empty())
+        {
+            return (tag, Some(anchor));
+        }
+    }
+    ("div", None)
+}
+
+fn site_node_has_explicit_width(node: &CoreNode) -> bool {
+    match &node.op {
+        Op::Layout(LayoutOp::Box {
+            width, max_width, ..
+        })
+        | Op::Layout(LayoutOp::Scroll {
+            width, max_width, ..
+        }) => width.is_some() || max_width.is_some(),
+        Op::Layout(LayoutOp::StyledBox { style, .. }) => {
+            style.width.is_some() || style.max_width.is_some()
+        }
+        Op::Layout(LayoutOp::Embed { width, .. }) => width.is_some(),
+        _ => false,
+    }
+}
+
+fn is_coalesced_paint_child(node: &CoreNode) -> bool {
+    matches!(node.op, Op::Paint(PaintOp::DrawRect { .. }))
 }
 
 fn static_form_label(field: &StaticFormField, control: String) -> String {
@@ -4382,5 +4511,310 @@ mod tests {
             later_case < first_case,
             "the first case must be emitted last so equal-specificity CSS wins"
         );
+    }
+
+    #[test]
+    fn site_shell_sizes_stretched_container_query_children() {
+        let root = WidgetId::explicit("stretch-box");
+        let responsive = WidgetId::explicit("responsive");
+        let fallback = WidgetId::explicit("fallback");
+        let background = WidgetId::explicit("background");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            fallback,
+            Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 1 }),
+            Vec::new(),
+        );
+        ir.add_node(
+            responsive,
+            Op::Layout(LayoutOp::Responsive {
+                query: fission_ir::op::ResponsiveQuery::Container,
+                cases: Vec::new(),
+            }),
+            vec![fallback],
+        );
+        ir.add_node(
+            background,
+            Op::Paint(PaintOp::DrawRect {
+                fill: None,
+                stroke: None,
+                corner_radius: 0.0,
+                shadow: None,
+            }),
+            Vec::new(),
+        );
+        ir.add_node(
+            root,
+            Op::Layout(LayoutOp::StyledBox {
+                style: fission_ir::op::BoxStyle {
+                    alignment: fission_ir::op::BoxAlignment::Stretch,
+                    ..Default::default()
+                },
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            }),
+            vec![responsive, background],
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered
+            .html
+            .contains("fission-site-box-stretch-auto-width"));
+        assert!(rendered.html.contains("fission-site-responsive"));
+        assert!(rendered.html.contains("container-type:inline-size"));
+        assert!(crate::site_base_css()
+            .contains(".fission-site-box-stretch-auto-width > .fission-site-node"));
+    }
+
+    #[test]
+    fn site_shell_preserves_explicit_width_on_stretch_children() {
+        let root = WidgetId::explicit("stretch-box-static");
+        let child = WidgetId::explicit("explicit-child");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            child,
+            Op::Layout(LayoutOp::Box {
+                width: Some(240.0),
+                height: Some(80.0),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+                aspect_ratio: None,
+            }),
+            Vec::new(),
+        );
+        ir.add_node(
+            root,
+            Op::Layout(LayoutOp::StyledBox {
+                style: fission_ir::op::BoxStyle {
+                    alignment: fission_ir::op::BoxAlignment::Stretch,
+                    ..Default::default()
+                },
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            }),
+            vec![child],
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(!rendered
+            .html
+            .contains("fission-site-box-stretch-auto-width"));
+        assert!(rendered.css.contains("width:240px"));
+    }
+
+    #[test]
+    fn site_shell_stretches_auto_width_grid_children() {
+        let root = WidgetId::explicit("stretch-box-grid");
+        let child = WidgetId::explicit("auto-grid");
+        let background = WidgetId::explicit("grid-background");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            child,
+            Op::Layout(LayoutOp::Grid {
+                columns: vec![fission_ir::op::GridTrack::Fr(1.0)],
+                rows: Vec::new(),
+                column_gap: None,
+                row_gap: None,
+                padding: [0.0; 4],
+            }),
+            Vec::new(),
+        );
+        ir.add_node(
+            background,
+            Op::Paint(PaintOp::DrawRect {
+                fill: None,
+                stroke: None,
+                corner_radius: 0.0,
+                shadow: None,
+            }),
+            Vec::new(),
+        );
+        ir.add_node(
+            root,
+            Op::Layout(LayoutOp::StyledBox {
+                style: fission_ir::op::BoxStyle {
+                    alignment: fission_ir::op::BoxAlignment::Stretch,
+                    ..Default::default()
+                },
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            }),
+            vec![child, background],
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered
+            .html
+            .contains("fission-site-box-stretch-auto-width"));
+    }
+
+    #[test]
+    fn site_shell_preserves_intrinsic_width_inside_links() {
+        let link = WidgetId::explicit("site-link");
+        let container = WidgetId::explicit("link-container");
+        let child = WidgetId::explicit("link-label");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            child,
+            Op::Paint(PaintOp::DrawText {
+                text: "Open details".into(),
+                size: 16.0,
+                color: Color::BLACK,
+                underline: false,
+                wrap: true,
+                caret_index: None,
+                caret_color: None,
+                caret_width: None,
+                caret_height: None,
+                caret_radius: None,
+                paragraph_style: None,
+            }),
+            Vec::new(),
+        );
+        ir.add_node(
+            container,
+            Op::Layout(LayoutOp::StyledBox {
+                style: fission_ir::op::BoxStyle {
+                    alignment: fission_ir::op::BoxAlignment::Stretch,
+                    ..Default::default()
+                },
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            }),
+            vec![child],
+        );
+        ir.add_node(
+            link,
+            Op::Semantics(Semantics {
+                role: Role::Link,
+                identifier: Some("site-link:#details".into()),
+                ..Default::default()
+            }),
+            vec![container],
+        );
+        ir.set_root(link);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered.html.contains("href=\"#details\""));
+        assert!(!rendered
+            .html
+            .contains("fission-site-box-stretch-auto-width"));
+    }
+
+    #[test]
+    fn site_semantics_emit_native_landmarks_headings_and_anchors() {
+        let root = WidgetId::explicit("root");
+        let heading_text = WidgetId::explicit("semantic-heading-text");
+        let identifiers = [
+            "site-header",
+            "site-main",
+            "site-navigation",
+            "site-section:features",
+            "site-heading-2:page-title",
+            "site-anchor:details",
+            "site-footer",
+        ];
+        let mut ir = CoreIR::new();
+        let mut semantic_nodes = Vec::new();
+        let node_ids = [
+            "semantic-header",
+            "semantic-main",
+            "semantic-navigation",
+            "semantic-section",
+            "semantic-heading",
+            "semantic-anchor",
+            "semantic-footer",
+        ];
+        ir.add_node(
+            heading_text,
+            Op::Paint(PaintOp::DrawText {
+                text: "Page heading".into(),
+                size: 24.0,
+                color: Color::BLACK,
+                underline: false,
+                wrap: true,
+                caret_index: None,
+                caret_color: None,
+                caret_width: None,
+                caret_height: None,
+                caret_radius: None,
+                paragraph_style: None,
+            }),
+            Vec::new(),
+        );
+        for (identifier, node_id) in identifiers.into_iter().zip(node_ids) {
+            let id = WidgetId::explicit(node_id);
+            let node_children = if identifier == "site-heading-2:page-title" {
+                vec![heading_text]
+            } else {
+                Vec::new()
+            };
+            ir.add_node(
+                id,
+                Op::Semantics(Semantics {
+                    role: Role::Generic,
+                    identifier: Some(identifier.to_string()),
+                    ..Default::default()
+                }),
+                node_children,
+            );
+            semantic_nodes.push(id);
+        }
+        ir.add_node(
+            root,
+            Op::Structural(fission_ir::StructuralOp::Group { stable_hash: 1 }),
+            semantic_nodes,
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered.html.contains("<header "));
+        assert!(rendered.html.contains("<main "));
+        assert!(rendered.html.contains("<nav "));
+        assert!(rendered.html.contains("<section "));
+        assert!(rendered.html.contains("id=\"features\""));
+        assert!(rendered.html.contains("<h2 "));
+        assert!(rendered.html.contains("id=\"page-title\""));
+        assert!(rendered.html.contains("Page heading"));
+        assert!(rendered.html.contains("id=\"details\""));
+        assert!(rendered.html.contains("<footer "));
+        assert!(crate::site_base_css().contains("h2.fission-site-semantics"));
+    }
+
+    #[test]
+    fn site_link_semantics_emit_an_ordinary_anchor() {
+        let root = WidgetId::explicit("site-link");
+        let mut ir = CoreIR::new();
+        ir.add_node(
+            root,
+            Op::Semantics(Semantics {
+                role: Role::Link,
+                identifier: Some("site-link:#details".into()),
+                label: Some("View details".into()),
+                ..Default::default()
+            }),
+            Vec::new(),
+        );
+        ir.set_root(root);
+
+        let rendered = render_ir_to_html(&ir, &HtmlRenderOptions::default()).unwrap();
+
+        assert!(rendered.html.contains("<a "));
+        assert!(rendered.html.contains("href=\"#details\""));
+        assert!(rendered.html.contains("aria-label=\"View details\""));
+        assert!(!rendered.html.contains("<form"));
     }
 }

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -1964,9 +1964,11 @@ impl HtmlRenderer<'_> {
             }
             if identifier == "site-theme-toggle" {
                 let children = self.render_children(&node.children, &HashSet::new())?;
+                let label = semantics.label.as_deref().unwrap_or("Toggle color theme");
                 return Ok(format!(
-                    "<button class=\"fission-site-node fission-site-theme-toggle\" type=\"button\" aria-label=\"Toggle color theme\" data-fission-theme-toggle data-fission-node=\"{}\">{children}</button>",
-                    node.id
+                    "<button class=\"fission-site-node fission-site-theme-toggle\" type=\"button\" aria-label=\"{}\" data-fission-theme-toggle data-fission-node=\"{}\">{children}</button>",
+                    escape_attr(label),
+                    node.id,
                 ));
             }
             if identifier == "site-search-trigger" {


### PR DESCRIPTION
## Summary

- preserve native-equivalent stretch sizing for auto-width children of site `Container` widgets, including decorated container-query `Responsive` and `Grid` content
- ignore coalesced background and border paint nodes when identifying the rendered content child
- preserve explicit child widths and intrinsic link and button sizing instead of broadly growing every site child
- emit opt-in HTML landmarks, headings, anchors, and ordinary links from site-shell semantic identifiers
- reset browser defaults on semantic wrapper elements so authored Fission styling remains authoritative
- add `FissionServerApp::light_dark_themes(...)` for parity with `FissionSite`, including both theme variable sets, the initial `data-theme`, and the existing local-storage-backed browser toggle
- honor authored semantics labels for theme-toggle controls, allowing localized accessible labels instead of forcing English

The rendering changes are confined to the web site shell shared by Static site
and SSR targets, plus the SSR app configuration needed for parity. Native shell
renderers and core/native layout behavior are unchanged.

## Validation

- `cargo fmt --all`
- `cargo test -p fission-shell-site --lib`
- `cargo test -p fission-shell-server`
