### PR TITLE
fix(showcase): unblock website WebAssembly build

### DIFF
--- a/examples/showcase/Cargo.toml
+++ b/examples/showcase/Cargo.toml
@@ -41,3 +41,6 @@ fission-design-system-codegen = { path = "../../crates/tools/fission-design-syst
 [dev-dependencies]
 fission-test-driver = { path = "../../crates/tools/fission-test-driver" }
 image = "0.25"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
Disable wasm-opt for the release showcase bundle because the pinned wasm-pack Binaryen validator rejects Rust's bulk-memory operations. The browser runtime supports these operations; this only skips the incompatible optimization pass.