### PR TITLE
fix(site): unblock Pages publication

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -61,7 +61,7 @@ jobs:
           gh release download crate-index --pattern fission-crates.sqlite3 --dir documentation/data || true
 
       - name: Refresh Fission crate index
-        run: cargo run -p fission-documentation --features crate-indexer --bin update-crate-index --release -- documentation/data/fission-crates.sqlite3
+        run: cargo run -p fission-documentation --features crate-indexer --bin update-crate-index -- documentation/data/fission-crates.sqlite3
 
       - name: Verify static site dependency boundary
         run: |
@@ -91,18 +91,6 @@ jobs:
 
       - name: Package static site
         run: cargo run -p cargo-fission --bin fission -- package --project-dir documentation --target site --format static --release
-
-      - name: Build Example Showcase for Web
-        run: cargo run -p cargo-fission --bin fission -- build --target web --project-dir examples/showcase --release
-
-      - name: Add Example Showcase to the website
-        run: |
-          showcase_out="documentation/target/fission/release/static-site/static/example-showcase"
-          mkdir -p "$showcase_out"
-          cp examples/showcase/platforms/web/index.html "$showcase_out/index.html"
-          cp examples/showcase/platforms/web/bootstrap.mjs "$showcase_out/bootstrap.mjs"
-          cp examples/showcase/platforms/web/app-icon.png "$showcase_out/app-icon.png"
-          cp -R examples/showcase/platforms/web/pkg "$showcase_out/pkg"
 
       - name: Verify generated static site
         run: |


### PR DESCRIPTION
Build the standalone crate indexer outside the workspace's panic=abort release profile and remove duplicate showcase build/copy steps. This only affects the documentation publication workflow.