### PR TITLE
Add native Windows toast notifications

### DIFF
--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -139,6 +139,17 @@ where
         self
     }
 
+    /// Configures the explicit AppUserModelID used by unpackaged Windows apps.
+    ///
+    /// Packaged Windows apps continue to use their package identity. Ordinary
+    /// desktop installers must assign the same value to the app's Start Menu
+    /// shortcut as `System.AppUserModel.ID`. This setting has no effect on
+    /// non-Windows targets.
+    pub fn with_windows_app_user_model_id(mut self, app_user_model_id: impl Into<String>) -> Self {
+        self.inner = self.inner.with_windows_app_user_model_id(app_user_model_id);
+        self
+    }
+
     pub fn with_nfc_host<H>(mut self, host: H) -> Self
     where
         H: NfcHost,

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -62,7 +62,17 @@ ndk-context = "0.1"
 winit = { package = "fission-winit", version = "0.30.13-fission.1", features = ["android-native-activity"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Media_MediaFoundation", "Win32_System_Com", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.58", features = [
+    "Data_Xml_Dom",
+    "UI_Notifications",
+    "Win32_Foundation",
+    "Win32_Media_MediaFoundation",
+    "Win32_Storage_Packaging_Appx",
+    "Win32_System_Com",
+    "Win32_System_WinRT",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gstreamer = { version = "0.25", optional = true }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -4271,6 +4271,35 @@ where
         self
     }
 
+    /// Configures the explicit AppUserModelID used by unpackaged Windows apps.
+    ///
+    /// Packaged Windows apps continue to use their package identity. For an
+    /// ordinary desktop installer, this value must also be assigned to the
+    /// app's Start Menu shortcut as `System.AppUserModel.ID`. Windows limits
+    /// AppUserModelIDs to 128 characters and does not allow spaces.
+    ///
+    /// This setting has no effect on non-Windows targets.
+    pub fn with_windows_app_user_model_id(self, app_user_model_id: impl Into<String>) -> Self {
+        #[cfg(target_os = "windows")]
+        {
+            let mut app = self;
+            notifications::register_notification_capabilities(
+                &mut app.async_registry,
+                Arc::new(
+                    notifications::native_notification_host_with_windows_app_user_model_id(
+                        app_user_model_id,
+                    ),
+                ),
+            );
+            app
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let _ = app_user_model_id;
+            self
+        }
+    }
+
     /// Registers the host implementation used for NFC effects.
     ///
     /// `host` owns scanning, writing, emulation, and cancellation. Install a

--- a/crates/shell/fission-shell-winit/src/notifications.rs
+++ b/crates/shell/fission-shell-winit/src/notifications.rs
@@ -28,6 +28,23 @@ use std::process::Command;
 use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use std::sync::{Condvar, Mutex, OnceLock};
+#[cfg(target_os = "windows")]
+use windows::{
+    core::{HSTRING, PCWSTR},
+    Data::Xml::Dom::XmlDocument,
+    Win32::{
+        Foundation::{APPMODEL_ERROR_NO_PACKAGE, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS},
+        Storage::Packaging::Appx::GetCurrentApplicationUserModelId,
+        System::{
+            Com::CoTaskMemFree,
+            WinRT::{RoInitialize, RoUninitialize, RO_INIT_MULTITHREADED},
+        },
+        UI::Shell::{
+            GetCurrentProcessExplicitAppUserModelID, SetCurrentProcessExplicitAppUserModelID,
+        },
+    },
+    UI::Notifications::{ToastNotification, ToastNotificationManager, ToastNotifier},
+};
 
 #[cfg(target_os = "ios")]
 #[link(name = "UIKit", kind = "framework")]
@@ -264,21 +281,35 @@ impl NotificationHost for MemoryNotificationHost {
 }
 
 #[derive(Debug, Default)]
-pub struct NativeNotificationHost;
+pub struct NativeNotificationHost {
+    #[cfg(target_os = "windows")]
+    windows_app_user_model_id: Option<String>,
+}
 
 pub(crate) fn native_notification_host() -> impl NotificationHost {
-    NativeNotificationHost
+    NativeNotificationHost::default()
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn native_notification_host_with_windows_app_user_model_id(
+    app_user_model_id: impl Into<String>,
+) -> impl NotificationHost {
+    let app_user_model_id = app_user_model_id.into();
+    prepare_windows_app_user_model_id(&app_user_model_id);
+    NativeNotificationHost {
+        windows_app_user_model_id: Some(app_user_model_id),
+    }
 }
 
 impl NativeNotificationHost {
-    #[cfg(any(test, not(target_os = "macos")))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn supported() -> bool {
         cfg!(target_os = "ios")
             || cfg!(target_os = "macos")
             || (cfg!(target_os = "linux") && command_exists("notify-send"))
     }
 
-    #[cfg(any(test, not(target_os = "macos")))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     fn native_settings() -> NotificationSettings {
         if Self::supported() {
             NotificationSettings {
@@ -331,7 +362,11 @@ impl NativeNotificationHost {
             }
 
             if cfg!(target_os = "windows") {
-                return Err(NotificationError::unsupported("show_windows_toast"));
+                #[cfg(target_os = "windows")]
+                {
+                    windows_show_notification(request, self.windows_app_user_model_id.as_deref())?;
+                    return Ok(());
+                }
             }
 
             Err(NotificationError::unsupported("show"))
@@ -348,7 +383,11 @@ impl NotificationHost for NativeNotificationHost {
         {
             macos_request_notification_permission()
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
+        {
+            windows_notification_settings(self.windows_app_user_model_id.as_deref())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
             #[cfg(target_os = "ios")]
             ios_register_local_notifications();
@@ -361,7 +400,11 @@ impl NotificationHost for NativeNotificationHost {
         {
             macos_notification_settings()
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
+        {
+            windows_notification_settings(self.windows_app_user_model_id.as_deref())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
             Ok(Self::native_settings())
         }
@@ -434,7 +477,7 @@ impl NotificationHost for NativeNotificationHost {
                 let request = request.clone();
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_millis(ms));
-                    let host = NativeNotificationHost;
+                    let host = NativeNotificationHost::default();
                     let _ = host.show_now(&request);
                 });
                 Ok(NotificationReceipt {
@@ -470,7 +513,7 @@ impl NotificationHost for NativeNotificationHost {
                 let request = request.clone();
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_millis(ms.saturating_sub(now_ms)));
-                    let host = NativeNotificationHost;
+                    let host = NativeNotificationHost::default();
                     let _ = host.show_now(&request);
                 });
                 Ok(NotificationReceipt {
@@ -488,7 +531,11 @@ impl NotificationHost for NativeNotificationHost {
             macos_cancel_notification(&request.id.0);
             Ok(())
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
+        {
+            windows_cancel_notification(&request.id.0, self.windows_app_user_model_id.as_deref())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
             let _ = request;
             Err(NotificationError::unsupported("cancel"))
@@ -501,7 +548,11 @@ impl NotificationHost for NativeNotificationHost {
             macos_cancel_all_notifications();
             Ok(())
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
+        {
+            windows_cancel_all_notifications(self.windows_app_user_model_id.as_deref())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
             Err(NotificationError::unsupported("cancel_all"))
         }
@@ -535,6 +586,369 @@ impl NotificationHost for NativeNotificationHost {
     fn unregister_push(&self) -> Result<(), NotificationError> {
         Err(NotificationError::unsupported("unregister_push"))
     }
+}
+
+#[cfg(target_os = "windows")]
+const WINDOWS_APP_USER_MODEL_ID_ENV: &str = "FISSION_WINDOWS_APP_USER_MODEL_ID";
+#[cfg(target_os = "windows")]
+const WINDOWS_TOAST_GROUP: &str = "fission";
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_toast_tag(id: &str) -> String {
+    // Windows toast tags are limited to 16 characters. FNV-1a gives cancellation
+    // a deterministic, process-independent tag without exposing or truncating
+    // the caller's logical notification id.
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_toast_xml(request: &NotificationRequest) -> String {
+    let mut text = String::new();
+    text.push_str("<text>");
+    text.push_str(&escape_notification_xml(&request.title));
+    text.push_str("</text>");
+    if let Some(subtitle) = request.subtitle.as_deref() {
+        text.push_str("<text>");
+        text.push_str(&escape_notification_xml(subtitle));
+        text.push_str("</text>");
+    }
+    text.push_str("<text>");
+    text.push_str(&escape_notification_xml(&request.body));
+    text.push_str("</text>");
+
+    let audio = match &request.sound {
+        fission_core::NotificationSound::Silent => r#"<audio silent="true"/>"#.to_string(),
+        fission_core::NotificationSound::Named(sound) => {
+            format!(r#"<audio src="{}"/>"#, escape_notification_xml(sound))
+        }
+        fission_core::NotificationSound::Default => String::new(),
+    };
+
+    format!(
+        r#"<toast><visual><binding template="ToastGeneric">{text}</binding></visual>{audio}</toast>"#
+    )
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn escape_notification_xml(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_settings_from_code(code: i32) -> NotificationSettings {
+    let permission = if code == 0 {
+        NotificationPermission::Granted
+    } else {
+        NotificationPermission::Denied
+    };
+    let enabled = matches!(permission, NotificationPermission::Granted);
+    NotificationSettings {
+        permission,
+        alerts: enabled,
+        badge: false,
+        sound: enabled,
+        scheduling: false,
+        push: false,
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct WindowsRuntimeGuard {
+    uninitialize: bool,
+}
+
+#[cfg(target_os = "windows")]
+impl WindowsRuntimeGuard {
+    fn initialize() -> Result<Self, NotificationError> {
+        match unsafe { RoInitialize(RO_INIT_MULTITHREADED) } {
+            Ok(()) => Ok(Self { uninitialize: true }),
+            // RPC_E_CHANGED_MODE means this thread was already initialized as
+            // an STA. WinRT remains available and must not be uninitialized by us.
+            Err(error) if error.code().0 as u32 == 0x80010106 => Ok(Self {
+                uninitialize: false,
+            }),
+            Err(error) => Err(windows_notification_error(
+                "windows_runtime_unavailable",
+                error,
+            )),
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for WindowsRuntimeGuard {
+    fn drop(&mut self) {
+        if self.uninitialize {
+            unsafe { RoUninitialize() };
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+enum WindowsToastIdentity {
+    Packaged,
+    AppUserModelId(HSTRING),
+}
+
+#[cfg(target_os = "windows")]
+struct WindowsToastContext {
+    notifier: ToastNotifier,
+    identity: WindowsToastIdentity,
+    _runtime: WindowsRuntimeGuard,
+}
+
+#[cfg(target_os = "windows")]
+fn windows_toast_context(
+    configured_app_user_model_id: Option<&str>,
+) -> Result<WindowsToastContext, NotificationError> {
+    let runtime = WindowsRuntimeGuard::initialize()?;
+
+    if windows_process_has_package_identity()? {
+        let notifier = ToastNotificationManager::CreateToastNotifier().map_err(|error| {
+            windows_identity_error(
+                "Windows could not create a toast notifier from the app package identity",
+                error,
+            )
+        })?;
+        return Ok(WindowsToastContext {
+            notifier,
+            identity: WindowsToastIdentity::Packaged,
+            _runtime: runtime,
+        });
+    }
+
+    if let Some(app_user_model_id) =
+        configured_windows_app_user_model_id(configured_app_user_model_id)?
+    {
+        let app_user_model_id = HSTRING::from(app_user_model_id);
+        let notifier = ToastNotificationManager::CreateToastNotifierWithId(&app_user_model_id)
+            .map_err(|error| {
+                windows_identity_error(
+                    "Windows could not create a toast notifier for the configured AppUserModelID",
+                    error,
+                )
+            })?;
+        return Ok(WindowsToastContext {
+            notifier,
+            identity: WindowsToastIdentity::AppUserModelId(app_user_model_id),
+            _runtime: runtime,
+        });
+    }
+
+    Err(NotificationError::new(
+        "windows_app_identity_missing",
+        format!(
+            "Windows local notifications require package identity or an explicit AppUserModelID. \
+             Configure one with WinitApp::with_windows_app_user_model_id, set \
+             {WINDOWS_APP_USER_MODEL_ID_ENV}, or set the current process AppUserModelID. \
+             Ordinary desktop installers must also create a matching Start Menu shortcut."
+        ),
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_process_has_package_identity() -> Result<bool, NotificationError> {
+    let mut length = 0u32;
+    let status =
+        unsafe { GetCurrentApplicationUserModelId(&mut length, windows::core::PWSTR::null()) };
+    match status {
+        ERROR_INSUFFICIENT_BUFFER | ERROR_SUCCESS => Ok(true),
+        APPMODEL_ERROR_NO_PACKAGE => Ok(false),
+        error => Err(NotificationError::new(
+            "windows_app_identity_unavailable",
+            format!(
+                "Windows could not determine whether this process has package identity \
+                 (Win32 error {})",
+                error.0
+            ),
+        )),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn prepare_windows_app_user_model_id(app_user_model_id: &str) {
+    // The process-level ID should be assigned before the first window is
+    // created. Preserve package-owned identity when this same binary runs from
+    // an MSIX package; the configured ID is only the unpackaged fallback.
+    if matches!(windows_process_has_package_identity(), Ok(false)) {
+        let _ = configure_windows_app_user_model_id(app_user_model_id);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn configured_windows_app_user_model_id(
+    configured: Option<&str>,
+) -> Result<Option<String>, NotificationError> {
+    if let Some(value) = configured {
+        return configure_windows_app_user_model_id(value).map(Some);
+    }
+
+    if let Some(value) = std::env::var_os(WINDOWS_APP_USER_MODEL_ID_ENV) {
+        let value = value.into_string().map_err(|_| {
+            NotificationError::new(
+                "windows_app_user_model_id_invalid",
+                format!("{WINDOWS_APP_USER_MODEL_ID_ENV} must contain valid Unicode"),
+            )
+        })?;
+        return configure_windows_app_user_model_id(&value).map(Some);
+    }
+
+    let value = match unsafe { GetCurrentProcessExplicitAppUserModelID() } {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+    let result = unsafe { value.to_string() }.ok();
+    unsafe { CoTaskMemFree(Some(value.as_ptr().cast())) };
+    result
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| configure_windows_app_user_model_id(&value))
+        .transpose()
+}
+
+#[cfg(target_os = "windows")]
+fn configure_windows_app_user_model_id(value: &str) -> Result<String, NotificationError> {
+    let value = validate_windows_app_user_model_id(value)?;
+    let wide = value
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    unsafe {
+        SetCurrentProcessExplicitAppUserModelID(PCWSTR::from_raw(wide.as_ptr())).map_err(
+            |error| windows_notification_error("windows_app_user_model_id_invalid", error),
+        )?;
+    }
+    Ok(value)
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn validate_windows_app_user_model_id(value: &str) -> Result<String, NotificationError> {
+    if value.is_empty()
+        || value.encode_utf16().count() > 128
+        || value.chars().any(char::is_whitespace)
+    {
+        return Err(NotificationError::new(
+            "windows_app_user_model_id_invalid",
+            "a Windows AppUserModelID must contain 1 to 128 characters and cannot contain spaces",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn windows_notification_settings(
+    configured_app_user_model_id: Option<&str>,
+) -> Result<NotificationSettings, NotificationError> {
+    let context = match windows_toast_context(configured_app_user_model_id) {
+        Ok(context) => context,
+        Err(error) if error.code == "windows_app_identity_missing" => {
+            return Ok(NotificationSettings {
+                permission: NotificationPermission::Unsupported,
+                ..Default::default()
+            });
+        }
+        Err(error) => return Err(error),
+    };
+    let setting = context
+        .notifier
+        .Setting()
+        .map_err(|error| windows_notification_error("windows_settings_unavailable", error))?;
+    Ok(windows_settings_from_code(setting.0))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_show_notification(
+    request: &NotificationRequest,
+    configured_app_user_model_id: Option<&str>,
+) -> Result<(), NotificationError> {
+    let context = windows_toast_context(configured_app_user_model_id)?;
+    let document = XmlDocument::new()
+        .map_err(|error| windows_notification_error("windows_toast_content_invalid", error))?;
+    document
+        .LoadXml(&HSTRING::from(windows_toast_xml(request)))
+        .map_err(|error| windows_notification_error("windows_toast_content_invalid", error))?;
+    let toast = ToastNotification::CreateToastNotification(&document)
+        .map_err(|error| windows_notification_error("windows_toast_unavailable", error))?;
+    toast
+        .SetTag(&HSTRING::from(windows_toast_tag(&request.id.0)))
+        .map_err(|error| windows_notification_error("windows_toast_unavailable", error))?;
+    toast
+        .SetGroup(&HSTRING::from(WINDOWS_TOAST_GROUP))
+        .map_err(|error| windows_notification_error("windows_toast_unavailable", error))?;
+    context
+        .notifier
+        .Show(&toast)
+        .map_err(|error| windows_notification_error("windows_toast_delivery_failed", error))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_cancel_notification(
+    id: &str,
+    configured_app_user_model_id: Option<&str>,
+) -> Result<(), NotificationError> {
+    let context = windows_toast_context(configured_app_user_model_id)?;
+    let history = ToastNotificationManager::History()
+        .map_err(|error| windows_notification_error("windows_toast_history_unavailable", error))?;
+    let tag = HSTRING::from(windows_toast_tag(id));
+    let group = HSTRING::from(WINDOWS_TOAST_GROUP);
+    match context.identity {
+        WindowsToastIdentity::Packaged => history.RemoveGroupedTag(&tag, &group),
+        WindowsToastIdentity::AppUserModelId(app_user_model_id) => {
+            history.RemoveGroupedTagWithId(&tag, &group, &app_user_model_id)
+        }
+    }
+    .map_err(|error| windows_notification_error("windows_toast_cancel_failed", error))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_cancel_all_notifications(
+    configured_app_user_model_id: Option<&str>,
+) -> Result<(), NotificationError> {
+    let context = windows_toast_context(configured_app_user_model_id)?;
+    let history = ToastNotificationManager::History()
+        .map_err(|error| windows_notification_error("windows_toast_history_unavailable", error))?;
+    match context.identity {
+        WindowsToastIdentity::Packaged => history.Clear(),
+        WindowsToastIdentity::AppUserModelId(app_user_model_id) => {
+            history.ClearWithId(&app_user_model_id)
+        }
+    }
+    .map_err(|error| windows_notification_error("windows_toast_cancel_failed", error))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_identity_error(context: &str, error: windows::core::Error) -> NotificationError {
+    NotificationError::new(
+        "windows_app_identity_missing",
+        format!(
+            "{context}: {error}. Packaged apps must have package identity. Ordinary desktop apps \
+             must set {WINDOWS_APP_USER_MODEL_ID_ENV} (or set the current process AppUserModelID) \
+             and install a Start Menu shortcut whose System.AppUserModel.ID matches it."
+        ),
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn windows_notification_error(code: &str, error: windows::core::Error) -> NotificationError {
+    NotificationError::new(
+        code,
+        format!("{error} (HRESULT {:#010x})", error.code().0 as u32),
+    )
 }
 
 #[cfg(target_os = "ios")]
@@ -1161,6 +1575,7 @@ mod tests {
         assert!(receipt.delivered);
     }
 
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     #[test]
     fn native_host_settings_are_honest_about_support() {
         let settings = NativeNotificationHost::native_settings();
@@ -1172,6 +1587,81 @@ mod tests {
             assert_eq!(settings.permission, NotificationPermission::Unsupported);
             assert!(!settings.alerts);
         }
+    }
+
+    #[test]
+    fn windows_toast_tags_are_stable_and_fit_the_platform_limit() {
+        assert_eq!(
+            windows_toast_tag("build-finished"),
+            windows_toast_tag("build-finished")
+        );
+        assert_ne!(
+            windows_toast_tag("build-finished"),
+            windows_toast_tag("deploy-finished")
+        );
+        assert_eq!(windows_toast_tag("build-finished").len(), 16);
+    }
+
+    #[test]
+    fn windows_toast_xml_escapes_visible_content_and_sound() {
+        let xml = windows_toast_xml(&NotificationRequest {
+            title: "Build & test".into(),
+            body: "Ready <now>".into(),
+            subtitle: Some(r#"Branch "main""#.into()),
+            sound: fission_core::NotificationSound::Named(
+                "ms-winsoundevent:Notification.Default".into(),
+            ),
+            ..Default::default()
+        });
+        assert!(xml.contains("<text>Build &amp; test</text>"));
+        assert!(xml.contains("<text>Branch &quot;main&quot;</text>"));
+        assert!(xml.contains("<text>Ready &lt;now&gt;</text>"));
+        assert!(
+            xml.contains(r#"<audio src="ms-winsoundevent:Notification.Default"/>"#),
+            "{xml}"
+        );
+    }
+
+    #[test]
+    fn windows_notification_settings_do_not_claim_unsupported_features() {
+        let enabled = windows_settings_from_code(0);
+        assert_eq!(enabled.permission, NotificationPermission::Granted);
+        assert!(enabled.alerts);
+        assert!(enabled.sound);
+        assert!(!enabled.badge);
+        assert!(!enabled.scheduling);
+        assert!(!enabled.push);
+
+        let disabled = windows_settings_from_code(2);
+        assert_eq!(disabled.permission, NotificationPermission::Denied);
+        assert!(!disabled.alerts);
+        assert!(!disabled.sound);
+    }
+
+    #[test]
+    fn windows_app_user_model_id_enforces_platform_shape() {
+        assert_eq!(
+            validate_windows_app_user_model_id("ExampleCompany.ExampleApp").unwrap(),
+            "ExampleCompany.ExampleApp"
+        );
+        assert_eq!(
+            validate_windows_app_user_model_id("Example Company.ExampleApp")
+                .unwrap_err()
+                .code,
+            "windows_app_user_model_id_invalid"
+        );
+        assert_eq!(
+            validate_windows_app_user_model_id(" ExampleCompany.ExampleApp")
+                .unwrap_err()
+                .code,
+            "windows_app_user_model_id_invalid"
+        );
+        assert_eq!(
+            validate_windows_app_user_model_id(&"a".repeat(129))
+                .unwrap_err()
+                .code,
+            "windows_app_user_model_id_invalid"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/tools/fission-command-core/src/lib.rs
+++ b/crates/tools/fission-command-core/src/lib.rs
@@ -2428,6 +2428,9 @@ fn scaffold_target_with_policy(
                     "Run `fission package --target windows --format msi --release --project-dir .` or `./platforms/windows/package-msi.ps1` to create an MSI package with WiX.",
                     "Set `WINDOWS_CERTIFICATE`, `WINDOWS_CERTIFICATE_BASE64`, or `WINDOWS_CERTIFICATE_THUMBPRINT` plus `WINDOWS_CERTIFICATE_PASSWORD` where needed; never commit certificate files or passwords.",
                     "Edit `[package.windows]` in `fission.toml` for Store package identity, publisher identity, package version, and installer preference.",
+                    "For an unpackaged NSIS app, build the architecture-matched shortcut helper with `./platforms/windows/build-shortcut-aumid-helper.ps1 -Architecture x64` (or `arm64`) and include `platforms/windows/fission-shortcut-aumid.nsh`. Embed the helper once, then apply one stable AppUserModelID to every Start Menu shortcut after `CreateShortCut`.",
+                    "Pass that exact AppUserModelID to `DesktopApp::with_windows_app_user_model_id`; package identity remains authoritative for MSIX, so the explicit value is only the unpackaged fallback.",
+                    "Sign the compiled shortcut helper before embedding it in a signed installer. The helper deliberately fails installation if it cannot persist the shortcut identity.",
                     "The generated MSIX manifest stages the desktop executable as a full-trust Windows app and copies `assets/app-icon.png` into the package asset set by default.",
                 ],
             )
@@ -2647,6 +2650,21 @@ fn scaffold_windows_bundle(
     write_file_with_policy(
         &root.join("platforms/windows/package-msi.ps1"),
         &render_windows_msi_package_script(project, &executable),
+        write_policy,
+    )?;
+    write_file_with_policy(
+        &root.join("platforms/windows/shortcut-aumid-helper.cpp"),
+        render_windows_shortcut_aumid_helper_source(),
+        write_policy,
+    )?;
+    write_file_with_policy(
+        &root.join("platforms/windows/build-shortcut-aumid-helper.ps1"),
+        render_windows_shortcut_aumid_helper_build_script(),
+        write_policy,
+    )?;
+    write_file_with_policy(
+        &root.join("platforms/windows/fission-shortcut-aumid.nsh"),
+        render_windows_shortcut_aumid_nsis_include(),
         write_policy,
     )?;
     Ok(())
@@ -2937,6 +2955,271 @@ Write-Output $MsiPath
         .replace("__MANUFACTURER__", manufacturer)
         .replace("__UPGRADE_CODE__", &upgrade_code)
         .replace("__EXECUTABLE__", executable)
+}
+
+fn render_windows_shortcut_aumid_helper_source() -> &'static str {
+    r#"#include <windows.h>
+
+#include <cwchar>
+#include <cwctype>
+#include <cstdio>
+
+#include <propkey.h>
+#include <propvarutil.h>
+#include <shobjidl.h>
+#include <wrl/client.h>
+
+namespace {
+
+using Microsoft::WRL::ComPtr;
+
+bool IsValidAppUserModelId(const wchar_t* app_user_model_id) {
+  if (app_user_model_id == nullptr) {
+    return false;
+  }
+
+  const size_t length = std::wcslen(app_user_model_id);
+  if (length == 0 || length > 128) {
+    return false;
+  }
+
+  for (size_t index = 0; index < length; ++index) {
+    if (std::iswspace(app_user_model_id[index]) != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+int ReportFailure(const wchar_t* operation, HRESULT result) {
+  std::fwprintf(
+      stderr,
+      L"%ls failed (HRESULT 0x%08lX).\n",
+      operation,
+      static_cast<unsigned long>(result));
+  return 1;
+}
+
+}  // namespace
+
+int wmain(int argc, wchar_t** argv) {
+  if (argc != 3) {
+    std::fwprintf(
+        stderr,
+        L"Usage: fission-shortcut-aumid.exe <shortcut.lnk> <app-user-model-id>\n");
+    return 2;
+  }
+
+  const wchar_t* shortcut_path = argv[1];
+  const wchar_t* app_user_model_id = argv[2];
+  if (!IsValidAppUserModelId(app_user_model_id)) {
+    std::fwprintf(
+        stderr,
+        L"The AppUserModelID must contain 1-128 UTF-16 code units and no whitespace.\n");
+    return 3;
+  }
+
+  const HRESULT initialize_result =
+      CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+  const bool should_uninitialize = SUCCEEDED(initialize_result);
+  if (FAILED(initialize_result) && initialize_result != RPC_E_CHANGED_MODE) {
+    return ReportFailure(L"CoInitializeEx", initialize_result);
+  }
+
+  int exit_code = 0;
+  ComPtr<IShellLinkW> shell_link;
+  HRESULT result = CoCreateInstance(
+      CLSID_ShellLink,
+      nullptr,
+      CLSCTX_INPROC_SERVER,
+      IID_PPV_ARGS(&shell_link));
+  if (FAILED(result)) {
+    exit_code = ReportFailure(L"CoCreateInstance(CLSID_ShellLink)", result);
+    goto finish;
+  }
+
+  {
+    ComPtr<IPersistFile> persist_file;
+    result = shell_link.As(&persist_file);
+    if (FAILED(result)) {
+      exit_code = ReportFailure(L"QueryInterface(IPersistFile)", result);
+      goto finish;
+    }
+
+    result = persist_file->Load(shortcut_path, STGM_READWRITE);
+    if (FAILED(result)) {
+      exit_code = ReportFailure(L"IPersistFile::Load", result);
+      goto finish;
+    }
+
+    ComPtr<IPropertyStore> property_store;
+    result = shell_link.As(&property_store);
+    if (FAILED(result)) {
+      exit_code = ReportFailure(L"QueryInterface(IPropertyStore)", result);
+      goto finish;
+    }
+
+    PROPVARIANT app_id_value;
+    PropVariantInit(&app_id_value);
+    result = InitPropVariantFromString(app_user_model_id, &app_id_value);
+    if (SUCCEEDED(result)) {
+      result = property_store->SetValue(PKEY_AppUserModel_ID, app_id_value);
+    }
+    if (SUCCEEDED(result)) {
+      result = property_store->Commit();
+    }
+    PropVariantClear(&app_id_value);
+    if (FAILED(result)) {
+      exit_code = ReportFailure(L"IPropertyStore::SetValue/Commit", result);
+      goto finish;
+    }
+
+    result = persist_file->Save(shortcut_path, TRUE);
+    if (FAILED(result)) {
+      exit_code = ReportFailure(L"IPersistFile::Save", result);
+      goto finish;
+    }
+  }
+
+finish:
+  if (should_uninitialize) {
+    CoUninitialize();
+  }
+  return exit_code;
+}
+"#
+}
+
+fn render_windows_shortcut_aumid_helper_build_script() -> &'static str {
+    r#"[CmdletBinding()]
+param(
+  [ValidateSet("x64", "arm64")]
+  [string] $Architecture = $(if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" })
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectDir = Resolve-Path (Join-Path $ScriptDir "..\..")
+$SourcePath = Join-Path $ScriptDir "shortcut-aumid-helper.cpp"
+$OutputDirectory = Join-Path $ProjectDir "target\fission\windows\shortcut-aumid\$Architecture"
+$OutputPath = Join-Path $OutputDirectory "fission-shortcut-aumid.exe"
+$ObjectPath = Join-Path $OutputDirectory "fission-shortcut-aumid.obj"
+
+if (-not (Test-Path $SourcePath -PathType Leaf)) {
+  throw "The shortcut AUMID helper source was not found at $SourcePath."
+}
+
+$VsWhere = Get-Command vswhere.exe -ErrorAction SilentlyContinue
+if (-not $VsWhere -and ${env:ProgramFiles(x86)}) {
+  $BundledVsWhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+  if (Test-Path $BundledVsWhere -PathType Leaf) {
+    $VsWhere = Get-Item $BundledVsWhere
+  }
+}
+if (-not $VsWhere) {
+  throw "vswhere.exe was not found. Install Visual Studio Build Tools with the target C++ toolchain."
+}
+$VsWherePath = if ($VsWhere -is [System.IO.FileInfo]) {
+  $VsWhere.FullName
+} else {
+  $VsWhere.Source
+}
+
+$RequiredComponent = if ($Architecture -eq "arm64") {
+  "Microsoft.VisualStudio.Component.VC.Tools.ARM64"
+} else {
+  "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+}
+$Installation = & $VsWherePath -latest -products * -requires $RequiredComponent -property installationPath
+if (-not $Installation) {
+  throw "Visual Studio Build Tools with component $RequiredComponent were not found for $Architecture."
+}
+$VsDevCmd = Join-Path $Installation "Common7\Tools\VsDevCmd.bat"
+if (-not (Test-Path $VsDevCmd -PathType Leaf)) {
+  throw "VsDevCmd.bat was not found at $VsDevCmd."
+}
+
+$DeveloperCommand = "call `"$VsDevCmd`" -no_logo -arch=$Architecture -host_arch=amd64 && set"
+$EnvironmentLines = & $env:ComSpec /d /c $DeveloperCommand
+if ($LASTEXITCODE -ne 0) {
+  throw "Visual Studio failed to initialize the $Architecture C++ build environment."
+}
+foreach ($Line in $EnvironmentLines) {
+  $Separator = $Line.IndexOf("=")
+  if ($Separator -gt 0) {
+    $Name = $Line.Substring(0, $Separator)
+    $Value = $Line.Substring($Separator + 1)
+    [Environment]::SetEnvironmentVariable($Name, $Value, "Process")
+  }
+}
+
+$Compiler = Get-Command cl.exe -ErrorAction SilentlyContinue
+if (-not $Compiler) {
+  throw "cl.exe was not available after initializing the $Architecture C++ build environment."
+}
+
+New-Item -ItemType Directory -Force $OutputDirectory | Out-Null
+$CompileArguments = @(
+  "/nologo",
+  "/EHsc",
+  "/MT",
+  "/DUNICODE",
+  "/D_UNICODE",
+  "/Fo$ObjectPath",
+  "/Fe$OutputPath",
+  $SourcePath,
+  "/link",
+  "ole32.lib",
+  "shell32.lib",
+  "propsys.lib"
+)
+& $Compiler.Source @CompileArguments | Out-Host
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path $OutputPath -PathType Leaf)) {
+  throw "The $Architecture shortcut AUMID helper build failed."
+}
+
+Write-Output $OutputPath
+"#
+}
+
+fn render_windows_shortcut_aumid_nsis_include() -> &'static str {
+    r#"!ifndef FISSION_SHORTCUT_AUMID_NSH
+!define FISSION_SHORTCUT_AUMID_NSH
+
+!include "LogicLib.nsh"
+
+; Embed the architecture-matched helper once in an installer section.
+!macro FissionEmbedShortcutAppUserModelIdHelper HELPER_PATH
+  InitPluginsDir
+  File "/oname=$PLUGINSDIR\fission-shortcut-aumid.exe" "${HELPER_PATH}"
+!macroend
+
+; Apply the same stable AppUserModelID passed to
+; WinitApp::with_windows_app_user_model_id or
+; DesktopApp::with_windows_app_user_model_id. Call this after CreateShortCut.
+!macro FissionSetShortcutAppUserModelId SHORTCUT_PATH APP_USER_MODEL_ID
+  Push $0
+  Push $1
+  nsExec::ExecToStack /TIMEOUT=30000 '"$PLUGINSDIR\fission-shortcut-aumid.exe" "${SHORTCUT_PATH}" "${APP_USER_MODEL_ID}"'
+  Pop $0
+  Pop $1
+  ${If} $0 != 0
+    DetailPrint "Failed to apply AppUserModelID to ${SHORTCUT_PATH}: exit=$0 output=$1"
+    MessageBox MB_ICONSTOP|MB_OK "Windows notification identity setup failed. The installation cannot continue."
+    Pop $1
+    Pop $0
+    SetErrors
+    Abort
+  ${EndIf}
+  Pop $1
+  Pop $0
+!macroend
+
+!endif
+"#
 }
 
 fn sanitize_file_stem(value: &str) -> String {
@@ -5817,6 +6100,60 @@ publisher = "CN=Example & Co"
         assert!(error
             .to_string()
             .contains("Windows package version `1.2.beta` must be numeric"));
+    }
+
+    #[test]
+    fn windows_scaffold_includes_opt_in_nsis_shortcut_identity_support() {
+        let dir = unique_dir("windows-shortcut-aumid-scaffold");
+        let project = FissionProject {
+            app: AppConfig {
+                name: "Example App".to_string(),
+                app_id: "com.example.app".to_string(),
+                splash: None,
+            },
+            targets: BTreeSet::from([Target::Windows]),
+            capabilities: BTreeSet::new(),
+            native: NativeConfig::default(),
+        };
+
+        scaffold_windows_bundle(&dir, &project, WritePolicy::Overwrite).unwrap();
+
+        let source =
+            fs::read_to_string(dir.join("platforms/windows/shortcut-aumid-helper.cpp")).unwrap();
+        assert!(source.contains("PKEY_AppUserModel_ID"));
+        assert!(source.contains("length > 128"));
+        assert!(source.contains("std::iswspace"));
+
+        let build =
+            fs::read_to_string(dir.join("platforms/windows/build-shortcut-aumid-helper.ps1"))
+                .unwrap();
+        assert!(build.contains(r#"[ValidateSet("x64", "arm64")]"#));
+        assert!(build.contains("/MT"));
+        assert!(build.contains("Microsoft.VisualStudio.Component.VC.Tools.ARM64"));
+        assert!(build.contains("propsys.lib"));
+
+        let nsis =
+            fs::read_to_string(dir.join("platforms/windows/fission-shortcut-aumid.nsh")).unwrap();
+        assert!(nsis.contains("nsExec::ExecToStack"));
+        assert!(nsis.contains("FissionEmbedShortcutAppUserModelIdHelper"));
+        assert!(nsis.contains("FissionSetShortcutAppUserModelId"));
+        assert!(nsis.contains("Abort"));
+        assert!(!nsis.contains("WinShell"));
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn windows_shortcut_identity_support_is_opt_in() {
+        let source = render_windows_shortcut_aumid_helper_source();
+        let build = render_windows_shortcut_aumid_helper_build_script();
+        let nsis = render_windows_shortcut_aumid_nsis_include();
+
+        assert!(source.contains("argv[2]"));
+        assert!(build.contains("$Architecture"));
+        assert!(nsis.contains("APP_USER_MODEL_ID"));
+        assert!(!nsis.contains("APP_USER_MODEL_ID ="));
+        assert!(!nsis.contains("!define FISSION_APP_USER_MODEL_ID"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add native Windows local toast delivery, settings, and cancellation through WinRT
- keep packaged identity authoritative and use an explicit AppUserModelID only as the unpackaged fallback
- expose opt-in desktop configuration plus generic x64/ARM64 shortcut-identity scaffolding for NSIS installers
- make the Windows identity builder a true no-op on non-Windows targets so custom macOS and Linux notification hosts remain untouched

## Stack
- based directly on `0857c9fe5e09dc019290a55e7b05a6b6e0d46a44`, preserving the complete currently pinned SSR, theme, and initial-window tree
- changes exactly five source/manifest files; `Cargo.lock` is unchanged
- generated scaffold contains only generic example data

## Validation
- `git diff --check 0857c9fe..HEAD`
- `rustfmt --edition 2021 --check` on all four changed Rust files
- `cargo metadata --no-deps --format-version 1 --locked --offline`
- recovered focused Rust validation: 2 command-core scaffold tests and 7 notification tests passed
- recovered desktop shell check passed
- recovered native validation compiled and exercised the shortcut helper with x64 and ARM64 MSVC toolchains, including persisted AUMID verification
- recovered stock NSIS include compile passed

A full rebuild was not repeated after the clean transplant because the shared host root had only 4.4 GiB free; the existing shared Cargo target was preserved and not cleaned.