### PR TITLE
fix(site): match documentation prototype design

### DIFF
--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -378,7 +378,7 @@ impl DocumentationPage<'_> {
         let mut children = vec![
             Container::new(Column {
                 children: vec![
-                    Text::new("Blog")
+                    Text::new("Notes from every surface.")
                         .size(tokens.typography.heading1_size)
                         .family(tokens.typography.font_family_serif.clone())
                         .weight(tokens.typography.font_weight_bold)
@@ -389,7 +389,7 @@ impl DocumentationPage<'_> {
                         .color(tokens.colors.heading)
                         .semantics_identifier("site-blog-index-title")
                         .into(),
-                    Text::new("Technical essays, release notes, and product updates for building with Fission.")
+                    Text::new("Engineering stories, release notes, and practical guides for building production Rust applications.")
                         .size(tokens.typography.body_large_size)
                         .line_height(
                             tokens.typography.body_large_size

--- a/documentation/site/overrides.css
+++ b/documentation/site/overrides.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
 /* Documentation-specific polish layered after generated Fission styles. */
 :root {
   --atlas-blue: #3157e8;
@@ -17,6 +19,7 @@
   --fs-color-border: #dedbed;
   --fs-color-border-strong: #c9c5dd;
 }
+
 
 [data-theme="dark"] {
   --fs-color-primary: #7890ff;
@@ -405,5 +408,708 @@ body {
   .fission-site-box:has(> .fission-site-product-page) {
     width: calc(100vw - 2rem) !important;
     max-width: calc(100vw - 2rem) !important;
+  }
+}
+/* Prototype fidelity layer. Keep these rules aligned with tmp/docs-site/src/styles.css. */
+:root {
+  --prototype-bg: #fbfbfe;
+  --prototype-surface: #fff;
+  --prototype-surface-2: #f4f1ff;
+  --prototype-ink: #111126;
+  --prototype-muted: #68677c;
+  --prototype-line: #dedbed;
+  --prototype-blue: #3157e8;
+  --prototype-violet: #7954ee;
+  --prototype-cyan: #31a7d9;
+  --prototype-green: #2e9c72;
+  --prototype-shadow: 0 16px 45px rgba(43, 31, 98, .1);
+  --prototype-header: rgba(251, 251, 254, .88);
+}
+
+:root[data-theme="dark"] {
+  --prototype-bg: #0b0b18;
+  --prototype-surface: #121224;
+  --prototype-surface-2: #191633;
+  --prototype-ink: #f4f2ff;
+  --prototype-muted: #aaa8bd;
+  --prototype-line: #2e2b47;
+  --prototype-blue: #7890ff;
+  --prototype-violet: #a688ff;
+  --prototype-cyan: #55c9eb;
+  --prototype-green: #56d5a4;
+  --prototype-shadow: 0 18px 55px rgba(0, 0, 0, .34);
+  --prototype-header: rgba(11, 11, 24, .88);
+}
+
+html,
+body,
+.fission-site-root {
+  background: var(--prototype-bg) !important;
+  color: var(--prototype-ink) !important;
+  font-family: 'Space Grotesk', system-ui, sans-serif !important;
+  font-size: 16px;
+}
+
+.fission-site-root *,
+.fission-site-rich-text,
+.fission-site-text-run {
+  font-family: 'Space Grotesk', system-ui, sans-serif !important;
+  box-sizing: border-box;
+}
+
+.fission-site-root code,
+.fission-site-root pre,
+.fission-site-root kbd {
+  font-family: 'DM Mono', monospace !important;
+}
+
+.fission-site-home-header,
+.fission-site-doc-header {
+  min-height: 76px !important;
+  height: 76px !important;
+  padding: 0 max(24px, calc((100vw - 1312px) / 2)) !important;
+  position: sticky !important;
+  top: 0;
+  z-index: 30;
+  background: var(--prototype-header) !important;
+  backdrop-filter: blur(18px);
+  border: 0 !important;
+  border-bottom: 1px solid var(--prototype-line) !important;
+  border-radius: 0 !important;
+}
+
+.fission-site-home-header > .fission-site-row,
+.fission-site-doc-header > .fission-site-row {
+  width: 100% !important;
+  max-width: 1312px !important;
+  height: 76px !important;
+  margin: auto !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+}
+
+.fission-site-home-header .fission-site-img,
+.fission-site-doc-header .fission-site-img {
+  width: 28px !important;
+  height: 34px !important;
+}
+
+.fission-site-home-header .fission-site-main-nav,
+.fission-site-doc-header .fission-site-doc-nav {
+  height: 76px !important;
+  gap: 36px !important;
+}
+
+.fission-site-home-header .fission-site-main-nav a,
+.fission-site-doc-header .fission-site-doc-nav a {
+  height: 76px !important;
+  display: flex !important;
+  align-items: center !important;
+  color: var(--prototype-muted) !important;
+  font-weight: 600 !important;
+  text-decoration: none !important;
+}
+
+.fission-site-theme-toggle,
+.fission-site-search-trigger {
+  width: 40px !important;
+  height: 40px !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 12px !important;
+  background: var(--prototype-surface) !important;
+  color: var(--prototype-ink) !important;
+  box-shadow: none !important;
+  overflow: hidden !important;
+  font-size: 0 !important;
+}
+
+.fission-site-theme-toggle > *,
+.fission-site-search-trigger > * {
+  display: none !important;
+}
+
+.fission-site-theme-toggle::after,
+.fission-site-search-trigger::after {
+  display: block;
+  font-size: 19px;
+  line-height: 38px;
+  text-align: center;
+}
+
+.fission-site-theme-toggle::after { content: "◐"; }
+.fission-site-search-trigger::after { content: "⌕"; }
+
+[data-fission-semantics="site-home-hero"] {
+  max-width: 1400px !important;
+  min-height: 618px;
+  margin: auto !important;
+  padding: 86px 48px 72px !important;
+  gap: 60px !important;
+  align-items: center !important;
+}
+
+[data-fission-semantics="site-home-hero"] > .fission-site-box:first-child {
+  flex: 1 1 52% !important;
+}
+
+[data-fission-semantics="site-home-hero"] > .fission-site-box:last-child {
+  flex: 1 1 48% !important;
+}
+
+.fission-site-home-hero-title .fission-site-text-run {
+  color: var(--prototype-ink) !important;
+  font-size: clamp(54px, 6vw, 88px) !important;
+  line-height: .98 !important;
+  letter-spacing: -.055em !important;
+  font-weight: 700 !important;
+}
+
+.fission-site-home-hero-title .fission-site-text-run::first-line {
+  color: var(--prototype-ink);
+}
+
+[data-fission-semantics="site-home-hero"] .fission-site-column > .fission-site-rich-text:first-child .fission-site-text-run,
+[data-fission-semantics="crate-directory-copy"] .fission-site-column > .fission-site-rich-text:first-child .fission-site-text-run {
+  color: var(--prototype-blue) !important;
+  font-size: 12px !important;
+  letter-spacing: .14em !important;
+  text-transform: uppercase;
+  font-weight: 700 !important;
+}
+
+[data-fission-semantics="site-home-hero"] .fission-site-column > .fission-site-rich-text:nth-child(3) .fission-site-text-run {
+  color: var(--prototype-muted) !important;
+  font-size: 20px !important;
+  line-height: 1.6 !important;
+}
+
+[data-fission-semantics="site-home-hero"] .fission-site-link {
+  min-height: 54px !important;
+  padding: 15px 22px !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 14px !important;
+  background: var(--prototype-surface) !important;
+  color: var(--prototype-ink) !important;
+  font-weight: 700 !important;
+}
+
+[data-fission-semantics="site-home-hero"] .fission-site-link:first-child {
+  background: var(--prototype-blue) !important;
+  border-color: var(--prototype-blue) !important;
+  color: #fff !important;
+}
+
+[data-fission-semantics="site-platform-atlas"] {
+  height: 460px !important;
+  min-height: 460px !important;
+  width: 100% !important;
+  position: relative;
+  overflow: hidden !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 32px !important;
+  background:
+    linear-gradient(var(--prototype-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--prototype-line) 1px, transparent 1px),
+    linear-gradient(145deg, var(--prototype-surface-2), transparent),
+    var(--prototype-surface) !important;
+  background-size: 52px 52px, 52px 52px, auto, auto !important;
+  box-shadow: var(--prototype-shadow) !important;
+}
+
+[data-fission-semantics="site-platform-atlas"] > .fission-site-column {
+  height: 100% !important;
+  justify-content: space-between !important;
+  padding: 28px !important;
+}
+
+[data-fission-semantics="site-platform-atlas"] > .fission-site-column > .fission-site-box {
+  width: 180px !important;
+  height: 180px !important;
+  min-height: 180px !important;
+  padding: 36px !important;
+  transform: rotate(-7deg);
+  background: linear-gradient(135deg, var(--prototype-blue), var(--prototype-violet)) !important;
+  border-radius: 30px !important;
+  box-shadow: 0 25px 50px rgba(71, 54, 222, .35) !important;
+}
+
+[data-fission-semantics^="site-atlas-target"] {
+  width: 74px !important;
+  min-width: 74px !important;
+  height: 74px !important;
+  min-height: 74px !important;
+  padding: 8px !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 18px !important;
+  background: var(--prototype-surface) !important;
+  box-shadow: 0 9px 26px rgba(38, 30, 91, .12) !important;
+}
+
+[data-fission-semantics="site-home-signals"] {
+  width: 100% !important;
+  max-width: none !important;
+  padding: 100px max(48px, calc((100vw - 1304px) / 2)) !important;
+  background: var(--prototype-surface-2) !important;
+  border-block: 1px solid var(--prototype-line) !important;
+}
+
+[data-fission-semantics="site-home-signals"] h2,
+[data-fission-semantics="site-home-signals"] .fission-site-text-run {
+  color: var(--prototype-ink);
+}
+
+/* Product pages use the prototype's restrained surface language. */
+.fission-site-product-page {
+  width: min(1304px, calc(100% - 48px)) !important;
+  max-width: 1304px !important;
+  margin: 0 auto !important;
+  padding: 62px 0 110px !important;
+}
+
+.fission-site-product-hero {
+  padding: 52px !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 28px !important;
+  background: linear-gradient(145deg, var(--prototype-surface-2), transparent), var(--prototype-surface) !important;
+  box-shadow: var(--prototype-shadow) !important;
+}
+
+.fission-site-product-hero > .fission-site-row {
+  flex-wrap: nowrap !important;
+  gap: 60px !important;
+  align-items: center !important;
+}
+
+.fission-site-product-hero > .fission-site-row > .fission-site-box {
+  flex: 1 1 50% !important;
+  min-width: 0 !important;
+}
+
+.fission-site-product-hero-title .fission-site-text-run {
+  color: var(--prototype-ink) !important;
+  font-size: clamp(54px, 5.5vw, 76px) !important;
+  line-height: 1 !important;
+  letter-spacing: -.055em !important;
+  font-weight: 700 !important;
+}
+
+.fission-site-product-hero-body .fission-site-text-run {
+  color: var(--prototype-muted) !important;
+  font-size: 20px !important;
+  line-height: 1.6 !important;
+}
+
+.fission-site-product-hero-ctas .fission-site-link {
+  padding: 15px 22px !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 14px !important;
+  background: var(--prototype-surface) !important;
+  color: var(--prototype-ink) !important;
+  font-weight: 700 !important;
+}
+
+.fission-site-product-hero-ctas .fission-site-link:first-child {
+  background: var(--prototype-blue) !important;
+  border-color: var(--prototype-blue) !important;
+  color: white !important;
+}
+
+.fission-site-product-feature-showcase,
+.fission-site-product-proof {
+  border-color: var(--prototype-line) !important;
+  border-radius: 24px !important;
+  background: var(--prototype-surface) !important;
+}
+
+/* Crate directory and detail pages. */
+[data-fission-semantics="crate-directory-page"] {
+  background: var(--prototype-bg) !important;
+}
+
+[data-fission-semantics="crate-directory-hero"] {
+  width: min(1400px, 100%) !important;
+  padding: 62px 48px 32px !important;
+}
+
+[data-fission-semantics="crate-directory-copy"] .fission-site-column > .fission-site-rich-text:nth-child(2) .fission-site-text-run {
+  color: var(--prototype-ink) !important;
+  font-size: 66px !important;
+  line-height: 1 !important;
+  letter-spacing: -.055em !important;
+  font-weight: 700 !important;
+}
+
+[data-fission-semantics="crate-directory-copy"] .fission-site-column > .fission-site-rich-text:nth-child(3) .fission-site-text-run {
+  color: var(--prototype-muted) !important;
+  font-size: 20px !important;
+  line-height: 1.6 !important;
+}
+
+[data-fission-semantics="crate-platform-legend"] {
+  width: min(1304px, calc(100% - 48px)) !important;
+  margin: 0 auto 40px !important;
+  padding: 14px !important;
+  display: block !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 24px !important;
+  background: var(--prototype-surface) !important;
+  box-shadow: var(--prototype-shadow) !important;
+}
+
+[data-fission-semantics="crate-platform-legend"] > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: repeat(9, minmax(0, 1fr)) !important;
+  gap: 10px !important;
+}
+
+[data-fission-semantics="crate-platform-legend"] > .fission-site-row > .fission-site-box {
+  min-height: 88px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 14px !important;
+  background: var(--prototype-surface) !important;
+  color: var(--prototype-blue) !important;
+}
+
+[data-fission-semantics="crate-results"] {
+  width: min(1304px, calc(100% - 48px)) !important;
+  margin: auto !important;
+  padding: 25px 0 100px !important;
+}
+
+[data-fission-semantics="crate-card"] {
+  padding: 24px !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-top: 4px solid var(--prototype-violet) !important;
+  border-radius: 20px !important;
+  background: var(--prototype-surface) !important;
+  box-shadow: 0 6px 20px rgba(40, 30, 90, .06) !important;
+}
+
+[data-fission-semantics="crate-detail-page"] {
+  width: min(1304px, calc(100% - 48px)) !important;
+  margin: auto !important;
+  padding: 42px 0 100px !important;
+}
+
+/* Documentation template: prototype three-column reading layout. */
+.fission-site-doc-layout {
+  width: min(1440px, 100%) !important;
+  max-width: 1440px !important;
+  margin: auto !important;
+  padding: 45px 38px 100px !important;
+  display: block !important;
+}
+
+.fission-site-doc-layout > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: 250px minmax(0, 760px) 190px !important;
+  gap: 65px !important;
+  align-items: start !important;
+}
+
+.fission-site-doc-sidebar {
+  width: 250px !important;
+  max-width: 250px !important;
+  padding-right: 26px !important;
+  border-right: 1px solid var(--prototype-line) !important;
+  background: transparent !important;
+}
+
+.fission-site-doc-sidebar .fission-site-sidebar-group {
+  margin-top: 28px !important;
+}
+
+.fission-site-doc-sidebar .fission-site-sidebar-item {
+  padding: 8px 10px !important;
+  border-radius: 7px !important;
+  color: var(--prototype-muted) !important;
+  font-size: 14px !important;
+}
+
+.fission-site-doc-sidebar .fission-site-sidebar-active {
+  background: var(--prototype-surface-2) !important;
+  color: var(--prototype-blue) !important;
+  font-weight: 600 !important;
+}
+
+.fission-site-doc-main {
+  width: 100% !important;
+  max-width: 760px !important;
+  color: var(--prototype-ink) !important;
+}
+
+.fission-site-doc-main h1,
+.fission-site-doc-main h1 .fission-site-text-run {
+  margin: 18px 0 !important;
+  color: var(--prototype-ink) !important;
+  font-family: 'Space Grotesk', system-ui, sans-serif !important;
+  font-size: 54px !important;
+  line-height: 1.05 !important;
+  letter-spacing: -.045em !important;
+  font-weight: 700 !important;
+}
+
+.fission-site-doc-main h2,
+.fission-site-doc-main h2 .fission-site-text-run {
+  margin-top: 46px !important;
+  color: var(--prototype-ink) !important;
+  font-family: 'Space Grotesk', system-ui, sans-serif !important;
+  font-size: 31px !important;
+  line-height: 1.2 !important;
+  font-weight: 700 !important;
+}
+
+.fission-site-doc-main p,
+.fission-site-doc-main li {
+  color: var(--prototype-muted) !important;
+  font-size: 16px !important;
+  line-height: 1.75 !important;
+}
+
+.fission-site-doc-main pre {
+  padding: 24px !important;
+  overflow: auto !important;
+  border-radius: 16px !important;
+  background: #111126 !important;
+  color: #e5e4f7 !important;
+  line-height: 1.7 !important;
+}
+
+.fission-site-doc-toc {
+  width: 190px !important;
+  padding-left: 20px !important;
+  position: sticky !important;
+  top: 120px !important;
+  border-left: 1px solid var(--prototype-line) !important;
+  color: var(--prototype-muted) !important;
+  font-size: 13px !important;
+}
+
+/* Blog index: prototype editorial hero, feature and three-column post grid. */
+.fission-site-blog-layout {
+  display: block !important;
+  width: min(1304px, calc(100% - 48px)) !important;
+  max-width: 1304px !important;
+  margin: auto !important;
+  padding: 80px 0 110px !important;
+}
+
+.fission-site-blog-layout .fission-site-doc-sidebar,
+.fission-site-blog-rail {
+  display: none !important;
+}
+
+.fission-site-blog-layout .fission-site-doc-main,
+.fission-site-blog-index {
+  width: 100% !important;
+  max-width: none !important;
+}
+
+.fission-site-blog-index-hero {
+  max-width: 850px !important;
+  margin: auto !important;
+  text-align: center !important;
+  align-items: center !important;
+}
+
+.fission-site-blog-index-title .fission-site-text-run,
+.fission-site-blog-index-hero h1 {
+  color: var(--prototype-ink) !important;
+  font-size: 70px !important;
+  line-height: .98 !important;
+  letter-spacing: -.055em !important;
+  font-weight: 700 !important;
+}
+
+.fission-site-blog-index-hero p,
+.fission-site-blog-index-hero p .fission-site-text-run {
+  color: var(--prototype-muted) !important;
+  font-size: 20px !important;
+  line-height: 1.6 !important;
+}
+
+.fission-site-blog-featured-card {
+  margin: 75px 0 !important;
+  padding: 34px !important;
+  border: 1px solid var(--prototype-line) !important;
+  border-radius: 28px !important;
+  background: linear-gradient(135deg, var(--prototype-surface-2), var(--prototype-surface)) !important;
+  box-shadow: var(--prototype-shadow) !important;
+}
+
+.fission-site-box:has(> .fission-site-blog-featured-card) {
+  display: contents !important;
+}
+
+.fission-site-blog-featured-card::before {
+  content: "0.9";
+  float: left;
+  display: grid;
+  place-items: center;
+  width: calc(50% - 32px);
+  height: 350px;
+  margin: -8px 52px -8px -8px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, var(--prototype-blue), var(--prototype-violet));
+  color: white;
+  font-size: 100px;
+  font-weight: 700;
+}
+
+.fission-site-blog-featured-card::after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.fission-site-blog-featured-card h2,
+.fission-site-blog-featured-card h2 .fission-site-text-run {
+  color: var(--prototype-ink) !important;
+  font-size: 38px !important;
+  line-height: 1.15 !important;
+  font-weight: 700 !important;
+}
+
+.fission-site-blog-post-list {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  gap: 22px !important;
+}
+
+.fission-site-blog-card {
+  padding: 24px 0 !important;
+  border: 0 !important;
+  border-top: 1px solid var(--prototype-line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.fission-site-blog-card h2,
+.fission-site-blog-card h2 .fission-site-text-run {
+  color: var(--prototype-ink) !important;
+  font-size: 24px !important;
+  line-height: 1.25 !important;
+  font-weight: 700 !important;
+}
+
+@media (max-width: 1000px) {
+  [data-fission-semantics="site-home-hero"] {
+    min-height: 0;
+    padding: 55px 24px !important;
+  }
+
+  [data-fission-semantics="site-platform-atlas"] {
+    height: 330px !important;
+    min-height: 330px !important;
+  }
+
+  [data-fission-semantics="crate-platform-legend"] {
+    overflow-x: auto;
+  }
+
+  [data-fission-semantics="crate-platform-legend"] > .fission-site-row {
+    display: flex !important;
+    width: max-content !important;
+  }
+
+  [data-fission-semantics="crate-platform-legend"] > .fission-site-row > .fission-site-box {
+    min-width: 100px !important;
+  }
+
+  .fission-site-doc-layout > .fission-site-row {
+    grid-template-columns: 220px minmax(0, 1fr) !important;
+    gap: 35px !important;
+  }
+
+  .fission-site-doc-toc {
+    display: none !important;
+  }
+
+  .fission-site-blog-post-list {
+    grid-template-columns: 1fr !important;
+  }
+
+  .fission-site-blog-featured-card::before {
+    float: none;
+    width: 100%;
+    height: 260px;
+    margin: 0 0 28px;
+  }
+}
+
+@media (max-width: 650px) {
+  .fission-site-home-header,
+  .fission-site-doc-header {
+    padding-inline: 18px !important;
+  }
+
+  [data-fission-semantics="site-home-hero"] {
+    padding: 55px 24px !important;
+  }
+
+  .fission-site-home-hero-title .fission-site-text-run,
+  [data-fission-semantics="crate-directory-copy"] .fission-site-column > .fission-site-rich-text:nth-child(2) .fission-site-text-run {
+    font-size: 50px !important;
+  }
+
+  [data-fission-semantics="site-platform-atlas"] {
+    height: 280px !important;
+    min-height: 280px !important;
+  }
+
+  [data-fission-semantics="site-platform-atlas"] > .fission-site-column > .fission-site-box {
+    width: 120px !important;
+    height: 120px !important;
+    min-height: 120px !important;
+    padding: 24px !important;
+  }
+
+  [data-fission-semantics^="site-atlas-target"] {
+    width: 52px !important;
+    min-width: 52px !important;
+    height: 52px !important;
+    min-height: 52px !important;
+  }
+
+  .fission-site-product-page,
+  .fission-site-blog-layout,
+  [data-fission-semantics="crate-detail-page"] {
+    width: calc(100% - 36px) !important;
+  }
+
+  .fission-site-product-hero {
+    padding: 28px !important;
+  }
+
+  .fission-site-product-hero-title .fission-site-text-run,
+  .fission-site-blog-index-title .fission-site-text-run {
+    font-size: 44px !important;
+  }
+
+  .fission-site-doc-layout {
+    display: block !important;
+    padding: 30px 20px 80px !important;
+  }
+
+  .fission-site-doc-layout > .fission-site-row {
+    display: block !important;
+  }
+
+  .fission-site-product-hero > .fission-site-row {
+    display: block !important;
+  }
+
+  .fission-site-doc-sidebar,
+  .fission-site-doc-toc {
+    display: none !important;
+  }
+
+  .fission-site-doc-main h1,
+  .fission-site-doc-main h1 .fission-site-text-run {
+    font-size: 44px !important;
   }
 }

--- a/documentation/src/components/crates.rs
+++ b/documentation/src/components/crates.rs
@@ -1,4 +1,5 @@
 use super::home_nav::HomePageNav;
+use super::home_sections::PlatformAtlas;
 use super::home_widgets::{page_fill, site_semantics, SemanticRow};
 use super::localized::LocalizedNav;
 use super::state::DocsState;
@@ -91,7 +92,41 @@ struct CrateHeroDesktop {
 
 impl From<CrateHeroDesktop> for Widget {
     fn from(hero: CrateHeroDesktop) -> Widget {
-        CrateHeroContent::new(hero.crate_count, false).into()
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        Container::new(SemanticRow::new(
+            "crate-directory-hero",
+            vec![
+                Container::new(CrateHeroContent::new(hero.crate_count, false))
+                    .flex_grow(1.0)
+                    .flex_shrink(1.0)
+                    .into(),
+                Container::new(PlatformAtlas)
+                    .width_length(Length::clamp(
+                        Length::points(360.0),
+                        Length::percent(42.0),
+                        Length::points(520.0),
+                    ))
+                    .flex_shrink(1.0)
+                    .into(),
+            ],
+            Some(tokens.spacing.xxxl),
+            FlexWrap::NoWrap,
+            AlignItems::Center,
+            JustifyContent::SpaceBetween,
+        ))
+        .width_length(Length::clamp(
+            Length::points(280.0),
+            Length::percent(100.0),
+            Length::points(1400.0),
+        ))
+        .padding_lengths([
+            Length::points(tokens.spacing.xxxl),
+            Length::points(tokens.spacing.xl),
+            Length::points(tokens.spacing.xxl),
+            Length::points(tokens.spacing.xl),
+        ])
+        .into()
     }
 }
 
@@ -102,7 +137,17 @@ struct CrateHeroPhone {
 
 impl From<CrateHeroPhone> for Widget {
     fn from(hero: CrateHeroPhone) -> Widget {
-        CrateHeroContent::new(hero.crate_count, true).into()
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        Container::new(CrateHeroContent::new(hero.crate_count, true))
+            .width_length(Length::percent(100.0))
+            .padding_lengths([
+                Length::points(tokens.spacing.xl),
+                Length::points(tokens.spacing.l),
+                Length::points(tokens.spacing.xxxl),
+                Length::points(tokens.spacing.l),
+            ])
+            .into()
     }
 }
 
@@ -152,29 +197,10 @@ impl From<CrateHeroContent> for Widget {
                     .into(),
             ],
             gap: Some(tokens.spacing.m),
-            semantics: Some(site_semantics("crate-directory-hero")),
+            semantics: Some(site_semantics("crate-directory-copy")),
             ..Default::default()
         })
-        .width_length(Length::clamp(
-            Length::points(280.0),
-            Length::percent(100.0),
-            Length::points(1304.0),
-        ))
-        .padding_lengths(if hero.compact {
-            [
-                Length::points(tokens.spacing.xl),
-                Length::points(tokens.spacing.l),
-                Length::points(tokens.spacing.xxl),
-                Length::points(tokens.spacing.l),
-            ]
-        } else {
-            [
-                Length::points(tokens.spacing.xxxl),
-                Length::points(tokens.spacing.xl),
-                Length::points(tokens.spacing.xxxl),
-                Length::points(tokens.spacing.xl),
-            ]
-        })
+        .width_length(Length::percent(100.0))
         .into()
     }
 }
@@ -236,6 +262,7 @@ impl From<CrateResults> for Widget {
                 ],
                 gap: Some(tokens.spacing.m),
                 align_items: AlignItems::Center,
+                semantics: Some(site_semantics("crate-results")),
                 ..Default::default()
             })
             .padding_all(tokens.spacing.xxxl)

--- a/documentation/src/components/home_sections.rs
+++ b/documentation/src/components/home_sections.rs
@@ -113,7 +113,7 @@ impl From<HomeHeroCopy> for Widget {
 }
 
 #[derive(Clone, Debug)]
-struct PlatformAtlas;
+pub(super) struct PlatformAtlas;
 
 impl From<PlatformAtlas> for Widget {
     fn from(_atlas: PlatformAtlas) -> Widget {
@@ -151,6 +151,7 @@ impl From<PlatformAtlas> for Widget {
             ],
             gap: Some(tokens.spacing.l),
             align_items: AlignItems::Center,
+            semantics: Some(super::home_widgets::site_semantics("site-platform-atlas")),
             ..Default::default()
         })
         .width_length(Length::percent(100.0))
@@ -193,6 +194,10 @@ impl From<AtlasTarget> for Widget {
             ],
             gap: Some(tokens.spacing.xs),
             align_items: AlignItems::Center,
+            semantics: Some(super::home_widgets::site_semantics(format!(
+                "site-atlas-target:{}",
+                target.label.to_lowercase()
+            ))),
             ..Default::default()
         })
         .width_length(Length::points(104.0))


### PR DESCRIPTION
Ports the provided documentation prototype design language to the retained Fission site across product, crates, blog, and documentation routes. Adds responsive platform visuals using Responsive and Length, aligns the shared shell and typography, and preserves static generation.