### PR TITLE
fix(docs): link examples to public showcase

### DIFF
--- a/documentation/content/docs/guides/input-events-text-and-env.mdx
+++ b/documentation/content/docs/guides/input-events-text-and-env.mdx
@@ -148,7 +148,7 @@ Nothing about that flow requires the widgets to reach into native browser or mob
 
 ## Where to go next
 
-If you want the full explanation of locale, translation bundles, and theme loading, continue to [Theming and internationalization](/docs/guides/theming-and-i18n). If you need to decide whether a value belongs in `GlobalState`, local widget state, `Env`, or a provider, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want the deeper explanation of resources, jobs, services, and reducer-side effects, read [Resources and async](/docs/guides/resources-and-async/). For a live proof of text-heavy interaction, open `text-lab` from the public [Examples](/examples) page.
+If you want the full explanation of locale, translation bundles, and theme loading, continue to [Theming and internationalization](/docs/guides/theming-and-i18n). If you need to decide whether a value belongs in `GlobalState`, local widget state, `Env`, or a provider, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want the deeper explanation of resources, jobs, services, and reducer-side effects, read [Resources and async](/docs/guides/resources-and-async/). For a live proof of text-heavy interaction, open `text-lab` from the public [Examples](/example-showcase/) page.
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/layout-and-widgets.mdx
+++ b/documentation/content/docs/guides/layout-and-widgets.mdx
@@ -311,7 +311,7 @@ This workflow matches the architecture of Fission itself. The app model stays sh
 
 ## Where to go next
 
-If you want to understand how input, viewport data, locale, and theme reach widgets, read [Input, text, and environment](/docs/guides/input-events-text-and-env). If you want the beginner explanation of `ViewHandle`, `BuildCtxHandle`, and selectors first, go back to [Runtime model](/docs/learn/runtime-model). For a live tour of built-in widgets, open the public [Examples](/examples) page and start with Widget Gallery.
+If you want to understand how input, viewport data, locale, and theme reach widgets, read [Input, text, and environment](/docs/guides/input-events-text-and-env). If you want the beginner explanation of `ViewHandle`, `BuildCtxHandle`, and selectors first, go back to [Runtime model](/docs/learn/runtime-model). For a live tour of built-in widgets, open the public [Examples](/example-showcase/) page and start with Widget Gallery.
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/media-animation-portals-and-3d.mdx
+++ b/documentation/content/docs/guides/media-animation-portals-and-3d.mdx
@@ -109,7 +109,7 @@ For 3D, watch scope. Treat the scene as a bounded part of the interface, not as 
 
 ## Where to go next
 
-If you want the underlying explanation of layout, viewport reasoning, and screen composition first, read [Layout and widgets](/docs/guides/layout-and-widgets). If you want the async and runtime side of jobs, timers, and long-lived work, continue to [Resources and async](/docs/guides/resources-and-async). For checked-in proofs, open `animation-gallery`, `chart-gallery`, `inbox`, or `fission-editor` from the public [Examples](/examples) page.
+If you want the underlying explanation of layout, viewport reasoning, and screen composition first, read [Layout and widgets](/docs/guides/layout-and-widgets). If you want the async and runtime side of jobs, timers, and long-lived work, continue to [Resources and async](/docs/guides/resources-and-async). For checked-in proofs, open `animation-gallery`, `chart-gallery`, `inbox`, or `fission-editor` from the public [Examples](/example-showcase/) page.
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/resources-and-async.mdx
+++ b/documentation/content/docs/guides/resources-and-async.mdx
@@ -370,7 +370,7 @@ The fifth mistake is choosing unstable resource keys or dependency payloads. Rec
 
 ## Where to go next
 
-If you want the app-model foundation behind reducers and pure `component conversion` methods, revisit [Runtime model](/docs/learn/runtime-model/). If you need the detailed rules for app state, local widget state, build handles, and provider scopes, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want a concrete streamed file-picker flow, read [How do I do file uploads in Fission?](/docs/guides/file-uploads/). If you want to see responsive user interface and state-driven composition before adding async work, read [Layout and widgets](/docs/guides/layout-and-widgets/). For a checked-in product example that uses job resources and timers heavily, inspect Fission Editor from the public [Examples](/examples) page after reading this guide.
+If you want the app-model foundation behind reducers and pure `component conversion` methods, revisit [Runtime model](/docs/learn/runtime-model/). If you need the detailed rules for app state, local widget state, build handles, and provider scopes, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want a concrete streamed file-picker flow, read [How do I do file uploads in Fission?](/docs/guides/file-uploads/). If you want to see responsive user interface and state-driven composition before adding async work, read [Layout and widgets](/docs/guides/layout-and-widgets/). For a checked-in product example that uses job resources and timers heavily, inspect Fission Editor from the public [Examples](/example-showcase/) page after reading this guide.
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/testing-and-diagnostics.mdx
+++ b/documentation/content/docs/guides/testing-and-diagnostics.mdx
@@ -184,7 +184,7 @@ Finally, avoid diagnostics spam without a question. Enable the categories that m
 
 ## Where to go next
 
-If you want the shell-side picture for target generation, host launchers, and public shell builders, read [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing). If you want the async model behind many live app behaviors, continue to [Resources and async](/docs/guides/resources-and-async). For live examples backed by checked-in tests, browse the public [Examples](/examples) page and inspect the `live_e2e.rs` tests linked there.
+If you want the shell-side picture for target generation, host launchers, and public shell builders, read [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing). If you want the async model behind many live app behaviors, continue to [Resources and async](/docs/guides/resources-and-async). For live examples backed by checked-in tests, browse the public [Examples](/example-showcase/) page and inspect the `live_e2e.rs` tests linked there.
 
 ## What you should have working
 

--- a/documentation/content/docs/learn/examples-and-targets.mdx
+++ b/documentation/content/docs/learn/examples-and-targets.mdx
@@ -91,7 +91,7 @@ If you keep that structure in mind, the site becomes much easier to navigate. Op
 
 ## Where to go next
 
-If you want the guided first-run flow, go to [Quickstart](/docs/learn/quickstart). If you want the fuller explanation of shell wrappers, generated hosts, and platform validation, continue to [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing). If you want help choosing an example by learning goal, visit the public [Examples](/examples) page.
+If you want the guided first-run flow, go to [Quickstart](/docs/learn/quickstart). If you want the fuller explanation of shell wrappers, generated hosts, and platform validation, continue to [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing). If you want help choosing an example by learning goal, visit the public [Examples](/example-showcase/) page.
 
 ## What you should be able to do next
 


### PR DESCRIPTION
Point the six public Examples links at the generated /example-showcase/ route so static-site link validation can complete.