### PR TITLE
feat(input): unify text input actions for Fission 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-08-13
+
+### Added
+
+- **Universal text-input event data** - Every `TextInput` edit now preserves the bound action and delivers an `UpdateTextInput` through `ReducerContext::input.text_change()`. The event contains the complete text, target widget ID, caret, and selection anchor.
+- **Cross-shell text-edit contract** - Native keyboard and IME edits, desktop accessibility edits, Web edits, and interactive SSR browser-island edits now use `ActionInput::TextChanged` and `ActionTrigger::TextChanged`.
+
+### Changed
+
+- **Breaking `TextInput` API** - `TextInput::on_change` is replaced by `TextInput::on_input`. The runtime no longer overwrites an action payload with a string or number. Reducers must read text-edit data from `ctx.input.text_change()`.
+- **Text-based authoring widgets** - `Combobox`, `Editable`, and `NumberInput` expose `on_input` for typed edits and use the same preserved-action contract.
+- **Numeric parsing belongs to reducers** - `NumberInput` forwards the user's text edit instead of asking the generic text runtime to synthesize an `f32` action payload. Applications decide how to handle empty, partial, invalid, clamped, or formatted numeric input.
+- **Declarative bindings are single-handler** - Repeated `ctx.bind(...)` or `ctx.bind_local(...)` calls for the same effective action ID retain each envelope's payload but install one reducer handler per build. Put per-widget context in the action payload; use explicit `register(...)` only when intentional multicast handling is required.
+- **Public event enums** - `ActionInput::TextChanged`, `ActionTrigger::TextChanged`, and `DiagEventKind::ActionDispatchFailed` are public variants. Downstream exhaustive matches over these enums must add an arm.
+
+### Fixed
+
+- **Dynamic and repeated form fields** - Editing no longer destroys application context stored in the bound action. Aggregate drafts, schema-generated forms, property inspectors, and repeated rows can bind a stable field identifier and read the new value separately.
+- **Action failure diagnostics** - Reducer deserialization failures now emit a structured diagnostic without recording the action payload or raw error text, and a failed reducer remains registered for later valid actions.
+
+### Migration notes
+
+- Update Fission dependencies to `0.11.0`:
+
+```toml
+fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
+```
+
+- Rename `TextInput::on_change` to `on_input`, preserve only stable application context in the bound action, and read the live edit with `ctx.input.text_change()` inside the reducer. This migration is required even for a reducer that only needs the new string.
+- Rename `Combobox::on_change`, `Editable::on_change`, and `NumberInput::on_change` to `on_input`. Parse `NumberInput` text in the reducer.
+- If several widgets bind the same action type, keep their differing context in the action value rather than in distinct reducer closures. Explicit `register(...)` remains multicast.
+- Code that exhaustively matches `ActionInput` or `ActionTrigger` must handle `TextChanged`. Diagnostics consumers that exhaustively match `DiagEventKind` must handle `ActionDispatchFailed`. These public API changes are why this release is `0.11.0`.
+- Static site output and ordinary SSR HTML remain inert. Per-keystroke reducers run on native and Web targets and in explicitly mounted SSR browser islands.
+
 ## [0.10.1] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking `TextInput` API** - `TextInput::on_change` is replaced by `TextInput::on_input`. The runtime no longer overwrites an action payload with a string or number. Reducers must read text-edit data from `ctx.input.text_change()`.
+- **Text edits are event data, not actions** - `UpdateTextInput` no longer implements `Action`; it is available only as the structured runtime value returned by `ctx.input.text_change()`.
 - **Text-based authoring widgets** - `Combobox`, `Editable`, and `NumberInput` expose `on_input` for typed edits and use the same preserved-action contract.
 - **Numeric parsing belongs to reducers** - `NumberInput` forwards the user's text edit instead of asking the generic text runtime to synthesize an `f32` action payload. Applications decide how to handle empty, partial, invalid, clamped, or formatted numeric input.
 - **Declarative bindings are single-handler** - Repeated `ctx.bind(...)` or `ctx.bind_local(...)` calls for the same effective action ID retain each envelope's payload but install one reducer handler per build. Put per-widget context in the action payload; use explicit `register(...)` only when intentional multicast handling is required.
@@ -34,6 +35,7 @@ fission = { version = "0.11.0", default-features = false, features = ["desktop"]
 ```
 
 - Rename `TextInput::on_change` to `on_input`, preserve only stable application context in the bound action, and read the live edit with `ctx.input.text_change()` inside the reducer. This migration is required even for a reducer that only needs the new string.
+- Replace any direct dispatch of `UpdateTextInput` with an application action bound to `on_input`; read the `UpdateTextInput` event from the reducer context.
 - Rename `Combobox::on_change`, `Editable::on_change`, and `NumberInput::on_change` to `on_input`. Parse `NumberInput` text in the reducer.
 - If several widgets bind the same action type, keep their differing context in the action value rather than in distinct reducer closures. Explicit `register(...)` remains multicast.
 - Code that exhaustively matches `ActionInput` or `ActionTrigger` must handle `TextChanged`. Diagnostics consumers that exhaustively match `DiagEventKind` must handle `ActionDispatchFailed`. These public API changes are why this release is `0.11.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Dynamic and repeated form fields** - Editing no longer destroys application context stored in the bound action. Aggregate drafts, schema-generated forms, property inspectors, and repeated rows can bind a stable field identifier and read the new value separately.
 - **Action failure diagnostics** - Reducer deserialization failures now emit a structured diagnostic without recording the action payload or raw error text, and a failed reducer remains registered for later valid actions.
+- **App Store-safe window dependency** - Fission now resolves the published `fission-winit` build that keeps private macOS blur APIs disabled unless an application explicitly enables the fork's opt-in feature, so crates.io consumers match the source qualified by the workspace.
 
 ### Migration notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,8 +3334,8 @@ dependencies = [
 
 [[package]]
 name = "fission-winit"
-version = "0.30.13-fission.1"
-source = "git+https://github.com/worka-ai/winit.git?rev=699b7f82b10f1aa65f735e3dbbf33a9701050dea#699b7f82b10f1aa65f735e3dbbf33a9701050dea"
+version = "0.30.13-fission.2"
+source = "git+https://github.com/worka-ai/winit.git?rev=60bc28cac67e4f19c05389674e08870ba852be20#60bc28cac67e4f19c05389674e08870ba852be20"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "fission-winit"
 version = "0.30.13-fission.2"
-source = "git+https://github.com/worka-ai/winit.git?rev=60bc28cac67e4f19c05389674e08870ba852be20#60bc28cac67e4f19c05389674e08870ba852be20"
+source = "git+https://github.com/worka-ai/winit.git?rev=95888ea5adf62ecd160a2df4652ddfffd0310bcf#95888ea5adf62ecd160a2df4652ddfffd0310bcf"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "animation-gallery"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fission"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1656,7 +1656,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chart-gallery"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "counter"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "embed-3d"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "embed-video"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "embed-webview"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "example-showcase"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "animation-gallery",
  "anyhow",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "field-inspector"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2695,7 +2695,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fission"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "fission-3d",
  "fission-charts",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "fission-3d"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "fission-charts"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "fission-core",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-package"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-release"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-run"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-command-core",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-server"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "toml 0.8.2",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-site"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-shell-site",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-ui"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "fission-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "fission-design-system-codegen"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "fission-diagnostics"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.13.0",
  "once_cell",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "fission-documentation"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "fission-editor"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2948,14 +2948,14 @@ dependencies = [
 
 [[package]]
 name = "fission-i18n"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fission-icons"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "heck 0.4.1",
  "serde_json",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "fission-ir"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "serde",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "fission-layout"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "fission-macros"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-ir",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render-vello"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "fission-semantics"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "fission-ir",
  "serde",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-desktop"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-mobile"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-server"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-site"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-terminal"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-web"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-winit"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test-driver"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3256,14 +3256,14 @@ dependencies = [
 
 [[package]]
 name = "fission-text-engine"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "fission-theme"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "fission-design-system-codegen",
  "fission-ir",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "fission-widgets"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "icons_gallery"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -4760,7 +4760,7 @@ checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "inbox"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-smoke"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "motion-memory-repro"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -6528,7 +6528,7 @@ dependencies = [
 
 [[package]]
 name = "pokemon-card-store"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "product-browser"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "text-lab"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8640,7 +8640,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todo-design-system"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -9370,7 +9370,7 @@ dependencies = [
 
 [[package]]
 name = "web-smoke"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "widget-gallery"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "fission",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ panic = "abort"
 
 [patch.crates-io]
 android-activity = { path = "third_party/android-activity/android-activity" }
-fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "60bc28cac67e4f19c05389674e08870ba852be20" }
+fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "95888ea5adf62ecd160a2df4652ddfffd0310bcf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ panic = "abort"
 
 [patch.crates-io]
 android-activity = { path = "third_party/android-activity/android-activity" }
-fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "699b7f82b10f1aa65f735e3dbbf33a9701050dea" }
+fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "60bc28cac67e4f19c05389674e08870ba852be20" }

--- a/crates/authoring/fission-charts/Cargo.toml
+++ b/crates/authoring/fission-charts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-charts"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 license = "MIT"
@@ -16,9 +16,9 @@ platforms = ["android", "ios", "linux", "macos", "windows", "web", "static-site"
 readme = "README.md"
 [dependencies]
 chrono = "0.4.44"
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-widgets = { path = "../fission-widgets", version = "0.10.1" }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/authoring/fission-charts/README.md
+++ b/crates/authoring/fission-charts/README.md
@@ -6,7 +6,7 @@ Chart widgets and data-visualization primitives for Fission applications.
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["desktop", "charts"] }
+fission = { version = "0.11.0", features = ["desktop", "charts"] }
 ```
 
 Most application code should import from `fission::prelude::*` and `fission::charts::*` rather than depending on this crate directly. Depend on `fission-charts` only when you are extending the chart layer itself.

--- a/crates/authoring/fission-icons/Cargo.toml
+++ b/crates/authoring/fission-icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-icons"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-macros/Cargo.toml
+++ b/crates/authoring/fission-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-macros"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-widgets"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -24,22 +24,22 @@ terminal = [
 ]
 
 [dependencies]
-fission-macros = { path = "../fission-macros", version = "0.10.1" }
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
-fission-icons = { path = "../fission-icons", version = "0.10.1" }
+fission-macros = { path = "../fission-macros", version = "0.11.0" }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-icons = { path = "../fission-icons", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.10.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 
 [dev-dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/authoring/fission-widgets/src/colour_picker.rs
+++ b/crates/authoring/fission-widgets/src/colour_picker.rs
@@ -175,8 +175,9 @@ pub struct ColourPicker {
     pub on_value_change: Option<ActionEnvelope>,
     /// Action receiving `f32` alpha in `0..=1`.
     pub on_alpha_change: Option<ActionEnvelope>,
-    /// Action receiving a `String` when the editable hex field changes.
-    pub on_hex_change: Option<ActionEnvelope>,
+    /// Action dispatched when the editable hex field changes. The new string
+    /// is available through `ReducerContext::input.text_change()`.
+    pub on_hex_input: Option<ActionEnvelope>,
 }
 
 /// American spelling alias for codebases that prefer `ColorPicker`.
@@ -208,7 +209,7 @@ impl Default for ColourPicker {
             on_saturation_change: None,
             on_value_change: None,
             on_alpha_change: None,
-            on_hex_change: None,
+            on_hex_input: None,
         }
     }
 }
@@ -695,7 +696,7 @@ fn inputs(picker: &ColourPicker, expanded: bool) -> Widget {
                 .map(|prefix| format!("{prefix}.hex")),
             value: hex,
             width: Some(if expanded { 112.0 } else { 96.0 }),
-            on_change: picker.on_hex_change.clone(),
+            on_input: picker.on_hex_input.clone(),
             ..Default::default()
         }
         .into(),

--- a/crates/authoring/fission-widgets/src/combobox.rs
+++ b/crates/authoring/fission-widgets/src/combobox.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 /// * `value` - Current text input value (controlled).
 /// * `items` - The list of available options to display.
 /// * `is_open` - Whether the dropdown list is visible.
-/// * `on_change` - Action dispatched when the text input value changes.
+/// * `on_input` - Action dispatched with text details in `ReducerContext::input`.
 /// * `on_select` - Closure that produces an action when an item is picked.
 /// * `on_toggle` - Action dispatched to open/close the dropdown.
 pub struct Combobox {
@@ -26,7 +26,7 @@ pub struct Combobox {
     pub is_open: bool,
     pub width: Option<f32>,
     pub max_popup_height: Option<f32>,
-    pub on_change: Option<ActionEnvelope>, // Text changed
+    pub on_input: Option<ActionEnvelope>, // Text details arrive through ActionInput.
     pub on_select: Option<Arc<dyn Fn(String) -> ActionEnvelope + Send + Sync>>, // Item picked
     pub on_toggle: Option<ActionEnvelope>, // Focus/Blur handling usually
 }
@@ -57,7 +57,7 @@ impl From<Combobox> for Widget {
         let input = TextInput {
             id: Some(input_id.into()),
             value: this.value.clone(),
-            on_change: this.on_change.clone(),
+            on_input: this.on_input.clone(),
             width: this.width,
             // TODO: on_focus -> open?
             ..Default::default()

--- a/crates/authoring/fission-widgets/src/date_picker.rs
+++ b/crates/authoring/fission-widgets/src/date_picker.rs
@@ -52,7 +52,7 @@ impl From<DatePicker> for Widget {
         let _trigger: Widget = TextInput {
             value: text.clone(),
             placeholder: Some("YYYY-MM-DD".into()),
-            on_change: None, // Read-only via text for now, or parse?
+            on_input: None, // Read-only via text for now, or parse?
             // If we want to toggle on click, we need to wrap it or use a Button disguised as Input.
             // TextInput captures focus.
             // Better: Button with TextInput look?

--- a/crates/authoring/fission-widgets/src/editable.rs
+++ b/crates/authoring/fission-widgets/src/editable.rs
@@ -8,7 +8,9 @@ pub struct Editable {
     pub value: String,
     pub placeholder: String,
     pub is_editing: bool,
-    pub on_change: Option<ActionEnvelope>,
+    /// Action dispatched when the editor text changes. The new text and
+    /// selection are available through `ReducerContext::input.text_change()`.
+    pub on_input: Option<ActionEnvelope>,
     pub on_submit: Option<ActionEnvelope>, // Enter key
     pub on_edit: Option<ActionEnvelope>,   // Click to edit
     pub on_cancel: Option<ActionEnvelope>, // Esc or blur
@@ -29,7 +31,7 @@ impl From<Editable> for Widget {
                 id: input_id.map(Into::into),
                 value: this.value.clone(),
                 placeholder: Some(this.placeholder.clone().into()),
-                on_change: this.on_change.clone(),
+                on_input: this.on_input.clone(),
                 // TODO: on_submit (Enter) and on_cancel (Esc/Blur) support in TextInput semantics?
                 // Currently TextInput semantics supports `actions` but specific triggers like Enter are handled by Runtime key events dispatching first semantics action.
                 // If we want Enter to submit, we should make sure `on_submit` is the primary action?

--- a/crates/authoring/fission-widgets/src/number_input.rs
+++ b/crates/authoring/fission-widgets/src/number_input.rs
@@ -1,7 +1,5 @@
 use crate::Icon;
-use fission_core::ui::{
-    Button, ButtonVariant, Container, Row, TextInput, TextInputChangePayload, Widget,
-};
+use fission_core::ui::{Button, ButtonVariant, Container, Row, TextInput, Widget};
 use fission_core::{ActionEnvelope, WidgetId};
 use fission_icons::material;
 use serde::{Deserialize, Serialize};
@@ -19,7 +17,9 @@ pub struct NumberInput {
     pub gap: Option<f32>,
     pub on_increment: Option<ActionEnvelope>,
     pub on_decrement: Option<ActionEnvelope>,
-    pub on_change: Option<ActionEnvelope>, // Text input change
+    /// Action dispatched for typed edits. Parse `ctx.input.text_change().new_text`
+    /// in the reducer so validation remains an application decision.
+    pub on_input: Option<ActionEnvelope>,
 }
 
 impl Default for NumberInput {
@@ -36,7 +36,7 @@ impl Default for NumberInput {
             gap: None,
             on_increment: None,
             on_decrement: None,
-            on_change: None,
+            on_input: None,
         }
     }
 }
@@ -88,12 +88,8 @@ impl From<NumberInput> for Widget {
                         value: display_text,
                         width: Some(field_width),
                         borderless: true,
-                        // NumberInput owns a numeric action contract; the
-                        // keyboard hint alone must not change generic text
-                        // input payloads.
                         keyboard_type: fission_ir::semantics::TextInputType::Number,
-                        change_payload: TextInputChangePayload::Number,
-                        on_change: this.on_change.clone(),
+                        on_input: this.on_input.clone(),
                         ..Default::default()
                     }
                     .into(),

--- a/crates/authoring/fission-widgets/tests/combobox_test.rs
+++ b/crates/authoring/fission-widgets/tests/combobox_test.rs
@@ -24,7 +24,7 @@ fn test_combobox_build() {
         is_open: true,
         width: Some(320.0),
         max_popup_height: Some(200.0),
-        on_change: None,
+        on_input: None,
         on_select: None,
         on_toggle: None,
     };

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -50,30 +50,30 @@ video = [
 web = ["dep:fission-shell-web"]
 
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-3d = { path = "../../core/fission-3d", version = "0.10.1", optional = true }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-text-engine = { path = "../../core/fission-text-engine", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.10.1" }
-fission-widgets = { path = "../fission-widgets", version = "0.10.1" }
-fission-macros = { path = "../fission-macros", version = "0.10.1" }
-fission-icons = { path = "../fission-icons", version = "0.10.1" }
-fission-charts = { path = "../fission-charts", version = "0.10.1", optional = true }
-fission-render = { path = "../../rendering/fission-render", version = "0.10.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.10.1" }
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.10.1", optional = true }
-fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.10.1", optional = true }
-fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.10.1", optional = true }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.10.1", optional = true }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-3d = { path = "../../core/fission-3d", version = "0.11.0", optional = true }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-text-engine = { path = "../../core/fission-text-engine", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.11.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.11.0" }
+fission-macros = { path = "../fission-macros", version = "0.11.0" }
+fission-icons = { path = "../fission-icons", version = "0.11.0" }
+fission-charts = { path = "../fission-charts", version = "0.11.0", optional = true }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.11.0", optional = true }
+fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.11.0", optional = true }
+fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.11.0", optional = true }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.10.1", optional = true }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.11.0", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.10.1", optional = true }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.11.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.10.1", optional = true }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.11.0", optional = true }

--- a/crates/authoring/fission/README.md
+++ b/crates/authoring/fission/README.md
@@ -15,7 +15,7 @@ This crate is the public facade. Application code should normally depend on `fis
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["desktop"] }
+fission = { version = "0.11.0", features = ["desktop"] }
 ```
 
 For the full developer workflow, install the Fission command:

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fission = { version = "0.10.1", default-features = false, features = ["desktop"] }
+//! fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
 //! ```
 //!
 //! Then use via:
@@ -171,7 +171,7 @@ pub use fission_core::ui::{
 
 // Core action/state types
 pub use fission_core::{
-    Action, ActionEnvelope, ActionId, ActionScopeId, AuthenticateBiometricCapability,
+    Action, ActionEnvelope, ActionId, ActionInput, ActionScopeId, AuthenticateBiometricCapability,
     BiometricAuthenticateRequest, BiometricAuthenticateResult, BiometricAvailability,
     BiometricEffects, BiometricError, BiometricKind, BiometricStrength, BoxFissionDataStream,
     BuildCtxHandle, CancelAllNotificationsCapability, CancelBiometricAuthenticationCapability,
@@ -190,12 +190,12 @@ pub use fission_core::{
     ScanNfcTagCapability, ScheduleNotificationCapability, ScrollAlignment, ScrollAxis,
     ScrollBehavior, ScrollIntoViewRequest, Selector, Semantics, SetBadgeCountCapability,
     SetBadgeCountRequest, ShowNotificationCapability, UnregisterPushNotificationsCapability,
-    ValueView, ViewHandle, WidgetId, WriteNfcTagCapability, AUTHENTICATE_BIOMETRIC,
-    CANCEL_ALL_NOTIFICATIONS, CANCEL_BIOMETRIC_AUTHENTICATION, CANCEL_NFC_SESSION,
-    CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_BIOMETRIC_AVAILABILITY, GET_NFC_AVAILABILITY,
-    GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS, REQUEST_NOTIFICATION_PERMISSION,
-    SCAN_NFC_TAG, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT, SHOW_NOTIFICATION,
-    UNREGISTER_PUSH_NOTIFICATIONS, WRITE_NFC_TAG,
+    UpdateTextInput, ValueView, ViewHandle, WidgetId, WriteNfcTagCapability,
+    AUTHENTICATE_BIOMETRIC, CANCEL_ALL_NOTIFICATIONS, CANCEL_BIOMETRIC_AUTHENTICATION,
+    CANCEL_NFC_SESSION, CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_BIOMETRIC_AVAILABILITY,
+    GET_NFC_AVAILABILITY, GET_NOTIFICATION_SETTINGS, REGISTER_PUSH_NOTIFICATIONS,
+    REQUEST_NOTIFICATION_PERMISSION, SCAN_NFC_TAG, SCHEDULE_NOTIFICATION, SET_BADGE_COUNT,
+    SHOW_NOTIFICATION, UNREGISTER_PUSH_NOTIFICATIONS, WRITE_NFC_TAG,
 };
 pub use fission_core::{
     AdjustVolumeLevelCapability, GetVolumeLevelCapability, SetVolumeLevelCapability,
@@ -413,27 +413,28 @@ pub mod prelude {
         reduce, reduce_with, video_asset, video_file, video_network, widgets, with_reducer,
     };
     pub use fission_core::{
-        Action, ActionEnvelope, ActionId, ActionScopeId, AuthenticateBiometricCapability,
-        BiometricAuthenticateRequest, BiometricAuthenticateResult, BiometricAvailability,
-        BiometricEffects, BiometricError, BiometricKind, BiometricStrength, BoxFissionDataStream,
-        BuildCtxHandle, CancelAllNotificationsCapability, CancelBiometricAuthenticationCapability,
-        CancelNotificationCapability, CancelNotificationRequest, ComputedView, DataStreamId,
-        DataStreamRegistry, DeepLink, DeepLinkConfig, DeepLinkReceived, DeepLinkSource, Effects,
-        EmulateNfcTagCapability, FissionDataStream, FissionDataStreamError,
-        FissionDataStreamErrorKind, FissionViewField, FlexDirection, FocusPolicy,
-        GetBiometricAvailabilityCapability, GetNfcAvailabilityCapability,
-        GetNotificationSettingsCapability, GlobalState, Handler, NfcAvailability, NfcEffects,
-        NfcEmulationRequest, NfcError, NfcRecord, NfcRecordTypeNameFormat, NfcScanRequest,
-        NfcSessionReceipt, NfcTag, NfcTagDiscovered, NfcTechnology, NfcWriteRequest,
-        NotificationActionButton, NotificationEffects, NotificationError, NotificationId,
-        NotificationPermission, NotificationPermissionRequest, NotificationReceipt,
-        NotificationRequest, NotificationResponse, NotificationResponseReceived,
-        NotificationSchedule, NotificationSettings, NotificationSound, Op, PortalLayer, Provider,
-        PushPlatform, PushRegistration, PushRegistrationRequest, ReducerContext,
-        RegisterPushNotificationsCapability, RequestNotificationPermissionCapability, Role,
-        ScanNfcTagCapability, ScheduleNotificationCapability, ScrollAlignment, ScrollAxis,
-        ScrollBehavior, ScrollIntoViewRequest, Selector, Semantics, SetBadgeCountCapability,
-        SetBadgeCountRequest, ShowNotificationCapability, UnregisterPushNotificationsCapability,
+        Action, ActionEnvelope, ActionId, ActionInput, ActionScopeId,
+        AuthenticateBiometricCapability, BiometricAuthenticateRequest, BiometricAuthenticateResult,
+        BiometricAvailability, BiometricEffects, BiometricError, BiometricKind, BiometricStrength,
+        BoxFissionDataStream, BuildCtxHandle, CancelAllNotificationsCapability,
+        CancelBiometricAuthenticationCapability, CancelNotificationCapability,
+        CancelNotificationRequest, ComputedView, DataStreamId, DataStreamRegistry, DeepLink,
+        DeepLinkConfig, DeepLinkReceived, DeepLinkSource, Effects, EmulateNfcTagCapability,
+        FissionDataStream, FissionDataStreamError, FissionDataStreamErrorKind, FissionViewField,
+        FlexDirection, FocusPolicy, GetBiometricAvailabilityCapability,
+        GetNfcAvailabilityCapability, GetNotificationSettingsCapability, GlobalState, Handler,
+        NfcAvailability, NfcEffects, NfcEmulationRequest, NfcError, NfcRecord,
+        NfcRecordTypeNameFormat, NfcScanRequest, NfcSessionReceipt, NfcTag, NfcTagDiscovered,
+        NfcTechnology, NfcWriteRequest, NotificationActionButton, NotificationEffects,
+        NotificationError, NotificationId, NotificationPermission, NotificationPermissionRequest,
+        NotificationReceipt, NotificationRequest, NotificationResponse,
+        NotificationResponseReceived, NotificationSchedule, NotificationSettings,
+        NotificationSound, Op, PortalLayer, Provider, PushPlatform, PushRegistration,
+        PushRegistrationRequest, ReducerContext, RegisterPushNotificationsCapability,
+        RequestNotificationPermissionCapability, Role, ScanNfcTagCapability,
+        ScheduleNotificationCapability, ScrollAlignment, ScrollAxis, ScrollBehavior,
+        ScrollIntoViewRequest, Selector, Semantics, SetBadgeCountCapability, SetBadgeCountRequest,
+        ShowNotificationCapability, UnregisterPushNotificationsCapability, UpdateTextInput,
         ValueView, ViewHandle, WidgetId, WindowEnv, WindowTitle, WriteNfcTagCapability,
         AUTHENTICATE_BIOMETRIC, CANCEL_ALL_NOTIFICATIONS, CANCEL_BIOMETRIC_AUTHENTICATION,
         CANCEL_NFC_SESSION, CANCEL_NOTIFICATION, EMULATE_NFC_TAG, GET_BIOMETRIC_AVAILABILITY,

--- a/crates/core/fission-3d/Cargo.toml
+++ b/crates/core/fission-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-3d"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 license = "MIT"
@@ -15,8 +15,8 @@ keywords = ["fission", "3d", "gpu-accelerated", "rendering", "cross-platform"]
 platforms = ["android", "ios", "linux", "macos", "windows", "web"]
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../fission-core", version = "0.10.1" }
-fission-ir = { path = "../fission-ir", version = "0.10.1" }
+fission-core = { path = "../fission-core", version = "0.11.0" }
+fission-ir = { path = "../fission-ir", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 wgpu = "26.0"
 bytemuck = { version = "1.18", features = ["derive"] }

--- a/crates/core/fission-3d/README.md
+++ b/crates/core/fission-3d/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["desktop", "three-d"] }
+fission = { version = "0.11.0", features = ["desktop", "three-d"] }
 ```
 
 Use this crate directly only when you are extending the framework's 3D model or renderer integration.

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-core"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,13 +15,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.10.1" }
-fission-layout = { path = "../fission-layout", version = "0.10.1" }
-fission-semantics = { path = "../fission-semantics", version = "0.10.1" }
-fission-theme = { path = "../fission-theme", version = "0.10.1" }
-fission-i18n = { path = "../fission-i18n", version = "0.10.1" }
-fission-text-engine = { path = "../fission-text-engine", version = "0.10.1" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.10.1" }
+fission-ir = { path = "../fission-ir", version = "0.11.0" }
+fission-layout = { path = "../fission-layout", version = "0.11.0" }
+fission-semantics = { path = "../fission-semantics", version = "0.11.0" }
+fission-theme = { path = "../fission-theme", version = "0.11.0" }
+fission-i18n = { path = "../fission-i18n", version = "0.11.0" }
+fission-text-engine = { path = "../fission-text-engine", version = "0.11.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -32,6 +32,6 @@ lazy_static = "1.4"
 blake3 = "1.5"
 unicode-segmentation = "1.10"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.10.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
 
 [dev-dependencies]

--- a/crates/core/fission-core/src/action/mod.rs
+++ b/crates/core/fission-core/src/action/mod.rs
@@ -157,10 +157,13 @@ impl ActionScopeId {
     }
 }
 
-/// Action dispatched by the text-editing controller when the user modifies a
-/// [`TextInput`](crate::ui::TextInput) field.
+/// Structured details for a text-input edit.
 ///
-/// Contains the full new text and updated caret/selection positions.
+/// Every [`TextInput`](crate::ui::TextInput) binding receives this value through
+/// [`ActionInput::text_change`](crate::ActionInput::text_change), while the
+/// bound action payload continues to carry the application's stable context.
+/// The type remains an [`Action`] for compatibility with code that dispatches
+/// `UpdateTextInput` directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdateTextInput {
     /// The widget identity of the text input that changed.

--- a/crates/core/fission-core/src/action/mod.rs
+++ b/crates/core/fission-core/src/action/mod.rs
@@ -162,8 +162,6 @@ impl ActionScopeId {
 /// Every [`TextInput`](crate::ui::TextInput) binding receives this value through
 /// [`ActionInput::text_change`](crate::ActionInput::text_change), while the
 /// bound action payload continues to carry the application's stable context.
-/// The type remains an [`Action`] for compatibility with code that dispatches
-/// `UpdateTextInput` directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdateTextInput {
     /// The widget identity of the text input that changed.
@@ -175,16 +173,6 @@ pub struct UpdateTextInput {
     /// Byte offset of the selection anchor (equals `new_caret` when no
     /// selection is active).
     pub new_anchor: usize,
-}
-
-impl Action for UpdateTextInput {
-    fn static_id() -> ActionId {
-        lazy_static! {
-            pub static ref UPDATE_TEXT_INPUT_ACTION_ID: ActionId =
-                ActionId::from_name("fission_core::UpdateTextInput");
-        }
-        *UPDATE_TEXT_INPUT_ACTION_ID
-    }
 }
 
 /// Payload dispatched when the caret/anchor position changes in a TextInput.

--- a/crates/core/fission-core/src/build.rs
+++ b/crates/core/fission-core/src/build.rs
@@ -406,6 +406,11 @@ impl<S: GlobalState> BuildCtxHandle<S> {
         unsafe { f(&mut *ctx) }
     }
 
+    /// Binds an action payload to one handler per action type in this build.
+    ///
+    /// Repeated bindings retain distinct payloads but share the first handler
+    /// registered for that [`crate::ActionId`]. Use [`Self::register`] for
+    /// intentional multicast handling.
     pub fn bind<A, H>(&self, action: A, handler: H) -> crate::ActionEnvelope
     where
         A: crate::Action,
@@ -443,9 +448,8 @@ impl<S: GlobalState> BuildCtxHandle<S> {
                   _input,
                   _callback_registry|
                   -> anyhow::Result<()> {
-                let action: A = serde_json::from_slice(&envelope.payload).map_err(|error| {
-                    anyhow::anyhow!("Failed to deserialize local action: {error}")
-                })?;
+                let action: A = serde_json::from_slice(&envelope.payload)
+                    .map_err(crate::registry::ActionDeserializationError::new)?;
                 let Some(store) = app_states
                     .get_mut(&TypeId::of::<crate::state::LocalStateStore>())
                     .and_then(|state| state.downcast_mut::<crate::state::LocalStateStore>())

--- a/crates/core/fission-core/src/build_context.rs
+++ b/crates/core/fission-core/src/build_context.rs
@@ -62,11 +62,17 @@ impl<S: GlobalState> BuildCtx<S> {
         }
     }
 
+    /// Binds an action payload to the handler for its action type.
+    ///
+    /// A build pass installs one bound handler per [`ActionId`]. Repeated
+    /// bindings of the same action type share that handler while retaining
+    /// their distinct payloads. Use [`Self::register`] when intentional
+    /// multicast handling is required.
     pub fn bind<A: Action, H>(&mut self, action: A, handler: H) -> ActionEnvelope
     where
         H: IntoHandler<S, A> + Send + Sync + 'static,
     {
-        self.registry.register(handler);
+        self.registry.register_bound(handler);
 
         ActionEnvelope {
             id: A::static_id(),

--- a/crates/core/fission-core/src/effect.rs
+++ b/crates/core/fission-core/src/effect.rs
@@ -6,7 +6,7 @@
 //! The platform executor fulfils the effect outside the deterministic core and
 //! dispatches the `on_ok` / `on_err` callback actions back into the pipeline.
 
-use crate::action::ActionEnvelope;
+use crate::action::{ActionEnvelope, UpdateTextInput};
 use crate::async_runtime::{
     JobRef, JobRequestPayload, JobSpec, ResourceExecutionContext, ServiceBindings,
     ServiceCommandPayload, ServiceSpec, ServiceStartPayload, ServiceStopPayload, ServiceType,
@@ -271,6 +271,11 @@ pub enum ActionInput {
         delta_x: f32,
         delta_y: f32,
     },
+    /// Runtime details accompanying a text-input action.
+    ///
+    /// The action envelope retains the application-defined payload, while this
+    /// input carries the edited value and selection independently.
+    TextChanged(UpdateTextInput),
     /// External file drop (e.g. from the OS file manager).
     Drop {
         paths: Vec<String>,
@@ -347,6 +352,17 @@ impl ActionInput {
             } => Some((*x, *y, *delta_x, *delta_y)),
             ActionInput::Drop { x, y, .. } => Some((*x, *y, 0.0, 0.0)),
             ActionInput::InternalDrop { x, y, .. } => Some((*x, *y, 0.0, 0.0)),
+            _ => None,
+        }
+    }
+
+    /// Returns the edit accompanying a text-input action.
+    ///
+    /// Scoped actions are unwrapped automatically, matching the other typed
+    /// input accessors.
+    pub fn text_change(&self) -> Option<&UpdateTextInput> {
+        match self.unscoped() {
+            ActionInput::TextChanged(change) => Some(change),
             _ => None,
         }
     }

--- a/crates/core/fission-core/src/input/mod.rs
+++ b/crates/core/fission-core/src/input/mod.rs
@@ -3,8 +3,9 @@ use crate::env::{
     TextEditStateMap,
 };
 use crate::event::InputEvent;
-use crate::{ActionEnvelope, ActionInput};
-use fission_ir::{CoreIR, Op, WidgetId};
+use crate::{ActionEnvelope, ActionId, ActionInput, UpdateTextInput};
+use fission_ir::semantics::ActionTrigger;
+use fission_ir::{CoreIR, Op, Semantics, WidgetId};
 use fission_layout::{LayoutSnapshot, TextMeasurer};
 use std::sync::Arc;
 
@@ -31,6 +32,65 @@ pub struct ControllerContext<'a> {
 
 pub trait InputController {
     fn handle_event(&mut self, ctx: &mut ControllerContext, event: &InputEvent) -> bool;
+}
+
+/// Builds the action envelope and event input for one committed text edit.
+///
+/// This is the shared integration boundary for the native text controller,
+/// accessibility adapters, browser islands, and other interactive shells.
+/// The bound action payload is preserved and the complete live edit is carried
+/// separately in [`ActionInput::TextChanged`].
+#[doc(hidden)]
+pub fn prepare_text_input_change(
+    semantics: &Semantics,
+    node_id: WidgetId,
+    new_text: String,
+    new_caret: usize,
+    new_anchor: usize,
+) -> Option<(ActionEnvelope, ActionInput)> {
+    let entry = semantics
+        .actions
+        .entries
+        .iter()
+        .find(|entry| entry.trigger == ActionTrigger::TextChanged)?;
+
+    // Lowered text inputs always retain a payload. Preserve an empty payload
+    // for malformed external IR so reducer dispatch reports a structured
+    // deserialization failure instead of silently dropping the edit here.
+    let payload = entry.payload_data.clone().unwrap_or_default();
+    let input = ActionInput::TextChanged(UpdateTextInput {
+        node_id,
+        new_text,
+        new_caret,
+        new_anchor,
+    });
+
+    Some((
+        ActionEnvelope {
+            id: ActionId::from_u128(entry.action_id),
+            payload,
+        },
+        input,
+    ))
+}
+
+/// Builds and action-scopes one committed text edit.
+///
+/// Interactive shells should use this boundary so native, accessibility, and
+/// browser-originated edits all preserve the same action payload and resolve
+/// the nearest ancestor action scope consistently.
+#[doc(hidden)]
+pub fn prepare_scoped_text_input_change(
+    ir: &CoreIR,
+    semantics: &Semantics,
+    node_id: WidgetId,
+    new_text: String,
+    new_caret: usize,
+    new_anchor: usize,
+) -> Option<(ActionEnvelope, ActionInput)> {
+    let (envelope, input) =
+        prepare_text_input_change(semantics, node_id, new_text, new_caret, new_anchor)?;
+    Some((envelope, scoped_action_input(ir, node_id, input)))
 }
 
 pub(crate) fn action_scope_for_node(ir: &CoreIR, node_id: WidgetId) -> Option<u128> {

--- a/crates/core/fission-core/src/input/text.rs
+++ b/crates/core/fission-core/src/input/text.rs
@@ -1755,32 +1755,14 @@ impl TextInputController {
         new_text: String,
     ) {
         Self::persist_runtime_state(ctx, node_id);
-        if let Some(action_entry) = semantics.actions.entries.iter().find(|e| {
-            matches!(
-                e.trigger,
-                fission_ir::semantics::ActionTrigger::Change
-                    | fission_ir::semantics::ActionTrigger::NumberChange
-            )
-        }) {
-            let payload = match action_entry.trigger {
-                fission_ir::semantics::ActionTrigger::Change => serde_json::to_vec(&new_text)
-                    .expect("serializing text input change payload should not fail"),
-                fission_ir::semantics::ActionTrigger::NumberChange => {
-                    let Ok(parsed) = new_text.trim().parse::<f32>() else {
-                        return;
-                    };
-                    serde_json::to_vec(&parsed)
-                        .expect("serializing numeric text input payload should not fail")
-                }
-                _ => unreachable!("filtered to text input change triggers"),
-            };
-
-            let envelope = ActionEnvelope {
-                id: ActionId::from_u128(action_entry.action_id),
-                payload,
-            };
-            let input =
-                crate::input::scoped_action_input(ctx.ir, node_id, crate::ActionInput::None);
+        let (new_caret, new_anchor) = ctx
+            .text_edit
+            .get(node_id)
+            .map(|state| (state.caret, state.anchor))
+            .unwrap_or((new_text.len(), new_text.len()));
+        if let Some((envelope, input)) = crate::input::prepare_scoped_text_input_change(
+            ctx.ir, semantics, node_id, new_text, new_caret, new_anchor,
+        ) {
             ctx.dispatched_actions.push((node_id, envelope, input));
 
             // State update moved to handle_key to avoid double borrow

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -195,7 +195,9 @@ pub mod public {
         pub use crate::view::*;
     }
 
-    pub use crate::action::{Action, ActionEnvelope, ActionId, ActionScopeId, GlobalState};
+    pub use crate::action::{
+        Action, ActionEnvelope, ActionId, ActionScopeId, GlobalState, UpdateTextInput,
+    };
     pub use crate::async_runtime::{
         BoxFuture, JobCtx, JobRef, JobSpec, ResourceExecutionContext, ServiceBindings, ServiceCtx,
         ServiceRunner, ServiceSlot, ServiceSpec, ServiceType,
@@ -371,7 +373,10 @@ pub mod public {
 #[cfg(test)]
 mod tests;
 
-pub use action::{Action, ActionEnvelope, ActionId, ActionScopeId, GlobalState, ShellRouteChanged};
+pub use action::{
+    Action, ActionEnvelope, ActionId, ActionScopeId, GlobalState, ShellRouteChanged,
+    UpdateTextInput,
+};
 pub use async_runtime::{
     BoxFuture, JobCtx, JobRef, JobSpec, ResourceExecutionContext, ServiceBindings, ServiceCtx,
     ServiceRunner, ServiceSlot, ServiceSpec, ServiceType,
@@ -731,5 +736,15 @@ impl EffectCallbackRegistry {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(&action_id)
             .unwrap_or_default()
+    }
+
+    pub(crate) fn clear(&self) -> usize {
+        let mut reducers = self
+            .reducers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let callback_count = reducers.values().map(Vec::len).sum();
+        reducers.clear();
+        callback_count
     }
 }

--- a/crates/core/fission-core/src/registry.rs
+++ b/crates/core/fission-core/src/registry.rs
@@ -124,7 +124,7 @@ type TypedReducer<S> = Box<
 
 fn into_boxed_runtime_reducer<S: GlobalState>(
     state_type_id: TypeId,
-    mut typed_reducer: TypedReducer<S>,
+    typed_reducer: TypedReducer<S>,
 ) -> BoxedReducer {
     Box::new(
         move |app_states: &mut HashMap<TypeId, Box<dyn GlobalState>>,

--- a/crates/core/fission-core/src/registry.rs
+++ b/crates/core/fission-core/src/registry.rs
@@ -12,10 +12,69 @@ use crate::{
     Action, ActionEnvelope, ActionId, BoxedReducer, GlobalState,
 };
 use anyhow::{anyhow, Result};
+use fission_diagnostics::prelude as diag;
 use fission_ir::WidgetId;
 use serde::Serialize;
 use std::any::TypeId;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub(crate) struct ActionDeserializationError;
+
+impl ActionDeserializationError {
+    pub(crate) fn new(_source: serde_json::Error) -> Self {
+        Self
+    }
+}
+
+impl fmt::Display for ActionDeserializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("failed to deserialize action payload")
+    }
+}
+
+impl Error for ActionDeserializationError {}
+
+pub(crate) fn emit_action_dispatch_failure(
+    action_id: ActionId,
+    target: WidgetId,
+    error: &anyhow::Error,
+) {
+    let failure_kind = if error.downcast_ref::<ActionDeserializationError>().is_some() {
+        "action_deserialization"
+    } else {
+        "reducer_dispatch"
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    eprintln!(
+        "{}",
+        action_dispatch_failure_message(action_id, target, failure_kind)
+    );
+    diag::emit(
+        diag::DiagCategory::Input,
+        diag::DiagLevel::Error,
+        diag::DiagEventKind::ActionDispatchFailed {
+            action_id: action_id.as_u128(),
+            target: target.as_u128(),
+            failure_kind: failure_kind.into(),
+        },
+    );
+}
+
+#[cfg(any(not(target_arch = "wasm32"), test))]
+fn action_dispatch_failure_message(
+    action_id: ActionId,
+    target: WidgetId,
+    failure_kind: &'static str,
+) -> String {
+    format!(
+        "Fission action dispatch failed: action_id={} target={} failure_kind={failure_kind}",
+        action_id.as_u128(),
+        target.as_u128()
+    )
+}
 
 /// The canonical 3-argument handler signature for modern reducers.
 ///
@@ -63,6 +122,37 @@ type TypedReducer<S> = Box<
         + Sync,
 >;
 
+fn into_boxed_runtime_reducer<S: GlobalState>(
+    state_type_id: TypeId,
+    mut typed_reducer: TypedReducer<S>,
+) -> BoxedReducer {
+    Box::new(
+        move |app_states: &mut HashMap<TypeId, Box<dyn GlobalState>>,
+              action: &ActionEnvelope,
+              target: WidgetId,
+              out_effects: &mut Vec<EffectEnvelope>,
+              input: &ActionInput,
+              callback_registry|
+              -> Result<()> {
+            if let Some(state_box) = app_states.get_mut(&state_type_id) {
+                let concrete_state = state_box
+                    .downcast_mut::<S>()
+                    .ok_or_else(|| anyhow!("Failed to downcast GlobalState to concrete type"))?;
+
+                let mut effects_builder = Effects::new_runtime(0, callback_registry.clone());
+
+                typed_reducer(concrete_state, action, target, &mut effects_builder, input)?;
+
+                out_effects.extend(effects_builder.out);
+
+                Ok(())
+            } else {
+                anyhow::bail!("Target GlobalState for reducer not found in runtime.");
+            }
+        },
+    )
+}
+
 /// A per-frame collection of action handlers registered during widget building.
 ///
 /// `ActionRegistry` is populated by [`BuildCtxHandle::bind`](crate::build::BuildCtxHandle::bind)
@@ -71,13 +161,15 @@ type TypedReducer<S> = Box<
 /// via [`Runtime::absorb_registry`](crate::Runtime::absorb_registry).
 pub struct ActionRegistry<S: GlobalState> {
     handlers: BTreeMap<ActionId, Vec<TypedReducer<S>>>,
-    runtime_handlers: BTreeMap<ActionId, Vec<BoxedReducer>>,
+    bound_handlers: BTreeMap<ActionId, TypedReducer<S>>,
+    runtime_handlers: BTreeMap<ActionId, BoxedReducer>,
 }
 
 impl<S: GlobalState> Default for ActionRegistry<S> {
     fn default() -> Self {
         Self {
             handlers: BTreeMap::new(),
+            bound_handlers: BTreeMap::new(),
             runtime_handlers: BTreeMap::new(),
         }
     }
@@ -88,6 +180,11 @@ impl<S: GlobalState> ActionRegistry<S> {
         Self::default()
     }
 
+    /// Registers an explicit handler for an action type.
+    ///
+    /// Every registered handler runs when the action is dispatched. Declarative
+    /// widget bindings use a separate exactly-once path; call `register` only
+    /// when multicast handling is intentional.
     pub fn register<A: Action, H: IntoHandler<S, A> + Send + Sync + 'static>(
         &mut self,
         handler: H,
@@ -100,7 +197,25 @@ impl<S: GlobalState> ActionRegistry<S> {
         action_id: ActionId,
         handler: H,
     ) {
-        let typed_reducer: TypedReducer<S> = Box::new(
+        self.handlers
+            .entry(action_id)
+            .or_default()
+            .push(Self::typed_reducer(handler));
+    }
+
+    pub(crate) fn register_bound<A: Action, H: IntoHandler<S, A> + Send + Sync + 'static>(
+        &mut self,
+        handler: H,
+    ) {
+        self.bound_handlers
+            .entry(A::static_id())
+            .or_insert_with(|| Self::typed_reducer(handler));
+    }
+
+    fn typed_reducer<A: Action, H: IntoHandler<S, A> + Send + Sync + 'static>(
+        handler: H,
+    ) -> TypedReducer<S> {
+        Box::new(
             move |state: &mut S,
                   envelope: &ActionEnvelope,
                   _target,
@@ -108,34 +223,29 @@ impl<S: GlobalState> ActionRegistry<S> {
                   input|
                   -> Result<()> {
                 let action: A = serde_json::from_slice(&envelope.payload)
-                    .map_err(|e| anyhow!("Failed to deserialize action: {}", e))?;
+                    .map_err(ActionDeserializationError::new)?;
 
                 let mut ctx = ReducerContext { effects, input };
 
                 handler.call(state, action, &mut ctx);
                 Ok(())
             },
-        );
-
-        self.handlers
-            .entry(action_id)
-            .or_default()
-            .push(typed_reducer);
+        )
     }
 
     pub fn action_ids(&self) -> Vec<ActionId> {
         self.handlers
             .keys()
+            .chain(self.bound_handlers.keys())
             .chain(self.runtime_handlers.keys())
             .copied()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
             .collect()
     }
 
     pub(crate) fn register_runtime_reducer(&mut self, action_id: ActionId, reducer: BoxedReducer) {
-        self.runtime_handlers
-            .entry(action_id)
-            .or_default()
-            .push(reducer);
+        self.runtime_handlers.entry(action_id).or_insert(reducer);
     }
 
     pub fn dispatch_with_input(
@@ -147,10 +257,20 @@ impl<S: GlobalState> ActionRegistry<S> {
     ) -> Result<Vec<EffectEnvelope>> {
         let mut effects_builder = Effects::new_headless(0);
         let target: WidgetId = target.into();
-        if let Some(reducers) = self.handlers.get_mut(&action.id) {
-            for reducer in reducers {
+        let dispatch_result = (|| {
+            if let Some(reducers) = self.handlers.get_mut(&action.id) {
+                reducers.iter_mut().try_for_each(|reducer| {
+                    reducer(state, action, target, &mut effects_builder, input)
+                })?;
+            }
+            if let Some(reducer) = self.bound_handlers.get_mut(&action.id) {
                 reducer(state, action, target, &mut effects_builder, input)?;
             }
+            Ok(())
+        })();
+        if let Err(error) = dispatch_result {
+            emit_action_dispatch_failure(action.id, target, &error);
+            return Err(error);
         }
         Ok(effects_builder.out)
     }
@@ -168,54 +288,24 @@ impl<S: GlobalState> ActionRegistry<S> {
         let mut runtime_reducers: HashMap<ActionId, Vec<BoxedReducer>> = HashMap::new();
         let state_type_id = TypeId::of::<S>();
 
-        for (action_id, mut reducers) in self.runtime_handlers {
-            runtime_reducers
-                .entry(action_id)
-                .or_default()
-                .append(&mut reducers);
+        for (action_id, reducer) in self.runtime_handlers {
+            runtime_reducers.entry(action_id).or_default().push(reducer);
         }
 
         for (action_id, typed_reducers) in self.handlers {
             for typed_reducer in typed_reducers {
-                let boxed_reducer: BoxedReducer = Box::new(
-                    move |app_states: &mut HashMap<TypeId, Box<dyn GlobalState>>,
-                          action: &ActionEnvelope,
-                          target: WidgetId,
-                          out_effects: &mut Vec<EffectEnvelope>,
-                          input: &ActionInput,
-                          callback_registry|
-                          -> Result<()> {
-                        if let Some(state_box) = app_states.get_mut(&state_type_id) {
-                            let concrete_state =
-                                state_box.downcast_mut::<S>().ok_or_else(|| {
-                                    anyhow!("Failed to downcast GlobalState to concrete type")
-                                })?;
-
-                            let mut effects_builder =
-                                Effects::new_runtime(0, callback_registry.clone());
-
-                            typed_reducer(
-                                concrete_state,
-                                action,
-                                target,
-                                &mut effects_builder,
-                                input,
-                            )?;
-
-                            out_effects.extend(effects_builder.out);
-
-                            Ok(())
-                        } else {
-                            anyhow::bail!("Target GlobalState for reducer not found in runtime.");
-                        }
-                    },
-                );
-
                 runtime_reducers
                     .entry(action_id)
                     .or_default()
-                    .push(boxed_reducer);
+                    .push(into_boxed_runtime_reducer(state_type_id, typed_reducer));
             }
+        }
+
+        for (action_id, typed_reducer) in self.bound_handlers {
+            runtime_reducers
+                .entry(action_id)
+                .or_default()
+                .push(into_boxed_runtime_reducer(state_type_id, typed_reducer));
         }
         runtime_reducers
     }
@@ -662,5 +752,25 @@ impl ResourceRegistry {
         let index = self.declarations.len();
         self.seen_keys.insert(declaration.key.clone(), index);
         self.declarations.push(declaration);
+    }
+}
+
+#[cfg(test)]
+mod dispatch_failure_tests {
+    use super::action_dispatch_failure_message;
+    use crate::{ActionId, WidgetId};
+
+    #[test]
+    fn fallback_message_contains_only_sanitized_dispatch_metadata() {
+        let message = action_dispatch_failure_message(
+            ActionId::from_u128(7),
+            WidgetId::from_u128(11),
+            "action_deserialization",
+        );
+
+        assert_eq!(
+            message,
+            "Fission action dispatch failed: action_id=7 target=11 failure_kind=action_deserialization"
+        );
     }
 }

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -469,6 +469,20 @@ impl Runtime {
         self.pending_effects.push(envelope);
     }
 
+    /// Rejects every queued host effect and its one-shot completion callbacks.
+    ///
+    /// This is only for shells that intentionally do not execute any effects
+    /// produced by a dispatch. Executing or retaining an effect after calling
+    /// this method would make its completion callback unavailable.
+    ///
+    /// Returns the total number of discarded effect envelopes and callbacks.
+    #[doc(hidden)]
+    pub fn discard_pending_effects(&mut self) -> usize {
+        let discarded = self.pending_effects.len() + self.effect_callbacks.clear();
+        self.pending_effects.clear();
+        discarded
+    }
+
     pub fn dispatch_with_input(
         &mut self,
         action: ActionEnvelope,
@@ -483,6 +497,20 @@ impl Runtime {
     }
 
     fn dispatch_node_with_input(
+        &mut self,
+        action: ActionEnvelope,
+        target: WidgetId,
+        input: &ActionInput,
+    ) -> Result<()> {
+        let action_id = action.id;
+        let result = self.try_dispatch_node_with_input(action, target, input);
+        if let Err(error) = &result {
+            crate::registry::emit_action_dispatch_failure(action_id, target, error);
+        }
+        result
+    }
+
+    fn try_dispatch_node_with_input(
         &mut self,
         action: ActionEnvelope,
         target: WidgetId,
@@ -537,7 +565,7 @@ impl Runtime {
             );
 
             let mut temp_reducers: Vec<BoxedReducer> = reducers.drain(..).collect();
-            for reducer_wrapper in temp_reducers.iter_mut() {
+            let dispatch_result = temp_reducers.iter_mut().try_for_each(|reducer_wrapper| {
                 reducer_wrapper(
                     &mut self.app_states,
                     &action,
@@ -545,9 +573,10 @@ impl Runtime {
                     &mut effects,
                     input,
                     &callback_registry,
-                )?;
-            }
+                )
+            });
             reducers.extend(temp_reducers);
+            dispatch_result?;
         }
 
         if let Some(reducers) = self.reducers.get_mut(&action_id) {
@@ -562,7 +591,7 @@ impl Runtime {
             );
 
             let mut temp_reducers: Vec<BoxedReducer> = reducers.drain(..).collect();
-            for reducer_wrapper in temp_reducers.iter_mut() {
+            let dispatch_result = temp_reducers.iter_mut().try_for_each(|reducer_wrapper| {
                 reducer_wrapper(
                     &mut self.app_states,
                     &action,
@@ -570,9 +599,10 @@ impl Runtime {
                     &mut effects,
                     input,
                     &callback_registry,
-                )?;
-            }
+                )
+            });
             reducers.extend(temp_reducers);
+            dispatch_result?;
         }
 
         for envelope in effects {

--- a/crates/core/fission-core/src/tests/effect_test.rs
+++ b/crates/core/fission-core/src/tests/effect_test.rs
@@ -86,6 +86,25 @@ impl Action for UploadFinished {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct RegisterUnusedCallback;
+
+impl Action for RegisterUnusedCallback {
+    fn static_id() -> ActionId {
+        ActionId::from_name("RegisterUnusedCallback")
+    }
+}
+
+fn register_unused_callback<'a, 'b, 'c>(
+    _: &mut TestState,
+    _: RegisterUnusedCallback,
+    ctx: &mut ReducerContext<'a, 'b, 'c, TestState>,
+) {
+    let _unused = ctx
+        .effects
+        .bind(UploadFinished, reduce_with!(on_upload_finished));
+}
+
 #[test]
 fn test_capability_effect_loop() {
     let mut runtime = Runtime::default();
@@ -141,6 +160,74 @@ fn test_capability_effect_loop() {
     let state = runtime.get_global_state::<TestState>().unwrap();
     assert_eq!(state.data, "uploaded 11 bytes");
     assert_eq!(state.completions, 1);
+}
+
+#[test]
+fn discard_pending_effects_removes_envelopes_and_one_shot_callbacks() {
+    let mut runtime = Runtime::default();
+    runtime
+        .add_global_state(Box::new(TestState::default()))
+        .unwrap();
+
+    let mut registry = crate::registry::ActionRegistry::new();
+    registry.register(reduce_with!(on_upload_requested));
+    runtime.absorb_registry(registry);
+    runtime
+        .dispatch(
+            ActionEnvelope {
+                id: UploadRequested::static_id(),
+                payload: UploadRequested.encode(),
+            },
+            crate::WidgetId::from_u128(0),
+        )
+        .unwrap();
+
+    let completion = runtime.pending_effects[0]
+        .on_ok
+        .clone()
+        .expect("capability continuation");
+    assert_eq!(runtime.discard_pending_effects(), 2);
+    assert!(runtime.pending_effects.is_empty());
+
+    runtime
+        .dispatch_with_input(
+            completion,
+            crate::WidgetId::from_u128(0),
+            &crate::ActionInput::CapabilityOk {
+                capability: "upload-file".into(),
+                req_id: 0,
+                payload: serde_json::to_vec(&UploadFileOk { bytes: 11 }).unwrap(),
+            },
+        )
+        .unwrap();
+    let state = runtime.get_global_state::<TestState>().unwrap();
+    assert!(state.loading);
+    assert_eq!(state.completions, 0);
+}
+
+#[test]
+fn discard_pending_effects_removes_unattached_callbacks() {
+    let mut runtime = Runtime::default();
+    runtime
+        .add_global_state(Box::new(TestState::default()))
+        .unwrap();
+    let mut registry = crate::registry::ActionRegistry::new();
+    registry.register(reduce_with!(register_unused_callback));
+    runtime.absorb_registry(registry);
+
+    runtime
+        .dispatch(
+            ActionEnvelope {
+                id: RegisterUnusedCallback::static_id(),
+                payload: RegisterUnusedCallback.encode(),
+            },
+            crate::WidgetId::from_u128(0),
+        )
+        .unwrap();
+
+    assert!(runtime.pending_effects.is_empty());
+    assert_eq!(runtime.discard_pending_effects(), 1);
+    assert_eq!(runtime.discard_pending_effects(), 0);
 }
 
 #[test]

--- a/crates/core/fission-core/src/ui/mod.rs
+++ b/crates/core/fission-core/src/ui/mod.rs
@@ -17,7 +17,6 @@ pub use widgets::{
     IosVideoAudioOptions, LayoutBuilder, LazyColumn, Overlay, Positioned, Pressable, PressableRole,
     PressableStyle, Provider, Radio, Responsive, ResponsiveCase, ResponsiveQuery, RichText,
     RichTextRun, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer, Switch, Text, TextContent,
-    TextContextMenuAction, TextContextMenuConfig, TextFontStyle, TextInput, TextInputChangePayload,
-    TextRunStyle, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource,
-    ZStack,
+    TextContextMenuAction, TextContextMenuConfig, TextFontStyle, TextInput, TextRunStyle, Video,
+    VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource, ZStack,
 };

--- a/crates/core/fission-core/src/ui/widgets/mod.rs
+++ b/crates/core/fission-core/src/ui/widgets/mod.rs
@@ -66,7 +66,7 @@ pub use spacer::Spacer;
 pub use stack::ZStack;
 pub use switch::Switch;
 pub use text::{RichText, RichTextRun, Text, TextContent, TextFontStyle, TextRunStyle};
-pub use text_input::{TextInput, TextInputChangePayload};
+pub use text_input::TextInput;
 pub use transform::Transform;
 pub use video::{
     IosAudioSessionCategory, IosAudioSessionCategoryOption, IosAudioSessionMode,

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -38,18 +38,6 @@ pub enum DragStartBehavior {
     Down,
 }
 
-/// Payload contract used by [`TextInput::on_change`].
-///
-/// The default keeps text input generic and dispatches `String` payloads even
-/// when the platform keyboard hint is numeric. Widgets that own a numeric
-/// contract, such as `NumberInput`, can opt into `Number` explicitly.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub enum TextInputChangePayload {
-    #[default]
-    Text,
-    Number,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TextUndoController {
     pub capacity: usize,
@@ -219,12 +207,12 @@ pub(crate) fn text_input_toolbar_button_id(
 /// # Example
 ///
 /// ```rust,ignore
-/// let on_change = ctx.bind(TextChanged { .. }, reduce_with!(handle_text));
+/// let on_input = ctx.bind(EditSearch, reduce_with!(handle_search_input));
 ///
 /// TextInput {
 ///     value: view.state().query.clone(),
 ///     placeholder: Some("Search...".into()),
-///     on_change: Some(on_change),
+///     on_input: Some(on_input),
 ///     ..Default::default()
 /// }
 /// ```
@@ -265,10 +253,10 @@ pub struct TextInput {
     /// Optional explicit counter text shown below the field.
     pub counter_text: Option<TextContent>,
     /// Action dispatched when the text changes.
-    pub on_change: Option<ActionEnvelope>,
-    /// Payload type dispatched for `on_change`.
-    #[serde(default)]
-    pub change_payload: TextInputChangePayload,
+    ///
+    /// The bound action payload is preserved. The reducer reads the live text,
+    /// widget identity, caret, and anchor from [`crate::ActionInput::text_change`].
+    pub on_input: Option<ActionEnvelope>,
     /// Action dispatched when the user submits the field (for example by pressing Enter
     /// on a single-line input).
     pub on_submit: Option<ActionEnvelope>,
@@ -767,8 +755,7 @@ impl Default for TextInput {
             helper_text: None,
             error_text: None,
             counter_text: None,
-            on_change: None,
-            change_payload: TextInputChangePayload::Text,
+            on_input: None,
             on_submit: None,
             on_editing_complete: None,
             on_tap_outside: None,
@@ -1905,16 +1892,11 @@ impl InternalLower for TextInput {
             capture_tab: self.capture_tab,
             auto_indent: self.auto_indent,
         };
-        if let Some(env) = &self.on_change {
+        if let Some(env) = &self.on_input {
             semantics.actions.entries.push(fission_ir::ActionEntry {
-                trigger: match self.change_payload {
-                    TextInputChangePayload::Text => fission_ir::semantics::ActionTrigger::Change,
-                    TextInputChangePayload::Number => {
-                        fission_ir::semantics::ActionTrigger::NumberChange
-                    }
-                },
+                trigger: fission_ir::semantics::ActionTrigger::TextChanged,
                 action_id: env.id.as_u128(),
-                payload_data: None,
+                payload_data: Some(env.payload.clone()),
             });
         }
         if let Some(env) = &self.on_cursor_change {

--- a/crates/core/fission-core/tests/input_controller_tests.rs
+++ b/crates/core/fission-core/tests/input_controller_tests.rs
@@ -404,9 +404,9 @@ fn create_text_node(id: WidgetId, val: &str, multiline: bool) -> CoreIR {
                 identifier: None,
                 actions: ActionSet {
                     entries: vec![ActionEntry {
-                        trigger: ActionTrigger::Change,
+                        trigger: ActionTrigger::TextChanged,
                         action_id: 1,
-                        payload_data: None,
+                        payload_data: Some(b"null".to_vec()),
                     }],
                 },
                 action_scope_id: None,
@@ -527,21 +527,6 @@ fn set_input_type(ir: &mut CoreIR, id: WidgetId, input_type: TextInputType) {
     if let Some(node) = ir.nodes.get_mut(&id) {
         if let Op::Semantics(semantics) = &mut node.op {
             semantics.text_input_type = input_type;
-        }
-    }
-}
-
-fn set_change_trigger(ir: &mut CoreIR, id: WidgetId, trigger: ActionTrigger) {
-    if let Some(node) = ir.nodes.get_mut(&id) {
-        if let Op::Semantics(semantics) = &mut node.op {
-            if let Some(entry) = semantics
-                .actions
-                .entries
-                .iter_mut()
-                .find(|entry| entry.trigger == ActionTrigger::Change)
-            {
-                entry.trigger = trigger;
-            }
         }
     }
 }
@@ -760,9 +745,14 @@ fn test_ime_commit_replaces_preedit_range_and_dispatches_change() {
     assert_eq!(state.caret, "hello 世界".len());
     assert_eq!(state.anchor, "hello 世界".len());
     assert_eq!(ctx.dispatched_actions.len(), 1);
-    let (_, change, _) = &ctx.dispatched_actions[0];
-    let changed_text: String = serde_json::from_slice(&change.payload).unwrap();
-    assert_eq!(changed_text, "hello 世界");
+    let (target, envelope, input) = &ctx.dispatched_actions[0];
+    assert_eq!(*target, node_id);
+    assert_eq!(envelope.payload, b"null");
+    let change = input.text_change().expect("text change input");
+    assert_eq!(change.node_id, node_id);
+    assert_eq!(change.new_text, "hello 世界");
+    assert_eq!(change.new_caret, "hello 世界".len());
+    assert_eq!(change.new_anchor, "hello 世界".len());
 }
 
 #[test]
@@ -827,9 +817,9 @@ fn create_rich_text_input_tree(
                 identifier: None,
                 actions: ActionSet {
                     entries: vec![ActionEntry {
-                        trigger: ActionTrigger::Change,
+                        trigger: ActionTrigger::TextChanged,
                         action_id: 1,
-                        payload_data: None,
+                        payload_data: Some(b"null".to_vec()),
                     }],
                 },
                 action_scope_id: None,
@@ -1046,10 +1036,10 @@ fn test_text_input_typing() {
     });
     assert!(controller.handle_event(&mut ctx, &event));
 
-    let (target, env, _input) = &ctx.dispatched_actions[0];
+    let (target, env, input) = &ctx.dispatched_actions[0];
     assert_eq!(*target, node_id);
-    let new_text: String = serde_json::from_slice(&env.payload).unwrap();
-    assert_eq!(new_text, "Hello!");
+    assert_eq!(env.payload, b"null");
+    assert_eq!(input.text_change().unwrap().new_text, "Hello!");
 
     let st = ctx.text_edit.get(node_id).unwrap();
     assert_eq!(st.caret, 6);
@@ -1095,12 +1085,14 @@ fn test_text_input_typing_without_relayout_does_not_drop_chars() {
     assert!(controller.handle_event(&mut ctx, &event_b));
     assert_eq!(ctx.dispatched_actions.len(), 2);
 
-    let first_payload: String =
-        serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-    let second_payload: String =
-        serde_json::from_slice(&ctx.dispatched_actions[1].1.payload).unwrap();
-    assert_eq!(first_payload, "a");
-    assert_eq!(second_payload, "ab");
+    assert_eq!(
+        ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+        "a"
+    );
+    assert_eq!(
+        ctx.dispatched_actions[1].2.text_change().unwrap().new_text,
+        "ab"
+    );
 
     let st = ctx.text_edit.get(node_id).unwrap();
     assert_eq!(st.buffer.to_string(), "ab");
@@ -1164,9 +1156,10 @@ fn test_text_input_copy_paste() {
         });
         assert!(controller.handle_event(&mut ctx, &event));
 
-        let new_text: String =
-            serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-        assert_eq!(new_text, "SelectMeSelect");
+        assert_eq!(
+            ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+            "SelectMeSelect"
+        );
     }
 }
 
@@ -1208,9 +1201,10 @@ fn test_emoji_navigation_and_deletion() {
         });
         assert!(controller.handle_event(&mut ctx, &event));
 
-        let new_text: String =
-            serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-        assert_eq!(new_text, "Hi ");
+        assert_eq!(
+            ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+            "Hi "
+        );
 
         let st = ctx.text_edit.get(node_id).unwrap();
         assert_eq!(st.caret, 3);
@@ -1426,9 +1420,9 @@ fn test_selection_mechanics() {
         });
         assert!(controller.handle_event(&mut ctx, &event));
 
-        let (_target, env, _input) = &ctx.dispatched_actions[0];
-        let new_text: String = serde_json::from_slice(&env.payload).unwrap();
-        assert_eq!(new_text, "XCD");
+        let (_target, env, input) = &ctx.dispatched_actions[0];
+        assert_eq!(env.payload, b"null");
+        assert_eq!(input.text_change().unwrap().new_text, "XCD");
 
         let st = ctx.text_edit.get(node_id).unwrap();
         assert_eq!(st.caret, 1);
@@ -1575,8 +1569,10 @@ fn test_forward_delete_removes_next_grapheme() {
     });
     assert!(controller.handle_event(&mut ctx, &event));
 
-    let new_text: String = serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-    assert_eq!(new_text, "acd");
+    assert_eq!(
+        ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+        "acd"
+    );
 
     let st = ctx.text_edit.get(node_id).unwrap();
     assert_eq!(st.caret, 1);
@@ -1670,9 +1666,10 @@ fn test_apple_meta_delete_shortcuts_trim_current_line() {
             modifiers: MOD_SUPER,
         });
         assert!(controller.handle_event(&mut ctx, &event));
-        let new_text: String =
-            serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-        assert_eq!(new_text, " world");
+        assert_eq!(
+            ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+            " world"
+        );
         let st = ctx.text_edit.get(node_id).unwrap();
         assert_eq!(st.caret, 0);
     }
@@ -1695,9 +1692,10 @@ fn test_apple_meta_delete_shortcuts_trim_current_line() {
             modifiers: MOD_SUPER,
         });
         assert!(controller.handle_event(&mut ctx, &event));
-        let new_text: String =
-            serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-        assert_eq!(new_text, "hello ");
+        assert_eq!(
+            ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+            "hello "
+        );
         let st = ctx.text_edit.get(node_id).unwrap();
         assert_eq!(st.caret, 6);
     }
@@ -2087,8 +2085,10 @@ fn test_text_capitalization_words_applies_to_inserted_text() {
         modifiers: 0,
     });
     assert!(controller.handle_event(&mut ctx, &event));
-    let new_text: String = serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-    assert_eq!(new_text, "hello W");
+    assert_eq!(
+        ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+        "hello W"
+    );
 }
 
 #[test]
@@ -2129,8 +2129,10 @@ fn test_digits_only_formatter_filters_paste() {
         modifiers: paste_mod,
     });
     assert!(controller.handle_event(&mut ctx, &event));
-    let new_text: String = serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-    assert_eq!(new_text, "123");
+    assert_eq!(
+        ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+        "123"
+    );
 }
 
 #[test]
@@ -2164,80 +2166,9 @@ fn test_number_keyboard_hint_filters_ime_commit_but_dispatches_text() {
         text: "12ab.3".into(),
     });
     assert!(controller.handle_event(&mut ctx, &event));
-    let new_text: String = serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-    assert_eq!(new_text, "12.3");
-}
-
-#[test]
-fn test_explicit_number_change_trigger_dispatches_float_payload() {
-    let node_id = WidgetId::derived(29, &[2]);
-    let mut ir = create_text_node(node_id, "", false);
-    set_input_type(&mut ir, node_id, TextInputType::Number);
-    set_change_trigger(&mut ir, node_id, ActionTrigger::NumberChange);
-    let layout = LayoutSnapshot::new(LayoutSize::new(100.0, 100.0));
-    let mut text_edit = TextEditStateMap::default();
-    let mut interaction = InteractionStateMap::default();
-    let mut scroll = ScrollStateMap::default();
-    let mut gesture = fission_core::env::GestureState::default();
-    let clipboard: Arc<dyn Clipboard> = Arc::new(MockClipboard::new());
-    let measurer: Arc<dyn TextMeasurer> = Arc::new(MockTextMeasurer);
-
-    interaction.set_focused(Some(node_id));
-    text_edit.set_caret(node_id, 0, Some(0));
-
-    let mut controller = TextInputController;
-    let mut ctx = setup_ctx(
-        &ir,
-        &layout,
-        &mut text_edit,
-        &mut interaction,
-        &mut scroll,
-        &mut gesture,
-        &clipboard,
-        Some(&measurer),
-    );
-    let event = InputEvent::Ime(fission_core::event::ImeEvent::Commit {
-        text: "12ab.3".into(),
-    });
-    assert!(controller.handle_event(&mut ctx, &event));
-    let new_val: f32 = serde_json::from_slice(&ctx.dispatched_actions[0].1.payload).unwrap();
-    assert_eq!(new_val, 12.3);
-}
-
-#[test]
-fn test_explicit_number_change_trigger_skips_invalid_float_commit() {
-    let node_id = WidgetId::derived(29, &[1]);
-    let mut ir = create_text_node(node_id, "", false);
-    set_input_type(&mut ir, node_id, TextInputType::Number);
-    set_change_trigger(&mut ir, node_id, ActionTrigger::NumberChange);
-    let layout = LayoutSnapshot::new(LayoutSize::new(100.0, 100.0));
-    let mut text_edit = TextEditStateMap::default();
-    let mut interaction = InteractionStateMap::default();
-    let mut scroll = ScrollStateMap::default();
-    let mut gesture = fission_core::env::GestureState::default();
-    let clipboard: Arc<dyn Clipboard> = Arc::new(MockClipboard::new());
-    let measurer: Arc<dyn TextMeasurer> = Arc::new(MockTextMeasurer);
-
-    interaction.set_focused(Some(node_id));
-    text_edit.set_caret(node_id, 0, Some(0));
-
-    let mut controller = TextInputController;
-    let mut ctx = setup_ctx(
-        &ir,
-        &layout,
-        &mut text_edit,
-        &mut interaction,
-        &mut scroll,
-        &mut gesture,
-        &clipboard,
-        Some(&measurer),
-    );
-    let event = InputEvent::Ime(fission_core::event::ImeEvent::Commit { text: "-".into() });
-
-    assert!(controller.handle_event(&mut ctx, &event));
-    assert!(
-        ctx.dispatched_actions.is_empty(),
-        "invalid numeric text should update editing state without dispatching a f32 payload"
+    assert_eq!(
+        ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+        "12.3"
     );
 }
 
@@ -3100,10 +3031,10 @@ fn test_multiline_enter_key() {
     });
     assert!(controller.handle_event(&mut ctx, &event));
 
-    let (target, env, _input) = &ctx.dispatched_actions[0];
+    let (target, env, input) = &ctx.dispatched_actions[0];
     assert_eq!(*target, node_id);
-    let new_text: String = serde_json::from_slice(&env.payload).unwrap();
-    assert_eq!(new_text, "Line One\n");
+    assert_eq!(env.payload, b"null");
+    assert_eq!(input.text_change().unwrap().new_text, "Line One\n");
     assert_eq!(
         ctx.text_edit.get(node_id).unwrap().caret,
         "Line One\n".len()

--- a/crates/core/fission-core/tests/text_input_contextual_actions.rs
+++ b/crates/core/fission-core/tests/text_input_contextual_actions.rs
@@ -532,8 +532,8 @@ fn second_handler(state: &mut MulticastState, _: EditText) {
 #[test]
 fn typed_action_registry_handlers_remain_multicast() {
     let mut registry = fission_core::ActionRegistry::<MulticastState>::new();
-    registry.register(fission_core::reduce!(first_handler));
-    registry.register(fission_core::reduce!(second_handler));
+    registry.register(first_handler as fn(&mut MulticastState, EditText));
+    registry.register(second_handler as fn(&mut MulticastState, EditText));
     let mut state = MulticastState::default();
 
     registry
@@ -574,7 +574,7 @@ fn handle_sensitive(state: &mut SensitiveState, _: SensitiveAction) {
 fn deserialization_failure_is_sanitized_and_does_not_remove_the_reducer() {
     let mut runtime = Runtime::default().with_global_state(SensitiveState::default());
     let mut registry = fission_core::ActionRegistry::<SensitiveState>::new();
-    registry.register(fission_core::reduce!(handle_sensitive));
+    registry.register(handle_sensitive as fn(&mut SensitiveState, SensitiveAction));
     runtime.absorb_registry(registry);
     let node_id = WidgetId::explicit("malformed-action");
     let malformed = ActionEnvelope {

--- a/crates/core/fission-core/tests/text_input_contextual_actions.rs
+++ b/crates/core/fission-core/tests/text_input_contextual_actions.rs
@@ -1,0 +1,608 @@
+use std::collections::BTreeMap;
+
+use fission_core::env::{
+    ContextMenuState, InteractionStateMap, ScrollStateMap, SelectableTextStateMap, TextEditStateMap,
+};
+use fission_core::event::{ImeEvent, InputEvent, KeyCode, KeyEvent};
+use fission_core::input::text::TextInputController;
+use fission_core::input::{
+    prepare_scoped_text_input_change, prepare_text_input_change, ControllerContext, InputController,
+};
+use fission_core::internal::{self, BuildCtx};
+use fission_core::ui::{Column, TextInput, Widget};
+use fission_core::{
+    build, Action, ActionEnvelope, ActionId, ActionInput, Env, GlobalState, ReducerContext,
+    Runtime, StateField, UpdateTextInput, View, WidgetId, WidgetIdExt,
+};
+use fission_ir::semantics::{ActionEntry, ActionSet, ActionTrigger, Role};
+use fission_ir::{CoreIR, Op, Semantics};
+use fission_layout::{LayoutSize, LayoutSnapshot};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EditText;
+
+impl Action for EditText {
+    fn static_id() -> ActionId {
+        ActionId::from_name("text_input_actions::EditText")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct UpdateField(String);
+
+impl Action for UpdateField {
+    fn static_id() -> ActionId {
+        ActionId::from_name("text_input_actions::UpdateField")
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct Draft {
+    values: BTreeMap<String, String>,
+    last_node: Option<WidgetId>,
+    last_selection: Option<(usize, usize)>,
+    invocations: usize,
+}
+
+impl GlobalState for Draft {}
+
+fn update_field(draft: &mut Draft, action: UpdateField, context: &mut ReducerContext<Draft>) {
+    let Some(change) = context.input.text_change() else {
+        return;
+    };
+    draft.values.insert(action.0, change.new_text.clone());
+    draft.last_node = Some(change.node_id);
+    draft.last_selection = Some((change.new_caret, change.new_anchor));
+    draft.invocations += 1;
+}
+
+fn envelope<A: Action>(action: A) -> ActionEnvelope {
+    ActionEnvelope {
+        id: A::static_id(),
+        payload: action.encode(),
+    }
+}
+
+fn bound_field_action(field: &str) -> ActionEnvelope {
+    envelope(UpdateField(field.to_string()))
+}
+
+fn text_semantics<'a>(ir: &'a CoreIR, identifier: &str) -> (WidgetId, &'a Semantics) {
+    ir.nodes
+        .iter()
+        .find_map(|(id, node)| match &node.op {
+            Op::Semantics(semantics)
+                if semantics.role == Role::TextInput
+                    && semantics.identifier.as_deref() == Some(identifier) =>
+            {
+                Some((*id, semantics))
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("text semantics `{identifier}`"))
+}
+
+fn one_action_semantics(action: &ActionEnvelope, value: &str) -> Semantics {
+    Semantics {
+        role: Role::TextInput,
+        value: Some(value.to_string()),
+        actions: ActionSet {
+            entries: vec![ActionEntry {
+                trigger: ActionTrigger::TextChanged,
+                action_id: action.id.as_u128(),
+                payload_data: Some(action.payload.clone()),
+            }],
+        },
+        focusable: true,
+        ..Semantics::default()
+    }
+}
+
+#[test]
+fn lowering_preserves_unit_and_field_action_payloads() {
+    let actions = [envelope(EditText), bound_field_action("smtp_host")];
+
+    for (index, action) in actions.into_iter().enumerate() {
+        let identifier = format!("field.{index}");
+        let ir = internal::lower_widget_to_ir(&Widget::from(TextInput {
+            semantics_identifier: Some(identifier.clone()),
+            on_input: Some(action.clone()),
+            ..Default::default()
+        }));
+        let (_, semantics) = text_semantics(&ir, &identifier);
+        let entry = semantics.actions.entries.first().expect("input action");
+        assert_eq!(entry.trigger, ActionTrigger::TextChanged);
+        assert_eq!(entry.action_id, action.id.as_u128());
+        assert_eq!(
+            entry.payload_data.as_deref(),
+            Some(action.payload.as_slice())
+        );
+    }
+}
+
+#[test]
+fn preparation_separates_static_context_from_complete_edit_details() {
+    let action = bound_field_action("smtp_host");
+    let node_id = WidgetId::explicit("smtp-host");
+    let semantics = one_action_semantics(&action, "");
+
+    let (prepared, input) =
+        prepare_text_input_change(&semantics, node_id, "greenmail".into(), 7, 2).unwrap();
+
+    assert_eq!(prepared, action);
+    let change = input.text_change().expect("text change");
+    assert_eq!(change.node_id, node_id);
+    assert_eq!(change.new_text, "greenmail");
+    assert_eq!(change.new_caret, 7);
+    assert_eq!(change.new_anchor, 2);
+}
+
+#[test]
+fn scoped_preparation_resolves_the_nearest_action_scope() {
+    let action = bound_field_action("smtp_host");
+    let node_id = WidgetId::explicit("scoped-input");
+    let mut semantics = one_action_semantics(&action, "");
+    semantics.action_scope_id = Some(73);
+    let mut ir = CoreIR::default();
+    ir.nodes.insert(
+        node_id,
+        fission_ir::CoreNode {
+            id: node_id,
+            parent: None,
+            children: Vec::new(),
+            op: Op::Semantics(semantics),
+            composite: fission_ir::CompositeStyle::default(),
+            hash: 0,
+        },
+    );
+    let semantics = match &ir.nodes[&node_id].op {
+        Op::Semantics(semantics) => semantics,
+        _ => unreachable!(),
+    };
+
+    let (prepared, input) =
+        prepare_scoped_text_input_change(&ir, semantics, node_id, "greenmail".into(), 9, 4)
+            .unwrap();
+
+    assert_eq!(prepared, action);
+    assert_eq!(input.action_scope_id(), Some(73));
+    assert_eq!(input.scoped_target(), Some(node_id));
+    assert_eq!(input.text_change().unwrap().new_text, "greenmail");
+}
+
+fn dispatch_native_edit(
+    event: InputEvent,
+    initial_text: &str,
+    caret: usize,
+) -> (WidgetId, ActionEnvelope, ActionInput) {
+    let action = bound_field_action("smtp_host");
+    let node_id = WidgetId::explicit("native-input");
+    let mut semantics = one_action_semantics(&action, initial_text);
+    semantics.action_scope_id = Some(91);
+    let mut ir = CoreIR::default();
+    ir.nodes.insert(
+        node_id,
+        fission_ir::CoreNode {
+            id: node_id,
+            parent: None,
+            children: Vec::new(),
+            op: Op::Semantics(semantics),
+            composite: fission_ir::CompositeStyle::default(),
+            hash: 0,
+        },
+    );
+
+    let layout = LayoutSnapshot::new(LayoutSize::new(100.0, 40.0));
+    let mut text_edit = TextEditStateMap::default();
+    text_edit.sync_from_runtime(node_id, initial_text, None, None);
+    text_edit.set_caret(node_id, caret, Some(caret));
+    let mut selectable_text = SelectableTextStateMap::default();
+    let mut context_menu = ContextMenuState::default();
+    let mut interaction = InteractionStateMap::default();
+    interaction.set_focused(Some(node_id));
+    let mut scroll = ScrollStateMap::default();
+    let mut gesture = fission_core::env::GestureState::default();
+    let mut context = ControllerContext {
+        ir: &ir,
+        layout: &layout,
+        text_edit: &mut text_edit,
+        selectable_text: &mut selectable_text,
+        context_menu: &mut context_menu,
+        interaction: &mut interaction,
+        scroll: &mut scroll,
+        gesture: &mut gesture,
+        clipboard: None,
+        measurer: None,
+        dispatched_actions: Vec::new(),
+    };
+
+    assert!(TextInputController.handle_event(&mut context, &event));
+    assert_eq!(context.dispatched_actions.len(), 1);
+    context.dispatched_actions.pop().unwrap()
+}
+
+#[test]
+fn keyboard_edit_preserves_action_and_reports_post_edit_selection() {
+    let (target, action, input) = dispatch_native_edit(
+        InputEvent::Keyboard(KeyEvent::Down {
+            key_code: KeyCode::Char('Z'),
+            modifiers: 0,
+        }),
+        "ab",
+        1,
+    );
+
+    assert_eq!(target, WidgetId::explicit("native-input"));
+    assert_eq!(action, bound_field_action("smtp_host"));
+    assert_eq!(input.action_scope_id(), Some(91));
+    let change = input.text_change().unwrap();
+    assert_eq!(change.new_text, "aZb");
+    assert_eq!((change.new_caret, change.new_anchor), (2, 2));
+}
+
+#[test]
+fn ime_commit_uses_the_same_text_input_contract() {
+    let (_, action, input) = dispatch_native_edit(
+        InputEvent::Ime(ImeEvent::Commit { text: "界".into() }),
+        "ab",
+        1,
+    );
+
+    assert_eq!(action, bound_field_action("smtp_host"));
+    let change = input.text_change().unwrap();
+    assert_eq!(change.new_text, "a界b");
+    assert_eq!((change.new_caret, change.new_anchor), (4, 4));
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SearchState {
+    value: String,
+    invocations: usize,
+    node: Option<WidgetId>,
+    selection: Option<(usize, usize)>,
+}
+
+impl GlobalState for SearchState {}
+
+fn edit_search(state: &mut SearchState, _: EditText, context: &mut ReducerContext<SearchState>) {
+    let Some(change) = context.input.text_change() else {
+        return;
+    };
+    state.value = change.new_text.clone();
+    state.invocations += 1;
+    state.node = Some(change.node_id);
+    state.selection = Some((change.new_caret, change.new_anchor));
+}
+
+struct GlobalEditor;
+
+impl From<GlobalEditor> for Widget {
+    fn from(_: GlobalEditor) -> Widget {
+        let (context, _) = build::current::<SearchState>();
+        TextInput {
+            semantics_identifier: Some("global.search".into()),
+            on_input: Some(context.bind(EditText, fission_core::reduce!(edit_search))),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+#[test]
+fn simple_static_action_reads_the_edit_from_reducer_input() {
+    let mut state = SearchState::default();
+    let runtime_state = fission_core::RuntimeState::default();
+    let env = Env::default();
+    let view = View::new(&state, &runtime_state, &env, None);
+    let mut context = BuildCtx::<SearchState>::new();
+    let widget = build::enter(&mut context, &view, || GlobalEditor.into());
+    let ir = internal::lower_widget_to_ir(&widget);
+    let (node_id, semantics) = text_semantics(&ir, "global.search");
+    let (action, input) =
+        prepare_text_input_change(semantics, node_id, "query".into(), 5, 1).unwrap();
+
+    context
+        .registry
+        .dispatch_with_input(&mut state, &action, node_id, &input)
+        .unwrap();
+
+    assert_eq!(state.value, "query");
+    assert_eq!(state.invocations, 1);
+    assert_eq!(state.node, Some(node_id));
+    assert_eq!(state.selection, Some((5, 1)));
+}
+
+struct GlobalFields;
+
+impl From<GlobalFields> for Widget {
+    fn from(_: GlobalFields) -> Widget {
+        let (context, view) = build::current::<Draft>();
+        Column {
+            children: ["first.host", "first.port", "second.host", "second.port"]
+                .into_iter()
+                .map(|field| {
+                    TextInput {
+                        id: Some(WidgetId::explicit(field)),
+                        semantics_identifier: Some(field.into()),
+                        value: view.state().values.get(field).cloned().unwrap_or_default(),
+                        on_input: Some(context.bind(
+                            UpdateField(field.into()),
+                            fission_core::reduce!(update_field),
+                        )),
+                        ..Default::default()
+                    }
+                    .into()
+                })
+                .collect(),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+fn rebuild_global_fields(runtime: &mut Runtime, env: &Env) -> CoreIR {
+    let (widget, context) = {
+        let state = runtime.get_global_state::<Draft>().unwrap();
+        let view = View::new(state, &runtime.runtime_state, env, None);
+        let mut context = BuildCtx::<Draft>::new();
+        let widget = build::enter(&mut context, &view, || GlobalFields.into());
+        (widget, context)
+    };
+    let ir = internal::lower_widget_to_ir(&widget);
+    runtime.clear_reducers();
+    runtime.absorb_registry(context.registry);
+    ir
+}
+
+#[test]
+fn repeated_global_bindings_invoke_once_per_field_edit() {
+    let mut runtime = Runtime::default().with_global_state(Draft::default());
+    let env = Env::default();
+    let edits = [
+        ("first.host", "greenmail"),
+        ("first.port", "3025"),
+        ("second.host", "mailpit"),
+        ("second.port", "1025"),
+    ];
+
+    for (index, (field, value)) in edits.into_iter().enumerate() {
+        let ir = rebuild_global_fields(&mut runtime, &env);
+        dispatch_named_edit(&mut runtime, &ir, field, value);
+        let state = runtime.get_global_state::<Draft>().unwrap();
+        assert_eq!(state.invocations, index + 1);
+        assert_eq!(state.values.get(field).unwrap(), value);
+    }
+}
+
+struct LocalEditor {
+    scope: &'static str,
+}
+
+impl From<LocalEditor> for Widget {
+    fn from(editor: LocalEditor) -> Widget {
+        let (context, _) = build::current::<()>();
+        let draft = StateField::new("LocalEditor", "draft", Draft::default());
+        let value = draft.get();
+        let mut children: Vec<Widget> = ["host", "port"]
+            .into_iter()
+            .map(|field| {
+                TextInput {
+                    id: Some(WidgetId::explicit(&format!("{}.{}", editor.scope, field))),
+                    semantics_identifier: Some(format!("{}.{}", editor.scope, field)),
+                    value: value.values.get(field).cloned().unwrap_or_default(),
+                    on_input: Some(context.bind_local(
+                        UpdateField(field.into()),
+                        draft.clone(),
+                        fission_core::reduce!(update_field),
+                    )),
+                    ..Default::default()
+                }
+                .into()
+            })
+            .collect();
+        children.push(
+            TextInput {
+                semantics_identifier: Some(format!("{}.invocations", editor.scope)),
+                value: value.invocations.to_string(),
+                enabled: false,
+                read_only: true,
+                ..Default::default()
+            }
+            .into(),
+        );
+
+        Column {
+            children,
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+struct LocalEditors;
+
+impl From<LocalEditors> for Widget {
+    fn from(_: LocalEditors) -> Widget {
+        Column {
+            children: vec![
+                LocalEditor { scope: "first" }.id(WidgetId::explicit("editor.first")),
+                LocalEditor { scope: "second" }.id(WidgetId::explicit("editor.second")),
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+fn rebuild_local_editors(runtime: &mut Runtime, env: &Env) -> CoreIR {
+    let (widget, context) = {
+        let view = View::new(&(), &runtime.runtime_state, env, None);
+        let mut context = BuildCtx::<()>::new();
+        let widget = build::enter(&mut context, &view, || LocalEditors.into());
+        (widget, context)
+    };
+    let ir = internal::lower_widget_to_ir(&widget);
+    runtime.clear_reducers();
+    runtime.absorb_registry(context.registry);
+    ir
+}
+
+fn dispatch_named_edit(runtime: &mut Runtime, ir: &CoreIR, identifier: &str, text: &str) {
+    let (node_id, semantics) = text_semantics(ir, identifier);
+    let (action, input) =
+        prepare_text_input_change(semantics, node_id, text.into(), text.len(), text.len()).unwrap();
+    runtime
+        .dispatch_with_input(action, node_id, &input)
+        .unwrap();
+}
+
+fn rendered_value<'a>(ir: &'a CoreIR, identifier: &str) -> &'a str {
+    text_semantics(ir, identifier).1.value.as_deref().unwrap()
+}
+
+#[test]
+fn repeated_local_fields_rebuild_once_per_edit_without_duplicate_reducers() {
+    let mut runtime = Runtime::default();
+    let env = Env::default();
+    let mut ir = rebuild_local_editors(&mut runtime, &env);
+    let edits = [
+        ("first.host", "greenmail", "first.invocations", "1"),
+        ("first.port", "3025", "first.invocations", "2"),
+        ("second.host", "mailpit", "second.invocations", "1"),
+        ("second.port", "1025", "second.invocations", "2"),
+    ];
+
+    for (field, value, counter, expected_count) in edits {
+        dispatch_named_edit(&mut runtime, &ir, field, value);
+        ir = rebuild_local_editors(&mut runtime, &env);
+        assert_eq!(rendered_value(&ir, field), value);
+        assert_eq!(rendered_value(&ir, counter), expected_count);
+    }
+
+    assert_eq!(rendered_value(&ir, "first.host"), "greenmail");
+    assert_eq!(rendered_value(&ir, "first.port"), "3025");
+    assert_eq!(rendered_value(&ir, "second.host"), "mailpit");
+    assert_eq!(rendered_value(&ir, "second.port"), "1025");
+}
+
+#[test]
+fn local_action_deserialization_failure_is_sanitized_and_recoverable() {
+    let mut runtime = Runtime::default();
+    let env = Env::default();
+    let ir = rebuild_local_editors(&mut runtime, &env);
+    let (node_id, semantics) = text_semantics(&ir, "first.host");
+    let (valid, input) =
+        prepare_text_input_change(semantics, node_id, "greenmail".into(), 9, 9).unwrap();
+    let malformed = ActionEnvelope {
+        id: valid.id,
+        payload: br#"{"credential":"credential-value"}"#.to_vec(),
+    };
+
+    let error = runtime
+        .dispatch_with_input(malformed, node_id, &input)
+        .expect_err("malformed local action payload must fail");
+    assert_eq!(error.to_string(), "failed to deserialize action payload");
+    assert!(!format!("{error:#?}").contains("credential-value"));
+
+    runtime
+        .dispatch_with_input(valid, node_id, &input)
+        .expect("failed deserialization must not remove a local reducer");
+    let rebuilt = rebuild_local_editors(&mut runtime, &env);
+    assert_eq!(rendered_value(&rebuilt, "first.host"), "greenmail");
+    assert_eq!(rendered_value(&rebuilt, "first.invocations"), "1");
+}
+
+#[derive(Debug, Clone, Default)]
+struct MulticastState {
+    first: usize,
+    second: usize,
+}
+
+impl GlobalState for MulticastState {}
+
+fn first_handler(state: &mut MulticastState, _: EditText) {
+    state.first += 1;
+}
+
+fn second_handler(state: &mut MulticastState, _: EditText) {
+    state.second += 1;
+}
+
+#[test]
+fn typed_action_registry_handlers_remain_multicast() {
+    let mut registry = fission_core::ActionRegistry::<MulticastState>::new();
+    registry.register(fission_core::reduce!(first_handler));
+    registry.register(fission_core::reduce!(second_handler));
+    let mut state = MulticastState::default();
+
+    registry
+        .dispatch(
+            &mut state,
+            &envelope(EditText),
+            WidgetId::explicit("target"),
+        )
+        .unwrap();
+
+    assert_eq!(state.first, 1);
+    assert_eq!(state.second, 1);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+enum SensitiveAction {
+    Allowed,
+}
+
+impl Action for SensitiveAction {
+    fn static_id() -> ActionId {
+        ActionId::from_name("text_input_actions::SensitiveAction")
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct SensitiveState {
+    invocations: usize,
+}
+
+impl GlobalState for SensitiveState {}
+
+fn handle_sensitive(state: &mut SensitiveState, _: SensitiveAction) {
+    state.invocations += 1;
+}
+
+#[test]
+fn deserialization_failure_is_sanitized_and_does_not_remove_the_reducer() {
+    let mut runtime = Runtime::default().with_global_state(SensitiveState::default());
+    let mut registry = fission_core::ActionRegistry::<SensitiveState>::new();
+    registry.register(fission_core::reduce!(handle_sensitive));
+    runtime.absorb_registry(registry);
+    let node_id = WidgetId::explicit("malformed-action");
+    let malformed = ActionEnvelope {
+        id: SensitiveAction::static_id(),
+        payload: br#""credential-value""#.to_vec(),
+    };
+    let input = ActionInput::TextChanged(UpdateTextInput {
+        node_id,
+        new_text: "new value".into(),
+        new_caret: 9,
+        new_anchor: 9,
+    });
+
+    let error = runtime
+        .dispatch_with_input(malformed, node_id, &input)
+        .expect_err("malformed action payload must fail");
+    assert_eq!(error.to_string(), "failed to deserialize action payload");
+    let rendered = format!("{error:#?}");
+    assert!(!rendered.contains("credential-value"));
+
+    runtime
+        .dispatch_with_input(envelope(SensitiveAction::Allowed), node_id, &input)
+        .expect("a failed deserialization must not remove the reducer");
+    assert_eq!(
+        runtime
+            .get_app_state::<SensitiveState>()
+            .unwrap()
+            .invocations,
+        1
+    );
+}

--- a/crates/core/fission-i18n/Cargo.toml
+++ b/crates/core/fission-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-i18n"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-ir/Cargo.toml
+++ b/crates/core/fission-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-ir"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-ir/src/semantics.rs
+++ b/crates/core/fission-ir/src/semantics.rs
@@ -107,12 +107,17 @@ pub enum ActionTrigger {
     Blur,
     /// A pointer-down happened outside the active text field.
     TapOutside,
-    /// The node's value changed (sliders, text inputs, etc.).
+    /// The node's value changed (for example, a slider moved).
     Change,
-    /// A text field changed and requests numeric `f32` payload dispatch.
+    /// Reserved legacy numeric text-change trigger.
     ///
-    /// This is intentionally separate from [`Change`] so a numeric keyboard
-    /// hint alone does not change the generic text-input payload contract.
+    /// Fission 0.11 `TextInput` never emits this trigger and shells must not
+    /// interpret it. It remains in place to preserve serialized IR enum
+    /// discriminants for the variants that follow it.
+    #[deprecated(
+        since = "0.11.0",
+        note = "TextInput uses TextChanged and carries live edits in ActionInput"
+    )]
     NumberChange,
     /// Text editing was explicitly completed by the current input method.
     EditingComplete,
@@ -128,6 +133,34 @@ pub enum ActionTrigger {
     DragLeave,
     /// Right-click or secondary mouse button.
     SecondaryClick,
+    /// A text field changed.
+    ///
+    /// The bound action payload remains unchanged. The edited value, widget
+    /// identity, caret, and anchor are delivered as runtime action input.
+    TextChanged,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActionTrigger;
+
+    #[test]
+    fn text_changed_round_trips_through_ir_serialization() {
+        let encoded = serde_json::to_string(&ActionTrigger::TextChanged).unwrap();
+        assert_eq!(encoded, "\"TextChanged\"");
+        let decoded: ActionTrigger = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, ActionTrigger::TextChanged);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn existing_action_trigger_discriminants_remain_stable() {
+        assert_eq!(ActionTrigger::Change as u8, 10);
+        assert_eq!(ActionTrigger::NumberChange as u8, 11);
+        assert_eq!(ActionTrigger::EditingComplete as u8, 12);
+        assert_eq!(ActionTrigger::SecondaryClick as u8, 18);
+        assert_eq!(ActionTrigger::TextChanged as u8, 19);
+    }
 }
 
 impl Default for ActionTrigger {

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-layout"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.10.1" }
+fission-ir = { path = "../fission-ir", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.10.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/Cargo.toml
+++ b/crates/core/fission-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-semantics"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,7 +15,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.10.1" }
+fission-ir = { path = "../fission-ir", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/core/fission-text-engine/Cargo.toml
+++ b/crates/core/fission-text-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-text-engine"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 license = "MIT"

--- a/crates/core/fission-theme/Cargo.toml
+++ b/crates/core/fission-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-theme"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -27,8 +27,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.10.1" }
+fission-ir = { path = "../fission-ir", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.10.1" }
+fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.11.0" }

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-vello"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,13 +15,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
+fission-render = { path = "../fission-render", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
 anyhow = "1.0"
 vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2", features = ["wgpu"] }
 parley = "0.7.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.10.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
 image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"

--- a/crates/rendering/fission-render-wgpu2d/Cargo.toml
+++ b/crates/rendering/fission-render-wgpu2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-wgpu2d"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -14,7 +14,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.10.1" }
+fission-render = { path = "../fission-render", version = "0.11.0" }
 anyhow = "1.0"
 bytemuck = { version = "1.16", features = ["derive"] }
 wgpu = { version = "26.0.1", default-features = false, features = ["std", "wgsl"] }

--- a/crates/rendering/fission-render/Cargo.toml
+++ b/crates/rendering/fission-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,8 +15,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -25,7 +25,7 @@ fission-shell = { path = "../fission-shell", version = "0.11.0" }
 fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.11.0" }
 fission-core = { path = "../../core/fission-core", version = "0.11.0" }
 fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
-winit = { package = "fission-winit", version = "0.30.13-fission.1" }
+winit = { package = "fission-winit", version = "0.30.13-fission.2" }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-desktop"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 license = "MIT"
@@ -21,19 +21,19 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.10.1" }
-fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.10.1" }
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
+fission-shell = { path = "../fission-shell", version = "0.11.0" }
+fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.11.0" }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
 anyhow = "1.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.10.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.10.1" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.10.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.10.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-desktop/tests/composition_cycles.rs
+++ b/crates/shell/fission-shell-desktop/tests/composition_cycles.rs
@@ -27,9 +27,11 @@ fn on_toggle(state: &mut GlobalState, _a: Toggle, _ctx: &mut ReducerContext<Glob
 }
 
 #[fission_macros::fission_action]
-struct UpdateText(String);
-fn on_update(state: &mut GlobalState, a: UpdateText, _ctx: &mut ReducerContext<GlobalState>) {
-    state.text = a.0;
+struct UpdateText;
+fn on_update(state: &mut GlobalState, _a: UpdateText, ctx: &mut ReducerContext<GlobalState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.text = change.new_text.clone();
+    }
 }
 
 #[derive(Clone, Default)]
@@ -83,7 +85,7 @@ impl From<Root> for Widget {
             TextInput {
                 value: view.state().text.clone(),
                 placeholder: Some("type".into()),
-                on_change: Some(ctx.bind(UpdateText("".into()), reduce_with!(on_update))),
+                on_input: Some(ctx.bind(UpdateText, reduce_with!(on_update))),
                 width: Some(200.0),
                 height: Some(40.0),
                 ..Default::default()

--- a/crates/shell/fission-shell-desktop/tests/composition_strict.rs
+++ b/crates/shell/fission-shell-desktop/tests/composition_strict.rs
@@ -30,9 +30,11 @@ fn on_toggle(state: &mut GlobalState, _a: Toggle, _ctx: &mut ReducerContext<Glob
 }
 
 #[fission_macros::fission_action]
-struct UpdateText(String);
-fn on_update(state: &mut GlobalState, a: UpdateText, _ctx: &mut ReducerContext<GlobalState>) {
-    state.text = a.0;
+struct UpdateText;
+fn on_update(state: &mut GlobalState, _a: UpdateText, ctx: &mut ReducerContext<GlobalState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.text = change.new_text.clone();
+    }
 }
 
 #[derive(Clone, Default)]
@@ -86,7 +88,7 @@ impl From<Root> for Widget {
             TextInput {
                 value: view.state().text.clone(),
                 placeholder: Some("type".into()),
-                on_change: Some(ctx.bind(UpdateText("".into()), reduce_with!(on_update))),
+                on_input: Some(ctx.bind(UpdateText, reduce_with!(on_update))),
                 width: Some(200.0),
                 height: Some(40.0),
                 ..Default::default()

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -27,6 +27,6 @@ fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-winit = { package = "fission-winit", version = "0.30.13-fission.1", features = ["android-native-activity"] }
+winit = { package = "fission-winit", version = "0.30.13-fission.2", features = ["android-native-activity"] }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-mobile"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -20,10 +20,10 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.10.1" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.10.1", default-features = false }
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
+fission-shell = { path = "../fission-shell", version = "0.11.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.11.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/shell/fission-shell-mobile/README.md
+++ b/crates/shell/fission-shell-mobile/README.md
@@ -8,9 +8,9 @@ Most application developers should use the public facade instead of depending on
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["android"] }
+fission = { version = "0.11.0", features = ["android"] }
 # or
-fission = { version = "0.10.1", features = ["ios"] }
+fission = { version = "0.11.0", features = ["ios"] }
 ```
 
 ## What it provides

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-server"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -28,12 +28,12 @@ axum = { version = "0.7", optional = true, default-features = false }
 base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-shell-site = { path = "../fission-shell-site", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-shell-site = { path = "../fission-shell-site", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
 getrandom = { version = "0.2", features = ["std"] }
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 moka = { version = "0.12", features = ["sync"] }
@@ -44,4 +44,4 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.10.1", default-features = false }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0", default-features = false }

--- a/crates/shell/fission-shell-server/README.md
+++ b/crates/shell/fission-shell-server/README.md
@@ -19,7 +19,7 @@ Most applications should depend on the public `fission` facade with the
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["server"] }
+fission = { version = "0.11.0", features = ["server"] }
 ```
 
 Enable adapter features through the facade when you want to host the renderer
@@ -27,7 +27,7 @@ inside an existing HTTP stack:
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["server", "server-axum"] }
+fission = { version = "0.11.0", features = ["server", "server-axum"] }
 ```
 
 See the guides and reference at <https://fission.rs> for the server app model,

--- a/crates/shell/fission-shell-server/assets/server-runtime.js
+++ b/crates/shell/fission-shell-server/assets/server-runtime.js
@@ -162,7 +162,14 @@
       case'set_checked_by_semantics': if(el&&'checked'in el)el.checked=!!op.checked; break;
       case'focus_by_semantics': if(el&&typeof el.focus==='function')el.focus(); break;
       case'blur_by_semantics': if(el&&typeof el.blur==='function')el.blur(); break;
-      case'replace_children_html_by_semantics': if(el&&typeof op.html==='string'){el.innerHTML=op.html;bindFissionBrowserActions(bridge);} break;
+      case'replace_children_html_by_semantics':
+        if(el&&typeof op.html==='string'){
+          var focused=captureFocusedTextControl(el);
+          el.innerHTML=op.html;
+          bindFissionBrowserActions(bridge);
+          restoreFocusedTextControl(el,focused);
+        }
+        break;
       case'set_stylesheet': setStylesheet(op.id,op.css); break;
       case'push_history': if(safeUrl(op.url))window.history.pushState({},'',op.url); break;
       case'replace_history': if(safeUrl(op.url))window.history.replaceState({},'',op.url); break;
@@ -213,8 +220,61 @@
     }
   }
 
+  function browserActionRoot(bridge){
+    if(bridge&&bridge.kind==='island'&&bridge.config&&bridge.config.mount_id){
+      return document.getElementById(bridge.config.mount_id)||bySemantics(bridge.config.mount_id);
+    }
+    return document;
+  }
+
+  function captureFocusedTextControl(root){
+    var active=document.activeElement;
+    if(!active||!root.contains(active)||!active.matches('input[data-fission-node],textarea[data-fission-node]'))return null;
+    return{
+      node:active.getAttribute('data-fission-node'),
+      start:typeof active.selectionStart==='number'?active.selectionStart:null,
+      end:typeof active.selectionEnd==='number'?active.selectionEnd:null,
+      direction:active.selectionDirection||'none'
+    };
+  }
+
+  function textControlByNode(root,node){
+    var controls=root.querySelectorAll('input[data-fission-node],textarea[data-fission-node]');
+    for(var index=0;index<controls.length;index++){
+      if(controls[index].getAttribute('data-fission-node')===node)return controls[index];
+    }
+    return null;
+  }
+
+  function restoreFocusedTextControl(root,focused){
+    if(!focused||!focused.node)return;
+    var control=textControlByNode(root,focused.node);
+    if(!control)return;
+    control.focus({preventScroll:true});
+    if(focused.start!==null&&focused.end!==null&&typeof control.setSelectionRange==='function'){
+      try{control.setSelectionRange(focused.start,focused.end,focused.direction);}catch(_error){}
+    }
+  }
+
+  function utf8Offset(value,utf16Offset){
+    var bounded=Math.max(0,Math.min(value.length,typeof utf16Offset==='number'?utf16Offset:value.length));
+    return textEncoder.encode(value.slice(0,bounded)).length;
+  }
+
+  function textControlSelection(el,value){
+    var start=typeof el.selectionStart==='number'?el.selectionStart:value.length;
+    var end=typeof el.selectionEnd==='number'?el.selectionEnd:start;
+    var backward=el.selectionDirection==='backward';
+    return{
+      caret:utf8Offset(value,backward?start:end),
+      anchor:utf8Offset(value,backward?end:start)
+    };
+  }
+
   function bindFissionBrowserActions(bridge){
-    document.querySelectorAll('[data-fission-browser-action="true"]').forEach(function(el){
+    var root=browserActionRoot(bridge);
+    if(!root)return;
+    root.querySelectorAll('[data-fission-browser-action="true"]').forEach(function(el){
       if(el.__fissionBrowserActionBound)return;
       el.__fissionBrowserActionBound=true;
       var handler=function(domEvent){
@@ -245,6 +305,56 @@
         }
       });
     });
+    root.querySelectorAll('[data-fission-browser-text-action="true"]').forEach(function(el){
+      if(el.__fissionBrowserTextActionBound)return;
+      el.__fissionBrowserTextActionBound=true;
+      var composing=false;
+      var compositionCommitValue=null;
+      el.addEventListener('compositionstart',function(){composing=true;compositionCommitValue=null;});
+      var dispatchTextInput=function(domEvent){
+        if(composing||domEvent.isComposing)return;
+        var value=String(el.value==null?'':el.value);
+        if(domEvent.type==='input'&&compositionCommitValue!==null){
+          var duplicateCompositionInput=value===compositionCommitValue;
+          compositionCommitValue=null;
+          if(duplicateCompositionInput)return;
+        }
+        var selection=textControlSelection(el,value);
+        var payload={
+          type:'event',
+          artifact:{kind:bridge.kind,id:bridge.id},
+          binding:{
+            semantics:el.getAttribute('data-fission-semantics')||null,
+            event:'input',
+            message:{
+              fission_browser_text_action:true,
+              target_node:el.getAttribute('data-fission-action-target')||''
+            }
+          },
+          value:value,
+          caret:selection.caret,
+          anchor:selection.anchor,
+          sequence:++bridge.sequence
+        };
+        try{dispatchBridgeEvent(bridge,payload);}catch(error){setTextBySemantics(bridge.statusSemantics,bridge.kind+' failed: '+error.message);}
+      };
+      el.addEventListener('compositionend',function(domEvent){
+        composing=false;
+        compositionCommitValue=String(el.value==null?'':el.value);
+        dispatchTextInput(domEvent);
+      });
+      el.addEventListener('input',dispatchTextInput);
+    });
+  }
+
+  if(globalThis.__FISSION_SERVER_RUNTIME_TEST_HOOK__){
+    globalThis.__FISSION_SERVER_RUNTIME_TEST_HOOK__={
+      bindFissionBrowserActions:bindFissionBrowserActions,
+      captureFocusedTextControl:captureFocusedTextControl,
+      restoreFocusedTextControl:restoreFocusedTextControl,
+      textControlSelection:textControlSelection,
+      utf8Offset:utf8Offset
+    };
   }
 
   function announce(text,politeness){

--- a/crates/shell/fission-shell-server/assets/server-runtime.test.mjs
+++ b/crates/shell/fission-shell-server/assets/server-runtime.test.mjs
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+class MockControl {
+  constructor(node, value = '') {
+    this.attributes = new Map([
+      ['data-fission-node', node],
+      ['data-fission-action-target', node],
+      ['data-fission-browser-text-action', 'true'],
+    ]);
+    this.value = value;
+    this.selectionStart = value.length;
+    this.selectionEnd = value.length;
+    this.selectionDirection = 'none';
+    this.listeners = new Map();
+    this.focused = false;
+    this.selectionSet = null;
+  }
+
+  addEventListener(kind, listener) {
+    const listeners = this.listeners.get(kind) || [];
+    listeners.push(listener);
+    this.listeners.set(kind, listeners);
+  }
+
+  emit(kind, event = {}) {
+    for (const listener of this.listeners.get(kind) || []) {
+      listener({ type: kind, isComposing: false, preventDefault() {}, ...event });
+    }
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  matches(selector) {
+    return selector.includes('input[data-fission-node]');
+  }
+
+  focus() {
+    this.focused = true;
+    globalThis.document.activeElement = this;
+  }
+
+  setSelectionRange(start, end, direction) {
+    this.selectionStart = start;
+    this.selectionEnd = end;
+    this.selectionDirection = direction;
+    this.selectionSet = [start, end, direction];
+  }
+}
+
+class MockRoot {
+  constructor(controls) {
+    this.controls = controls;
+  }
+
+  querySelectorAll(selector) {
+    if (selector === '[data-fission-browser-text-action="true"]') return this.controls;
+    if (selector.includes('input[data-fission-node]')) return this.controls;
+    return [];
+  }
+
+  contains(element) {
+    return this.controls.includes(element);
+  }
+}
+
+const roots = new Map();
+globalThis.document = {
+  activeElement: null,
+  body: {},
+  documentElement: { getAttribute() { return null; }, lang: 'en' },
+  addEventListener() {},
+  getElementById(id) { return roots.get(id) ?? null; },
+  querySelector() { return null; },
+  querySelectorAll() { return []; },
+};
+globalThis.window = {
+  CSS: { escape(value) { return String(value); } },
+  history: { pushState() {}, replaceState() {} },
+  location: { href: 'https://example.test/', pathname: '/' },
+};
+globalThis.__FISSION_SERVER_RUNTIME_TEST_HOOK__ = true;
+
+const runtimeSource = readFileSync(new URL('./server-runtime.js', import.meta.url), 'utf8');
+vm.runInThisContext(runtimeSource, { filename: 'server-runtime.js' });
+const hooks = globalThis.__FISSION_SERVER_RUNTIME_TEST_HOOK__;
+
+function boundBridge(root, control) {
+  roots.set('mount', root);
+  const posted = [];
+  const bridge = {
+    id: 'test-island',
+    kind: 'island',
+    config: { mount_id: 'mount' },
+    worker: { postMessage(message) { posted.push(message); } },
+    sequence: 0,
+    boundEvents: Object.create(null),
+  };
+  hooks.bindFissionBrowserActions(bridge);
+  return { bridge, control, posted };
+}
+
+function postedPayload(posted, index = 0) {
+  assert.equal(posted[index]?.kind, 'event');
+  return posted[index].payload;
+}
+
+test('text input sends value and UTF-8 selection without action metadata', () => {
+  const control = new MockControl('901', 'café');
+  control.selectionStart = 3;
+  control.selectionEnd = 4;
+  control.selectionDirection = 'backward';
+  const { posted } = boundBridge(new MockRoot([control]), control);
+
+  control.emit('input');
+
+  const payload = postedPayload(posted);
+  assert.equal(payload.value, 'café');
+  assert.equal(payload.caret, 3);
+  assert.equal(payload.anchor, 5);
+  assert.deepEqual(payload.binding.message, {
+    fission_browser_text_action: true,
+    target_node: '901',
+  });
+  assert.equal(payload.binding.message.action_id, undefined);
+  assert.equal(payload.binding.message.payload_hex, undefined);
+});
+
+test('number input falls back to the UTF-8 end when selection APIs are unavailable', () => {
+  const control = new MockControl('902', '2525');
+  control.selectionStart = null;
+  control.selectionEnd = null;
+  const { posted } = boundBridge(new MockRoot([control]), control);
+
+  control.emit('input');
+
+  const payload = postedPayload(posted);
+  assert.equal(payload.value, '2525');
+  assert.equal(payload.caret, 4);
+  assert.equal(payload.anchor, 4);
+});
+
+test('IME commit dispatches once and does not swallow the next real edit', () => {
+  const control = new MockControl('903');
+  const { posted } = boundBridge(new MockRoot([control]), control);
+
+  control.emit('compositionstart');
+  control.value = 'に';
+  control.selectionStart = 1;
+  control.selectionEnd = 1;
+  control.emit('input', { isComposing: true });
+  assert.equal(posted.length, 0);
+
+  control.emit('compositionend');
+  assert.equal(posted.length, 1);
+  assert.equal(postedPayload(posted).value, 'に');
+
+  control.emit('input');
+  assert.equal(posted.length, 1, 'duplicate post-composition input must be ignored');
+
+  control.value = '日本';
+  control.selectionStart = 2;
+  control.selectionEnd = 2;
+  control.emit('input');
+  assert.equal(posted.length, 2, 'next distinct edit must not be swallowed');
+  assert.equal(postedPayload(posted, 1).value, '日本');
+  assert.equal(postedPayload(posted, 1).caret, 6);
+});
+
+test('renderer replacement restores focused text selection by retained node', () => {
+  const original = new MockControl('904', 'abcdef');
+  original.selectionStart = 2;
+  original.selectionEnd = 5;
+  original.selectionDirection = 'backward';
+  const root = new MockRoot([original]);
+  document.activeElement = original;
+
+  const focused = hooks.captureFocusedTextControl(root);
+  const replacement = new MockControl('904', 'abcdef');
+  root.controls = [replacement];
+  hooks.restoreFocusedTextControl(root, focused);
+
+  assert.equal(replacement.focused, true);
+  assert.deepEqual(replacement.selectionSet, [2, 5, 'backward']);
+});
+
+test('UTF-16 DOM offsets convert to UTF-8 byte offsets', () => {
+  assert.equal(hooks.utf8Offset('a😀b', 0), 0);
+  assert.equal(hooks.utf8Offset('a😀b', 1), 1);
+  assert.equal(hooks.utf8Offset('a😀b', 3), 5);
+  assert.equal(hooks.utf8Offset('a😀b', 4), 6);
+});

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -2725,6 +2725,30 @@ same_site = "none"
         let runtime = runtime.body_string();
         assert!(runtime.contains("fission_bridge_alloc"));
         assert!(runtime.contains("fission-site-text-run"));
+        assert!(runtime.contains("data-fission-browser-text-action"));
+        assert!(runtime.contains("selectionDirection"));
+        assert!(runtime.contains("textEncoder.encode(value.slice(0,bounded)).length"));
+        assert!(runtime.contains("compositionCommitValue"));
+        assert!(runtime.contains("__FISSION_SERVER_RUNTIME_TEST_HOOK__"));
+    }
+
+    #[test]
+    fn server_runtime_dom_event_fixture_passes_when_node_is_available() {
+        let node = match std::process::Command::new("node").arg("--version").output() {
+            Ok(output) if output.status.success() => "node",
+            Ok(_) | Err(_) => {
+                eprintln!("node is unavailable; skipping server runtime DOM-event fixture");
+                return;
+            }
+        };
+        let fixture =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/server-runtime.test.mjs");
+        let status = std::process::Command::new(node)
+            .arg("--test")
+            .arg(&fixture)
+            .status()
+            .expect("failed to launch server runtime DOM-event fixture");
+        assert!(status.success(), "server runtime DOM-event fixture failed");
     }
 
     #[test]

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-site"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -17,13 +17,13 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-icons = { path = "../../authoring/fission-icons", version = "0.10.1" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.10.1", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-icons = { path = "../../authoring/fission-icons", version = "0.11.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -6,7 +6,7 @@ Static site shell for Fission applications and documentation sites.
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["site"] }
+fission = { version = "0.11.0", features = ["site"] }
 ```
 
 ```sh

--- a/crates/shell/fission-shell-site/src/browser_island.rs
+++ b/crates/shell/fission-shell-site/src/browser_island.rs
@@ -461,8 +461,8 @@ mod tests {
     use fission_core::op::Color;
     use fission_core::ui::TextInput;
     use fission_core::{
-        reduce, reduce_with, Action, ActionInput, ActionScope, ActionScopeId, Button, Effect,
-        ReducerContext, RuntimeEffect, StateField, Text,
+        reduce, reduce_with, Action, ActionInput, ActionScope, ActionScopeId, Button,
+        ReducerContext, StateField, Text,
     };
     use fission_ir::semantics::TextInputType;
 
@@ -695,9 +695,12 @@ mod tests {
         let on_ok = ctx
             .effects
             .bind(EffectFinished, reduce_with!(effect_finished));
+        ctx.effects.cancel(77);
         ctx.effects
-            .add(Effect::Runtime(RuntimeEffect::Cancel { req_id: 77 }))
-            .on_ok(on_ok);
+            .out
+            .last_mut()
+            .expect("cancel effect was queued")
+            .on_ok = Some(on_ok);
     }
 
     #[derive(Clone)]

--- a/crates/shell/fission-shell-site/src/browser_island.rs
+++ b/crates/shell/fission-shell-site/src/browser_island.rs
@@ -2,11 +2,12 @@ use crate::{render_ir_to_html_with_styles, CssVariableMap, HtmlRenderOptions, St
 use anyhow::{anyhow, Context, Result};
 use fission_core::internal::BuildCtx;
 use fission_core::internal::InternalLoweringCx;
-use fission_core::registry::{ActionRegistry, VideoRegistration, WebRegistration};
+use fission_core::registry::{VideoRegistration, WebRegistration};
 use fission_core::ui::{Overlay, ZStack};
 use fission_core::{
-    ActionEnvelope, ActionId, Env, GlobalState, RuntimeState, View, Widget, WidgetId,
+    ActionEnvelope, ActionId, Env, GlobalState, Runtime, RuntimeState, View, Widget, WidgetId,
 };
+use fission_ir::{semantics::ActionTrigger, CoreIR, Op, Role, Semantics};
 use fission_theme::Theme;
 use serde_json::{json, Value};
 use std::any::Any;
@@ -31,9 +32,10 @@ where
 {
     id: String,
     mount_id: String,
-    state: S,
+    runtime: Runtime,
     widget: W,
     theme: Theme,
+    _state: std::marker::PhantomData<fn() -> S>,
 }
 
 impl<S, W> BrowserIslandApp<S, W>
@@ -48,12 +50,14 @@ where
     /// semantic identifier rendered by the server page, because the browser
     /// bridge replaces that region with the island's current widget output.
     pub fn new(id: impl Into<String>, mount_id: impl Into<String>, state: S, widget: W) -> Self {
+        let runtime = Runtime::default().with_global_state(state);
         Self {
             id: id.into(),
             mount_id: mount_id.into(),
-            state,
+            runtime,
             widget,
             theme: Theme::default(),
+            _state: std::marker::PhantomData,
         }
     }
 
@@ -76,6 +80,9 @@ where
     }
 
     fn dispatch_browser_action(&mut self, message: &Value) -> Result<()> {
+        if is_browser_text_action(message) {
+            return self.dispatch_browser_text_action(message);
+        }
         let action = message
             .get("binding")
             .and_then(|binding| binding.get("message"))
@@ -100,31 +107,76 @@ where
             .unwrap_or_default();
 
         let output = self.build_widget();
-        let mut registry = output.registry;
-        registry.dispatch(
-            &mut self.state,
-            &ActionEnvelope {
+        self.install_registry(output.registry);
+        let dispatch = self.runtime.dispatch(
+            ActionEnvelope {
                 id: ActionId::from_u128(action_id),
                 payload,
             },
             WidgetId::from_u128(target),
-        )?;
+        );
+        self.finish_browser_dispatch(dispatch)?;
+        Ok(())
+    }
+
+    fn dispatch_browser_text_action(&mut self, message: &Value) -> Result<()> {
+        let action = message
+            .get("binding")
+            .and_then(|binding| binding.get("message"))
+            .ok_or_else(|| anyhow!("browser island text event is missing action metadata"))?;
+        let target = action
+            .get("target_node")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("browser island text event is missing target_node"))?
+            .parse::<u128>()
+            .context("browser island text target_node is not a u128")?;
+        let target = WidgetId::from_u128(target);
+        let new_text = message
+            .get("value")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("browser island text event is missing value"))?
+            .to_string();
+        let new_caret = bridge_text_offset(message, "caret", &new_text)?;
+        let new_anchor = bridge_text_offset(message, "anchor", &new_text)?;
+
+        let output = self.build_widget();
+        let ir = lower_browser_island_widget(
+            output.node,
+            output.portals,
+            &self.theme,
+            &self.runtime.runtime_state,
+        );
+        let semantics = ir
+            .nodes
+            .get(&target)
+            .and_then(|node| match &node.op {
+                Op::Semantics(semantics) => Some(semantics),
+                _ => None,
+            })
+            .ok_or_else(|| anyhow!("browser island text target {target} is not a semantic node"))?;
+        validate_browser_text_target(target, semantics)?;
+        let (envelope, input) = fission_core::input::prepare_scoped_text_input_change(
+            &ir, semantics, target, new_text, new_caret, new_anchor,
+        )
+        .ok_or_else(|| anyhow!("browser island text target {target} has no text-change action"))?;
+        self.install_registry(output.registry);
+        let dispatch = self.runtime.dispatch_with_input(envelope, target, &input);
+        self.finish_browser_dispatch(dispatch)?;
         Ok(())
     }
 
     fn render_bridge_output(&mut self, sequence: u64) -> Result<String> {
         let output = self.build_widget();
-        let node = compose_browser_island_portals(output.node, output.portals);
-        let runtime = RuntimeState::default();
-        let mut env = Env::default();
-        env.theme = self.theme.clone();
-        let mut lowering = InternalLoweringCx::new(&env, &runtime, None, None);
-        let root = fission_core::internal::lower_widget(&node, &mut lowering);
-        lowering.ir.set_root(root);
+        let ir = lower_browser_island_widget(
+            output.node,
+            output.portals,
+            &self.theme,
+            &self.runtime.runtime_state,
+        );
 
         let mut styles = StyleRegistry::default();
         let rendered = render_ir_to_html_with_styles(
-            &lowering.ir,
+            &ir,
             &HtmlRenderOptions {
                 document_title: self.id.clone(),
                 root_class: "fission-browser-island-root".to_string(),
@@ -177,10 +229,13 @@ where
     }
 
     fn build_widget(&self) -> BrowserIslandBuildOutput<S> {
-        let runtime = RuntimeState::default();
         let mut env = Env::default();
         env.theme = self.theme.clone();
-        let view = View::new(&self.state, &runtime, &env, None);
+        let state = self
+            .runtime
+            .get_global_state::<S>()
+            .expect("browser island state is registered at construction");
+        let view = View::new(state, &self.runtime.runtime_state, &env, None);
         let mut ctx = BuildCtx::<S>::new();
         let node = fission_core::build::enter(&mut ctx, &view, || self.widget.clone().into());
         let motion_declarations = ctx.take_motion_declarations();
@@ -197,11 +252,77 @@ where
             portals,
         }
     }
+
+    fn install_registry(&mut self, registry: fission_core::registry::ActionRegistry<S>) {
+        self.runtime.clear_reducers();
+        self.runtime.absorb_registry(registry);
+    }
+
+    fn finish_browser_dispatch(&mut self, dispatch: Result<()>) -> Result<()> {
+        let discarded_effects = self.runtime.discard_pending_effects();
+        dispatch?;
+        if discarded_effects > 0 {
+            anyhow::bail!(
+                "browser island `{}` reducer queued unsupported effects; discarded {discarded_effects} effect envelope(s) and completion callback(s)",
+                self.id
+            );
+        }
+        Ok(())
+    }
+}
+
+fn validate_browser_text_target(target: WidgetId, semantics: &Semantics) -> Result<()> {
+    if !matches!(semantics.role, Role::TextInput | Role::Input) {
+        anyhow::bail!("browser island text target {target} is not a text input");
+    }
+    if semantics.disabled {
+        anyhow::bail!("browser island text target {target} is disabled");
+    }
+    if semantics.read_only {
+        anyhow::bail!("browser island text target {target} is read-only");
+    }
+    if !semantics
+        .actions
+        .entries
+        .iter()
+        .any(|entry| entry.trigger == ActionTrigger::TextChanged)
+    {
+        anyhow::bail!("browser island text target {target} has no text-change action");
+    }
+    Ok(())
+}
+
+fn lower_browser_island_widget(
+    node: Widget,
+    portals: Vec<(Option<WidgetId>, Widget)>,
+    theme: &Theme,
+    runtime: &RuntimeState,
+) -> CoreIR {
+    let node = compose_browser_island_portals(node, portals);
+    let mut env = Env::default();
+    env.theme = theme.clone();
+    let mut lowering = InternalLoweringCx::new(&env, runtime, None, None);
+    let root = fission_core::internal::lower_widget(&node, &mut lowering);
+    lowering.ir.set_root(root);
+    lowering.ir
+}
+
+fn bridge_text_offset(message: &Value, field: &str, text: &str) -> Result<usize> {
+    let raw = message
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("browser island text event is missing {field}"))?;
+    let offset = usize::try_from(raw)
+        .with_context(|| format!("browser island text {field} does not fit usize"))?;
+    if offset > text.len() || !text.is_char_boundary(offset) {
+        anyhow::bail!("browser island text {field} is not a UTF-8 boundary");
+    }
+    Ok(offset)
 }
 
 struct BrowserIslandBuildOutput<S: GlobalState> {
     node: Widget,
-    registry: ActionRegistry<S>,
+    registry: fission_core::registry::ActionRegistry<S>,
     motion_declarations: Vec<fission_core::MotionDeclaration>,
     video_registrations: Vec<VideoRegistration>,
     web_registrations: Vec<WebRegistration>,
@@ -274,9 +395,25 @@ fn is_action_event(message: &Value) -> bool {
         && message
             .get("binding")
             .and_then(|binding| binding.get("message"))
-            .and_then(|action| action.get("fission_browser_action"))
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
+            .is_some_and(|action| {
+                action
+                    .get("fission_browser_action")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                    || action
+                        .get("fission_browser_text_action")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+            })
+}
+
+fn is_browser_text_action(message: &Value) -> bool {
+    message
+        .get("binding")
+        .and_then(|binding| binding.get("message"))
+        .and_then(|action| action.get("fission_browser_text_action"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn browser_island_error(id: &str, error: anyhow::Error) -> String {
@@ -322,7 +459,12 @@ fn hex_value(byte: u8) -> Option<u8> {
 mod tests {
     use super::*;
     use fission_core::op::Color;
-    use fission_core::{reduce_with, Action, Button, ReducerContext, Text};
+    use fission_core::ui::TextInput;
+    use fission_core::{
+        reduce, reduce_with, Action, ActionInput, ActionScope, ActionScopeId, Button, Effect,
+        ReducerContext, RuntimeEffect, StateField, Text,
+    };
+    use fission_ir::semantics::TextInputType;
 
     #[derive(Debug, Default, Clone)]
     struct CounterState {
@@ -366,6 +508,231 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default, Clone)]
+    struct FieldState {
+        field: String,
+        value: String,
+        observed_node: Option<WidgetId>,
+        observed_caret: usize,
+        observed_anchor: usize,
+    }
+    impl GlobalState for FieldState {}
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct UpdateField(String);
+    impl Action for UpdateField {
+        fn static_id() -> ActionId {
+            ActionId::from_name("fission.site.browser-island.update-field")
+        }
+    }
+
+    fn update_field(
+        state: &mut FieldState,
+        action: UpdateField,
+        ctx: &mut ReducerContext<FieldState>,
+    ) {
+        let change = ctx
+            .input
+            .text_change()
+            .expect("browser text edit must carry ActionInput");
+        state.field = action.0;
+        state.value = change.new_text.clone();
+        state.observed_node = Some(change.node_id);
+        state.observed_caret = change.new_caret;
+        state.observed_anchor = change.new_anchor;
+    }
+
+    #[derive(Clone)]
+    struct FieldIsland;
+
+    impl From<FieldIsland> for Widget {
+        fn from(_component: FieldIsland) -> Widget {
+            let (ctx, view) = fission_core::build::current::<FieldState>();
+            TextInput {
+                id: Some(WidgetId::from_u128(901)),
+                value: view.state().value.clone(),
+                on_input: Some(
+                    ctx.bind(UpdateField("smtp_host".into()), reduce_with!(update_field)),
+                ),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct LocalFieldIsland;
+
+    fn update_local_field(
+        value: &mut String,
+        _action: UpdateField,
+        ctx: &mut ReducerContext<String>,
+    ) {
+        *value = ctx
+            .input
+            .text_change()
+            .expect("local browser text edit must carry ActionInput")
+            .new_text
+            .clone();
+    }
+
+    impl From<LocalFieldIsland> for Widget {
+        fn from(_component: LocalFieldIsland) -> Widget {
+            let (ctx, _) = fission_core::build::current::<()>();
+            let value = StateField::new("BrowserIslandField", "value", String::new());
+            TextInput {
+                id: Some(WidgetId::from_u128(902)),
+                value: value.get(),
+                on_input: Some(ctx.bind_local(
+                    UpdateField("smtp_host".into()),
+                    value,
+                    reduce!(update_local_field),
+                )),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct NumberFieldIsland;
+
+    impl From<NumberFieldIsland> for Widget {
+        fn from(_component: NumberFieldIsland) -> Widget {
+            let (ctx, view) = fission_core::build::current::<FieldState>();
+            TextInput {
+                id: Some(WidgetId::from_u128(903)),
+                value: view.state().value.clone(),
+                keyboard_type: TextInputType::Number,
+                on_input: Some(
+                    ctx.bind(UpdateField("smtp_port".into()), reduce_with!(update_field)),
+                ),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct NonDispatchableFieldIsland {
+        read_only: bool,
+    }
+
+    #[derive(Debug, Default, Clone)]
+    struct ScopedFieldState {
+        scope: Option<u128>,
+        target: Option<WidgetId>,
+        value: String,
+    }
+    impl GlobalState for ScopedFieldState {}
+
+    fn update_scoped_field(
+        state: &mut ScopedFieldState,
+        _action: UpdateField,
+        ctx: &mut ReducerContext<ScopedFieldState>,
+    ) {
+        let ActionInput::ScopedRaw {
+            scope_id, target, ..
+        } = ctx.input
+        else {
+            panic!("browser text action must retain its enclosing scope");
+        };
+        state.scope = Some(*scope_id);
+        state.target = Some(*target);
+        state.value = ctx.input.text_change().unwrap().new_text.clone();
+    }
+
+    #[derive(Clone)]
+    struct ScopedFieldIsland;
+
+    impl From<ScopedFieldIsland> for Widget {
+        fn from(_component: ScopedFieldIsland) -> Widget {
+            let (ctx, view) = fission_core::build::current::<ScopedFieldState>();
+            ActionScope::new(
+                ActionScopeId::from_u128(5150),
+                TextInput {
+                    id: Some(WidgetId::from_u128(905)),
+                    value: view.state().value.clone(),
+                    on_input: Some(ctx.bind(
+                        UpdateField("scoped".into()),
+                        reduce_with!(update_scoped_field),
+                    )),
+                    ..Default::default()
+                },
+            )
+            .into()
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct QueueUnsupportedEffect;
+    impl Action for QueueUnsupportedEffect {
+        fn static_id() -> ActionId {
+            ActionId::from_name("fission.site.browser-island.queue-unsupported-effect")
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct EffectFinished;
+    impl Action for EffectFinished {
+        fn static_id() -> ActionId {
+            ActionId::from_name("fission.site.browser-island.effect-finished")
+        }
+    }
+
+    fn effect_finished(
+        _state: &mut CounterState,
+        _action: EffectFinished,
+        _ctx: &mut ReducerContext<CounterState>,
+    ) {
+    }
+
+    fn queue_unsupported_effect(
+        _state: &mut CounterState,
+        _action: QueueUnsupportedEffect,
+        ctx: &mut ReducerContext<CounterState>,
+    ) {
+        let on_ok = ctx
+            .effects
+            .bind(EffectFinished, reduce_with!(effect_finished));
+        ctx.effects
+            .add(Effect::Runtime(RuntimeEffect::Cancel { req_id: 77 }))
+            .on_ok(on_ok);
+    }
+
+    #[derive(Clone)]
+    struct EffectIsland;
+
+    impl From<EffectIsland> for Widget {
+        fn from(_component: EffectIsland) -> Widget {
+            let (ctx, _) = fission_core::build::current::<CounterState>();
+            Button {
+                on_press: Some(ctx.bind(
+                    QueueUnsupportedEffect,
+                    reduce_with!(queue_unsupported_effect),
+                )),
+                child: Some(Text::new("Queue effect").into()),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
+    impl From<NonDispatchableFieldIsland> for Widget {
+        fn from(component: NonDispatchableFieldIsland) -> Widget {
+            let (ctx, view) = fission_core::build::current::<FieldState>();
+            TextInput {
+                id: Some(WidgetId::from_u128(904)),
+                value: view.state().value.clone(),
+                read_only: component.read_only,
+                enabled: component.read_only,
+                on_input: Some(ctx.bind(UpdateField("blocked".into()), reduce_with!(update_field))),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
     #[test]
     fn browser_island_runs_reducer_and_rerenders_html() {
         let id = format!("counter-{}", std::process::id());
@@ -384,6 +751,284 @@ mod tests {
             BrowserIslandApp::new(&id, "counter-mount", CounterState::default(), CounterIsland)
         });
         assert!(update.contains("1 clicks"));
+    }
+
+    #[test]
+    fn browser_island_dispatches_text_with_static_context_and_utf8_selection() {
+        let id = format!("field-{}", std::process::id());
+        let boot = run_browser_island(&id, r#"{"type":"boot"}"#, || {
+            BrowserIslandApp::new(&id, "field-mount", FieldState::default(), FieldIsland)
+        });
+        assert!(boot.contains("data-fission-browser-text-action"));
+
+        let event = r#"{
+            "type":"event",
+            "sequence":2,
+            "binding":{
+                "event":"input",
+                "message":{
+                    "fission_browser_text_action":true,
+                    "target_node":"901"
+                }
+            },
+            "value":"café",
+            "caret":5,
+            "anchor":3
+        }"#;
+        let update = run_browser_island(&id, event, || {
+            BrowserIslandApp::new(&id, "field-mount", FieldState::default(), FieldIsland)
+        });
+        assert!(!update.contains("browser island `"));
+        assert!(update.contains("value=\\\"café\\\""));
+
+        BROWSER_ISLANDS.with(|instances| {
+            let instances = instances.borrow();
+            let island = instances
+                .get(&id)
+                .and_then(|entry| entry.downcast_ref::<BrowserIslandApp<FieldState, FieldIsland>>())
+                .unwrap();
+            let state = island.runtime.get_global_state::<FieldState>().unwrap();
+            assert_eq!(state.field, "smtp_host");
+            assert_eq!(state.value, "café");
+            assert_eq!(state.observed_node, Some(WidgetId::from_u128(901)));
+            assert_eq!(state.observed_caret, 5);
+            assert_eq!(state.observed_anchor, 3);
+        });
+    }
+
+    #[test]
+    fn browser_island_number_input_dispatches_text_and_selection() {
+        let id = format!("field-number-{}", std::process::id());
+        let event = r#"{
+            "type":"event",
+            "binding":{"message":{
+                "fission_browser_text_action":true,
+                "target_node":"903"
+            }},
+            "value":"2525",
+            "caret":4,
+            "anchor":4
+        }"#;
+        let update = run_browser_island(&id, event, || {
+            BrowserIslandApp::new(&id, "field-mount", FieldState::default(), NumberFieldIsland)
+        });
+        assert!(!update.contains("browser island `"));
+        BROWSER_ISLANDS.with(|instances| {
+            let instances = instances.borrow();
+            let island = instances
+                .get(&id)
+                .and_then(|entry| {
+                    entry.downcast_ref::<BrowserIslandApp<FieldState, NumberFieldIsland>>()
+                })
+                .unwrap();
+            let state = island.runtime.get_global_state::<FieldState>().unwrap();
+            assert_eq!(state.field, "smtp_port");
+            assert_eq!(state.value, "2525");
+            assert_eq!(state.observed_caret, 4);
+            assert_eq!(state.observed_anchor, 4);
+        });
+    }
+
+    #[test]
+    fn browser_island_rejects_disabled_and_read_only_text_events() {
+        for (read_only, expected) in [(true, "read-only"), (false, "disabled")] {
+            let id = format!("field-blocked-{read_only}-{}", std::process::id());
+            let event = r#"{
+                "type":"event",
+                "binding":{"message":{
+                    "fission_browser_text_action":true,
+                    "target_node":"904"
+                }},
+                "value":"must-not-dispatch",
+                "caret":17,
+                "anchor":17
+            }"#;
+            let output = run_browser_island(&id, event, || {
+                BrowserIslandApp::new(
+                    &id,
+                    "field-mount",
+                    FieldState::default(),
+                    NonDispatchableFieldIsland { read_only },
+                )
+            });
+            assert!(output.contains(expected), "unexpected output: {output}");
+        }
+    }
+
+    #[test]
+    fn browser_island_text_target_validation_requires_text_role_and_change_action() {
+        let target = WidgetId::from_u128(42);
+        let generic = Semantics {
+            role: Role::Generic,
+            ..Default::default()
+        };
+        assert!(validate_browser_text_target(target, &generic)
+            .unwrap_err()
+            .to_string()
+            .contains("not a text input"));
+
+        let text_without_action = Semantics {
+            role: Role::TextInput,
+            ..Default::default()
+        };
+        assert!(validate_browser_text_target(target, &text_without_action)
+            .unwrap_err()
+            .to_string()
+            .contains("has no text-change action"));
+    }
+
+    #[test]
+    fn browser_island_rejects_selection_that_splits_utf8() {
+        let id = format!("field-invalid-{}", std::process::id());
+        let event = r#"{
+            "type":"event",
+            "binding":{
+                "message":{
+                    "fission_browser_text_action":true,
+                    "target_node":"901"
+                }
+            },
+            "value":"é",
+            "caret":1,
+            "anchor":0
+        }"#;
+        let update = run_browser_island(&id, event, || {
+            BrowserIslandApp::new(&id, "field-mount", FieldState::default(), FieldIsland)
+        });
+        assert!(update.contains("caret is not a UTF-8 boundary"));
+    }
+
+    #[test]
+    fn browser_island_text_dispatch_preserves_enclosing_action_scope() {
+        let id = format!("field-scoped-{}", std::process::id());
+        let event = r#"{
+            "type":"event",
+            "binding":{"message":{
+                "fission_browser_text_action":true,
+                "target_node":"905"
+            }},
+            "value":"scoped value",
+            "caret":12,
+            "anchor":12
+        }"#;
+        let update = run_browser_island(&id, event, || {
+            BrowserIslandApp::new(
+                &id,
+                "field-mount",
+                ScopedFieldState::default(),
+                ScopedFieldIsland,
+            )
+        });
+        assert!(!update.contains("browser island `"));
+        BROWSER_ISLANDS.with(|instances| {
+            let instances = instances.borrow();
+            let island = instances
+                .get(&id)
+                .and_then(|entry| {
+                    entry.downcast_ref::<BrowserIslandApp<ScopedFieldState, ScopedFieldIsland>>()
+                })
+                .unwrap();
+            let state = island
+                .runtime
+                .get_global_state::<ScopedFieldState>()
+                .unwrap();
+            assert_eq!(state.scope, Some(5150));
+            assert_eq!(state.target, Some(WidgetId::from_u128(905)));
+            assert_eq!(state.value, "scoped value");
+        });
+    }
+
+    #[test]
+    fn browser_island_sequential_text_edits_keep_field_identity() {
+        let id = format!("field-sequential-{}", std::process::id());
+        let first = r#"{
+            "type":"event",
+            "binding":{"message":{
+                "fission_browser_text_action":true,
+                "target_node":"901"
+            }},
+            "value":"green",
+            "caret":5,
+            "anchor":5
+        }"#;
+        let second = r#"{
+            "type":"event",
+            "binding":{"message":{
+                "fission_browser_text_action":true,
+                "target_node":"901"
+            }},
+            "value":"greenmail",
+            "caret":9,
+            "anchor":9
+        }"#;
+        let first_output = run_browser_island(&id, first, || {
+            BrowserIslandApp::new(&id, "field-mount", FieldState::default(), FieldIsland)
+        });
+        assert!(!first_output.contains("browser island `"));
+        let second_output = run_browser_island(&id, second, || {
+            BrowserIslandApp::new(&id, "field-mount", FieldState::default(), FieldIsland)
+        });
+        assert!(!second_output.contains("browser island `"));
+
+        BROWSER_ISLANDS.with(|instances| {
+            let instances = instances.borrow();
+            let island = instances
+                .get(&id)
+                .and_then(|entry| entry.downcast_ref::<BrowserIslandApp<FieldState, FieldIsland>>())
+                .unwrap();
+            let state = island.runtime.get_global_state::<FieldState>().unwrap();
+            assert_eq!(state.field, "smtp_host");
+            assert_eq!(state.value, "greenmail");
+            assert_eq!(state.observed_caret, 9);
+            assert_eq!(state.observed_anchor, 9);
+        });
+    }
+
+    #[test]
+    fn browser_island_text_updates_bind_local_state() {
+        let id = format!("field-local-{}", std::process::id());
+        let boot = run_browser_island(&id, r#"{"type":"boot"}"#, || {
+            BrowserIslandApp::new(&id, "field-mount", (), LocalFieldIsland)
+        });
+        assert!(boot.contains("data-fission-browser-text-action"));
+        let event = r#"{
+            "type":"event",
+            "binding":{"message":{
+                "fission_browser_text_action":true,
+                "target_node":"902"
+            }},
+            "value":"greenmail",
+            "caret":9,
+            "anchor":9
+        }"#;
+        let update = run_browser_island(&id, event, || {
+            BrowserIslandApp::new(&id, "field-mount", (), LocalFieldIsland)
+        });
+        assert!(!update.contains("browser island `"));
+        assert!(update.contains("value=\\\"greenmail\\\""));
+    }
+
+    #[test]
+    fn browser_island_rejects_and_discards_effects_and_callbacks() {
+        let mut island = BrowserIslandApp::new(
+            "effect-island",
+            "effect-mount",
+            CounterState::default(),
+            EffectIsland,
+        );
+        let action_id = QueueUnsupportedEffect::static_id().as_u128();
+        let payload_hex = test_hex_encode(&QueueUnsupportedEffect.encode());
+        let event = format!(
+            r#"{{"type":"event","binding":{{"message":{{"fission_browser_action":true,"action_id":"{action_id}","target_node":"1","payload_hex":"{payload_hex}"}}}}}}"#
+        );
+
+        let first = island.handle(&event).unwrap_err().to_string();
+        assert!(first.contains("discarded 2 effect envelope(s) and completion callback(s)"));
+        assert_eq!(island.runtime.discard_pending_effects(), 0);
+
+        let second = island.handle(&event).unwrap_err().to_string();
+        assert!(second.contains("discarded 2 effect envelope(s) and completion callback(s)"));
+        assert_eq!(island.runtime.discard_pending_effects(), 0);
     }
 
     fn test_hex_encode(bytes: &[u8]) -> String {

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -2122,6 +2122,21 @@ impl HtmlRenderer<'_> {
         semantics: &Semantics,
     ) -> Result<String> {
         let mut attrs = self.native_control_attrs(node, semantics);
+        if self.options.browser_action_bindings
+            && matches!(semantics.role, Role::TextInput | Role::Input)
+            && !semantics.disabled
+            && !semantics.read_only
+            && semantics
+                .actions
+                .entries
+                .iter()
+                .any(|entry| entry.trigger == ActionTrigger::TextChanged)
+        {
+            attrs.push_str(&format!(
+                " data-fission-browser-text-action=\"true\" data-fission-action-target=\"{}\"",
+                node.id.as_u128()
+            ));
+        }
         let children = self.render_children(&node.children, &HashSet::new())?;
         let label_text = semantics.label.as_deref().unwrap_or_default();
         match semantics.role {
@@ -4862,6 +4877,141 @@ mod tests {
         assert!(rendered
             .html
             .contains("data-fission-action-payload=\"dead\""));
+    }
+
+    #[test]
+    fn browser_action_options_bind_text_controls_without_exposing_action_metadata() {
+        let input = WidgetId::explicit("browser-text-input");
+        let mut semantics = Semantics {
+            role: Role::TextInput,
+            value: Some("before".into()),
+            ..Default::default()
+        };
+        semantics.actions = ActionSet {
+            entries: vec![ActionEntry {
+                trigger: ActionTrigger::TextChanged,
+                action_id: 11,
+                payload_data: Some(br#"["smtp_host","secret-marker-8bd4"]"#.to_vec()),
+            }],
+        };
+        let mut ir = CoreIR::new();
+        ir.nodes.insert(
+            input,
+            CoreNode {
+                id: input,
+                op: Op::Semantics(semantics),
+                composite: Default::default(),
+                children: Vec::new(),
+                parent: None,
+                hash: 0,
+            },
+        );
+        ir.set_root(input);
+
+        let interactive = render_ir_to_html(
+            &ir,
+            &HtmlRenderOptions {
+                browser_action_bindings: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(interactive
+            .html
+            .contains("data-fission-browser-text-action=\"true\""));
+        assert!(interactive.html.contains(&format!(
+            "data-fission-action-target=\"{}\"",
+            input.as_u128()
+        )));
+        assert!(!interactive.html.contains("smtp_host"));
+        assert!(!interactive.html.contains("secret-marker-8bd4"));
+        assert!(!interactive.html.contains("data-fission-action-payload"));
+        assert!(!interactive.html.contains("data-fission-action-id"));
+        assert!(!interactive
+            .html
+            .contains(&hex_encode(br#"["smtp_host","secret-marker-8bd4"]"#)));
+
+        let server_only = render_ir_to_html(
+            &ir,
+            &HtmlRenderOptions {
+                server_action_post_path: Some("/__fission/action".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(!server_only
+            .html
+            .contains("data-fission-browser-text-action"));
+    }
+
+    #[test]
+    fn browser_action_options_do_not_bind_non_dispatchable_text_controls() {
+        for (disabled, read_only) in [(true, false), (false, true)] {
+            let input = WidgetId::explicit(if disabled {
+                "disabled-browser-text-input"
+            } else {
+                "readonly-browser-text-input"
+            });
+            let mut semantics = Semantics {
+                role: Role::TextInput,
+                disabled,
+                read_only,
+                ..Default::default()
+            };
+            semantics.actions = ActionSet {
+                entries: vec![ActionEntry {
+                    trigger: ActionTrigger::TextChanged,
+                    action_id: 17,
+                    payload_data: Some(vec![1, 2, 3]),
+                }],
+            };
+            let mut ir = CoreIR::new();
+            ir.add_node(input, Op::Semantics(semantics), Vec::new());
+            ir.set_root(input);
+
+            let rendered = render_ir_to_html(
+                &ir,
+                &HtmlRenderOptions {
+                    browser_action_bindings: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            assert!(!rendered.html.contains("data-fission-browser-text-action"));
+            assert!(!rendered.html.contains("data-fission-action-id"));
+            assert!(!rendered.html.contains("data-fission-action-payload"));
+        }
+    }
+
+    #[test]
+    fn browser_action_options_require_a_text_input_role() {
+        let node = WidgetId::explicit("generic-text-change-node");
+        let mut semantics = Semantics {
+            role: Role::Generic,
+            ..Default::default()
+        };
+        semantics.actions = ActionSet {
+            entries: vec![ActionEntry {
+                trigger: ActionTrigger::TextChanged,
+                action_id: 21,
+                payload_data: Some(vec![4, 5, 6]),
+            }],
+        };
+        let mut ir = CoreIR::new();
+        ir.add_node(node, Op::Semantics(semantics), Vec::new());
+        ir.set_root(node);
+
+        let rendered = render_ir_to_html(
+            &ir,
+            &HtmlRenderOptions {
+                browser_action_bindings: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(!rendered.html.contains("data-fission-browser-text-action"));
+        assert!(!rendered.html.contains("data-fission-action-id"));
+        assert!(!rendered.html.contains("data-fission-action-payload"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-terminal/Cargo.toml
+++ b/crates/shell/fission-shell-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-terminal"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -21,9 +21,9 @@ crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["png"] }
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.10.1" }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.0" }
 base64 = "0.22"

--- a/crates/shell/fission-shell-terminal/README.md
+++ b/crates/shell/fission-shell-terminal/README.md
@@ -8,7 +8,7 @@ Application developers normally enable it through the facade crate:
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["terminal-shell"] }
+fission = { version = "0.11.0", features = ["terminal-shell"] }
 ```
 
 ## What it contains

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-web"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -21,9 +21,9 @@ video = ["fission-shell-winit/video"]
 
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
-fission-shell = { path = "../fission-shell", version = "0.10.1" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.10.1", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-shell = { path = "../fission-shell", version = "0.11.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.11.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -30,7 +30,7 @@ fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
 fission-semantics = { path = "../../core/fission-semantics", version = "0.11.0" }
 fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
 fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.11.0" }
-winit = { package = "fission-winit", version = "0.30.13-fission.1" }
+winit = { package = "fission-winit", version = "0.30.13-fission.2" }
 fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
 fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.0" }
 image = "0.25"
@@ -64,7 +64,7 @@ accesskit_winit = { package = "fission-accesskit-winit", version = "0.33.1-fissi
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"
 ndk-context = "0.1"
-winit = { package = "fission-winit", version = "0.30.13-fission.1", features = ["android-native-activity"] }
+winit = { package = "fission-winit", version = "0.30.13-fission.2", features = ["android-native-activity"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-winit"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 description = "Shared winit shell runtime for desktop and mobile Fission hosts"
 categories = ["gui", "rendering"]
@@ -21,18 +21,18 @@ three-d = ["dep:fission-3d"]
 video = ["dep:gstreamer", "dep:gstreamer-video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.10.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.10.1" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.10.1" }
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
-fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.10.1" }
+fission-shell = { path = "../fission-shell", version = "0.11.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.0" }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.11.0" }
 winit = { package = "fission-winit", version = "0.30.13-fission.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.10.1" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.10.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.0" }
 image = "0.25"
 tiny-skia = "0.11.4"
 fontdue = "0.9.3"
@@ -108,6 +108,6 @@ dispatch = "0.2"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.10.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.10.1" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-winit/src/accessibility.rs
+++ b/crates/shell/fission-shell-winit/src/accessibility.rs
@@ -10,6 +10,7 @@ mod imp {
     };
     use accesskit_winit::Adapter;
     use fission_core::event::ImeEvent;
+    use fission_core::input::prepare_scoped_text_input_change;
     use fission_core::{ActionEnvelope, ActionId, ActionInput, InputEvent, Runtime};
     use fission_ir::semantics::{ActionTrigger, Role, TextInputType};
     use fission_ir::{CoreIR, Op, PaintOp, Semantics, WidgetId};
@@ -194,73 +195,113 @@ mod imp {
         ) -> bool {
             self.active = true;
             let node_map = self.shared.latest_node_map.lock().ok();
-            let Some(target) = node_map
-                .as_ref()
-                .and_then(|map| map.get(&request.target_node).copied())
-            else {
-                return false;
-            };
-            let Some(semantics) = semantics_for(ir, target) else {
-                return false;
-            };
+            node_map.as_ref().is_some_and(|node_map| {
+                dispatch_mapped_accessibility_action(request, runtime, ir, layout, node_map)
+            })
+        }
+    }
 
-            match request.action {
-                Action::Click => dispatch_semantics_action(
+    fn dispatch_mapped_accessibility_action(
+        request: ActionRequest,
+        runtime: &mut Runtime,
+        ir: &CoreIR,
+        layout: &LayoutSnapshot,
+        node_map: &HashMap<NodeId, WidgetId>,
+    ) -> bool {
+        let Some(target) = node_map.get(&request.target_node).copied() else {
+            return false;
+        };
+        let Some(semantics) = semantics_for(ir, target) else {
+            return false;
+        };
+        dispatch_accessibility_action(request, runtime, ir, layout, target, semantics)
+    }
+
+    fn dispatch_accessibility_action(
+        request: ActionRequest,
+        runtime: &mut Runtime,
+        ir: &CoreIR,
+        layout: &LayoutSnapshot,
+        target: WidgetId,
+        semantics: &Semantics,
+    ) -> bool {
+        match request.action {
+            Action::Click => dispatch_semantics_action(
+                runtime,
+                ir,
+                target,
+                semantics,
+                ActionTrigger::Default,
+                ActionInput::None,
+            ),
+            Action::Focus => set_focus(runtime, ir, Some(target)),
+            Action::Blur => set_focus(runtime, ir, None),
+            Action::ReplaceSelectedText => {
+                if !editable_text_input(semantics) || !has_text_input_action(semantics) {
+                    crate::log_input_dispatch_failure(
+                        "accessibility_replace_selected_text_rejected",
+                        Some(target),
+                    );
+                    return false;
+                }
+                let Some(text) = value_action_data(&request.data) else {
+                    return false;
+                };
+                set_focus(runtime, ir, Some(target));
+                runtime
+                    .handle_input(
+                        InputEvent::Ime(ImeEvent::Commit {
+                            text: text.to_string(),
+                        }),
+                        ir,
+                        layout,
+                    )
+                    .is_ok()
+            }
+            Action::SetValue => match &request.data {
+                Some(ActionData::Value(value)) => {
+                    set_text_input_value(runtime, ir, target, semantics, value)
+                }
+                Some(ActionData::NumericValue(value)) if semantics.role == Role::TextInput => {
+                    set_text_input_value(runtime, ir, target, semantics, &value.to_string())
+                }
+                Some(ActionData::NumericValue(value)) => set_numeric_value(
                     runtime,
+                    ir,
                     target,
                     semantics,
-                    ActionTrigger::Default,
-                    ActionInput::None,
-                ),
-                Action::Focus => set_focus(runtime, ir, Some(target)),
-                Action::Blur => set_focus(runtime, ir, None),
-                Action::ReplaceSelectedText => {
-                    let Some(text) = value_action_data(&request.data) else {
-                        return false;
-                    };
-                    set_focus(runtime, ir, Some(target));
-                    runtime
-                        .handle_input(
-                            InputEvent::Ime(ImeEvent::Commit {
-                                text: text.to_string(),
-                            }),
-                            ir,
-                            layout,
-                        )
-                        .is_ok()
-                }
-                Action::SetValue => match &request.data {
-                    Some(ActionData::Value(value)) => {
-                        set_text_input_value(runtime, ir, target, semantics, value)
-                    }
-                    Some(ActionData::NumericValue(value)) => set_numeric_value(
-                        runtime,
-                        target,
-                        semantics,
-                        (*value as f32).clamp(
-                            semantics.min_value.unwrap_or(f32::NEG_INFINITY),
-                            semantics.max_value.unwrap_or(f32::INFINITY),
-                        ),
+                    (*value as f32).clamp(
+                        semantics.min_value.unwrap_or(f32::NEG_INFINITY),
+                        semantics.max_value.unwrap_or(f32::INFINITY),
                     ),
-                    _ => false,
-                },
-                Action::SetTextSelection => {
-                    let Some(ActionData::SetTextSelection(selection)) = &request.data else {
-                        return false;
-                    };
-                    set_text_selection(runtime, ir, target, semantics, selection)
-                }
-                Action::ScrollDown
-                | Action::ScrollUp
-                | Action::ScrollLeft
-                | Action::ScrollRight => {
-                    handle_scroll_action(runtime, ir, layout, target, request.action, &request.data)
-                }
-                Action::Increment => adjust_numeric_value(runtime, target, semantics, 1.0),
-                Action::Decrement => adjust_numeric_value(runtime, target, semantics, -1.0),
+                ),
                 _ => false,
+            },
+            Action::SetTextSelection => {
+                let Some(ActionData::SetTextSelection(selection)) = &request.data else {
+                    return false;
+                };
+                set_text_selection(runtime, ir, target, semantics, selection)
             }
+            Action::ScrollDown | Action::ScrollUp | Action::ScrollLeft | Action::ScrollRight => {
+                handle_scroll_action(runtime, ir, layout, target, request.action, &request.data)
+            }
+            Action::Increment => adjust_numeric_value(runtime, ir, target, semantics, 1.0),
+            Action::Decrement => adjust_numeric_value(runtime, ir, target, semantics, -1.0),
+            _ => false,
         }
+    }
+
+    fn editable_text_input(semantics: &Semantics) -> bool {
+        semantics.role == Role::TextInput && !semantics.disabled && !semantics.read_only
+    }
+
+    fn has_text_input_action(semantics: &Semantics) -> bool {
+        semantics
+            .actions
+            .entries
+            .iter()
+            .any(|entry| entry.trigger == ActionTrigger::TextChanged)
     }
 
     pub fn window_must_start_hidden() -> bool {
@@ -488,9 +529,13 @@ mod imp {
                             });
                         }
                     }
-                    node.add_action(Action::ReplaceSelectedText);
-                    node.add_action(Action::SetValue);
-                    node.add_action(Action::SetTextSelection);
+                    if editable_text_input(semantics) && has_text_input_action(semantics) {
+                        node.add_action(Action::ReplaceSelectedText);
+                        node.add_action(Action::SetValue);
+                    }
+                    if !semantics.disabled {
+                        node.add_action(Action::SetTextSelection);
+                    }
                     if semantics.read_only {
                         node.set_read_only();
                     }
@@ -692,6 +737,7 @@ mod imp {
             if let Some(old_semantics) = semantics_for(ir, old_id) {
                 let _ = dispatch_semantics_action(
                     runtime,
+                    ir,
                     old_id,
                     old_semantics,
                     ActionTrigger::Blur,
@@ -713,6 +759,7 @@ mod imp {
             if let Some(new_semantics) = semantics_for(ir, new_id) {
                 let _ = dispatch_semantics_action(
                     runtime,
+                    ir,
                     new_id,
                     new_semantics,
                     ActionTrigger::Focus,
@@ -725,6 +772,7 @@ mod imp {
 
     fn dispatch_semantics_action(
         runtime: &mut Runtime,
+        ir: &CoreIR,
         target: WidgetId,
         semantics: &Semantics,
         trigger: ActionTrigger,
@@ -742,22 +790,26 @@ mod imp {
             id: ActionId::from_u128(entry.action_id),
             payload: entry.payload_data.clone().unwrap_or_default(),
         };
-        let input = scoped_semantics_input(target, semantics, input);
+        let input = scoped_semantics_input(ir, target, input);
         runtime
             .dispatch_with_input(envelope, target, &input)
             .is_ok()
     }
 
-    fn scoped_semantics_input(
-        target: WidgetId,
-        semantics: &Semantics,
-        input: ActionInput,
-    ) -> ActionInput {
-        if let Some(scope_id) = semantics.action_scope_id {
-            ActionInput::scoped_raw(scope_id, target, input)
-        } else {
-            input
+    fn scoped_semantics_input(ir: &CoreIR, target: WidgetId, input: ActionInput) -> ActionInput {
+        let mut current = Some(target);
+        while let Some(node_id) = current {
+            let Some(node) = ir.nodes.get(&node_id) else {
+                break;
+            };
+            if let Op::Semantics(semantics) = &node.op {
+                if let Some(scope_id) = semantics.action_scope_id {
+                    return ActionInput::scoped_raw(scope_id, target, input);
+                }
+            }
+            current = node.parent;
         }
+        input
     }
 
     fn value_action_data(data: &Option<ActionData>) -> Option<&str> {
@@ -774,9 +826,10 @@ mod imp {
         semantics: &Semantics,
         value: &str,
     ) -> bool {
-        if semantics.role != Role::TextInput || semantics.disabled || semantics.read_only {
+        if !editable_text_input(semantics) {
             return false;
         }
+        let previous_text_state = runtime.runtime_state.text_edit.get(target).cloned();
         set_focus(runtime, ir, Some(target));
         runtime.runtime_state.text_edit.sync_from_runtime(
             target,
@@ -793,9 +846,35 @@ mod imp {
             state.pending_model_sync = true;
             state.clear_preedit();
         }
-        let mut changed = dispatch_text_change(runtime, target, semantics, value.to_string());
-        changed |= dispatch_cursor_change(runtime, target, semantics, value.len(), value.len());
-        changed
+        if !dispatch_text_change(
+            runtime,
+            ir,
+            target,
+            semantics,
+            value.to_string(),
+            value.len(),
+            value.len(),
+        ) {
+            if let Some(previous) = previous_text_state {
+                runtime
+                    .runtime_state
+                    .text_edit
+                    .states
+                    .insert(target, previous);
+            } else {
+                runtime.runtime_state.text_edit.states.remove(&target);
+            }
+            return false;
+        }
+
+        let has_cursor_action = semantics
+            .actions
+            .entries
+            .iter()
+            .any(|entry| entry.trigger == ActionTrigger::CursorChange);
+        let cursor_changed =
+            dispatch_cursor_change(runtime, ir, target, semantics, value.len(), value.len());
+        !has_cursor_action || cursor_changed
     }
 
     fn set_text_selection(
@@ -805,7 +884,7 @@ mod imp {
         semantics: &Semantics,
         selection: &TextSelection,
     ) -> bool {
-        if semantics.role != Role::TextInput {
+        if semantics.role != Role::TextInput || semantics.disabled {
             return false;
         }
         set_focus(runtime, ir, Some(target));
@@ -827,7 +906,7 @@ mod imp {
             .runtime_state
             .text_edit
             .set_caret(target, caret, Some(anchor));
-        dispatch_cursor_change(runtime, target, semantics, caret, anchor)
+        dispatch_cursor_change(runtime, ir, target, semantics, caret, anchor)
     }
 
     fn char_to_byte(value: &str, character_index: usize) -> usize {
@@ -849,36 +928,30 @@ mod imp {
 
     fn dispatch_text_change(
         runtime: &mut Runtime,
+        ir: &CoreIR,
         target: WidgetId,
         semantics: &Semantics,
         new_text: String,
+        new_caret: usize,
+        new_anchor: usize,
     ) -> bool {
-        let Some(entry) = semantics
-            .actions
-            .entries
-            .iter()
-            .find(|entry| entry.trigger == ActionTrigger::Change)
-        else {
+        let Some((envelope, input)) = prepare_scoped_text_input_change(
+            ir, semantics, target, new_text, new_caret, new_anchor,
+        ) else {
+            crate::log_input_dispatch_failure(
+                "accessibility_text_input_missing_action",
+                Some(target),
+            );
             return false;
         };
-        let Ok(payload) = serde_json::to_vec(&new_text) else {
-            return false;
-        };
-        let input = scoped_semantics_input(target, semantics, ActionInput::None);
         runtime
-            .dispatch_with_input(
-                ActionEnvelope {
-                    id: ActionId::from_u128(entry.action_id),
-                    payload,
-                },
-                target,
-                &input,
-            )
+            .dispatch_with_input(envelope, target, &input)
             .is_ok()
     }
 
     fn dispatch_cursor_change(
         runtime: &mut Runtime,
+        ir: &CoreIR,
         target: WidgetId,
         semantics: &Semantics,
         caret: usize,
@@ -896,7 +969,7 @@ mod imp {
         let Ok(payload) = serde_json::to_vec(&cursor_changed) else {
             return false;
         };
-        let input = scoped_semantics_input(target, semantics, ActionInput::None);
+        let input = scoped_semantics_input(ir, target, ActionInput::None);
         runtime
             .dispatch_with_input(
                 ActionEnvelope {
@@ -911,6 +984,7 @@ mod imp {
 
     fn adjust_numeric_value(
         runtime: &mut Runtime,
+        ir: &CoreIR,
         target: WidgetId,
         semantics: &Semantics,
         direction: f32,
@@ -921,11 +995,12 @@ mod imp {
         let min = semantics.min_value.unwrap_or(f32::NEG_INFINITY);
         let max = semantics.max_value.unwrap_or(f32::INFINITY);
         let next = (current + direction).clamp(min, max);
-        set_numeric_value(runtime, target, semantics, next)
+        set_numeric_value(runtime, ir, target, semantics, next)
     }
 
     fn set_numeric_value(
         runtime: &mut Runtime,
+        ir: &CoreIR,
         target: WidgetId,
         semantics: &Semantics,
         value: f32,
@@ -944,7 +1019,7 @@ mod imp {
         else {
             return false;
         };
-        let input = scoped_semantics_input(target, semantics, ActionInput::None);
+        let input = scoped_semantics_input(ir, target, ActionInput::None);
         runtime
             .dispatch_with_input(
                 ActionEnvelope {
@@ -1041,8 +1116,163 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use fission_core::action::CursorChanged;
+        use fission_core::{
+            Action as FissionAction, ActionId as FissionActionId, ActionRegistry, GlobalState,
+            ReducerContext, UpdateTextInput,
+        };
         use fission_ir::{ActionEntry, ActionSet, CoreIR, CoreNode, Op};
         use fission_layout::{LayoutNodeGeometry, LayoutPoint, LayoutSize};
+        use serde::{Deserialize, Serialize};
+        use std::collections::BTreeMap;
+
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        struct UpdateField(String);
+
+        impl FissionAction for UpdateField {
+            fn static_id() -> FissionActionId {
+                FissionActionId::from_name("accessibility_tests::UpdateField")
+            }
+        }
+
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        struct RecordedContextualEdit {
+            change: UpdateTextInput,
+            scoped_target: Option<WidgetId>,
+        }
+
+        #[derive(Debug, Default)]
+        struct TextDispatchState {
+            contextual: BTreeMap<(u128, String), RecordedContextualEdit>,
+            cursors: Vec<(CursorChanged, Option<u128>, Option<WidgetId>)>,
+        }
+
+        impl GlobalState for TextDispatchState {}
+
+        fn record_contextual_edit(
+            state: &mut TextDispatchState,
+            action: UpdateField,
+            ctx: &mut ReducerContext<TextDispatchState>,
+        ) {
+            let change = ctx
+                .input
+                .text_change()
+                .expect("contextual edit input")
+                .clone();
+            state.contextual.insert(
+                (ctx.input.action_scope_id().unwrap_or_default(), action.0),
+                RecordedContextualEdit {
+                    change,
+                    scoped_target: ctx.input.scoped_target(),
+                },
+            );
+        }
+
+        fn record_cursor(
+            state: &mut TextDispatchState,
+            action: CursorChanged,
+            ctx: &mut ReducerContext<TextDispatchState>,
+        ) {
+            state.cursors.push((
+                action,
+                ctx.input.action_scope_id(),
+                ctx.input.scoped_target(),
+            ));
+        }
+
+        fn text_dispatch_runtime() -> Runtime {
+            let mut runtime = Runtime::default();
+            runtime
+                .add_app_state(Box::new(TextDispatchState::default()))
+                .expect("register text dispatch test state");
+            let mut registry = ActionRegistry::<TextDispatchState>::new();
+            registry.register(
+                record_contextual_edit
+                    as fn(
+                        &mut TextDispatchState,
+                        UpdateField,
+                        &mut ReducerContext<TextDispatchState>,
+                    ),
+            );
+            registry.register(
+                record_cursor
+                    as fn(
+                        &mut TextDispatchState,
+                        CursorChanged,
+                        &mut ReducerContext<TextDispatchState>,
+                    ),
+            );
+            runtime.absorb_registry(registry);
+            runtime
+        }
+
+        fn contextual_text_semantics(field: &str) -> Semantics {
+            Semantics {
+                role: Role::TextInput,
+                focusable: true,
+                value: Some(String::new()),
+                actions: ActionSet {
+                    entries: vec![ActionEntry {
+                        trigger: ActionTrigger::TextChanged,
+                        action_id: UpdateField::static_id().as_u128(),
+                        payload_data: Some(UpdateField(field.to_string()).encode()),
+                    }],
+                },
+                ..Semantics::default()
+            }
+        }
+
+        fn dispatch_set_value_request(
+            runtime: &mut Runtime,
+            ir: &CoreIR,
+            target: WidgetId,
+            value: impl Into<Box<str>>,
+        ) -> bool {
+            dispatch_set_value_data(
+                runtime,
+                ir,
+                &LayoutSnapshot::new(LayoutSize::new(320.0, 80.0)),
+                target,
+                ActionData::Value(value.into()),
+            )
+        }
+
+        fn dispatch_set_value_data(
+            runtime: &mut Runtime,
+            ir: &CoreIR,
+            layout: &LayoutSnapshot,
+            target: WidgetId,
+            data: ActionData,
+        ) -> bool {
+            let access_node = NodeId((target.as_u128() as u64).max(2));
+            let node_map = HashMap::from([(access_node, target)]);
+            let request = ActionRequest {
+                action: Action::SetValue,
+                target_tree: TreeId::ROOT,
+                target_node: access_node,
+                data: Some(data),
+            };
+            dispatch_mapped_accessibility_action(request, runtime, ir, layout, &node_map)
+        }
+
+        fn add_scoped_text_input(
+            ir: &mut CoreIR,
+            target: WidgetId,
+            scope_node: WidgetId,
+            scope_id: u128,
+            semantics: Semantics,
+        ) {
+            add_node(ir, target, Op::Semantics(semantics), vec![]);
+            add_node(
+                ir,
+                scope_node,
+                Op::Semantics(Semantics {
+                    action_scope_id: Some(scope_id),
+                    ..Semantics::default()
+                }),
+                vec![target],
+            );
+        }
 
         fn add_node(ir: &mut CoreIR, id: WidgetId, op: Op, children: Vec<WidgetId>) {
             ir.nodes.insert(
@@ -1192,6 +1422,378 @@ mod imp {
                 semantic_value(&runtime, input, &fallback_semantics).as_deref(),
                 Some("Stale retained buffer")
             );
+        }
+
+        #[test]
+        fn accesskit_set_value_preserves_context_and_edit_geometry_across_fields() {
+            let first = WidgetId::explicit("first-field");
+            let second = WidgetId::explicit("second-field");
+            let first_scope_node = WidgetId::explicit("first-scope");
+            let second_scope_node = WidgetId::explicit("second-scope");
+            let first_scope = 0xabc;
+            let second_scope = 0xdef;
+            let first_semantics = contextual_text_semantics("smtp_host");
+            let second_semantics = contextual_text_semantics("smtp_port");
+            let mut ir = CoreIR::new();
+            add_scoped_text_input(
+                &mut ir,
+                first,
+                first_scope_node,
+                first_scope,
+                first_semantics.clone(),
+            );
+            add_scoped_text_input(
+                &mut ir,
+                second,
+                second_scope_node,
+                second_scope,
+                second_semantics.clone(),
+            );
+            let mut runtime = text_dispatch_runtime();
+
+            assert!(dispatch_set_value_request(
+                &mut runtime,
+                &ir,
+                first,
+                "greenmail",
+            ));
+            assert!(dispatch_set_value_request(
+                &mut runtime,
+                &ir,
+                second,
+                "3025",
+            ));
+
+            let state = runtime
+                .get_app_state::<TextDispatchState>()
+                .expect("text dispatch state");
+            let first_edit = state
+                .contextual
+                .get(&(first_scope, "smtp_host".into()))
+                .expect("first contextual edit");
+            assert_eq!(
+                first_edit.change,
+                UpdateTextInput {
+                    node_id: first,
+                    new_text: "greenmail".into(),
+                    new_caret: "greenmail".len(),
+                    new_anchor: "greenmail".len(),
+                }
+            );
+            assert_eq!(first_edit.scoped_target, Some(first));
+            let second_edit = state
+                .contextual
+                .get(&(second_scope, "smtp_port".into()))
+                .expect("second contextual edit");
+            assert_eq!(second_edit.change.node_id, second);
+            assert_eq!(second_edit.change.new_text, "3025");
+            assert_eq!(second_edit.change.new_caret, 4);
+            assert_eq!(second_edit.change.new_anchor, 4);
+            assert_eq!(second_edit.scoped_target, Some(second));
+        }
+
+        #[test]
+        fn native_ime_and_accesskit_set_value_share_the_text_edit_contract() {
+            let target = WidgetId::explicit("ime-accessibility-parity");
+            let scope_node = WidgetId::explicit("ime-accessibility-scope");
+            let scope_id = 0x717;
+            let semantics = contextual_text_semantics("display_name");
+            let mut ir = CoreIR::new();
+            add_scoped_text_input(&mut ir, target, scope_node, scope_id, semantics.clone());
+            ir.root = Some(scope_node);
+            let layout = LayoutSnapshot::new(LayoutSize::new(320.0, 80.0));
+
+            let mut native_runtime = text_dispatch_runtime();
+            native_runtime
+                .runtime_state
+                .interaction
+                .set_focused(Some(target));
+            native_runtime
+                .handle_input(
+                    InputEvent::Ime(ImeEvent::Commit {
+                        text: "café".into(),
+                    }),
+                    &ir,
+                    &layout,
+                )
+                .expect("native IME dispatch");
+            let native_edit = native_runtime
+                .get_app_state::<TextDispatchState>()
+                .and_then(|state| state.contextual.get(&(scope_id, "display_name".into())))
+                .cloned()
+                .expect("native contextual edit");
+
+            let mut accessibility_runtime = text_dispatch_runtime();
+            assert!(dispatch_set_value_request(
+                &mut accessibility_runtime,
+                &ir,
+                target,
+                "café",
+            ));
+            let accessibility_edit = accessibility_runtime
+                .get_app_state::<TextDispatchState>()
+                .and_then(|state| state.contextual.get(&(scope_id, "display_name".into())))
+                .cloned()
+                .expect("accessibility contextual edit");
+
+            assert_eq!(native_edit, accessibility_edit);
+            assert_eq!(native_edit.change.new_caret, "café".len());
+            assert_eq!(native_edit.change.new_anchor, "café".len());
+        }
+
+        #[test]
+        fn identically_named_contextual_fields_remain_isolated_by_scope() {
+            let first = WidgetId::explicit("account-one-host");
+            let second = WidgetId::explicit("account-two-host");
+            let first_scope = 0x111;
+            let second_scope = 0x222;
+            let semantics = contextual_text_semantics("host");
+            let mut ir = CoreIR::new();
+            add_scoped_text_input(
+                &mut ir,
+                first,
+                WidgetId::explicit("account-one"),
+                first_scope,
+                semantics.clone(),
+            );
+            add_scoped_text_input(
+                &mut ir,
+                second,
+                WidgetId::explicit("account-two"),
+                second_scope,
+                semantics.clone(),
+            );
+            let mut runtime = text_dispatch_runtime();
+
+            assert!(dispatch_set_value_request(
+                &mut runtime,
+                &ir,
+                first,
+                "mail-one",
+            ));
+            assert!(dispatch_set_value_request(
+                &mut runtime,
+                &ir,
+                second,
+                "mail-two",
+            ));
+
+            let state = runtime
+                .get_app_state::<TextDispatchState>()
+                .expect("text dispatch state");
+            assert_eq!(
+                state
+                    .contextual
+                    .get(&(first_scope, "host".into()))
+                    .map(|edit| edit.change.new_text.as_str()),
+                Some("mail-one")
+            );
+            assert_eq!(
+                state
+                    .contextual
+                    .get(&(second_scope, "host".into()))
+                    .map(|edit| edit.change.new_text.as_str()),
+                Some("mail-two")
+            );
+        }
+
+        #[test]
+        fn accesskit_numeric_text_input_preserves_context_and_transitional_text() {
+            let number = WidgetId::explicit("numeric-text-input");
+            let scope_node = WidgetId::explicit("numeric-text-scope");
+            let scope_id = 0x515;
+            let mut number_semantics = contextual_text_semantics("retry_count");
+            number_semantics.text_input_type = TextInputType::Number;
+            let mut ir = CoreIR::new();
+            add_scoped_text_input(
+                &mut ir,
+                number,
+                scope_node,
+                scope_id,
+                number_semantics.clone(),
+            );
+            let mut runtime = text_dispatch_runtime();
+
+            assert!(dispatch_set_value_request(&mut runtime, &ir, number, "-",));
+            assert_eq!(
+                runtime
+                    .get_app_state::<TextDispatchState>()
+                    .and_then(|state| { state.contextual.get(&(scope_id, "retry_count".into())) })
+                    .map(|edit| edit.change.new_text.as_str()),
+                Some("-")
+            );
+            assert!(dispatch_set_value_data(
+                &mut runtime,
+                &ir,
+                &LayoutSnapshot::new(LayoutSize::new(320.0, 80.0)),
+                number,
+                ActionData::NumericValue(12.5),
+            ));
+
+            let state = runtime
+                .get_app_state::<TextDispatchState>()
+                .expect("text dispatch state");
+            let edit = state
+                .contextual
+                .get(&(scope_id, "retry_count".into()))
+                .expect("numeric contextual edit");
+            assert_eq!(edit.change.new_text, "12.5");
+            assert_eq!(edit.change.node_id, number);
+            assert_eq!(edit.scoped_target, Some(number));
+        }
+
+        #[test]
+        fn accesskit_rejects_and_does_not_advertise_edits_for_disabled_or_read_only_inputs() {
+            let disabled = WidgetId::explicit("disabled-text-input");
+            let read_only = WidgetId::explicit("read-only-text-input");
+            let root = WidgetId::explicit("text-input-root");
+            let mut disabled_semantics = contextual_text_semantics("disabled");
+            disabled_semantics.disabled = true;
+            let mut read_only_semantics = contextual_text_semantics("read_only");
+            read_only_semantics.read_only = true;
+            let mut ir = CoreIR::new();
+            add_node(
+                &mut ir,
+                disabled,
+                Op::Semantics(disabled_semantics.clone()),
+                vec![],
+            );
+            add_node(
+                &mut ir,
+                read_only,
+                Op::Semantics(read_only_semantics.clone()),
+                vec![],
+            );
+            add_node(
+                &mut ir,
+                root,
+                Op::Semantics(Semantics::default()),
+                vec![disabled, read_only],
+            );
+            ir.root = Some(root);
+            let mut runtime = text_dispatch_runtime();
+
+            assert!(!dispatch_set_value_request(
+                &mut runtime,
+                &ir,
+                disabled,
+                "must-not-dispatch",
+            ));
+            assert!(!dispatch_set_value_request(
+                &mut runtime,
+                &ir,
+                read_only,
+                "must-not-dispatch",
+            ));
+            assert!(runtime
+                .get_app_state::<TextDispatchState>()
+                .expect("text dispatch state")
+                .contextual
+                .is_empty());
+            assert!(runtime.runtime_state.text_edit.get(disabled).is_none());
+            assert!(runtime.runtime_state.text_edit.get(read_only).is_none());
+
+            let layout = LayoutSnapshot::new(LayoutSize::new(320.0, 80.0));
+            let update = build_tree_update(&ir, &layout, &runtime, 1.0).update;
+            let text_inputs = update
+                .nodes
+                .iter()
+                .filter(|(_, node)| node.role() == AccessRole::TextInput)
+                .map(|(_, node)| node)
+                .collect::<Vec<_>>();
+            assert_eq!(text_inputs.len(), 2);
+            assert!(text_inputs.iter().all(|node| {
+                !node.supports_action(Action::SetValue)
+                    && !node.supports_action(Action::ReplaceSelectedText)
+            }));
+        }
+
+        #[test]
+        fn accessibility_selection_dispatches_unicode_byte_offsets_in_scope() {
+            let target = WidgetId::explicit("unicode-selection");
+            let scope_node = WidgetId::explicit("unicode-scope");
+            let scope_id = 0x404;
+            let semantics = Semantics {
+                role: Role::TextInput,
+                focusable: true,
+                value: Some("aé🦀z".into()),
+                actions: ActionSet {
+                    entries: vec![ActionEntry {
+                        trigger: ActionTrigger::CursorChange,
+                        action_id: CursorChanged::static_id().as_u128(),
+                        payload_data: None,
+                    }],
+                },
+                ..Semantics::default()
+            };
+            let mut ir = CoreIR::new();
+            add_scoped_text_input(&mut ir, target, scope_node, scope_id, semantics.clone());
+            let mut runtime = text_dispatch_runtime();
+            let access_node = NodeId(77);
+            let selection = TextSelection {
+                anchor: TextPosition {
+                    node: access_node,
+                    character_index: 1,
+                },
+                focus: TextPosition {
+                    node: access_node,
+                    character_index: 3,
+                },
+            };
+
+            assert!(set_text_selection(
+                &mut runtime,
+                &ir,
+                target,
+                &semantics,
+                &selection,
+            ));
+
+            let state = runtime
+                .get_app_state::<TextDispatchState>()
+                .expect("text dispatch state");
+            assert_eq!(
+                state.cursors,
+                [(
+                    CursorChanged {
+                        caret: 7,
+                        anchor: 1,
+                    },
+                    Some(scope_id),
+                    Some(target),
+                )]
+            );
+        }
+
+        #[test]
+        fn accesskit_set_value_reports_dispatch_failure_and_restores_editor_state() {
+            let target = WidgetId::explicit("bad-contextual-payload");
+            let semantics = Semantics {
+                role: Role::TextInput,
+                actions: ActionSet {
+                    entries: vec![ActionEntry {
+                        trigger: ActionTrigger::TextChanged,
+                        action_id: UpdateField::static_id().as_u128(),
+                        payload_data: Some(b"not-json".to_vec()),
+                    }],
+                },
+                ..Semantics::default()
+            };
+            let mut ir = CoreIR::new();
+            add_node(&mut ir, target, Op::Semantics(semantics.clone()), vec![]);
+            let mut runtime = text_dispatch_runtime();
+
+            assert!(!dispatch_set_value_request(
+                &mut runtime,
+                &ir,
+                target,
+                "value",
+            ));
+            let state = runtime
+                .get_app_state::<TextDispatchState>()
+                .expect("text dispatch state");
+            assert!(state.contextual.is_empty());
+            assert!(runtime.runtime_state.text_edit.get(target).is_none());
         }
     }
 }

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -9570,7 +9570,11 @@ mod tests {
         runtime
             .runtime_state
             .text_edit
-            .sync_from_runtime(target, "before", Some(2), Some(1));
+            .sync_from_runtime(target, "before", None, None);
+        runtime
+            .runtime_state
+            .text_edit
+            .set_caret(target, 2, Some(1));
         let query = fission_test_driver::SelectorQuery::semantic_identifier("live.text");
 
         let response = handle_fill_text_selector(&query, "private-value", &mut runtime, &pipeline);

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -3013,9 +3013,7 @@ fn handle_key_down<S: GlobalState>(
             key_code: code,
             modifiers,
         });
-        if let Err(e) = runtime.handle_input(input_event, ir, layout) {
-            eprintln!("Keyboard error: {:?}", e);
-        }
+        let _ = runtime.handle_input(input_event, ir, layout);
         invalidations.mark_build();
         mark_text_trace_handled(pending_text_traces, trace_seq);
         if process_pending_effects(
@@ -3543,6 +3541,15 @@ fn scoped_action_input_for_node(ir: &CoreIR, target: WidgetId, input: ActionInpu
     input
 }
 
+fn log_input_dispatch_failure(origin: &str, target: Option<WidgetId>) {
+    match target {
+        Some(target) => {
+            eprintln!("Fission input dispatch failed ({origin}, target {target})");
+        }
+        None => eprintln!("Fission input dispatch failed ({origin})"),
+    }
+}
+
 fn dispatch_text_change(
     ir: &CoreIR,
     runtime: &mut Runtime,
@@ -3550,27 +3557,15 @@ fn dispatch_text_change(
     semantics: &Semantics,
     new_text: String,
 ) -> bool {
-    let Some(entry) = semantics
-        .actions
-        .entries
-        .iter()
-        .find(|entry| entry.trigger == ActionTrigger::Change)
-    else {
+    let selection = new_text.len();
+    let Some((envelope, input)) = fission_core::input::prepare_scoped_text_input_change(
+        ir, semantics, target, new_text, selection, selection,
+    ) else {
+        log_input_dispatch_failure("live_test_fill_text_missing_action", Some(target));
         return false;
     };
-    let Ok(payload) = serde_json::to_vec(&new_text) else {
-        return false;
-    };
-    let input = scoped_action_input_for_node(ir, target, ActionInput::None);
     runtime
-        .dispatch_with_input(
-            ActionEnvelope {
-                id: ActionId::from_u128(entry.action_id),
-                payload,
-            },
-            target,
-            &input,
-        )
+        .dispatch_with_input(envelope, target, &input)
         .is_ok()
 }
 
@@ -3662,6 +3657,7 @@ fn set_text_value_for_test(
     {
         return false;
     }
+    let previous_text_state = runtime.runtime_state.text_edit.get(record.id).cloned();
     set_focus_for_test(runtime, ir, record.id, &record.semantics);
     runtime.runtime_state.text_edit.sync_from_runtime(
         record.id,
@@ -3681,9 +3677,26 @@ fn set_text_value_for_test(
         state.pending_model_sync = true;
         state.clear_preedit();
     }
-    let mut changed =
-        dispatch_text_change(ir, runtime, record.id, &record.semantics, value.to_string());
-    changed |= dispatch_cursor_change(
+    if !dispatch_text_change(ir, runtime, record.id, &record.semantics, value.to_string()) {
+        if let Some(previous) = previous_text_state {
+            runtime
+                .runtime_state
+                .text_edit
+                .states
+                .insert(record.id, previous);
+        } else {
+            runtime.runtime_state.text_edit.states.remove(&record.id);
+        }
+        return false;
+    }
+
+    let has_cursor_action = record
+        .semantics
+        .actions
+        .entries
+        .iter()
+        .any(|entry| entry.trigger == ActionTrigger::CursorChange);
+    let cursor_changed = dispatch_cursor_change(
         ir,
         runtime,
         record.id,
@@ -3691,7 +3704,7 @@ fn set_text_value_for_test(
         value.len(),
         value.len(),
     );
-    changed
+    !has_cursor_action || cursor_changed
 }
 
 fn resolve_selector_response(
@@ -3908,8 +3921,19 @@ fn handle_fill_text_selector(
             vec![(record, Some("not a text input".into()))],
         );
     }
-    set_text_value_for_test(runtime, ir, &record, text);
-    fission_test_driver::TestResponse::Ok {}
+    if set_text_value_for_test(runtime, ir, &record, text) {
+        fission_test_driver::TestResponse::Ok {}
+    } else {
+        selector_failure(
+            query.clone(),
+            fission_test_driver::SelectorFailureKind::UnsupportedAction,
+            "text input edit could not be dispatched",
+            vec![(
+                record,
+                Some("text input action unavailable or rejected".into()),
+            )],
+        )
+    }
 }
 
 fn handle_toggle_selector(
@@ -5125,15 +5149,13 @@ where
                                     target,
                                     presented_frames,
                                 );
-                                runtime
-                                    .handle_input(
-                                        InputEvent::Ime(fission_core::event::ImeEvent::Commit {
-                                            text: text.clone(),
-                                        }),
-                                        ir,
-                                        layout,
-                                    )
-                                    .ok();
+                                let _ = runtime.handle_input(
+                                    InputEvent::Ime(fission_core::event::ImeEvent::Commit {
+                                        text: text.clone(),
+                                    }),
+                                    ir,
+                                    layout,
+                                );
                                 invalidations.mark_build();
                                 mark_text_trace_handled(&mut pending_text_traces, trace_seq);
                                 if process_pending_effects(
@@ -5211,16 +5233,14 @@ where
                                 target,
                                 presented_frames,
                             );
-                            runtime
-                                .handle_input(
-                                    InputEvent::Ime(fission_core::event::ImeEvent::Preedit {
-                                        text,
-                                        cursor,
-                                    }),
-                                    ir,
-                                    layout,
-                                )
-                                .ok();
+                            let _ = runtime.handle_input(
+                                InputEvent::Ime(fission_core::event::ImeEvent::Preedit {
+                                    text,
+                                    cursor,
+                                }),
+                                ir,
+                                layout,
+                            );
                             invalidations.mark_build();
                             mark_text_trace_handled(&mut pending_text_traces, trace_seq);
                             request_redraw_logged(
@@ -5250,13 +5270,11 @@ where
                                 target,
                                 presented_frames,
                             );
-                            runtime
-                                .handle_input(
-                                    InputEvent::Ime(fission_core::event::ImeEvent::Commit { text }),
-                                    ir,
-                                    layout,
-                                )
-                                .ok();
+                            let _ = runtime.handle_input(
+                                InputEvent::Ime(fission_core::event::ImeEvent::Commit { text }),
+                                ir,
+                                layout,
+                            );
                             invalidations.mark_build();
                             mark_text_trace_handled(&mut pending_text_traces, trace_seq);
                             request_redraw_logged(
@@ -5286,13 +5304,11 @@ where
                                 target,
                                 presented_frames,
                             );
-                            runtime
-                                .handle_input(
-                                    InputEvent::Ime(fission_core::event::ImeEvent::Cancel),
-                                    ir,
-                                    layout,
-                                )
-                                .ok();
+                            let _ = runtime.handle_input(
+                                InputEvent::Ime(fission_core::event::ImeEvent::Cancel),
+                                ir,
+                                layout,
+                            );
                             invalidations.mark_build();
                             mark_text_trace_handled(&mut pending_text_traces, trace_seq);
                             request_redraw_logged(
@@ -8616,7 +8632,7 @@ where
                                         target,
                                         presented_frames,
                                     );
-                                    runtime.handle_input(e, ir, layout).ok();
+                                    let _ = runtime.handle_input(e, ir, layout);
                                     invalidations.mark_build();
                                     mark_text_trace_handled(&mut pending_text_traces, trace_seq);
                                     if process_pending_effects(
@@ -9072,9 +9088,10 @@ mod tests {
     use super::{
         animation_redraw_interval, build_window_attributes, clamp_copy_extent_to_texture,
         collect_semantic_records, collect_startup_deep_links_from, cursor_icon_for,
-        downscale_rgba_box, layout_size_to_image_dimensions, logical_viewport_to_physical_size,
-        logical_viewport_to_render_target_size, native_window_size_for_logical_viewport,
-        normalize_scale_factor, normalize_winit_scroll_delta, physical_position_to_layout_point,
+        downscale_rgba_box, handle_fill_text_selector, layout_size_to_image_dimensions,
+        logical_viewport_to_physical_size, logical_viewport_to_render_target_size,
+        native_window_size_for_logical_viewport, normalize_scale_factor,
+        normalize_winit_scroll_delta, physical_position_to_layout_point,
         physical_size_to_layout_size, preferred_native_present_mode, preferred_surface_alpha_mode,
         present_frame_with_winit_coordination, rect_visible_in_scroll_ancestors,
         repeating_animation_redraw_interval, resize_is_unsettled, resolve_build_viewport,
@@ -9087,17 +9104,102 @@ mod tests {
     use crate::pipeline::CompositorTexturePlan;
     use crate::renderer_diagnostics::RendererRequest;
     use crate::InvalidationSet;
+    use fission_core::{
+        Action as FissionAction, ActionId as FissionActionId, ActionRegistry, DeepLinkConfig,
+        GlobalState, MotionPropertyId, ReducerContext, Runtime, UpdateTextInput, WidgetId,
+    };
     use fission_core::{ActiveMotion, MotionEasing, MotionStateMap, MotionValue, ScrollStateMap};
-    use fission_core::{DeepLinkConfig, MotionPropertyId, WidgetId};
-    use fission_ir::semantics::MouseCursor;
+    use fission_ir::semantics::{ActionTrigger, MouseCursor};
     use fission_ir::{CoreIR, FlexDirection, LayoutOp, Op, Role, Semantics};
     use fission_layout::{LayoutNodeGeometry, LayoutRect, LayoutSize, LayoutSnapshot};
+    use serde::{Deserialize, Serialize};
     use std::cell::RefCell;
     use std::collections::HashMap;
     use std::time::Duration;
     use winit::dpi::{PhysicalPosition, PhysicalSize};
     use winit::event::MouseScrollDelta;
     use winit::window::CursorIcon;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct LiveTextAction(String);
+
+    impl FissionAction for LiveTextAction {
+        fn static_id() -> FissionActionId {
+            FissionActionId::from_name("winit_live_test::LiveTextAction")
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct LiveTextState {
+        edit: Option<(String, UpdateTextInput)>,
+    }
+
+    impl GlobalState for LiveTextState {}
+
+    fn record_live_text(
+        state: &mut LiveTextState,
+        action: LiveTextAction,
+        context: &mut ReducerContext<LiveTextState>,
+    ) {
+        state.edit = Some((
+            action.0,
+            context
+                .input
+                .text_change()
+                .expect("live text input")
+                .clone(),
+        ));
+    }
+
+    fn live_text_runtime() -> Runtime {
+        let mut runtime = Runtime::default().with_global_state(LiveTextState::default());
+        let mut registry = ActionRegistry::<LiveTextState>::new();
+        registry.register(
+            record_live_text
+                as fn(&mut LiveTextState, LiveTextAction, &mut ReducerContext<LiveTextState>),
+        );
+        runtime.absorb_registry(registry);
+        runtime
+    }
+
+    fn live_text_pipeline(payload: Option<Vec<u8>>) -> (crate::Pipeline, WidgetId) {
+        let target = WidgetId::explicit("live-text-input");
+        let mut ir = CoreIR::new();
+        let actions = payload
+            .map(|payload_data| fission_ir::ActionSet {
+                entries: vec![fission_ir::ActionEntry {
+                    trigger: ActionTrigger::TextChanged,
+                    action_id: LiveTextAction::static_id().as_u128(),
+                    payload_data: Some(payload_data),
+                }],
+            })
+            .unwrap_or_default();
+        ir.add_node(
+            target,
+            Op::Semantics(Semantics {
+                role: Role::TextInput,
+                identifier: Some("live.text".into()),
+                value: Some(String::new()),
+                actions,
+                focusable: true,
+                ..Semantics::default()
+            }),
+            Vec::new(),
+        );
+        ir.set_root(target);
+        let mut snapshot = LayoutSnapshot::new(LayoutSize::new(320.0, 80.0));
+        snapshot.nodes.insert(
+            target,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(12.0, 12.0, 240.0, 40.0),
+                content_size: LayoutSize::new(240.0, 40.0),
+            },
+        );
+        let mut pipeline = crate::Pipeline::new();
+        pipeline.prev_ir = Some(ir);
+        pipeline.last_snapshot = Some(snapshot);
+        (pipeline, target)
+    }
 
     #[test]
     fn initial_window_maximization_is_opt_in() {
@@ -9412,6 +9514,83 @@ mod tests {
             node.visibility,
             fission_test_driver::VisibilityState::FullyVisible
         );
+    }
+
+    #[test]
+    fn live_test_fill_text_preserves_bound_payload_and_reports_runtime_edit() {
+        let (pipeline, target) =
+            live_text_pipeline(Some(LiveTextAction("smtp_host".into()).encode()));
+        let mut runtime = live_text_runtime();
+        let query = fission_test_driver::SelectorQuery::semantic_identifier("live.text");
+
+        let response = handle_fill_text_selector(&query, "greenmail", &mut runtime, &pipeline);
+
+        assert!(matches!(response, fission_test_driver::TestResponse::Ok {}));
+        let (field, change) = runtime
+            .get_global_state::<LiveTextState>()
+            .and_then(|state| state.edit.as_ref())
+            .expect("live text edit");
+        assert_eq!(field, "smtp_host");
+        assert_eq!(change.node_id, target);
+        assert_eq!(change.new_text, "greenmail");
+        assert_eq!(change.new_caret, "greenmail".len());
+        assert_eq!(change.new_anchor, "greenmail".len());
+    }
+
+    #[test]
+    fn live_test_fill_text_fails_when_text_input_has_no_input_action() {
+        let (pipeline, target) = live_text_pipeline(None);
+        let mut runtime = live_text_runtime();
+        let query = fission_test_driver::SelectorQuery::semantic_identifier("live.text");
+
+        let response = handle_fill_text_selector(&query, "not-retained", &mut runtime, &pipeline);
+
+        match response {
+            fission_test_driver::TestResponse::SelectorError { failure } => {
+                assert_eq!(
+                    failure.kind,
+                    fission_test_driver::SelectorFailureKind::UnsupportedAction
+                );
+                assert_eq!(failure.message, "text input edit could not be dispatched");
+            }
+            other => panic!("expected selector error, got {other:?}"),
+        }
+        assert!(runtime
+            .get_global_state::<LiveTextState>()
+            .expect("live text state")
+            .edit
+            .is_none());
+        assert!(runtime.runtime_state.text_edit.get(target).is_none());
+    }
+
+    #[test]
+    fn live_test_fill_text_fails_and_restores_editor_state_on_dispatch_error() {
+        let (pipeline, target) = live_text_pipeline(Some(b"not-json".to_vec()));
+        let mut runtime = live_text_runtime();
+        runtime
+            .runtime_state
+            .text_edit
+            .sync_from_runtime(target, "before", Some(2), Some(1));
+        let query = fission_test_driver::SelectorQuery::semantic_identifier("live.text");
+
+        let response = handle_fill_text_selector(&query, "private-value", &mut runtime, &pipeline);
+
+        assert!(matches!(
+            response,
+            fission_test_driver::TestResponse::SelectorError { .. }
+        ));
+        assert!(runtime
+            .get_global_state::<LiveTextState>()
+            .expect("live text state")
+            .edit
+            .is_none());
+        let editor = runtime
+            .runtime_state
+            .text_edit
+            .get(target)
+            .expect("restored editor state");
+        assert_eq!(editor.buffer.to_string(), "before");
+        assert_eq!((editor.caret, editor.anchor), (2, 1));
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/tests/composition_cycles.rs
+++ b/crates/shell/fission-shell-winit/tests/composition_cycles.rs
@@ -27,9 +27,11 @@ fn on_toggle(state: &mut GlobalState, _a: Toggle, _ctx: &mut ReducerContext<Glob
 }
 
 #[fission_macros::fission_action]
-struct UpdateText(String);
-fn on_update(state: &mut GlobalState, a: UpdateText, _ctx: &mut ReducerContext<GlobalState>) {
-    state.text = a.0;
+struct UpdateText;
+fn on_update(state: &mut GlobalState, _a: UpdateText, ctx: &mut ReducerContext<GlobalState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.text = change.new_text.clone();
+    }
 }
 
 #[derive(Clone, Default)]
@@ -83,7 +85,7 @@ impl From<Root> for Widget {
             TextInput {
                 value: view.state().text.clone(),
                 placeholder: Some("type".into()),
-                on_change: Some(ctx.bind(UpdateText("".into()), reduce_with!(on_update))),
+                on_input: Some(ctx.bind(UpdateText, reduce_with!(on_update))),
                 width: Some(200.0),
                 height: Some(40.0),
                 ..Default::default()

--- a/crates/shell/fission-shell-winit/tests/composition_strict.rs
+++ b/crates/shell/fission-shell-winit/tests/composition_strict.rs
@@ -30,9 +30,11 @@ fn on_toggle(state: &mut GlobalState, _a: Toggle, _ctx: &mut ReducerContext<Glob
 }
 
 #[fission_macros::fission_action]
-struct UpdateText(String);
-fn on_update(state: &mut GlobalState, a: UpdateText, _ctx: &mut ReducerContext<GlobalState>) {
-    state.text = a.0;
+struct UpdateText;
+fn on_update(state: &mut GlobalState, _a: UpdateText, ctx: &mut ReducerContext<GlobalState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.text = change.new_text.clone();
+    }
 }
 
 #[derive(Clone, Default)]
@@ -86,7 +88,7 @@ impl From<Root> for Widget {
             TextInput {
                 value: view.state().text.clone(),
                 placeholder: Some("type".into()),
-                on_change: Some(ctx.bind(UpdateText("".into()), reduce_with!(on_update))),
+                on_input: Some(ctx.bind(UpdateText, reduce_with!(on_update))),
                 width: Some(200.0),
                 height: Some(40.0),
                 ..Default::default()

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.10.1" } # Corrected path
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.0" } # Corrected path
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/tools/cargo-fission/Cargo.toml
+++ b/crates/tools/cargo-fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fission"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -29,10 +29,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.10.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.10.1" }
-fission-command-release = { path = "../fission-command-release", version = "0.10.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.10.1" }
-fission-command-server = { path = "../fission-command-server", version = "0.10.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.10.1" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.10.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.11.0" }
+fission-command-release = { path = "../fission-command-release", version = "0.11.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.11.0" }
+fission-command-server = { path = "../fission-command-server", version = "0.11.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.11.0" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.11.0" }

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -1517,7 +1517,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fission = { version = "0.10.1", default-features = false, features = ["desktop"] }
+fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
 "#,
         )
         .unwrap();
@@ -1544,7 +1544,7 @@ edition = "2021"
 anyhow = "1"
 
 [dependencies.fission]
-version = "0.10.1"
+version = "0.11.0"
 default-features = true
 features = ["desktop"]
 "#,

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-core"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-core/assets/AGENTS.md
+++ b/crates/tools/fission-command-core/assets/AGENTS.md
@@ -217,7 +217,7 @@ Outside the Fission source workspace, prefer the published crate pinned to the s
 
 ```toml
 [build-dependencies]
-fission-design-system-codegen = { version = "0.10.1" }
+fission-design-system-codegen = { version = "0.11.0" }
 ```
 
 Generate a typed design system from the copied DSP file in `build.rs`:

--- a/crates/tools/fission-command-package/Cargo.toml
+++ b/crates/tools/fission-command-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-package"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -20,9 +20,9 @@ aws-config = "1"
 aws-sdk-s3 = "1"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.10.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.10.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.10.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.11.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.11.0" }
 flate2 = "1.0"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-release/Cargo.toml
+++ b/crates/tools/fission-command-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-release"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -18,9 +18,9 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.10.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.10.1" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.10.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.11.0" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.11.0" }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 jsonwebtoken = "9"
 md-5 = "0.10"

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-run"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,10 +16,10 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-command-core = { path = "../fission-command-core", version = "0.10.1" }
-fission-command-server = { path = "../fission-command-server", version = "0.10.1" }
-fission-command-site = { path = "../fission-command-site", version = "0.10.1" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.10.1" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
+fission-command-server = { path = "../fission-command-server", version = "0.11.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.11.0" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.11.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ureq = "2"

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-server"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-site"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,6 +16,6 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.10.1" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.11.0" }
 serde_json = "1"
 toml = "0.8"

--- a/crates/tools/fission-command-ui/Cargo.toml
+++ b/crates/tools/fission-command-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-ui"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,11 +16,11 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../authoring/fission", version = "0.10.1", default-features = false, features = ["desktop", "terminal-shell"] }
-fission-command-core = { path = "../fission-command-core", version = "0.10.1" }
-fission-command-package = { path = "../fission-command-package", version = "0.10.1" }
-fission-command-release = { path = "../fission-command-release", version = "0.10.1" }
-fission-command-run = { path = "../fission-command-run", version = "0.10.1" }
+fission = { path = "../../authoring/fission", version = "0.11.0", default-features = false, features = ["desktop", "terminal-shell"] }
+fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.11.0" }
+fission-command-release = { path = "../fission-command-release", version = "0.11.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.11.0" }
 rfd = { version = "0.14.1", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 toml_edit = "0.23"

--- a/crates/tools/fission-command-ui/src/actions.rs
+++ b/crates/tools/fission-command-ui/src/actions.rs
@@ -40,34 +40,48 @@ pub fn select_command_session(state: &mut UiState, id: u64) {
 }
 
 #[fission_reducer(SetInitName)]
-pub fn set_init_name(state: &mut UiState, value: String) {
-    state.init_name = value;
+pub fn set_init_name(state: &mut UiState, ctx: &mut ReducerContext<UiState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.init_name = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetInitAppId)]
-pub fn set_init_app_id(state: &mut UiState, value: String) {
-    state.init_app_id = value;
+pub fn set_init_app_id(state: &mut UiState, ctx: &mut ReducerContext<UiState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.init_app_id = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetInitLocalPath)]
-pub fn set_init_local_path(state: &mut UiState, value: String) {
-    state.init_local_path = value;
+pub fn set_init_local_path(state: &mut UiState, ctx: &mut ReducerContext<UiState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.init_local_path = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetHost)]
-pub fn set_host(state: &mut UiState, value: String) {
-    state.host = value;
+pub fn set_host(state: &mut UiState, ctx: &mut ReducerContext<UiState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.host = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetPort)]
-pub fn set_port(state: &mut UiState, value: String) {
-    state.port = value;
+pub fn set_port(state: &mut UiState, ctx: &mut ReducerContext<UiState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.port = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetScrollbackLimitInput)]
-pub fn set_scrollback_limit_input(state: &mut UiState, value: String) {
+pub fn set_scrollback_limit_input(state: &mut UiState, ctx: &mut ReducerContext<UiState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    let value = &change.new_text;
     state.scrollback_limit_input = value.clone();
-    if let Some(limit) = parse_scrollback_limit(&value) {
+    if let Some(limit) = parse_scrollback_limit(value) {
         state.set_scrollback_limit(limit);
     }
 }

--- a/crates/tools/fission-command-ui/src/components/controls.rs
+++ b/crates/tools/fission-command-ui/src/components/controls.rs
@@ -151,7 +151,7 @@ impl From<FormTextField> for Widget {
             value: component.value.clone(),
             label: Some(component.label.clone().into()),
             placeholder: Some(component.placeholder.clone().into()),
-            on_change: Some(component.action.clone()),
+            on_input: Some(component.action.clone()),
             width: Some(component.width),
             height: Some(density.text_input_height()),
             padding: Some(density.text_input_padding()),

--- a/crates/tools/fission-command-ui/src/publish/mod.rs
+++ b/crates/tools/fission-command-ui/src/publish/mod.rs
@@ -3,13 +3,10 @@ use fission::op::{Color, Fill};
 use fission::prelude::*;
 use fission_command_core::{read_project_config, DistributionProvider, Target};
 use fission_command_package::{
-    package_silent, publish_flow_snapshot, CheckSeverity, CheckStatus, PackageFormat,
-    PackageOptions, PublishFlowSnapshot, PublishShellOptions, ReadinessCheck,
+    package_silent, CheckSeverity, CheckStatus, PackageFormat, PackageOptions, PublishShellOptions,
+    ReadinessCheck,
 };
-use fission_command_release::{
-    publish_workflow, release_plan_snapshot, release_readiness_checks, PublishWorkflowOptions,
-    ReleasePlanSnapshot,
-};
+use fission_command_release::{publish_workflow, PublishWorkflowOptions, ReleasePlanSnapshot};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
@@ -20,6 +17,7 @@ use std::thread;
 
 mod fission_toml;
 mod fs_ops;
+mod snapshot;
 mod style;
 #[cfg(test)]
 mod tests;
@@ -27,6 +25,7 @@ mod widgets;
 
 use fission_toml::*;
 use fs_ops::*;
+use snapshot::*;
 use style::theme_for_mode;
 pub use widgets::PublishApp;
 
@@ -881,113 +880,6 @@ impl PublishUiState {
     }
 }
 
-fn redact_output_lines(output: &str) -> Vec<String> {
-    output.lines().map(redact_sensitive_text).collect()
-}
-
-fn redact_sensitive_text(text: &str) -> String {
-    let mut redacted = text.to_string();
-    for (key, value) in secret_env_values() {
-        redacted = redacted.replace(&value, &format!("<redacted:{key}>"));
-    }
-    redacted
-}
-
-fn secret_env_values() -> Vec<(String, String)> {
-    let mut values = env::vars()
-        .filter(|(key, value)| secretish_env_key(key) && value.len() >= 8)
-        .map(|(key, value)| (key.to_ascii_uppercase(), value))
-        .collect::<Vec<_>>();
-    values.sort_by(|(_, left), (_, right)| right.len().cmp(&left.len()));
-    values.dedup_by(|(_, left), (_, right)| left == right);
-    values
-}
-
-fn secretish_env_key(key: &str) -> bool {
-    let key = key.to_ascii_uppercase();
-    [
-        "PASSWORD",
-        "TOKEN",
-        "SECRET",
-        "PRIVATE",
-        "CREDENTIAL",
-        "KEYSTORE",
-        "SERVICE_ACCOUNT",
-        "API_KEY",
-        "ACCESS_KEY",
-        "CLIENT_SECRET",
-        "CERTIFICATE",
-        "P8",
-        "P12",
-        "PFX",
-        "JKS",
-    ]
-    .iter()
-    .any(|needle| key.contains(needle))
-}
-
-#[derive(Clone, Debug)]
-struct SnapshotRefreshResult {
-    snapshot: PublishFlowSnapshot,
-    release_plan: Option<ReleasePlanSnapshot>,
-    release_checks: Vec<ReadinessCheck>,
-}
-
-fn collect_refresh_snapshot(options: PublishShellOptions) -> Result<SnapshotRefreshResult> {
-    let snapshot = publish_flow_snapshot(&options)?;
-    let workflow_options = publish_workflow_options_for_snapshot(&options, &snapshot);
-    let release_plan = release_plan_snapshot(workflow_options.clone()).ok();
-    let release_checks = release_readiness_checks(workflow_options)
-        .unwrap_or_else(|err| readiness_error("release.plan.readiness_failed", err));
-    Ok(SnapshotRefreshResult {
-        snapshot,
-        release_plan,
-        release_checks,
-    })
-}
-
-fn publish_workflow_options_for_snapshot(
-    options: &PublishShellOptions,
-    snapshot: &PublishFlowSnapshot,
-) -> PublishWorkflowOptions {
-    PublishWorkflowOptions {
-        project_dir: snapshot.project_dir.clone(),
-        provider: snapshot.provider,
-        target: Some(snapshot.target),
-        format: Some(snapshot.format),
-        artifact: if snapshot.artifact_manifest.as_os_str().is_empty() {
-            None
-        } else {
-            Some(snapshot.artifact_manifest.clone())
-        },
-        site: snapshot.site.clone(),
-        deploy: options.deploy.clone(),
-        track: snapshot.track.clone().or_else(|| options.track.clone()),
-        locales: if snapshot.locales.is_empty() {
-            options.locales.clone()
-        } else {
-            snapshot.locales.clone()
-        },
-        overwrite_remote: false,
-        dry_run: true,
-        yes: true,
-        json: true,
-    }
-}
-
-fn readiness_error(id: &str, err: anyhow::Error) -> Vec<ReadinessCheck> {
-    vec![ReadinessCheck {
-        id: id.to_string(),
-        severity: CheckSeverity::Error,
-        status: CheckStatus::Failed,
-        summary: "release plan could not be loaded".to_string(),
-        details: Some(err.to_string()),
-        remediation: vec![
-            "Run `fission readiness release --json` for full release-plan diagnostics.".to_string(),
-        ],
-    }]
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PublishBoard {
     Android,
@@ -1662,70 +1554,8 @@ struct PublishTaskData {
     output: Vec<String>,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct SnapshotRefreshState {
-    shared: Arc<Mutex<SnapshotRefreshData>>,
-}
-
-impl SnapshotRefreshState {
-    fn new() -> Self {
-        Self {
-            shared: Arc::new(Mutex::new(SnapshotRefreshData {
-                status: TaskStatus::Running,
-                revision: 1,
-                message: "Refreshing preflight...".to_string(),
-                result: None,
-            })),
-        }
-    }
-
-    fn status(&self) -> TaskStatus {
-        self.shared
-            .lock()
-            .expect("snapshot refresh lock poisoned")
-            .status
-    }
-
-    fn revision(&self) -> u64 {
-        self.shared
-            .lock()
-            .expect("snapshot refresh lock poisoned")
-            .revision
-    }
-
-    fn message(&self) -> String {
-        self.shared
-            .lock()
-            .expect("snapshot refresh lock poisoned")
-            .message
-            .clone()
-    }
-
-    fn result(&self) -> Option<Result<SnapshotRefreshResult, String>> {
-        self.shared
-            .lock()
-            .expect("snapshot refresh lock poisoned")
-            .result
-            .clone()
-    }
-}
-
-impl PartialEq for SnapshotRefreshState {
-    fn eq(&self, other: &Self) -> bool {
-        self.revision() == other.revision()
-    }
-}
-
-#[derive(Clone, Debug)]
-struct SnapshotRefreshData {
-    status: TaskStatus,
-    revision: u64,
-    message: String,
-    result: Option<Result<SnapshotRefreshResult, String>>,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum TaskStatus {
+pub(super) enum TaskStatus {
     Running,
     Ok,
     Failed,
@@ -1769,108 +1599,180 @@ fn publish_toggle_theme(state: &mut PublishUiState) {
     };
 }
 
+fn text_input_value(ctx: &ReducerContext<PublishUiState>) -> Option<String> {
+    ctx.input
+        .text_change()
+        .map(|change| change.new_text.clone())
+}
+
 #[fission_reducer(PublishSetTrack)]
-fn publish_set_track(state: &mut PublishUiState, value: String) {
+fn publish_set_track(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    let Some(value) = text_input_value(ctx) else {
+        return;
+    };
     state.track = value;
     state.status_message =
         "Track updated; refresh preflight to re-check provider readiness.".into();
 }
 
 #[fission_reducer(PublishSetLocales)]
-fn publish_set_locales(state: &mut PublishUiState, value: String) {
+fn publish_set_locales(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    let Some(value) = text_input_value(ctx) else {
+        return;
+    };
     state.locales_input = value;
     state.status_message =
         "Locales updated; refresh preflight to re-check release readiness.".into();
 }
 
 #[fission_reducer(PublishSetPlayJson)]
-fn publish_set_play_json(state: &mut PublishUiState, value: String) {
-    state.play_json_path = value;
+fn publish_set_play_json(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.play_json_path = value;
+    }
 }
 
 #[fission_reducer(PublishSetAndroidJks)]
-fn publish_set_android_jks(state: &mut PublishUiState, value: String) {
-    state.android_jks_path = value;
+fn publish_set_android_jks(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.android_jks_path = value;
+    }
 }
 
 #[fission_reducer(PublishSetAndroidAlias)]
-fn publish_set_android_alias(state: &mut PublishUiState, value: String) {
-    state.android_alias = value;
+fn publish_set_android_alias(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.android_alias = value;
+    }
 }
 
 #[fission_reducer(PublishSetAndroidPassword)]
-fn publish_set_android_password(state: &mut PublishUiState, value: String) {
-    state.android_password = value;
+fn publish_set_android_password(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.android_password = value;
+    }
 }
 
 #[fission_reducer(PublishSetAppStoreKeyPath)]
-fn publish_set_app_store_key_path(state: &mut PublishUiState, value: String) {
-    state.app_store_key_path = value;
+fn publish_set_app_store_key_path(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.app_store_key_path = value;
+    }
 }
 
 #[fission_reducer(PublishSetAppStoreKeyId)]
-fn publish_set_app_store_key_id(state: &mut PublishUiState, value: String) {
-    state.app_store_key_id = value;
+fn publish_set_app_store_key_id(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.app_store_key_id = value;
+    }
 }
 
 #[fission_reducer(PublishSetAppStoreIssuerId)]
-fn publish_set_app_store_issuer_id(state: &mut PublishUiState, value: String) {
-    state.app_store_issuer_id = value;
+fn publish_set_app_store_issuer_id(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.app_store_issuer_id = value;
+    }
 }
 
 #[fission_reducer(PublishSetWindowsPfx)]
-fn publish_set_windows_pfx(state: &mut PublishUiState, value: String) {
-    state.windows_pfx_path = value;
+fn publish_set_windows_pfx(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.windows_pfx_path = value;
+    }
 }
 
 #[fission_reducer(PublishSetWindowsPassword)]
-fn publish_set_windows_password(state: &mut PublishUiState, value: String) {
-    state.windows_password = value;
+fn publish_set_windows_password(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.windows_password = value;
+    }
 }
 
 #[fission_reducer(PublishSetAzureTenant)]
-fn publish_set_azure_tenant(state: &mut PublishUiState, value: String) {
-    state.azure_tenant_id = value;
+fn publish_set_azure_tenant(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.azure_tenant_id = value;
+    }
 }
 
 #[fission_reducer(PublishSetAzureClient)]
-fn publish_set_azure_client(state: &mut PublishUiState, value: String) {
-    state.azure_client_id = value;
+fn publish_set_azure_client(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.azure_client_id = value;
+    }
 }
 
 #[fission_reducer(PublishSetMicrosoftSecret)]
-fn publish_set_microsoft_secret(state: &mut PublishUiState, value: String) {
-    state.microsoft_secret = value;
+fn publish_set_microsoft_secret(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.microsoft_secret = value;
+    }
 }
 
 #[fission_reducer(PublishSetAwsProfile)]
-fn publish_set_aws_profile(state: &mut PublishUiState, value: String) {
-    state.aws_profile = value;
+fn publish_set_aws_profile(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.aws_profile = value;
+    }
 }
 
 #[fission_reducer(PublishSetAwsRegion)]
-fn publish_set_aws_region(state: &mut PublishUiState, value: String) {
-    state.aws_region = value;
+fn publish_set_aws_region(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.aws_region = value;
+    }
 }
 
 #[fission_reducer(PublishSetAwsEndpoint)]
-fn publish_set_aws_endpoint(state: &mut PublishUiState, value: String) {
-    state.aws_endpoint = value;
+fn publish_set_aws_endpoint(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.aws_endpoint = value;
+    }
 }
 
 #[fission_reducer(PublishSetAwsAccessKey)]
-fn publish_set_aws_access_key(state: &mut PublishUiState, value: String) {
-    state.aws_access_key_id = value;
+fn publish_set_aws_access_key(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.aws_access_key_id = value;
+    }
 }
 
 #[fission_reducer(PublishSetAwsSecretKey)]
-fn publish_set_aws_secret_key(state: &mut PublishUiState, value: String) {
-    state.aws_secret_access_key = value;
+fn publish_set_aws_secret_key(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    if let Some(value) = text_input_value(ctx) {
+        state.aws_secret_access_key = value;
+    }
 }
 
 #[fission_reducer(PublishSetConfirmation)]
-fn publish_set_confirmation(state: &mut PublishUiState, value: String) {
-    state.publish_confirmation = value;
+fn publish_set_confirmation(state: &mut PublishUiState, ctx: &mut ReducerContext<PublishUiState>) {
+    if let Some(value) = text_input_value(ctx) {
+        state.publish_confirmation = value;
+    }
 }
 
 #[fission_reducer(PublishSaveCredentials)]
@@ -1890,14 +1792,26 @@ fn publish_close_config_editor(state: &mut PublishUiState) {
 }
 
 #[fission_reducer(PublishSetConfigFieldPath)]
-fn publish_set_config_field_path(state: &mut PublishUiState, value: String) {
+fn publish_set_config_field_path(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    let Some(value) = text_input_value(ctx) else {
+        return;
+    };
     if let Some(editor) = &mut state.config_editor {
         editor.field_path = value;
     }
 }
 
 #[fission_reducer(PublishSetConfigFieldValue)]
-fn publish_set_config_field_value(state: &mut PublishUiState, value: String) {
+fn publish_set_config_field_value(
+    state: &mut PublishUiState,
+    ctx: &mut ReducerContext<PublishUiState>,
+) {
+    let Some(value) = text_input_value(ctx) else {
+        return;
+    };
     if let Some(editor) = &mut state.config_editor {
         editor.value = value;
     }

--- a/crates/tools/fission-command-ui/src/publish/snapshot.rs
+++ b/crates/tools/fission-command-ui/src/publish/snapshot.rs
@@ -1,0 +1,182 @@
+use super::TaskStatus;
+use anyhow::Result;
+use fission_command_package::{
+    publish_flow_snapshot, CheckSeverity, CheckStatus, PublishFlowSnapshot, PublishShellOptions,
+    ReadinessCheck,
+};
+use fission_command_release::{
+    release_plan_snapshot, release_readiness_checks, PublishWorkflowOptions, ReleasePlanSnapshot,
+};
+use std::env;
+use std::sync::{Arc, Mutex};
+
+pub(super) fn redact_output_lines(output: &str) -> Vec<String> {
+    output.lines().map(redact_sensitive_text).collect()
+}
+
+fn redact_sensitive_text(text: &str) -> String {
+    let mut redacted = text.to_string();
+    for (key, value) in secret_env_values() {
+        redacted = redacted.replace(&value, &format!("<redacted:{key}>"));
+    }
+    redacted
+}
+
+fn secret_env_values() -> Vec<(String, String)> {
+    let mut values = env::vars()
+        .filter(|(key, value)| secretish_env_key(key) && value.len() >= 8)
+        .map(|(key, value)| (key.to_ascii_uppercase(), value))
+        .collect::<Vec<_>>();
+    values.sort_by(|(_, left), (_, right)| right.len().cmp(&left.len()));
+    values.dedup_by(|(_, left), (_, right)| left == right);
+    values
+}
+
+fn secretish_env_key(key: &str) -> bool {
+    let key = key.to_ascii_uppercase();
+    [
+        "PASSWORD",
+        "TOKEN",
+        "SECRET",
+        "PRIVATE",
+        "CREDENTIAL",
+        "KEYSTORE",
+        "SERVICE_ACCOUNT",
+        "API_KEY",
+        "ACCESS_KEY",
+        "CLIENT_SECRET",
+        "CERTIFICATE",
+        "P8",
+        "P12",
+        "PFX",
+        "JKS",
+    ]
+    .iter()
+    .any(|needle| key.contains(needle))
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SnapshotRefreshResult {
+    pub(super) snapshot: PublishFlowSnapshot,
+    pub(super) release_plan: Option<ReleasePlanSnapshot>,
+    pub(super) release_checks: Vec<ReadinessCheck>,
+}
+
+pub(super) fn collect_refresh_snapshot(
+    options: PublishShellOptions,
+) -> Result<SnapshotRefreshResult> {
+    let snapshot = publish_flow_snapshot(&options)?;
+    let workflow_options = publish_workflow_options_for_snapshot(&options, &snapshot);
+    let release_plan = release_plan_snapshot(workflow_options.clone()).ok();
+    let release_checks = release_readiness_checks(workflow_options)
+        .unwrap_or_else(|err| readiness_error("release.plan.readiness_failed", err));
+    Ok(SnapshotRefreshResult {
+        snapshot,
+        release_plan,
+        release_checks,
+    })
+}
+
+fn publish_workflow_options_for_snapshot(
+    options: &PublishShellOptions,
+    snapshot: &PublishFlowSnapshot,
+) -> PublishWorkflowOptions {
+    PublishWorkflowOptions {
+        project_dir: snapshot.project_dir.clone(),
+        provider: snapshot.provider,
+        target: Some(snapshot.target),
+        format: Some(snapshot.format),
+        artifact: if snapshot.artifact_manifest.as_os_str().is_empty() {
+            None
+        } else {
+            Some(snapshot.artifact_manifest.clone())
+        },
+        site: snapshot.site.clone(),
+        deploy: options.deploy.clone(),
+        track: snapshot.track.clone().or_else(|| options.track.clone()),
+        locales: if snapshot.locales.is_empty() {
+            options.locales.clone()
+        } else {
+            snapshot.locales.clone()
+        },
+        overwrite_remote: false,
+        dry_run: true,
+        yes: true,
+        json: true,
+    }
+}
+
+fn readiness_error(id: &str, err: anyhow::Error) -> Vec<ReadinessCheck> {
+    vec![ReadinessCheck {
+        id: id.to_string(),
+        severity: CheckSeverity::Error,
+        status: CheckStatus::Failed,
+        summary: "release plan could not be loaded".to_string(),
+        details: Some(err.to_string()),
+        remediation: vec![
+            "Run `fission readiness release --json` for full release-plan diagnostics.".to_string(),
+        ],
+    }]
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SnapshotRefreshState {
+    pub(super) shared: Arc<Mutex<SnapshotRefreshData>>,
+}
+
+impl SnapshotRefreshState {
+    pub(super) fn new() -> Self {
+        Self {
+            shared: Arc::new(Mutex::new(SnapshotRefreshData {
+                status: TaskStatus::Running,
+                revision: 1,
+                message: "Refreshing preflight...".to_string(),
+                result: None,
+            })),
+        }
+    }
+
+    pub(super) fn status(&self) -> TaskStatus {
+        self.shared
+            .lock()
+            .expect("snapshot refresh lock poisoned")
+            .status
+    }
+
+    pub(super) fn revision(&self) -> u64 {
+        self.shared
+            .lock()
+            .expect("snapshot refresh lock poisoned")
+            .revision
+    }
+
+    pub(super) fn message(&self) -> String {
+        self.shared
+            .lock()
+            .expect("snapshot refresh lock poisoned")
+            .message
+            .clone()
+    }
+
+    pub(super) fn result(&self) -> Option<Result<SnapshotRefreshResult, String>> {
+        self.shared
+            .lock()
+            .expect("snapshot refresh lock poisoned")
+            .result
+            .clone()
+    }
+}
+
+impl PartialEq for SnapshotRefreshState {
+    fn eq(&self, other: &Self) -> bool {
+        self.revision() == other.revision()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SnapshotRefreshData {
+    pub(super) status: TaskStatus,
+    pub(super) revision: u64,
+    pub(super) message: String,
+    pub(super) result: Option<Result<SnapshotRefreshResult, String>>,
+}

--- a/crates/tools/fission-command-ui/src/publish/widgets/boards.rs
+++ b/crates/tools/fission-command-ui/src/publish/widgets/boards.rs
@@ -288,28 +288,12 @@ impl From<AndroidBoard> for Widget {
     fn from(board: AndroidBoard) -> Widget {
         let (ctx, view) = fission::build::current::<PublishUiState>();
         let m = metrics(board.layout);
-        let set_play = with_reducer!(
-            ctx,
-            PublishSetPlayJson(String::new()),
-            publish_set_play_json
-        );
-        let set_jks = with_reducer!(
-            ctx,
-            PublishSetAndroidJks(String::new()),
-            publish_set_android_jks
-        );
-        let set_alias = with_reducer!(
-            ctx,
-            PublishSetAndroidAlias(String::new()),
-            publish_set_android_alias
-        );
-        let set_pass = with_reducer!(
-            ctx,
-            PublishSetAndroidPassword(String::new()),
-            publish_set_android_password
-        );
-        let set_track = with_reducer!(ctx, PublishSetTrack(String::new()), publish_set_track);
-        let set_locales = with_reducer!(ctx, PublishSetLocales(String::new()), publish_set_locales);
+        let set_play = with_reducer!(ctx, PublishSetPlayJson, publish_set_play_json);
+        let set_jks = with_reducer!(ctx, PublishSetAndroidJks, publish_set_android_jks);
+        let set_alias = with_reducer!(ctx, PublishSetAndroidAlias, publish_set_android_alias);
+        let set_pass = with_reducer!(ctx, PublishSetAndroidPassword, publish_set_android_password);
+        let set_track = with_reducer!(ctx, PublishSetTrack, publish_set_track);
+        let set_locales = with_reducer!(ctx, PublishSetLocales, publish_set_locales);
         let pick_play = with_reducer!(
             ctx,
             PublishOpenFilePicker(FilePurpose::PlayServiceJson),
@@ -341,11 +325,7 @@ impl From<AndroidBoard> for Widget {
             PublishStartTask(PublishTaskKind::Publish),
             publish_start_task
         );
-        let confirm = with_reducer!(
-            ctx,
-            PublishSetConfirmation(String::new()),
-            publish_set_confirmation
-        );
+        let confirm = with_reducer!(ctx, PublishSetConfirmation, publish_set_confirmation);
         BoardRows { rows: vec![
             vec![
                 NumberedPanel { number: 1, title: "Android-specific preflight".into(), subtitle: "We'll check your Android toolchain and environment.".into(), width: m.col, height: m.top_h, tone: tone_for_checks(&view.state().package_checks), children: widgets![
@@ -450,17 +430,13 @@ impl From<IosBoard> for Widget {
         let third = (m.full - board.layout.gap * 2.0) / 3.0;
         let key_path = with_reducer!(
             ctx,
-            PublishSetAppStoreKeyPath(String::new()),
+            PublishSetAppStoreKeyPath,
             publish_set_app_store_key_path
         );
-        let key_id = with_reducer!(
-            ctx,
-            PublishSetAppStoreKeyId(String::new()),
-            publish_set_app_store_key_id
-        );
+        let key_id = with_reducer!(ctx, PublishSetAppStoreKeyId, publish_set_app_store_key_id);
         let issuer = with_reducer!(
             ctx,
-            PublishSetAppStoreIssuerId(String::new()),
+            PublishSetAppStoreIssuerId,
             publish_set_app_store_issuer_id
         );
         let browse = with_reducer!(
@@ -484,11 +460,7 @@ impl From<IosBoard> for Widget {
             PublishStartTask(PublishTaskKind::Publish),
             publish_start_task
         );
-        let confirm = with_reducer!(
-            ctx,
-            PublishSetConfirmation(String::new()),
-            publish_set_confirmation
-        );
+        let confirm = with_reducer!(ctx, PublishSetConfirmation, publish_set_confirmation);
         BoardRows { rows: vec![
             vec![
                 NumberedPanel { number: 1, title: "Preflight: iOS Environment".into(), subtitle: "Check host, Xcode, toolchain, and signing setup.".into(), width: third, height: m.top_h, tone: tone_for_checks(&view.state().package_checks), children: widgets![CheckList { checks: view.state().package_checks.clone(), limit: 10 }, Callout { tone: StatusTone::Info, text: "All checks are local and can be re-run before upload.".into() }]},
@@ -542,31 +514,11 @@ impl From<WindowsBoard> for Widget {
         let (ctx, view) = fission::build::current::<PublishUiState>();
         let m = metrics(board.layout);
         let third = (m.full - board.layout.gap * 2.0) / 3.0;
-        let pfx = with_reducer!(
-            ctx,
-            PublishSetWindowsPfx(String::new()),
-            publish_set_windows_pfx
-        );
-        let password = with_reducer!(
-            ctx,
-            PublishSetWindowsPassword(String::new()),
-            publish_set_windows_password
-        );
-        let tenant = with_reducer!(
-            ctx,
-            PublishSetAzureTenant(String::new()),
-            publish_set_azure_tenant
-        );
-        let client = with_reducer!(
-            ctx,
-            PublishSetAzureClient(String::new()),
-            publish_set_azure_client
-        );
-        let secret = with_reducer!(
-            ctx,
-            PublishSetMicrosoftSecret(String::new()),
-            publish_set_microsoft_secret
-        );
+        let pfx = with_reducer!(ctx, PublishSetWindowsPfx, publish_set_windows_pfx);
+        let password = with_reducer!(ctx, PublishSetWindowsPassword, publish_set_windows_password);
+        let tenant = with_reducer!(ctx, PublishSetAzureTenant, publish_set_azure_tenant);
+        let client = with_reducer!(ctx, PublishSetAzureClient, publish_set_azure_client);
+        let secret = with_reducer!(ctx, PublishSetMicrosoftSecret, publish_set_microsoft_secret);
         let browse = with_reducer!(
             ctx,
             PublishOpenFilePicker(FilePurpose::WindowsCertificate),
@@ -588,11 +540,7 @@ impl From<WindowsBoard> for Widget {
             PublishStartTask(PublishTaskKind::Publish),
             publish_start_task
         );
-        let confirm = with_reducer!(
-            ctx,
-            PublishSetConfirmation(String::new()),
-            publish_set_confirmation
-        );
+        let confirm = with_reducer!(ctx, PublishSetConfirmation, publish_set_confirmation);
         BoardRows { rows: vec![
             vec![
                 NumberedPanel { number: 1, title: "Windows preflight".into(), subtitle: "Verify your environment before building and submitting.".into(), width: third, height: m.top_h, tone: tone_for_checks(&view.state().package_checks), children: widgets![CheckList { checks: view.state().package_checks.clone(), limit: 9 }, Callout { tone: StatusTone::Info, text: "Issues must be resolved before continuing to submission.".into() }]},
@@ -626,31 +574,11 @@ impl From<S3Board> for Widget {
     fn from(board: S3Board) -> Widget {
         let (ctx, view) = fission::build::current::<PublishUiState>();
         let m = metrics(board.layout);
-        let profile = with_reducer!(
-            ctx,
-            PublishSetAwsProfile(String::new()),
-            publish_set_aws_profile
-        );
-        let region = with_reducer!(
-            ctx,
-            PublishSetAwsRegion(String::new()),
-            publish_set_aws_region
-        );
-        let endpoint = with_reducer!(
-            ctx,
-            PublishSetAwsEndpoint(String::new()),
-            publish_set_aws_endpoint
-        );
-        let access = with_reducer!(
-            ctx,
-            PublishSetAwsAccessKey(String::new()),
-            publish_set_aws_access_key
-        );
-        let secret = with_reducer!(
-            ctx,
-            PublishSetAwsSecretKey(String::new()),
-            publish_set_aws_secret_key
-        );
+        let profile = with_reducer!(ctx, PublishSetAwsProfile, publish_set_aws_profile);
+        let region = with_reducer!(ctx, PublishSetAwsRegion, publish_set_aws_region);
+        let endpoint = with_reducer!(ctx, PublishSetAwsEndpoint, publish_set_aws_endpoint);
+        let access = with_reducer!(ctx, PublishSetAwsAccessKey, publish_set_aws_access_key);
+        let secret = with_reducer!(ctx, PublishSetAwsSecretKey, publish_set_aws_secret_key);
         let save = with_reducer!(ctx, PublishSaveCredentials, publish_save_credentials);
         let package = with_reducer!(
             ctx,
@@ -667,11 +595,7 @@ impl From<S3Board> for Widget {
             PublishStartTask(PublishTaskKind::Publish),
             publish_start_task
         );
-        let confirm = with_reducer!(
-            ctx,
-            PublishSetConfirmation(String::new()),
-            publish_set_confirmation
-        );
+        let confirm = with_reducer!(ctx, PublishSetConfirmation, publish_set_confirmation);
         BoardRows { rows: vec![
             vec![
                 NumberedPanel { number: 1, title: "S3 Preflight".into(), subtitle: "Ensure the environment is ready to publish.".into(), width: m.col, height: m.top_h, tone: tone_for_checks(&view.state().distribution_checks), children: widgets![CheckList { checks: view.state().distribution_checks.clone(), limit: 8 }, Callout { tone: StatusTone::Info, text: "One item needing review blocks final upload until resolved.".into() }]},

--- a/crates/tools/fission-command-ui/src/publish/widgets/config_editor.rs
+++ b/crates/tools/fission-command-ui/src/publish/widgets/config_editor.rs
@@ -99,12 +99,12 @@ impl From<ConfigEditorBody> for Widget {
             });
         let field_path = with_reducer!(
             ctx.clone(),
-            PublishSetConfigFieldPath(String::new()),
+            PublishSetConfigFieldPath,
             publish_set_config_field_path
         );
         let field_value = with_reducer!(
             ctx.clone(),
-            PublishSetConfigFieldValue(String::new()),
+            PublishSetConfigFieldValue,
             publish_set_config_field_value
         );
         let apply = with_reducer!(

--- a/crates/tools/fission-command-ui/src/publish/widgets/primitives.rs
+++ b/crates/tools/fission-command-ui/src/publish/widgets/primitives.rs
@@ -816,7 +816,7 @@ impl From<PublishTextField> for Widget {
             label: Some(field.label.into()),
             value: field.value,
             placeholder: Some(field.placeholder.into()),
-            on_change: Some(field.on_change),
+            on_input: Some(field.on_change),
             width: Some(if layout.terminal {
                 layout.column_width - 2.0
             } else {

--- a/crates/tools/fission-command-ui/src/screens/project.rs
+++ b/crates/tools/fission-command-ui/src/screens/project.rs
@@ -18,10 +18,9 @@ impl From<ProjectScreen> for Widget {
         let palette = UiPalette::for_mode(view.state().theme_mode);
         let init = with_reducer!(ctx, RequestCommand(UiCommand::InitProject), request_command);
         let refresh = with_reducer!(ctx, RequestCommand(UiCommand::Refresh), request_command);
-        let set_name = with_reducer!(ctx, SetInitName(String::new()), set_init_name);
-        let set_app_id = with_reducer!(ctx, SetInitAppId(String::new()), set_init_app_id);
-        let set_local_path =
-            with_reducer!(ctx, SetInitLocalPath(String::new()), set_init_local_path);
+        let set_name = with_reducer!(ctx, SetInitName, set_init_name);
+        let set_app_id = with_reducer!(ctx, SetInitAppId, set_init_app_id);
+        let set_local_path = with_reducer!(ctx, SetInitLocalPath, set_init_local_path);
         let mut target_buttons = Vec::new();
         for target in all_targets() {
             let configured = view.state().targets.contains(&target);

--- a/crates/tools/fission-command-ui/src/screens/run_build_test.rs
+++ b/crates/tools/fission-command-ui/src/screens/run_build_test.rs
@@ -148,8 +148,8 @@ impl From<ExecutionScreen> for Widget {
     }
 }
 fn network_fields(ctx: BuildCtxHandle<UiState>, view: ViewHandle<UiState>) -> Widget {
-    let host = with_reducer!(ctx, SetHost(String::new()), set_host);
-    let port = with_reducer!(ctx, SetPort(String::new()), set_port);
+    let host = with_reducer!(ctx, SetHost, set_host);
+    let port = with_reducer!(ctx, SetPort, set_port);
     Row {
         gap: Some(1.0),
         children: vec![

--- a/crates/tools/fission-command-ui/src/screens/settings.rs
+++ b/crates/tools/fission-command-ui/src/screens/settings.rs
@@ -15,11 +15,8 @@ impl From<SettingsScreen> for Widget {
     fn from(_component: SettingsScreen) -> Self {
         let (ctx, view) = fission::build::current::<UiState>();
         let palette = UiPalette::for_mode(view.state().theme_mode);
-        let set_limit_input = with_reducer!(
-            ctx,
-            SetScrollbackLimitInput(String::new()),
-            set_scrollback_limit_input
-        );
+        let set_limit_input =
+            with_reducer!(ctx, SetScrollbackLimitInput, set_scrollback_limit_input);
         let compact = with_reducer!(ctx, ToggleCompactMode, toggle_compact_mode);
         let presets = [10_000usize, 100_000, 500_000, 1_000_000]
             .into_iter()

--- a/crates/tools/fission-command-ui/src/screens/site.rs
+++ b/crates/tools/fission-command-ui/src/screens/site.rs
@@ -22,8 +22,8 @@ impl From<SiteScreen> for Widget {
         let serve = with_reducer!(ctx, RequestCommand(UiCommand::SiteServe), request_command);
         let release = with_reducer!(ctx, ToggleRelease, toggle_release);
         let no_open = with_reducer!(ctx, ToggleNoOpen, toggle_no_open);
-        let host = with_reducer!(ctx, SetHost(String::new()), set_host);
-        let port = with_reducer!(ctx, SetPort(String::new()), set_port);
+        let host = with_reducer!(ctx, SetHost, set_host);
+        let port = with_reducer!(ctx, SetPort, set_port);
 
         Column {
             gap: Some(1.0),

--- a/crates/tools/fission-design-system-codegen/Cargo.toml
+++ b/crates/tools/fission-design-system-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-design-system-codegen"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-diagnostics"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-diagnostics/src/lib.rs
+++ b/crates/tools/fission-diagnostics/src/lib.rs
@@ -251,6 +251,15 @@ pub enum DiagEventKind {
         target: Option<u128>,
         position: Option<(f32, f32)>,
     },
+    /// An action reached its reducer but could not be dispatched.
+    ///
+    /// The serialized action payload is deliberately excluded because it may
+    /// contain credentials or other application secrets.
+    ActionDispatchFailed {
+        action_id: u128,
+        target: u128,
+        failure_kind: String,
+    },
 
     MediaEvent {
         kind: String,
@@ -656,5 +665,31 @@ mod tests {
         assert!(json.contains("RendererSelected"));
         assert!(json.contains("webgpu-vello"));
         assert!(json.contains("BrowserWebGpu"));
+    }
+
+    #[test]
+    fn action_dispatch_failure_diagnostic_contains_no_action_payload_or_raw_error() {
+        let event = DiagEventKind::ActionDispatchFailed {
+            action_id: 42,
+            target: 7,
+            failure_kind: "action_deserialization".to_string(),
+        };
+        let json = serde_json::to_string(&event).expect("serialize action failure diagnostic");
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("parse action failure diagnostic");
+        let fields = value
+            .get("payload")
+            .and_then(serde_json::Value::as_object)
+            .expect("diagnostic event payload object");
+
+        assert!(json.contains("ActionDispatchFailed"));
+        assert!(json.contains("action_deserialization"));
+        assert_eq!(fields.len(), 3);
+        assert!(fields.contains_key("action_id"));
+        assert!(fields.contains_key("target"));
+        assert!(fields.contains_key("failure_kind"));
+        assert!(!fields.contains_key("action_payload"));
+        assert!(!json.contains("error"));
+        assert!(!json.contains("credential-value"));
     }
 }

--- a/crates/tools/fission-test-driver/Cargo.toml
+++ b/crates/tools/fission-test-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test-driver"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test/Cargo.toml
+++ b/crates/tools/fission-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,23 +15,23 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.10.1" }
-fission-ir = { path = "../../core/fission-ir", version = "0.10.1" }
-fission-layout = { path = "../../core/fission-layout", version = "0.10.1" }
-fission-render = { path = "../../rendering/fission-render", version = "0.10.1" }
-fission-shell = { path = "../../shell/fission-shell", version = "0.10.1" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.10.1" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.10.1" }
+fission-core = { path = "../../core/fission-core", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
+fission-shell = { path = "../../shell/fission-shell", version = "0.11.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.11.0" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
-fission-macros = { path = "../../authoring/fission-macros", version = "0.10.1" }
-fission-diagnostics = { path = "../fission-diagnostics", version = "0.10.1" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.10.1" }
-fission-theme = { path = "../../core/fission-theme", version = "0.10.1" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
+fission-diagnostics = { path = "../fission-diagnostics", version = "0.11.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
 fontique = "0.7"
 read-fonts = "0.35"
 serde_json = "1.0"
 
 [dev-dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.10.1" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.11.0" }

--- a/crates/tools/fission-test/tests/text_input_large_scroll.rs
+++ b/crates/tools/fission-test/tests/text_input_large_scroll.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use fission_core::event::{ImeEvent, InputEvent};
 use fission_core::op::{Color, FlexDirection};
 use fission_core::ui::{Column, Container, Positioned, Scroll, Spacer, TextInput, Widget, ZStack};
-use fission_core::GlobalState;
+use fission_core::{GlobalState, ReducerContext};
 use fission_ir::semantics::Role;
 use fission_ir::{Op, PaintOp, WidgetId};
 use fission_test::{TestDriver, TestHarness};
@@ -15,10 +15,12 @@ struct State {
 impl GlobalState for State {}
 
 #[fission_macros::fission_action]
-struct UpdateText(String);
+struct UpdateText;
 
-fn update_text(state: &mut State, action: UpdateText) {
-    state.text = action.0;
+fn update_text(state: &mut State, _action: UpdateText, ctx: &mut ReducerContext<State>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.text = change.new_text.clone();
+    }
 }
 
 #[derive(Clone)]
@@ -48,9 +50,9 @@ impl From<LargeScrollEditor> for Widget {
         let text_input = TextInput {
             id: Some(WidgetId::explicit("large.editor.body")),
             value: view.state().text.clone(),
-            on_change: Some(ctx.bind(
-                UpdateText(String::new()),
-                update_text as fn(&mut State, UpdateText),
+            on_input: Some(ctx.bind(
+                UpdateText,
+                update_text as fn(&mut State, UpdateText, &mut ReducerContext<State>),
             )),
             width: Some(672.0),
             height: Some(912.0),

--- a/crates/tools/fission-test/tests/widget_state_interactions.rs
+++ b/crates/tools/fission-test/tests/widget_state_interactions.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use fission_core::motion::MotionPropertyId;
 use fission_core::ui::{Text, Widget};
-use fission_core::{Action, ActionEnvelope, GlobalState, WidgetId};
+use fission_core::{Action, ActionEnvelope, GlobalState, ReducerContext, WidgetId};
 use fission_ir::semantics::{Role, TextInputType};
 use fission_render::DisplayOp;
 use fission_test::{TestDriver, TestHarness};
@@ -46,8 +46,13 @@ struct DateSelected(String);
 #[fission_macros::fission_action]
 struct DrawerDismissed;
 
-fn number_changed(state: &mut State, action: NumberChanged) {
-    state.number = action.0;
+fn number_changed(state: &mut State, _action: NumberChanged, ctx: &mut ReducerContext<State>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    if let Ok(number) = change.new_text.parse::<f32>() {
+        state.number = number;
+    }
 }
 
 fn date_navigated(state: &mut State, action: DateNavigated) {
@@ -82,9 +87,9 @@ fn number_input_text_entry_dispatches_parsed_float() -> Result<()> {
                 id: Some(WidgetId::explicit("quantity")),
                 value: view.state().number,
                 display_text: Some(String::new()),
-                on_change: Some(ctx.bind(
+                on_input: Some(ctx.bind(
                     NumberChanged(0.0),
-                    number_changed as fn(&mut State, NumberChanged),
+                    number_changed as fn(&mut State, NumberChanged, &mut ReducerContext<State>),
                 )),
                 ..Default::default()
             }
@@ -136,9 +141,9 @@ fn number_input_ignores_invalid_intermediate_float() -> Result<()> {
                 id: Some(WidgetId::explicit("quantity")),
                 value: view.state().number,
                 display_text: Some(String::new()),
-                on_change: Some(ctx.bind(
+                on_input: Some(ctx.bind(
                     NumberChanged(0.0),
-                    number_changed as fn(&mut State, NumberChanged),
+                    number_changed as fn(&mut State, NumberChanged, &mut ReducerContext<State>),
                 )),
                 ..Default::default()
             }

--- a/docs/rfc-widget-authoring-api-v2.md
+++ b/docs/rfc-widget-authoring-api-v2.md
@@ -875,22 +875,26 @@ Interactive widgets receive action descriptors produced by binding, not local st
 
 ```rust
 #[fission_reducer(QueryChanged)]
-fn set_query(query: &mut String, value: String) {
-    *query = value;
+fn set_query(query: &mut String, ctx: &mut ReducerContext<String>) {
+    if let Some(change) = ctx.input.text_change() {
+        *query = change.new_text.clone();
+    }
 }
 
 let (ctx, _) = fission::build::current::<GlobalState>();
 let query = search.query();
 let query_changed = ctx.bind_local(
-    QueryChanged(String::new()),
+    QueryChanged,
     query,
     reduce!(set_query),
 );
 
-TextField::new()
-    .placeholder(search.placeholder)
-    .value(query.get())
-    .on_change(query_changed)
+TextInput {
+    placeholder: Some(search.placeholder.into()),
+    value: query.get(),
+    on_input: Some(query_changed),
+    ..Default::default()
+}
 ```
 
 For manual updates:

--- a/documentation/Cargo.toml
+++ b/documentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-documentation"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 default-run = "fission-documentation"
 

--- a/documentation/content/blog/2026-08-13-fission-0-11-0-universal-text-input-actions.mdx
+++ b/documentation/content/blog/2026-08-13-fission-0-11-0-universal-text-input-actions.mdx
@@ -1,0 +1,145 @@
+---
+title: Fission 0.11.0: One text-input contract
+description: Text edits now preserve bound actions and deliver complete runtime edit data consistently across Fission's interactive shells.
+authors:
+  - fission
+categories:
+  - Releases
+tags:
+  - release
+  - text-input
+  - forms
+  - accessibility
+  - web
+show_adjacent_posts: true
+---
+
+# Fission 0.11.0: One text-input contract
+
+Fission 0.11.0 replaces `TextInput::on_change` with one universal
+`TextInput::on_input` contract. The action an application binds is never
+rewritten by the text runtime. The complete edited text, widget ID, caret, and
+selection anchor arrive separately through `ReducerContext::input`.
+
+This is deliberately a breaking release. The old API was convenient for
+`SetText(String)` but made the action payload mean two incompatible things: the
+application's stable context before dispatch and the current text after
+dispatch. That failed for dynamic fields whose reducer needed both a field ID
+and its new value. One contract is simpler to reason about and works for simple
+fields and dynamic forms alike.
+
+## Migrate `on_change` to `on_input`
+
+Bind an action that contains only stable application context:
+
+```rust
+TextInput {
+    value: draft.metadata.get(&field).cloned().unwrap_or_default(),
+    on_input: Some(ctx.bind_local(
+        UpdateIntegrationField(field.clone()),
+        draft.clone(),
+        reduce!(update_integration_field),
+    )),
+    ..Default::default()
+}
+```
+
+Read the transient edit in the reducer:
+
+```rust
+#[fission_reducer(UpdateIntegrationField)]
+fn update_integration_field(
+    draft: &mut IntegrationDraft,
+    field: FieldId,
+    ctx: &mut ReducerContext<IntegrationDraft>,
+) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+
+    draft.metadata.insert(field, change.new_text.clone());
+}
+```
+
+`text_change()` returns an `UpdateTextInput` with `node_id`, `new_text`,
+`new_caret`, and `new_anchor`. Offsets are UTF-8 byte offsets. Fission does not
+inspect application JSON, replace the last string in a tuple, or synthesize a
+different action at dispatch time.
+
+A field that only updates one string uses the same contract. Bind a unit action
+and read `change.new_text`; there is no legacy payload-replacement mode to opt
+into.
+
+Declarative binding also now installs one reducer handler per effective action
+ID during a build. Repeated fields can bind the same action type with different
+payloads without dispatching the same reducer once per mounted field. Put
+field-specific context in the action value, as above. Explicit `register(...)`
+continues to run every registered handler and is the API for intentional
+multicast dispatch.
+
+## Numeric input is explicit too
+
+`NumberInput::on_input` forwards the same text-edit event. Parse in the reducer
+so the application owns product decisions around empty input, a leading minus
+sign, decimal separators, invalid text, clamping, and formatting:
+
+```rust
+#[fission_reducer(SetQuantity)]
+fn set_quantity(state: &mut OrderState, ctx: &mut ReducerContext<OrderState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    if let Ok(quantity) = change.new_text.parse::<f32>() {
+        state.quantity = quantity.clamp(1.0, 100.0);
+    }
+}
+```
+
+`Combobox` and `Editable` also rename their typed-edit hook to `on_input` and
+forward this contract from their inner `TextInput`.
+
+## One event across interactive shells
+
+Core keyboard and input-method edits, winit accessibility value changes, native
+desktop and mobile input, Web input, and interactive SSR browser islands all
+dispatch `ActionInput::TextChanged(UpdateTextInput)`. Core IR identifies the
+binding with `ActionTrigger::TextChanged`. Browser islands retain the runtime
+and local widget state across edits rather than reconstructing the action from
+DOM payloads.
+
+Static site output and ordinary SSR HTML are intentionally inert: they render
+native controls but do not execute per-keystroke Rust reducers. Use an
+interactive browser island when an SSR page needs this reducer contract in the
+browser. Browser islands are not yet a general client-side effects runtime;
+input reducers are supported, while queued effects and callbacks are rejected.
+
+Reducer action-deserialization failures now emit sanitized diagnostics and
+return errors instead of looking like silently lost input. Diagnostics identify
+the action and target without logging serialized form payloads or raw errors
+that may contain credentials.
+
+## Breaking surface
+
+Applications must make these migrations:
+
+- rename `TextInput::on_change` to `TextInput::on_input`;
+- update text reducers to read `ctx.input.text_change()` instead of an action
+  string or number;
+- rename `Combobox`, `Editable`, and `NumberInput` typed-edit hooks to
+  `on_input`;
+- parse `NumberInput` text in the reducer; and
+- move per-widget context captured by distinct reducer closures into the bound
+  action payload when several widgets use the same action type;
+- add `TextChanged` arms to exhaustive matches over public `ActionInput` and
+  `ActionTrigger` enums;
+- add an `ActionDispatchFailed` arm to exhaustive matches over the public
+  `DiagEventKind` enum.
+
+Update the Fission dependency used by the application:
+
+```toml
+fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
+```
+
+The clean break is the reason this release is `0.11.0` rather than a patch to
+the previous payload-replacement behavior.

--- a/documentation/content/blog/2026-08-13-fission-0-11-0-universal-text-input-actions.mdx
+++ b/documentation/content/blog/2026-08-13-fission-0-11-0-universal-text-input-actions.mdx
@@ -66,6 +66,11 @@ fn update_integration_field(
 inspect application JSON, replace the last string in a tuple, or synthesize a
 different action at dispatch time.
 
+`UpdateTextInput` is runtime event data and no longer implements `Action`.
+Applications bind their own unit or contextual action to `on_input` and read
+the edit from the reducer context; they do not dispatch `UpdateTextInput`
+directly.
+
 A field that only updates one string uses the same contract. Bind a unit action
 and read `change.new_text`; there is no legacy payload-replacement mode to opt
 into.
@@ -123,16 +128,18 @@ that may contain credentials.
 Applications must make these migrations:
 
 - rename `TextInput::on_change` to `TextInput::on_input`;
+- replace direct `UpdateTextInput` action dispatch with an application action
+  bound to `on_input`;
 - update text reducers to read `ctx.input.text_change()` instead of an action
   string or number;
 - rename `Combobox`, `Editable`, and `NumberInput` typed-edit hooks to
   `on_input`;
-- parse `NumberInput` text in the reducer; and
+- parse `NumberInput` text in the reducer;
 - move per-widget context captured by distinct reducer closures into the bound
   action payload when several widgets use the same action type;
 - add `TextChanged` arms to exhaustive matches over public `ActionInput` and
   `ActionTrigger` enums;
-- add an `ActionDispatchFailed` arm to exhaustive matches over the public
+- and add an `ActionDispatchFailed` arm to exhaustive matches over the public
   `DiagEventKind` enum.
 
 Update the Fission dependency used by the application:

--- a/documentation/content/docs/cookbook/add-accessible-semantics.mdx
+++ b/documentation/content/docs/cookbook/add-accessible-semantics.mdx
@@ -28,7 +28,7 @@ pub struct SettingsState {
 impl GlobalState for SettingsState {}
 
 #[derive(Action)]
-pub struct EmailChanged(pub String);
+pub struct EmailChanged;
 
 #[derive(Action)]
 pub struct ToggleMarketing;
@@ -37,8 +37,11 @@ pub struct ToggleMarketing;
 pub struct SaveSettings;
 
 #[fission_reducer(EmailChanged)]
-fn email_changed(state: &mut SettingsState, action: EmailChanged) {
-    state.email = action.0;
+fn email_changed(state: &mut SettingsState, ctx: &mut ReducerContext<SettingsState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.email = change.new_text.clone();
 }
 
 #[fission_reducer(ToggleMarketing)]
@@ -86,7 +89,7 @@ impl From<AccountSettings> for Widget {
         let save_label = tr(&view, "settings.save", "Save settings");
         let panel_label = tr(&view, "settings.account", "Account settings");
 
-        let email_changed = ctx.bind(EmailChanged(String::new()), reduce_with!(email_changed));
+        let email_changed = ctx.bind(EmailChanged, reduce_with!(email_changed));
         let toggle_marketing = ctx.bind(ToggleMarketing, reduce_with!(toggle_marketing));
         let save_settings = ctx.bind(SaveSettings, reduce_with!(save_settings));
 
@@ -98,7 +101,7 @@ impl From<AccountSettings> for Widget {
                     TextInput {
                         value: state.email.clone(),
                         label: Some(email_label.into()),
-                        on_change: Some(email_changed),
+                        on_input: Some(email_changed),
                         ..Default::default()
                     }
                     .semantics_identifier("settings.email")

--- a/documentation/content/docs/cookbook/modal-text-flow.mdx
+++ b/documentation/content/docs/cookbook/modal-text-flow.mdx
@@ -59,22 +59,21 @@ Text flows become easier to reason about when every update has a named action.
 pub struct SetShowComposeModal(pub bool);
 
 #[fission_action]
-#[serde(transparent)]
-pub struct SetDraftTo(pub String);
+pub struct SetDraftTo;
 
 #[fission_action]
-#[serde(transparent)]
-pub struct SetDraftSubject(pub String);
+pub struct SetDraftSubject;
 
 #[fission_action]
-#[serde(transparent)]
-pub struct SetDraftBody(pub String);
+pub struct SetDraftBody;
 
 #[fission_action]
 pub struct ApplyCompose;
 ```
 
-The `Set...` actions mirror user editing. `SetShowComposeModal` controls visibility. `ApplyCompose` represents the user choosing to commit the modal.
+The draft actions name user editing without carrying transient text.
+`SetShowComposeModal` controls visibility. `ApplyCompose` represents the user
+choosing to commit the modal.
 
 This is a good beginner pattern because it makes the reducer story very obvious.
 
@@ -93,26 +92,32 @@ fn on_set_show_compose_modal(
 
 fn on_set_draft_to(
     state: &mut ComposeState,
-    action: SetDraftTo,
-    _ctx: &mut ReducerContext<ComposeState>,
+    _action: SetDraftTo,
+    ctx: &mut ReducerContext<ComposeState>,
 ) {
-    state.draft_to = action.0;
+    if let Some(change) = ctx.input.text_change() {
+        state.draft_to = change.new_text.clone();
+    }
 }
 
 fn on_set_draft_subject(
     state: &mut ComposeState,
-    action: SetDraftSubject,
-    _ctx: &mut ReducerContext<ComposeState>,
+    _action: SetDraftSubject,
+    ctx: &mut ReducerContext<ComposeState>,
 ) {
-    state.draft_subject = action.0;
+    if let Some(change) = ctx.input.text_change() {
+        state.draft_subject = change.new_text.clone();
+    }
 }
 
 fn on_set_draft_body(
     state: &mut ComposeState,
-    action: SetDraftBody,
-    _ctx: &mut ReducerContext<ComposeState>,
+    _action: SetDraftBody,
+    ctx: &mut ReducerContext<ComposeState>,
 ) {
-    state.draft_body = action.0;
+    if let Some(change) = ctx.input.text_change() {
+        state.draft_body = change.new_text.clone();
+    }
 }
 
 fn on_apply_compose(
@@ -182,18 +187,9 @@ That answer comes from state, not from a hidden overlay manager that only the wi
 Inside the modal, each field reads from state and writes back through an action.
 
 ```rust
-let set_to = ctx.bind(
-    SetDraftTo(String::new()),
-    reduce_with!(on_set_draft_to),
-);
-let set_subject = ctx.bind(
-    SetDraftSubject(String::new()),
-    reduce_with!(on_set_draft_subject),
-);
-let set_body = ctx.bind(
-    SetDraftBody(String::new()),
-    reduce_with!(on_set_draft_body),
-);
+let set_to = ctx.bind(SetDraftTo, reduce_with!(on_set_draft_to));
+let set_subject = ctx.bind(SetDraftSubject, reduce_with!(on_set_draft_subject));
+let set_body = ctx.bind(SetDraftBody, reduce_with!(on_set_draft_body));
 
 let modal_fields = Column {
     gap: Some(10.0),
@@ -201,21 +197,21 @@ let modal_fields = Column {
         TextInput {
             value: view.state().draft_to.clone(),
             placeholder: Some("To".into()),
-            on_change: Some(set_to),
+            on_input: Some(set_to),
             ..Default::default()
         }
         .into(),
         TextInput {
             value: view.state().draft_subject.clone(),
             placeholder: Some("Subject".into()),
-            on_change: Some(set_subject),
+            on_input: Some(set_subject),
             ..Default::default()
         }
         .into(),
         TextInput {
             value: view.state().draft_body.clone(),
             placeholder: Some("Write your message".into()),
-            on_change: Some(set_body),
+            on_input: Some(set_body),
             multiline: true,
             height: Some(180.0),
             ..Default::default()
@@ -229,7 +225,11 @@ let modal_fields = Column {
 
 This is the essential text flow in Fission.
 
-The input widget does not keep the authoritative text by itself. It shows the current value from `view.state()`. When the user edits the field, the widget emits the bound action. The reducer updates state. The next conversion pass reads the new value and renders it back into the field.
+The input widget does not keep the authoritative text by itself. It shows the
+current value from `view.state()`. When the user edits the field, the widget
+emits the bound action and places the edit in `ctx.input.text_change()`. The
+reducer updates state. The next conversion pass reads the new value and renders
+it back into the field.
 
 If you know web user interface, this should feel like a deliberately explicit controlled-input pattern.
 

--- a/documentation/content/docs/fission/for/compose-developers.mdx
+++ b/documentation/content/docs/fission/for/compose-developers.mdx
@@ -145,8 +145,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -179,7 +182,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -213,7 +216,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/dioxus-developers.mdx
+++ b/documentation/content/docs/fission/for/dioxus-developers.mdx
@@ -155,8 +155,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -189,7 +192,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -223,7 +226,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/electron-developers.mdx
+++ b/documentation/content/docs/fission/for/electron-developers.mdx
@@ -148,8 +148,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -182,7 +185,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -216,7 +219,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/flutter-developers.mdx
+++ b/documentation/content/docs/fission/for/flutter-developers.mdx
@@ -162,8 +162,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -196,7 +199,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -230,7 +233,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/leptos-developers.mdx
+++ b/documentation/content/docs/fission/for/leptos-developers.mdx
@@ -147,8 +147,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -181,7 +184,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -215,7 +218,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/react-developers.mdx
+++ b/documentation/content/docs/fission/for/react-developers.mdx
@@ -165,8 +165,11 @@ pub struct TodoComposer {
 }
 
 #[fission_reducer(SetLocalDraft)]
-fn set_local_draft(draft: &mut String, value: String) {
-    *draft = value;
+fn set_local_draft(draft: &mut String, ctx: &mut ReducerContext<String>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    *draft = change.new_text.clone();
 }
 
 #[fission_reducer(ClearLocalDraft)]
@@ -179,7 +182,7 @@ impl From<TodoComposer> for Widget {
         let (ctx, _) = fission::build::current::<()>();
         let draft = composer.draft();
         let update_draft = ctx.bind_local(
-            SetLocalDraft(String::new()),
+            SetLocalDraft,
             draft.clone(),
             reduce!(set_local_draft),
         );
@@ -197,7 +200,7 @@ impl From<TodoComposer> for Widget {
                     value: draft.get(),
                     label: Some("New task".into()),
                     placeholder: Some("Add a task".into()),
-                    on_change: Some(update_draft),
+                    on_input: Some(update_draft),
                     width: Some(320.0),
                     ..Default::default()
                 },
@@ -278,8 +281,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -312,7 +318,7 @@ pub struct TodoApp;
 impl From<TodoApp> for Widget {
     fn from(_app: TodoApp) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update = with_reducer!(ctx, SetDraft, set_draft);
         let add = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -345,7 +351,7 @@ impl From<TodoApp> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update),
+                            on_input: Some(update),
                             width: Some(320.0),
                             ..Default::default()
                         },

--- a/documentation/content/docs/fission/for/swiftui-developers.mdx
+++ b/documentation/content/docs/fission/for/swiftui-developers.mdx
@@ -155,8 +155,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -189,7 +192,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -223,7 +226,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/tauri-developers.mdx
+++ b/documentation/content/docs/fission/for/tauri-developers.mdx
@@ -136,8 +136,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -170,7 +173,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -204,7 +207,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/terminal-ui-developers.mdx
+++ b/documentation/content/docs/fission/for/terminal-ui-developers.mdx
@@ -136,8 +136,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -170,7 +173,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -204,7 +207,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/fission/for/yew-developers.mdx
+++ b/documentation/content/docs/fission/for/yew-developers.mdx
@@ -153,8 +153,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(SetDraft)]
-fn set_draft(state: &mut TodoState, draft: String) {
-    state.draft = draft;
+fn set_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddDraftTodo)]
@@ -187,7 +190,7 @@ pub struct TodoScreen;
 impl From<TodoScreen> for Widget {
     fn from(_screen: TodoScreen) -> Widget {
         let (ctx, view) = fission::build::current::<TodoState>();
-        let update_draft = with_reducer!(ctx, SetDraft(String::new()), set_draft);
+        let update_draft = with_reducer!(ctx, SetDraft, set_draft);
         let add_todo = with_reducer!(ctx, AddDraftTodo, add_draft_todo);
 
         let rows = view.state().todos.iter().map(|todo| {
@@ -221,7 +224,7 @@ impl From<TodoScreen> for Widget {
                             value: view.state().draft.clone(),
                             label: Some("New task".into()),
                             placeholder: Some("Add a task".into()),
-                            on_change: Some(update_draft),
+                            on_input: Some(update_draft),
                             ..Default::default()
                         }
                         .semantics_identifier("todo.title"),

--- a/documentation/content/docs/guides/design-system.mdx
+++ b/documentation/content/docs/guides/design-system.mdx
@@ -69,10 +69,10 @@ Add the generator as a build dependency:
 
 ```toml title="Cargo.toml"
 [dependencies]
-fission = { version = "0.10.1", default-features = false, features = ["desktop"] }
+fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
 
 [build-dependencies]
-fission-design-system-codegen = "0.10.1"
+fission-design-system-codegen = "0.11.0"
 ```
 
 ## What you should have working

--- a/documentation/content/docs/guides/input-events-text-and-env.mdx
+++ b/documentation/content/docs/guides/input-events-text-and-env.mdx
@@ -37,6 +37,72 @@ That is why Fission owns text editing behavior inside the runtime instead of lea
 
 Built-in text widgets already depend on this shared input model, and custom text-heavy widgets can do the same. The `text-lab` example is useful because it isolates the parts of user interface work that usually become fragile first: multiline editing, comboboxes, menus, focus changes, and modal text flows.
 
+## Bind text input without losing action context
+
+Every text field binds a stable application action and reads the live edit from
+`ReducerContext::input`:
+
+```rust
+#[fission_reducer(SetName)]
+fn set_name(state: &mut ProfileState, ctx: &mut ReducerContext<ProfileState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.name = change.new_text.clone();
+}
+
+TextInput {
+    value: view.state().name.clone(),
+    on_input: Some(ctx.bind(SetName, reduce!(set_name))),
+    ..Default::default()
+}
+```
+
+A dynamic form uses the same contract. Its bound action can also carry the
+stable identity of the field while the runtime event carries the transient
+edit:
+
+```rust
+#[fission_reducer(UpdateIntegrationField)]
+fn update_integration_field(
+    draft: &mut IntegrationDraft,
+    field: FieldId,
+    ctx: &mut ReducerContext<IntegrationDraft>,
+) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+
+    draft.metadata.insert(field, change.new_text.clone());
+}
+```
+
+Bind only the stable field identity in the action:
+
+```rust
+TextInput {
+    id: Some(WidgetId::explicit(&format!("integration.{field}"))),
+    value: draft.metadata.get(&field).cloned().unwrap_or_default(),
+    on_input: Some(ctx.bind_local(
+        UpdateIntegrationField(field.clone()),
+        draft.clone(),
+        reduce!(update_integration_field),
+    )),
+    ..Default::default()
+}
+```
+
+`ctx.input.text_change()` returns one `UpdateTextInput` value containing
+`new_text`, `node_id`, `new_caret`, and `new_anchor`. Fission preserves the
+bound action exactly, so the reducer receives the same `FieldId` that the
+component bound. There is no string-replacement or numeric mode: Fission never
+inspects or rewrites arbitrary application JSON.
+
+This contract is shared by native keyboard and input-method edits, desktop
+accessibility actions, Web input, and interactive browser islands. Static site
+and plain SSR output remain inert HTML; a browser island is required when a
+retained reducer must run in the browser.
+
 ## Input method editor support, in beginner terms
 
 An input method editor is the system tool that lets a user compose text before it is committed. This is essential for many writing systems, including Japanese, Chinese, and Korean, and it also matters for accents, emoji pickers, and other composed-text workflows.

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -89,7 +89,7 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["server", "server-redis"] }
+fission = { version = "0.11.0", features = ["server", "server-redis"] }
 ```
 
 ## Invalidate cached pages after writes

--- a/documentation/content/docs/guides/server-site-security.mdx
+++ b/documentation/content/docs/guides/server-site-security.mdx
@@ -78,14 +78,14 @@ Hyper is available with the normal `server` feature:
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["server"] }
+fission = { version = "0.11.0", features = ["server"] }
 ```
 
 Axum and Actix adapters are feature-gated to avoid pulling those dependencies into projects that do not use them:
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["server", "server-axum"] }
+fission = { version = "0.11.0", features = ["server", "server-axum"] }
 tower = "0.5"
 ```
 

--- a/documentation/content/docs/guides/static-sites.mdx
+++ b/documentation/content/docs/guides/static-sites.mdx
@@ -221,7 +221,7 @@ Use front matter to describe each post:
 
 ```mdx
 ---
-title: Fission 0.10.1
+title: Fission 0.11.0
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -232,7 +232,7 @@ tags:
   - authoring
 ---
 
-# Fission 0.10.1
+# Fission 0.11.0
 
 Write the post body here.
 ```

--- a/documentation/content/docs/guides/terminal-user-interfaces.mdx
+++ b/documentation/content/docs/guides/terminal-user-interfaces.mdx
@@ -21,7 +21,7 @@ Use the Fission facade crate and enable the terminal shell feature for tools tha
 
 ```toml
 [dependencies]
-fission = { version = "0.10.1", features = ["terminal-shell"] }
+fission = { version = "0.11.0", features = ["terminal-shell"] }
 ```
 
 ## What you should have working

--- a/documentation/content/docs/learn/runtime-model.mdx
+++ b/documentation/content/docs/learn/runtime-model.mdx
@@ -61,8 +61,11 @@ A reducer is just a function that receives the current state plus an action and 
 
 ```rust
 #[fission_reducer(UpdateDraft)]
-fn on_update_draft(state: &mut NoteState, draft: String) {
-    state.draft = draft;
+fn on_update_draft(state: &mut NoteState, ctx: &mut ReducerContext<NoteState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
     state.save_error = None;
 }
 
@@ -80,7 +83,11 @@ fn on_save_failed(state: &mut NoteState) {
 
 The syntax in a reducer signature is easier than it first appears.
 
-`state: &mut NoteState` means the reducer receives a mutable reference to the current app state, so it is allowed to change that state. `#[fission_reducer(UpdateDraft)]` means this reducer handles the generated `UpdateDraft` action. The `draft: String` parameter becomes the payload inside that generated action, so the widget can later construct `UpdateDraft(String::new())` when it wires the text field.
+`state: &mut NoteState` means the reducer receives a mutable reference to the
+current app state, so it is allowed to change that state.
+`#[fission_reducer(UpdateDraft)]` means this reducer handles the generated unit
+action. `ctx.input.text_change()` reads the runtime edit that accompanied that
+action.
 
 So if you strip away the syntax noise, the first reducer reads like this: "when an `UpdateDraft` action arrives, change the note state by replacing the draft and clearing any old save error."
 
@@ -117,7 +124,7 @@ impl From<NoteEditor> for Widget {
                 TextInput {
                     value: view.state().draft.clone(),
                     placeholder: Some("Write something...".into()),
-                    on_change: Some(with_reducer!(ctx, UpdateDraft(String::new()), on_update_draft)),
+                    on_input: Some(with_reducer!(ctx, UpdateDraft, on_update_draft)),
                     ..Default::default()
                 }
                 .into(),
@@ -144,7 +151,7 @@ The Rust scaffolding around the widget is doing a few predictable jobs.
 Inside the widget, there are a few pieces of syntax that are worth translating instead of ignoring:
 
 - `view.state().draft.clone()` means "read the current draft text from state and make a copy of the string so the text input can own it."
-- `UpdateDraft(String::new())` is a placeholder action value used so `with_reducer!(...)` knows which action type to wire up. The runtime replaces the placeholder string with the real current input text when the user edits the field.
+- `UpdateDraft` is the stable application action. The runtime preserves it and delivers the current edit separately through `ctx.input.text_change()`.
 - `with_reducer!(ctx, action, reducer)` creates the `ActionEnvelope` a widget stores for later dispatch.
 - `..Default::default()` means "use the normal default values for every field I did not set by hand."
 
@@ -185,9 +192,17 @@ If the type name `ViewHandle<S>` looks abstract, read it as "the read-only input
 
 The `ctx` argument has a very different job. `BuildCtxHandle` is for recording what the runtime should wire up around the user interface description.
 
-The most common use is `with_reducer!(...)`. Binding connects a widget event, such as a button press or text change, to an action and reducer handler. In the note editor example, `with_reducer!(ctx, UpdateDraft(...), on_update_draft)` creates the action path that lets typing update state.
+The most common use is `with_reducer!(...)`. Binding connects a widget event,
+such as a button press or text input, to an action and reducer handler. In the
+note editor example, `with_reducer!(ctx, UpdateDraft, on_update_draft)` creates
+the action path that lets typing update state.
 
-This is also the place where Rust type hints can look noisier than the underlying idea. A call such as `with_reducer!(ctx, UpdateDraft(String::new()), on_update_draft)` is really doing one simple thing: it tells the runtime, "when this event happens, dispatch an `UpdateDraft` action and send it to `on_update_draft`."
+This is also the place where Rust type hints can look noisier than the
+underlying idea. A call such as
+`with_reducer!(ctx, UpdateDraft, on_update_draft)` tells the runtime, "when this
+event happens, dispatch an `UpdateDraft` action and send it to
+`on_update_draft`." The reducer then reads event-specific data from its
+`ReducerContext`.
 
 As an app grows, `BuildCtxHandle` also lets widgets declare other runtime-managed behavior such as animations, portals, media registrations, web views, and resources. The shared idea is the same in every case: `BuildCtxHandle` records intent for the runtime. It does not perform the work right now.
 

--- a/documentation/content/docs/learn/testing.mdx
+++ b/documentation/content/docs/learn/testing.mdx
@@ -128,7 +128,7 @@ client.wait_for_ready(15_000)?;
 Prefer semantic selectors over coordinates. Coordinates are still useful for low-level input bugs, but product tests should name the UI element they intend to use.
 
 ```rust
-client.fill_text_semantic_identifier("todo.title", "Publish 0.10.1")?;
+client.fill_text_semantic_identifier("todo.title", "Publish 0.11.0")?;
 client.tap_semantic_identifier("todo.add")?;
 client.wait_for_visible(
     SelectorQuery::semantic_identifier("todo.row.0"),
@@ -148,7 +148,7 @@ TextInput {
     id: Some(WidgetId::explicit("todo-title-input")),
     value: view.state().draft.clone(),
     label: Some("New task".into()),
-    on_change: Some(update_draft),
+    on_input: Some(update_draft),
     ..Default::default()
 }
 .semantics_identifier("todo.title")

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -419,7 +419,7 @@ Example:
 
 ```mdx
 ---
-title: Fission 0.10.1
+title: Fission 0.11.0
 description: A release note for the authoring API update.
 authors:
   - fission
@@ -431,7 +431,7 @@ tags:
 show_adjacent_posts: true
 ---
 
-# Fission 0.10.1
+# Fission 0.11.0
 
 Write the post body here.
 ```

--- a/documentation/content/reference/core/environment-input-and-ime.mdx
+++ b/documentation/content/reference/core/environment-input-and-ime.mdx
@@ -64,6 +64,17 @@ The public variants are:
 
 This normalization is a major reason cross-platform behavior stays consistent and testable.
 
+Reducer actions may also carry an `ActionInput`. The action envelope holds the
+application-defined, serialized action, while `ActionInput` carries transient
+runtime facts that should not be substituted into that payload. Typed accessors
+unwrap action scopes automatically.
+
+Every `TextInput::on_input` action delivers `ActionInput::TextChanged`. Read it
+with `ctx.input.text_change()` to obtain the complete new text, target widget
+ID, caret, and selection anchor while the action envelope retains the exact
+application payload that was bound. Native input, accessibility value changes,
+Web input, and interactive browser islands use this same event shape.
+
 ## Pointer and keyboard details
 
 `PointerEvent` covers pointer down, up, move, and scroll. Pointer buttons are represented by `PointerButton`.

--- a/documentation/content/reference/core/state-system.mdx
+++ b/documentation/content/reference/core/state-system.mdx
@@ -93,6 +93,12 @@ let (ctx, _) = fission::build::current::<()>();
 | `bind(action, handler)` | Creates an `ActionEnvelope` for a normal app-state reducer |
 | `register::<A, H>(handler)` | Registers a reducer handler without immediately binding a widget event |
 | `bind_local(action, field, handler)` | Binds a reducer to a retained local `StateField<T>` |
+
+Declarative `bind(...)` and `bind_local(...)` install one handler per effective
+action ID in each build while preserving the payload of every returned action
+envelope. Repeated widgets should carry their differing stable context in the
+action value. `register(...)` is different: it is explicitly multicast, so all
+handlers registered for that action type run on dispatch.
 | `request_animation_for(id, request)` | Queues an animation request for a widget id |
 | `anim_for(id)` | Creates a scoped animation helper for a target widget id |
 | `register_video(...)` | Registers a video node with the runtime |

--- a/documentation/content/reference/widgets/widget-pages/combobox.mdx
+++ b/documentation/content/reference/widgets/widget-pages/combobox.mdx
@@ -15,6 +15,17 @@ It combines a [`TextInput`](/reference/widgets/text-input) with a popover list. 
 use fission::prelude::*;
 use std::sync::Arc;
 
+#[fission_reducer(SetAssigneeQuery)]
+fn on_set_assignee_query(
+    state: &mut PeopleState,
+    ctx: &mut ReducerContext<PeopleState>,
+) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.assignee_query = change.new_text.clone();
+}
+
 let widget: Widget = Combobox {
 id: WidgetId::explicit("assignee_box"),
 value: view.state().assignee_query.clone(),
@@ -22,10 +33,7 @@ items: view.state().filtered_people.clone(),
 is_open: view.state().assignee_open,
 width: Some(280.0),
 max_popup_height: Some(240.0),
-on_change: Some(ctx.bind(
-    SetAssigneeQuery(String::new()),
-    reduce_with!(on_set_assignee_query),
-)),
+on_input: Some(ctx.bind(SetAssigneeQuery, reduce_with!(on_set_assignee_query))),
 on_toggle: Some(ctx.bind(
     ToggleAssigneeOpen,
     reduce_with!(on_toggle_assignee_open),
@@ -38,7 +46,9 @@ on_select: Some(Arc::new(move |name| ActionEnvelope {
 .into();
 ```
 
-In a real reducer, `on_change` usually updates the query and refreshes `filtered_people`, `on_toggle` opens or closes the popup, and `on_select` stores the chosen value and closes the popup.
+In a real reducer, `on_input` reads `ctx.input.text_change()`, updates the query,
+and refreshes `filtered_people`; `on_toggle` opens or closes the popup, and
+`on_select` stores the chosen value and closes the popup.
 
 ## Field table
 
@@ -50,13 +60,18 @@ In a real reducer, `on_change` usually updates the query and refreshes `filtered
 | `is_open` | `bool` | Whether the popup list is visible. | Controlled by app state. |
 | `width` | `Option<f32>` | Width of the text field and popup. | Defaults to the input's natural width, with popup width falling back to `320.0`. |
 | `max_popup_height` | `Option<f32>` | Maximum popup height before scrolling begins. | Defaults to `240.0`. |
-| `on_change` | `Option<ActionEnvelope>` | Action fired when the user edits the text. | Like `TextInput`, the runtime replaces the payload with the current `String`. |
+| `on_input` | `Option<ActionEnvelope>` | Action fired when the user edits the text. | Preserves the bound action; read the edit through `ctx.input.text_change()`. |
 | `on_select` | `Option<Arc<dyn Fn(String) -> ActionEnvelope + Send + Sync>>` | Closure that builds the action for a selected item. | Called with the chosen item string. |
 | `on_toggle` | `Option<ActionEnvelope>` | Action used to open or close the popup. | Also used as the close action when the popover dismisses itself. |
 
 ## How the event flow works
 
-There are two different kinds of events here. Typing uses the text-input path: the runtime dispatches `on_change` with the new string, your reducer stores that query, and the next conversion passes a filtered `items` list back in. Picking an item uses the `on_select` closure, which turns the chosen string into an `ActionEnvelope` immediately.
+There are two different kinds of events here. Typing uses the text-input path:
+the runtime dispatches the preserved `on_input` action with an
+`ActionInput::TextChanged`, your reducer stores that query, and the next
+conversion passes a filtered `items` list back in. Picking an item uses the
+`on_select` closure, which turns the chosen string into an `ActionEnvelope`
+immediately.
 
 This split is intentional. Free text and confirmed selection are not the same product event. Keep them separate in your actions.
 
@@ -68,7 +83,7 @@ If the user must choose from a fixed short list and should not type arbitrary te
 
 For `Combobox`, review the fields that change behavior before treating the widget as finished: `id`, `value`, `items`, `is_open`, `width`, `max_popup_height`. The goal is to make the product rule visible in state and actions, not hidden inside ad-hoc construction code.
 
-- Bind `on_change`, `on_select` to explicit reducer actions and test that the reducer handles unavailable, duplicate, or invalid input safely.
+- Bind `on_input` and `on_select` to explicit reducer actions and test that the reducer handles unavailable, duplicate, or invalid input safely.
 - When child widgets are generated from data, give reordered or filtered rows an explicit `WidgetId` so retained local state and scroll behavior do not drift between items.
 - Set `id` only when identity must be stable across filtering, reordering, diagnostics, or tests; otherwise let Fission derive identity from structure.
 - Check the semantics tree for the user-facing label or role that makes this widget understandable without relying only on pixels.
@@ -80,4 +95,3 @@ If a screen starts repeating the same `Combobox` setup, extract a named componen
 ## Related
 
 [`TextInput`](/reference/widgets/text-input), [`Select`](/reference/widgets/select), [`Menu`](/reference/widgets/menu), and [`FormControl`](/reference/widgets/form-control).
-

--- a/documentation/content/reference/widgets/widget-pages/editable.mdx
+++ b/documentation/content/reference/widgets/widget-pages/editable.mdx
@@ -14,12 +14,22 @@ In read mode it renders a low-emphasis button showing the current value. In edit
 ```rust
 use fission::prelude::*;
 
+#[fission_reducer(SetProjectNameDraft)]
+fn on_set_project_name_draft(
+    state: &mut ProjectState,
+    ctx: &mut ReducerContext<ProjectState>,
+) {
+    if let Some(change) = ctx.input.text_change() {
+        state.project_name_draft = change.new_text.clone();
+    }
+}
+
 let widget: Widget = Editable {
 id: Some(WidgetId::explicit("rename_project")),
 value: view.state().project_name_draft.clone(),
 placeholder: "Untitled project".into(),
 is_editing: view.state().renaming_project,
-on_change: Some(with_reducer!(ctx, SetProjectNameDraft(String::new()), on_set_project_name_draft)),
+on_input: Some(with_reducer!(ctx, SetProjectNameDraft, on_set_project_name_draft)),
 on_edit: Some(with_reducer!(ctx, BeginProjectRename, on_begin_project_rename)),
 on_submit: Some(finish_project_rename_action),
 on_cancel: Some(cancel_project_rename_action),
@@ -27,7 +37,9 @@ on_cancel: Some(cancel_project_rename_action),
 .into();
 ```
 
-The usual reducer flow is to keep both the committed value and the draft in state, start editing with `on_edit`, update the draft with `on_change`, and only commit when the product decides the edit is complete.
+The usual reducer flow is to keep both the committed value and the draft in
+state, start editing with `on_edit`, update the draft from `on_input`, and only
+commit when the product decides the edit is complete.
 
 ## Field table
 
@@ -37,14 +49,16 @@ The usual reducer flow is to keep both the committed value and the draft in stat
 | `value` | `String` | Current displayed or edited text. | Controlled by app state. |
 | `placeholder` | `String` | Text shown when `value` is empty. | Required for a good empty-state experience. |
 | `is_editing` | `bool` | Whether the widget is currently in edit mode. | Controlled by app state. |
-| `on_change` | `Option<ActionEnvelope>` | Action fired when the text changes in edit mode. | Like `TextInput`, the runtime replaces the payload with the current `String`. |
+| `on_input` | `Option<ActionEnvelope>` | Action fired when the text changes in edit mode. | Preserves the bound action; read the edit through `ctx.input.text_change()`. |
 | `on_submit` | `Option<ActionEnvelope>` | Intended submit action. | Present in the struct, but not currently wired by the checked-in implementation. |
 | `on_edit` | `Option<ActionEnvelope>` | Action fired when the read-mode button is pressed. | Usually flips `is_editing` to `true`. |
 | `on_cancel` | `Option<ActionEnvelope>` | Intended cancel action. | Present in the struct, but not currently wired by the checked-in implementation. |
 
 ## Current behavior
 
-The important implementation detail is that only `on_edit` and `on_change` are active today. `on_submit` and `on_cancel` exist in the public struct, but the checked-in widget does not yet connect them to Enter, Escape, or blur behavior.
+The important implementation detail is that only `on_edit` and `on_input` are
+active today. `on_submit` and `on_cancel` exist in the public struct, but the
+checked-in widget does not yet connect them to Enter, Escape, or blur behavior.
 
 That means `Editable` is best for simple inline editing where your app can commit changes another way, or where changing the text live is enough.
 
@@ -54,9 +68,9 @@ If you need reliable submit-on-Enter or cancel-on-Escape right now, compose a [`
 
 ## Production checklist
 
-For `Editable`, review the fields that change behavior before treating the widget as finished: `id`, `value`, `placeholder`, `is_editing`, `on_change`, `on_submit`. The goal is to make the product rule visible in state and actions, not hidden inside ad-hoc construction code.
+For `Editable`, review the fields that change behavior before treating the widget as finished: `id`, `value`, `placeholder`, `is_editing`, `on_input`, `on_submit`. The goal is to make the product rule visible in state and actions, not hidden inside ad-hoc construction code.
 
-- Bind `on_change`, `on_submit`, `on_edit`, `on_cancel` to explicit reducer actions and test that the reducer handles unavailable, duplicate, or invalid input safely.
+- Bind `on_input`, `on_submit`, `on_edit`, and `on_cancel` to explicit reducer actions and test that the reducer handles unavailable, duplicate, or invalid input safely.
 - Set `id` only when identity must be stable across filtering, reordering, diagnostics, or tests; otherwise let Fission derive identity from structure.
 - Check the semantics tree for the user-facing label or role that makes this widget understandable without relying only on pixels.
 - Add at least one component or harness test that confirms the visible text, semantic role, action dispatch, and layout constraint that matter for this widget in context.
@@ -66,4 +80,3 @@ If a screen starts repeating the same `Editable` setup, extract a named componen
 ## Related
 
 [`TextInput`](/reference/widgets/text-input), [`Button`](/reference/widgets/button), [`FormControl`](/reference/widgets/form-control), and [`FocusScope`](/reference/widgets/focus-scope).
-

--- a/documentation/content/reference/widgets/widget-pages/form-control.mdx
+++ b/documentation/content/reference/widgets/widget-pages/form-control.mdx
@@ -24,7 +24,7 @@ child:
     TextInput {
         value: view.state().email.clone(),
         label: Some("Email address".into()),
-        on_change: Some(email_change_action),
+        on_input: Some(email_input_action),
         ..Default::default()
     }
     .into(),
@@ -69,4 +69,3 @@ If a screen starts repeating the same `FormControl` setup, extract a named compo
 ## Related
 
 [`TextInput`](/reference/widgets/text-input), [`Select`](/reference/widgets/select), [`Combobox`](/reference/widgets/combobox), and [`Checkbox`](/reference/widgets/checkbox).
-

--- a/documentation/content/reference/widgets/widget-pages/number-input.mdx
+++ b/documentation/content/reference/widgets/widget-pages/number-input.mdx
@@ -14,6 +14,16 @@ It renders a minus button, a central text display, and a plus button inside one 
 ```rust
 use fission::prelude::*;
 
+#[fission_reducer(SetQuantity)]
+fn set_quantity(state: &mut OrderState, ctx: &mut ReducerContext<OrderState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    if let Ok(quantity) = change.new_text.parse::<f32>() {
+        state.quantity = quantity.clamp(1.0, 10.0);
+    }
+}
+
 let widget: Widget = NumberInput {
 value: view.state().quantity as f32,
 display_text: Some(view.state().quantity.to_string()),
@@ -22,13 +32,14 @@ max: Some(10.0),
 step: 1.0,
 on_increment: Some(increment_quantity_action),
 on_decrement: Some(decrement_quantity_action),
-on_change: Some(change_quantity_text_action),
+on_input: Some(ctx.bind(SetQuantity, reduce_with!(set_quantity))),
 ..Default::default()
 }
 .into();
 ```
 
-The reducer usually owns the real numeric value and decides how to clamp, parse, or reject changes.
+The reducer owns the real numeric value and decides how to parse, clamp, or
+reject the edit exposed by `ctx.input.text_change()`.
 
 ## Field table
 
@@ -45,13 +56,20 @@ The reducer usually owns the real numeric value and decides how to clamp, parse,
 | `gap` | `Option<f32>` | Spacing between the buttons and field. | Defaults to `4.0`. |
 | `on_increment` | `Option<ActionEnvelope>` | Action fired by the plus button. | Defaults to `None`. |
 | `on_decrement` | `Option<ActionEnvelope>` | Action fired by the minus button. | Defaults to `None`. |
-| `on_change` | `Option<ActionEnvelope>` | Intended text-edit action. | Present in the struct, but not currently wired by the checked-in implementation. |
+| `on_input` | `Option<ActionEnvelope>` | Action fired for typed edits in the central field. | Preserves the bound action; parse `ctx.input.text_change().new_text` in the reducer. |
 
 ## Current behavior and limitations
 
-The central field is rendered with [`TextInput`](/reference/widgets/text-input), but in the checked-in implementation its `on_change` hook is not passed through yet. Likewise, `min`, `max`, and `step` are meaningful configuration fields for your product logic, but the widget does not enforce or apply them by itself.
+The central field is rendered with [`TextInput`](/reference/widgets/text-input)
+and forwards `on_input`. `min`, `max`, and `step` are meaningful configuration
+fields for your product logic, but the widget does not enforce or apply them by
+itself.
 
-In practice that means `NumberInput` is best today for stepper-style adjustment through the plus and minus buttons. If you need full free-form numeric typing with validation on every keystroke, compose a `TextInput` directly and parse inside the reducer.
+Typed edits arrive as text because incomplete numeric input such as an empty
+field, `-`, or a trailing decimal point is not always an `f32`. Parse inside the
+reducer and decide whether to retain a separate draft string when intermediate
+states matter. The plus and minus buttons continue to dispatch
+`on_increment` and `on_decrement` independently.
 
 ## Specific advice
 
@@ -71,4 +89,3 @@ If a screen starts repeating the same `NumberInput` setup, extract a named compo
 ## Related
 
 [`TextInput`](/reference/widgets/text-input), [`Slider`](/reference/widgets/slider), [`TimePicker`](/reference/widgets/time-picker), and [`FormControl`](/reference/widgets/form-control).
-

--- a/documentation/content/reference/widgets/widget-pages/text-input.mdx
+++ b/documentation/content/reference/widgets/widget-pages/text-input.mdx
@@ -13,14 +13,20 @@ It covers ordinary single-line fields, multiline editors, password fields, synta
 
 ```rust
 use fission::prelude::*;
+
+#[fission_reducer(SetEmail)]
+fn set_email(state: &mut SettingsState, ctx: &mut ReducerContext<SettingsState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.email = change.new_text.clone();
+}
+
 let widget: Widget = TextInput {
 value: view.state().email.clone(),
 label: Some("Email address".into()),
 placeholder: Some("name@example.com".into()),
-on_change: Some(ctx.bind(
-    SetEmail(String::new()),
-    reduce_with!((|state: &mut SettingsState, action: SetEmail, _| state.email = action.0)),
-)),
+on_input: Some(ctx.bind(SetEmail, reduce_with!(set_email))),
 on_submit: Some(save_email_action),
 width: Some(320.0),
 ..Default::default()
@@ -28,7 +34,10 @@ width: Some(320.0),
 .into();
 ```
 
-The empty string inside `SetEmail(String::new())` is only a placeholder so `ctx.bind(...)` knows the action type. When the user edits the field, the runtime replaces the payload with the current `String` before dispatching the action.
+The runtime preserves `SetEmail` and exposes the live edit through
+`ctx.input.text_change()`. The returned `UpdateTextInput` contains `new_text`,
+`node_id`, `new_caret`, and `new_anchor`. An action can therefore remain a unit
+action or carry stable application context such as a field or row identity.
 
 ## Core field table
 
@@ -41,7 +50,7 @@ The empty string inside `SetEmail(String::new())` is only a placeholder so `ctx.
 | `helper_text` | `Option<TextContent>` | Supporting text below the field. | Defaults to `None`. |
 | `error_text` | `Option<TextContent>` | Validation message below the field. | Defaults to `None`. |
 | `counter_text` | `Option<TextContent>` | Explicit counter text below the field. | Defaults to `None`. |
-| `on_change` | `Option<ActionEnvelope>` | Action fired when the text changes. | The runtime serializes the current `String` into the payload. |
+| `on_input` | `Option<ActionEnvelope>` | Action fired when the text changes. | Preserves the bound action; read the edit through `ctx.input.text_change()`. |
 | `on_submit` | `Option<ActionEnvelope>` | Action fired when the user submits the field. | Uses the payload you provided on the envelope. |
 | `on_editing_complete` | `Option<ActionEnvelope>` | Action fired when editing is explicitly completed. | Defaults to `None`. |
 | `on_tap_outside` | `Option<ActionEnvelope>` | Action fired when the user taps or clicks away from the active field. | Defaults to `None`. |
@@ -89,6 +98,27 @@ The empty string inside `SetEmail(String::new())` is only a placeholder so `ctx.
 
 This is why `component conversion` stays pure even for rich text entry. The widget describes the field, the runtime manages the live editing mechanics, and state remains explicit.
 
+When the reducer also needs stable application context, put that context in the
+action and continue to read the edit separately:
+
+```rust
+#[fission_reducer(UpdateField)]
+fn update_field(
+    draft: &mut Draft,
+    field: FieldId,
+    ctx: &mut ReducerContext<Draft>,
+) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    draft.values.insert(field, change.new_text.clone());
+}
+```
+
+The widget binds `UpdateField(field.clone())` to `on_input`. Static site and
+plain SSR output do not run reducers; use a browser island when the field must
+remain interactive in generated HTML.
+
 ## Specific advice
 
 Use a real label for accessibility; placeholder text is not a good substitute because it disappears once typing begins. Keep expensive parsing or validation out of the raw keystroke path unless you truly need it on every change. If a field needs stable focus or selection behavior across reconversions, give it a stable `id`.
@@ -97,7 +127,7 @@ Use a real label for accessibility; placeholder text is not a good substitute be
 
 For `TextInput`, review the fields that change behavior before treating the widget as finished: `id`, `value`, `label`, `placeholder`, `helper_text`, `error_text`. The goal is to make the product rule visible in state and actions, not hidden inside ad-hoc construction code.
 
-- Bind `on_change` to explicit reducer actions and test that the reducer handles unavailable, duplicate, or invalid input safely.
+- Bind `on_input` to an explicit reducer action, read `ctx.input.text_change()`, and test that the reducer handles unavailable, duplicate, or invalid input safely.
 - Set `id` only when identity must be stable across filtering, reordering, diagnostics, or tests; otherwise let Fission derive identity from structure.
 - Check the semantics tree for the user-facing label or role that makes this widget understandable without relying only on pixels.
 - Add at least one component or harness test that confirms the visible text, semantic role, action dispatch, and layout constraint that matter for this widget in context.

--- a/documentation/content/reference/widgets/widget-pages/video.mdx
+++ b/documentation/content/reference/widgets/widget-pages/video.mdx
@@ -118,7 +118,7 @@ In the winit shell path, macOS and iOS use AVFoundation player layers, Windows u
 Native Linux video is behind the `video` Cargo feature so ordinary desktop apps do not need GStreamer development packages unless they use embedded video:
 
 ```toml
-fission = { version = "0.10.1", default-features = false, features = ["desktop", "video"] }
+fission = { version = "0.11.0", default-features = false, features = ["desktop", "video"] }
 ```
 
 On Debian or Ubuntu, enabling that feature requires:

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -126,7 +126,7 @@ impl From<FooterIdentity> for Widget {
                     ..Default::default()
                 }
                 .into(),
-                Text::new("Fission 0.10.1")
+                Text::new("Fission 0.11.0")
                     .size(tokens.typography.font_size_sm)
                     .family(tokens.typography.font_family_mono.clone())
                     .color(tokens.colors.text_muted)

--- a/examples/animation-gallery/Cargo.toml
+++ b/examples/animation-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animation-gallery"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/chart-gallery/Cargo.toml
+++ b/examples/chart-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chart-gallery"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "counter"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-editor"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/editor/src/command_palette.rs
+++ b/examples/editor/src/command_palette.rs
@@ -9,7 +9,7 @@ use crate::model::{
 };
 use crate::palette::{FLYOUT_BG, FLYOUT_BORDER, MODAL_BACKDROP};
 use fission::core::ui::{Container, GestureDetector, Positioned, TextInput, Widget, ZStack};
-use fission::core::{reduce_with, WidgetId};
+use fission::core::{reduce_with, ReducerContext, WidgetId};
 use fission::widgets::{Spacer, VStack};
 
 pub struct CommandPalette;
@@ -42,8 +42,16 @@ impl From<CommandPalette> for Widget {
         );
 
         let update_query = ctx.bind(
-            UpdateCommandQuery(String::new()),
-            reduce_with!((|s: &mut EditorState, a: UpdateCommandQuery, _| s.command_query = a.0)),
+            UpdateCommandQuery,
+            reduce_with!(
+                (|s: &mut EditorState,
+                  _a: UpdateCommandQuery,
+                  ctx: &mut ReducerContext<EditorState>| {
+                    if let Some(change) = ctx.input.text_change() {
+                        s.command_query = change.new_text.clone();
+                    }
+                })
+            ),
         );
 
         let commands = vec![
@@ -210,7 +218,7 @@ impl From<CommandPalette> for Widget {
                     id: Some(fission::WidgetId::explicit("editor_command_palette_input")),
                     value: view.state().command_query.clone(),
                     placeholder: Some("Type a command...".into()),
-                    on_change: Some(update_query),
+                    on_input: Some(update_query),
                     ..Default::default()
                 })
                 .padding_all(tokens.spacing.s)

--- a/examples/editor/src/editor_surface.rs
+++ b/examples/editor/src/editor_surface.rs
@@ -8,8 +8,8 @@ use crate::layout::{
 use crate::minimap::Minimap;
 use crate::model::{EditorState, UpdateCursorPosition, UpdateEditorDocument};
 use crate::palette::{BORDER_COLOR, BRIGHT_TEXT, EDITOR_SELECTION, WELCOME_BG};
-use fission::core::reduce_with;
 use fission::core::ui::{Container, Row, TextInput, Widget};
+use fission::core::{reduce_with, ReducerContext};
 use fission::widgets::{Spacer, VStack};
 use fission::WidgetId;
 
@@ -64,9 +64,14 @@ impl From<EditorSurface> for Widget {
         let path = tab.path.clone();
 
         let update_document = ctx.bind(
-            UpdateEditorDocument(String::new()),
+            UpdateEditorDocument,
             reduce_with!(
-                (|s: &mut EditorState, a: UpdateEditorDocument, _| {
+                (|s: &mut EditorState,
+                  _a: UpdateEditorDocument,
+                  ctx: &mut ReducerContext<EditorState>| {
+                    let Some(change) = ctx.input.text_change() else {
+                        return;
+                    };
                     if let Some(tab) = s.open_tabs.get(s.active_tab) {
                         let path = tab.path.clone();
                         if let Some(buf) = s.file_contents.get_mut(&path) {
@@ -74,7 +79,7 @@ impl From<EditorSurface> for Widget {
                                 s.status_message = Some("This document is not editable".into());
                                 return;
                             }
-                            buf.replace_document(&a.0);
+                            buf.replace_document(&change.new_text);
                         }
                         s.mark_active_tab_dirty();
                         s.notify_buffer_changed(&path);
@@ -101,7 +106,7 @@ impl From<EditorSurface> for Widget {
         let editor_input: Widget = TextInput {
             id: Some(WidgetId::explicit(&format!("editor_input_{}", path))),
             value: buffer.display_content(),
-            on_change: Some(update_document),
+            on_input: Some(update_document),
             on_cursor_change: Some(update_cursor),
             width: Some(editor_viewport_width),
             height: Some(editor_viewport_height),

--- a/examples/editor/src/file_tree.rs
+++ b/examples/editor/src/file_tree.rs
@@ -129,10 +129,14 @@ impl From<FileTree> for Widget {
             .id;
 
         let rename_input_id = ctx.bind(
-            UpdateRenameInput(String::new()),
+            UpdateRenameInput,
             reduce_with!(
-                (|s: &mut EditorState, a: UpdateRenameInput, _| {
-                    s.rename_input = a.0;
+                (|s: &mut EditorState,
+                  _a: UpdateRenameInput,
+                  ctx: &mut fission::core::ReducerContext<EditorState>| {
+                    if let Some(change) = ctx.input.text_change() {
+                        s.rename_input = change.new_text.clone();
+                    }
                 })
             ),
         );

--- a/examples/editor/src/file_tree_entry.rs
+++ b/examples/editor/src/file_tree_entry.rs
@@ -84,7 +84,7 @@ impl From<FileTreeEntry> for Widget {
                 id: Some(fission::WidgetId::explicit("rename_input")),
                 value: view.state().rename_input.clone(),
                 placeholder: Some("New name".into()),
-                on_change: Some(component.rename_input_action.clone()),
+                on_input: Some(component.rename_input_action.clone()),
                 ..Default::default()
             }
             .into()

--- a/examples/editor/src/find_replace_bar.rs
+++ b/examples/editor/src/find_replace_bar.rs
@@ -1,8 +1,8 @@
 use crate::layout::{FIND_BAR_HEIGHT, TOOLBAR_CONTROL_SIZE};
 use crate::model::*;
 use crate::palette::{BRIGHT_TEXT, DIM_TEXT, FIND_BAR_BG, FLYOUT_BORDER};
-use fission::core::reduce_with;
 use fission::core::ui::{Button, ButtonVariant, Container, Icon, Row, Text, TextInput, Widget};
+use fission::core::{reduce_with, ReducerContext};
 use fission::icons::material;
 use fission::widgets::Spacer;
 
@@ -21,18 +21,31 @@ impl From<FindReplaceBar> for Widget {
         }
 
         let update_find = ctx.bind(
-            UpdateFindQuery(String::new()),
+            UpdateFindQuery,
             reduce_with!(
-                (|s: &mut EditorState, a: UpdateFindQuery, _| {
-                    s.find_query = a.0;
+                (|s: &mut EditorState,
+                  _a: UpdateFindQuery,
+                  ctx: &mut ReducerContext<EditorState>| {
+                    let Some(change) = ctx.input.text_change() else {
+                        return;
+                    };
+                    s.find_query = change.new_text.clone();
                     s.find_next(); // Auto-search as you type
                 })
             ),
         );
 
         let update_replace = ctx.bind(
-            UpdateReplaceQuery(String::new()),
-            reduce_with!((|s: &mut EditorState, a: UpdateReplaceQuery, _| s.replace_query = a.0)),
+            UpdateReplaceQuery,
+            reduce_with!(
+                (|s: &mut EditorState,
+                  _a: UpdateReplaceQuery,
+                  ctx: &mut ReducerContext<EditorState>| {
+                    if let Some(change) = ctx.input.text_change() {
+                        s.replace_query = change.new_text.clone();
+                    }
+                })
+            ),
         );
 
         let close_find = ctx.bind(
@@ -99,7 +112,7 @@ impl From<FindReplaceBar> for Widget {
             id: Some(fission::WidgetId::explicit("find_input")),
             value: view.state().find_query.clone(),
             placeholder: Some("Find".into()),
-            on_change: Some(update_find),
+            on_input: Some(update_find),
             ..Default::default()
         })
         .flex_grow(1.0)
@@ -109,7 +122,7 @@ impl From<FindReplaceBar> for Widget {
             id: Some(fission::WidgetId::explicit("replace_input")),
             value: view.state().replace_query.clone(),
             placeholder: Some("Replace".into()),
-            on_change: Some(update_replace),
+            on_input: Some(update_replace),
             ..Default::default()
         })
         .flex_grow(1.0)

--- a/examples/editor/src/model.rs
+++ b/examples/editor/src/model.rs
@@ -1206,8 +1206,7 @@ pub struct ApplyEditorEdit {
 }
 
 #[fission_action]
-#[serde(transparent)]
-pub struct UpdateEditorDocument(pub String);
+pub struct UpdateEditorDocument;
 
 #[fission_action]
 #[allow(dead_code)]
@@ -1219,8 +1218,7 @@ pub struct SetEditorPreedit {
 pub struct ToggleCommandPalette;
 
 #[fission_action]
-#[serde(transparent)]
-pub struct UpdateCommandQuery(pub String);
+pub struct UpdateCommandQuery;
 
 #[fission_action]
 pub struct ToggleSidebar;
@@ -1257,8 +1255,7 @@ pub struct RenameContextTarget;
 pub struct DeleteContextTarget;
 
 #[fission_action]
-#[serde(transparent)]
-pub struct UpdateSearchQuery(pub String);
+pub struct UpdateSearchQuery;
 
 #[fission_action]
 pub struct ExecuteSearch;
@@ -1304,12 +1301,10 @@ pub struct RefreshTree;
 pub struct ToggleFindReplace;
 
 #[fission_action]
-#[serde(transparent)]
-pub struct UpdateFindQuery(pub String);
+pub struct UpdateFindQuery;
 
 #[fission_action]
-#[serde(transparent)]
-pub struct UpdateReplaceQuery(pub String);
+pub struct UpdateReplaceQuery;
 
 #[fission_action]
 pub struct FindNext;
@@ -1356,8 +1351,7 @@ pub struct ConfirmRename;
 pub struct CancelRename;
 
 #[fission_action]
-#[serde(transparent)]
-pub struct UpdateRenameInput(pub String);
+pub struct UpdateRenameInput;
 
 #[fission_action]
 pub struct SetActiveMenu(pub Option<String>);

--- a/examples/editor/src/search_panel.rs
+++ b/examples/editor/src/search_panel.rs
@@ -13,8 +13,16 @@ impl From<SearchPanel> for Widget {
         let tokens = &view.env().theme.tokens;
 
         let update_query = ctx.bind(
-            UpdateSearchQuery(String::new()),
-            reduce_with!((|s: &mut EditorState, a: UpdateSearchQuery, _| s.search_query = a.0)),
+            UpdateSearchQuery,
+            reduce_with!(
+                (|s: &mut EditorState,
+                  _a: UpdateSearchQuery,
+                  ctx: &mut ReducerContext<EditorState>| {
+                    if let Some(change) = ctx.input.text_change() {
+                        s.search_query = change.new_text.clone();
+                    }
+                })
+            ),
         );
 
         let execute = ctx.bind(
@@ -36,7 +44,7 @@ impl From<SearchPanel> for Widget {
                     id: Some(fission::WidgetId::explicit("editor_search_query_input")),
                     value: view.state().search_query.clone(),
                     placeholder: Some("Search...".into()),
-                    on_change: Some(update_query),
+                    on_input: Some(update_query),
                     borderless: true,
                     ..Default::default()
                 },

--- a/examples/embed-3d/Cargo.toml
+++ b/examples/embed-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-3d"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/examples/embed-video/Cargo.toml
+++ b/examples/embed-video/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-video"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/examples/embed-webview/Cargo.toml
+++ b/examples/embed-webview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-webview"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/Cargo.toml
+++ b/examples/field-inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-inspector"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/fission.toml
+++ b/examples/field-inspector/fission.toml
@@ -24,13 +24,13 @@ capabilities = [
 [app]
 name = "field-inspector"
 app_id = "com.fission.examples.fieldinspector"
-version = "0.10.1"
+version = "0.11.0"
 build = 1
 
 [package.android]
 package_name = "com.fission.examples.fieldinspector"
 version_code = 1
-version_name = "0.10.1"
+version_name = "0.11.0"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -41,13 +41,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.fission.examples.fieldinspector"
-marketing_version = "0.10.1"
+marketing_version = "0.11.0"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.fission.examples.fieldinspector"
 publisher = "CN=Fission Developer"
-version = "0.10.1"
+version = "0.11.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/icons_gallery/Cargo.toml
+++ b/examples/icons_gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icons_gallery"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/inbox/Cargo.toml
+++ b/examples/inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inbox"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/inbox/src/components/email_detail.rs
+++ b/examples/inbox/src/components/email_detail.rs
@@ -7,7 +7,7 @@ use fission::core::op::ImageFit;
 use fission::core::ui::{
     Button, ButtonVariant, Container, Scroll, Text, TextContent, Video, Widget,
 };
-use fission::core::{reduce_with, ActionEnvelope, WidgetId};
+use fission::core::{reduce_with, ActionEnvelope, ReducerContext, WidgetId};
 use fission::icons::material;
 use fission::widgets::{
     Accordion, AccordionItem, Alert, AlertKind, AspectRatio, Avatar, Card, Code, Divider, HStack,
@@ -84,7 +84,17 @@ impl From<EmailDetail> for Widget {
         let reply_body_id = ctx
             .bind(
                 SetReplyBody("".into()),
-                reduce_with!((|s: &mut InboxState, a: SetReplyBody, _| s.reply_body = a.0)),
+                reduce_with!(
+                    (|s: &mut InboxState,
+                      a: SetReplyBody,
+                      ctx: &mut ReducerContext<InboxState>| {
+                        s.reply_body = ctx
+                            .input
+                            .text_change()
+                            .map(|change| change.new_text.clone())
+                            .unwrap_or(a.0);
+                    })
+                ),
             )
             .id;
         let send_reply_id = ctx
@@ -473,9 +483,9 @@ impl From<EmailDetail> for Widget {
                 fission::widgets::TextInput {
                     value: view.state().reply_body.clone(),
                     placeholder: Some(TextContent::Key("email.reply_placeholder".into())),
-                    on_change: Some(ActionEnvelope {
+                    on_input: Some(ActionEnvelope {
                         id: reply_body_id,
-                        payload: Vec::new(),
+                        payload: serde_json::to_vec(&SetReplyBody(String::new())).unwrap(),
                     }),
                     multiline: true,
                     height: Some(120.0),

--- a/examples/inbox/src/components/email_list.rs
+++ b/examples/inbox/src/components/email_list.rs
@@ -7,7 +7,7 @@ use fission::core::ui::{
     Button, ButtonContentAlign, ButtonVariant, Checkbox, Container, Row, Text, TextContent, Widget,
 };
 use fission::core::ActionEnvelope;
-use fission::core::{reduce_with, Length, WidgetId};
+use fission::core::{reduce_with, Length, ReducerContext, WidgetId};
 use fission::icons::material;
 use fission::theme::ComponentSize;
 use fission::widgets::{
@@ -135,7 +135,17 @@ impl From<EmailList> for Widget {
         let search_id = ctx
             .bind(
                 UpdateSearch("".into()),
-                reduce_with!((|s: &mut InboxState, a: UpdateSearch, _| s.search_query = a.0)),
+                reduce_with!(
+                    (|s: &mut InboxState,
+                      a: UpdateSearch,
+                      ctx: &mut ReducerContext<InboxState>| {
+                        s.search_query = ctx
+                            .input
+                            .text_change()
+                            .map(|change| change.new_text.clone())
+                            .unwrap_or(a.0);
+                    })
+                ),
             )
             .id;
         let select_id = ctx
@@ -262,9 +272,9 @@ impl From<EmailList> for Widget {
             TextInput {
                 value: view.state().search_query.clone(),
                 placeholder: Some(TextContent::Key("search.placeholder".into())),
-                on_change: Some(ActionEnvelope {
+                on_input: Some(ActionEnvelope {
                     id: search_id,
-                    payload: Vec::new(),
+                    payload: serde_json::to_vec(&UpdateSearch(String::new())).unwrap(),
                 }),
                 ..Default::default()
             }

--- a/examples/inbox/src/features/compose.rs
+++ b/examples/inbox/src/features/compose.rs
@@ -5,7 +5,7 @@ use crate::model::{
 };
 use chrono::Local;
 use fission::core::ui::Widget;
-use fission::core::{reduce_with, ActionEnvelope, WidgetId};
+use fission::core::{reduce_with, ActionEnvelope, ReducerContext, WidgetId};
 use fission::widgets::{
     Combobox, DatePicker, Dropzone, FileUpload, FocusScope, FormControl, Modal, ModalAction,
     TextInput, TimePicker, VStack, Wrap,
@@ -28,21 +28,49 @@ impl From<ComposeModal> for Widget {
         let to_id = ctx
             .bind(
                 SetComposeTo("".into()),
-                reduce_with!((|s: &mut InboxState, a: SetComposeTo, _| s.compose_to = a.0)),
+                reduce_with!(
+                    (|s: &mut InboxState,
+                      a: SetComposeTo,
+                      ctx: &mut ReducerContext<InboxState>| {
+                        s.compose_to = ctx
+                            .input
+                            .text_change()
+                            .map(|change| change.new_text.clone())
+                            .unwrap_or(a.0);
+                    })
+                ),
             )
             .id;
         let subject_id = ctx
             .bind(
                 SetComposeSubject("".into()),
                 reduce_with!(
-                    (|s: &mut InboxState, a: SetComposeSubject, _| s.compose_subject = a.0)
+                    (|s: &mut InboxState,
+                      a: SetComposeSubject,
+                      ctx: &mut ReducerContext<InboxState>| {
+                        s.compose_subject = ctx
+                            .input
+                            .text_change()
+                            .map(|change| change.new_text.clone())
+                            .unwrap_or(a.0);
+                    })
                 ),
             )
             .id;
         let body_id = ctx
             .bind(
                 SetComposeBody("".into()),
-                reduce_with!((|s: &mut InboxState, a: SetComposeBody, _| s.compose_body = a.0)),
+                reduce_with!(
+                    (|s: &mut InboxState,
+                      a: SetComposeBody,
+                      ctx: &mut ReducerContext<InboxState>| {
+                        s.compose_body = ctx
+                            .input
+                            .text_change()
+                            .map(|change| change.new_text.clone())
+                            .unwrap_or(a.0);
+                    })
+                ),
             )
             .id;
         let date_id = ctx
@@ -195,9 +223,9 @@ impl From<ComposeModal> for Widget {
                             is_open: !query.is_empty() && !has_exact_match,
                             width: Some(field_width),
                             max_popup_height: Some(180.0),
-                            on_change: Some(ActionEnvelope {
+                            on_input: Some(ActionEnvelope {
                                 id: to_id,
-                                payload: Vec::new(),
+                                payload: serde_json::to_vec(&SetComposeTo(String::new())).unwrap(),
                             }),
                             on_select: Some(Arc::new(move |val| ActionEnvelope {
                                 id: to_id,
@@ -220,9 +248,9 @@ impl From<ComposeModal> for Widget {
                         id: Some(subject_node_id),
                         value: view.state().compose_subject.clone(),
                         placeholder: Some("Subject".into()),
-                        on_change: Some(ActionEnvelope {
+                        on_input: Some(ActionEnvelope {
                             id: subject_id,
-                            payload: Vec::new(),
+                            payload: serde_json::to_vec(&SetComposeSubject(String::new())).unwrap(),
                         }),
                         ..Default::default()
                     }
@@ -280,9 +308,9 @@ impl From<ComposeModal> for Widget {
                         id: Some(body_node_id),
                         value: view.state().compose_body.clone(),
                         placeholder: Some("Type your message...".into()),
-                        on_change: Some(ActionEnvelope {
+                        on_input: Some(ActionEnvelope {
                             id: body_id,
-                            payload: Vec::new(),
+                            payload: serde_json::to_vec(&SetComposeBody(String::new())).unwrap(),
                         }),
                         multiline: true,
                         height: Some(160.0),

--- a/examples/inbox/src/features/settings.rs
+++ b/examples/inbox/src/features/settings.rs
@@ -10,7 +10,7 @@ use fission::core::ui::widgets::GestureDetector;
 use fission::core::ui::{
     Button, ButtonVariant, Container, Grid, GridItem, Scroll, Text, TextContent, Widget,
 };
-use fission::core::{reduce_with, ActionEnvelope, FlexDirection, WidgetId};
+use fission::core::{reduce_with, ActionEnvelope, FlexDirection, ReducerContext, WidgetId};
 use fission::i18n::Locale;
 use fission::icons::material;
 use fission::widgets::{
@@ -85,7 +85,17 @@ impl From<SettingsModal> for Widget {
         let signature_id = ctx
             .bind(
                 SetSignature("".into()),
-                reduce_with!((|s: &mut InboxState, a: SetSignature, _| s.signature = a.0)),
+                reduce_with!(
+                    (|s: &mut InboxState,
+                      a: SetSignature,
+                      ctx: &mut ReducerContext<InboxState>| {
+                        s.signature = ctx
+                            .input
+                            .text_change()
+                            .map(|change| change.new_text.clone())
+                            .unwrap_or(a.0);
+                    })
+                ),
             )
             .id;
         let signature_edit_id = ctx
@@ -318,7 +328,7 @@ impl From<SettingsModal> for Widget {
             value: view.state().signature.clone(),
             placeholder: "Add a signature".into(),
             is_editing: view.state().signature_editing,
-            on_change: Some(ActionEnvelope {
+            on_input: Some(ActionEnvelope {
                 id: signature_id,
                 payload: serde_json::to_vec(&SetSignature(view.state().signature.clone())).unwrap(),
             }),
@@ -804,7 +814,7 @@ impl From<SettingsModal> for Widget {
                                     step: 10.0,
                                     on_increment: None,
                                     on_decrement: None,
-                                    on_change: None,
+                                    on_input: None,
                                     ..Default::default()
                                 }
                                 .into(),

--- a/examples/mobile-smoke/Cargo.toml
+++ b/examples/mobile-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-smoke"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/examples/motion-memory-repro/Cargo.toml
+++ b/examples/motion-memory-repro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion-memory-repro"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/pokemon-card-store/Cargo.toml
+++ b/examples/pokemon-card-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pokemon-card-store"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 publish = false
 

--- a/examples/pokemon-card-store/fission.toml
+++ b/examples/pokemon-card-store/fission.toml
@@ -19,7 +19,7 @@ preload = "route"
 
 [package.docker]
 port = 8080
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.10.1"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.11.0"]
 
 [distribution.docker_registry.production]
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.10.1"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.11.0"]

--- a/examples/product-browser/Cargo.toml
+++ b/examples/product-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product-browser"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/product-browser/src/components/browser.rs
+++ b/examples/product-browser/src/components/browser.rs
@@ -27,7 +27,7 @@ impl From<ProductBrowserApp> for Widget {
         let products_failed = with_reducer!(ctx, ProductsFailed, on_products_failed);
         let categories_loaded = with_reducer!(ctx, CategoriesLoaded, on_categories_loaded);
         let categories_failed = with_reducer!(ctx, CategoriesFailed, on_categories_failed);
-        let search_changed = with_reducer!(ctx, SearchChanged(String::new()), on_search_changed);
+        let search_changed = with_reducer!(ctx, SearchChanged, on_search_changed);
         let pull_started = with_reducer!(ctx, PullStarted, on_pull_started);
         let pull_updated = with_reducer!(ctx, PullUpdated, on_pull_updated);
         let pull_canceled = with_reducer!(ctx, PullCanceled, on_pull_canceled);

--- a/examples/product-browser/src/components/header.rs
+++ b/examples/product-browser/src/components/header.rs
@@ -51,7 +51,7 @@ impl From<ProductBrowserHeader> for Widget {
             semantics_identifier: Some("product-browser.search".into()),
             value: view.state().query.clone(),
             placeholder: Some("Search products".into()),
-            on_change: Some(header.on_search),
+            on_input: Some(header.on_search),
             ..Default::default()
         })
         .width_length(Length::clamp(

--- a/examples/product-browser/src/model.rs
+++ b/examples/product-browser/src/model.rs
@@ -72,8 +72,14 @@ impl ProductBrowserState {
 impl GlobalState for ProductBrowserState {}
 
 #[fission_reducer(SearchChanged)]
-pub fn on_search_changed(state: &mut ProductBrowserState, query: String) {
-    state.query = query;
+pub fn on_search_changed(
+    state: &mut ProductBrowserState,
+    ctx: &mut ReducerContext<ProductBrowserState>,
+) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.query = change.new_text.clone();
     state.selected_category = None;
     state.selected_product_id = None;
     state.compact_detail_open = false;

--- a/examples/showcase/Cargo.toml
+++ b/examples/showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-showcase"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/examples/showcase/fission.toml
+++ b/examples/showcase/fission.toml
@@ -8,19 +8,19 @@ targets = [
 [app]
 name = "example-showcase"
 app_id = "rs.fission.examples.showcase"
-version = "0.10.1"
+version = "0.11.0"
 build = 1
 
 [package.macos]
 bundle_id = "rs.fission.examples.showcase"
-marketing_version = "0.10.1"
+marketing_version = "0.11.0"
 build_number = "1"
 minimum_os = "13.0"
 
 [package.windows]
 identity_name = "rs.fission.examples.showcase"
 publisher = "CN=Fission Developer"
-version = "0.10.1"
+version = "0.11.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/showcase/src/components/app_header.rs
+++ b/examples/showcase/src/components/app_header.rs
@@ -30,11 +30,7 @@ impl From<ExpandedHeader> for Widget {
     fn from(_component: ExpandedHeader) -> Self {
         let (ctx, view) = fission::build::current::<ShowcaseState>();
         let tokens = &view.env().theme.tokens;
-        let search = with_reducer!(
-            ctx,
-            SearchChanged(view.state().search.clone()),
-            on_search_changed
-        );
+        let search = with_reducer!(ctx, SearchChanged, on_search_changed);
         let open_github = with_reducer!(
             ctx,
             OpenSource("https://github.com/fission-ui/fission".into()),
@@ -55,7 +51,7 @@ impl From<ExpandedHeader> for Widget {
                     semantics_identifier: Some("showcase.search".into()),
                     value: view.state().search.clone(),
                     placeholder: Some(TextContent::Key("showcase.nav.search".into())),
-                    on_change: Some(search),
+                    on_input: Some(search),
                     width: Some(tokens.spacing.xxxxl * 2.6),
                     ..Default::default()
                 },
@@ -91,11 +87,7 @@ impl From<CompactHeader> for Widget {
     fn from(_component: CompactHeader) -> Self {
         let (ctx, view) = fission::build::current::<ShowcaseState>();
         let tokens = &view.env().theme.tokens;
-        let search = with_reducer!(
-            ctx,
-            SearchChanged(view.state().search.clone()),
-            on_search_changed
-        );
+        let search = with_reducer!(ctx, SearchChanged, on_search_changed);
         Container::new(Column {
             children: widgets![
                 Row {
@@ -115,7 +107,7 @@ impl From<CompactHeader> for Widget {
                     semantics_identifier: Some("showcase.search".into()),
                     value: view.state().search.clone(),
                     placeholder: Some(TextContent::Key("showcase.nav.search".into())),
-                    on_change: Some(search),
+                    on_input: Some(search),
                     ..Default::default()
                 },
             ],

--- a/examples/showcase/src/state.rs
+++ b/examples/showcase/src/state.rs
@@ -44,8 +44,14 @@ pub(crate) fn on_navigate(state: &mut ShowcaseState, path: String) {
 }
 
 #[fission_reducer(SearchChanged)]
-pub(crate) fn on_search_changed(state: &mut ShowcaseState, query: String) {
-    state.search = query;
+pub(crate) fn on_search_changed(
+    state: &mut ShowcaseState,
+    ctx: &mut ReducerContext<ShowcaseState>,
+) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.search = change.new_text.clone();
 }
 
 #[fission_reducer(FilterChanged)]

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/text-lab/Cargo.toml
+++ b/examples/text-lab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-lab"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/text-lab/src/state.rs
+++ b/examples/text-lab/src/state.rs
@@ -17,33 +17,57 @@ pub struct TextLabState {
 impl GlobalState for TextLabState {}
 
 #[fission_reducer(SetSingleLine)]
-pub(crate) fn set_single_line(state: &mut TextLabState, value: String) {
-    state.single_line = value;
+pub(crate) fn set_single_line(state: &mut TextLabState, ctx: &mut ReducerContext<TextLabState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.single_line = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetMultiline)]
-pub(crate) fn set_multiline(state: &mut TextLabState, value: String) {
-    state.multiline = value;
+pub(crate) fn set_multiline(state: &mut TextLabState, ctx: &mut ReducerContext<TextLabState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.multiline = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetInlineCombobox)]
-pub(crate) fn set_inline_combobox(state: &mut TextLabState, value: String) {
-    state.inline_combobox = value;
+pub(crate) fn set_inline_combobox(
+    state: &mut TextLabState,
+    value: String,
+    ctx: &mut ReducerContext<TextLabState>,
+) {
+    state.inline_combobox = ctx
+        .input
+        .text_change()
+        .map(|change| change.new_text.clone())
+        .unwrap_or(value);
 }
 
 #[fission_reducer(SetModalTo)]
-pub(crate) fn set_modal_to(state: &mut TextLabState, value: String) {
-    state.modal_to = value;
+pub(crate) fn set_modal_to(
+    state: &mut TextLabState,
+    value: String,
+    ctx: &mut ReducerContext<TextLabState>,
+) {
+    state.modal_to = ctx
+        .input
+        .text_change()
+        .map(|change| change.new_text.clone())
+        .unwrap_or(value);
 }
 
 #[fission_reducer(SetModalSubject)]
-pub(crate) fn set_modal_subject(state: &mut TextLabState, value: String) {
-    state.modal_subject = value;
+pub(crate) fn set_modal_subject(state: &mut TextLabState, ctx: &mut ReducerContext<TextLabState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.modal_subject = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetModalBody)]
-pub(crate) fn set_modal_body(state: &mut TextLabState, value: String) {
-    state.modal_body = value;
+pub(crate) fn set_modal_body(state: &mut TextLabState, ctx: &mut ReducerContext<TextLabState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.modal_body = change.new_text.clone();
+    }
 }
 
 #[fission_reducer(SetShowModal)]

--- a/examples/text-lab/src/text_lab_content.rs
+++ b/examples/text-lab/src/text_lab_content.rs
@@ -18,11 +18,11 @@ impl From<TextLabContent> for Widget {
         let tokens = &view.env().theme.tokens;
         let typography = &tokens.typography;
 
-        let set_single_line_id =
-            with_reducer!(ctx, SetSingleLine(String::new()), set_single_line).id;
-        let set_multiline_id = with_reducer!(ctx, SetMultiline(String::new()), set_multiline).id;
-        let set_inline_combobox_id =
-            with_reducer!(ctx, SetInlineCombobox(String::new()), set_inline_combobox).id;
+        let set_single_line = with_reducer!(ctx, SetSingleLine, set_single_line);
+        let set_multiline = with_reducer!(ctx, SetMultiline, set_multiline);
+        let set_inline_combobox =
+            with_reducer!(ctx, SetInlineCombobox(String::new()), set_inline_combobox);
+        let set_inline_combobox_id = set_inline_combobox.id;
         let set_show_modal_id = with_reducer!(ctx, SetShowModal(false), set_show_modal).id;
         let set_menu_open_id = with_reducer!(ctx, SetMenuOpen(false), set_menu_open).id;
         let menu_picked_id = with_reducer!(ctx, MenuPicked(String::new()), menu_picked).id;
@@ -73,10 +73,7 @@ impl From<TextLabContent> for Widget {
                         semantics_identifier: Some("text-lab.single-line".into()),
                         value: view.state().single_line.clone(),
                         placeholder: Some("Type quickly here".into()),
-                        on_change: Some(ActionEnvelope {
-                            id: set_single_line_id,
-                            payload: Vec::new(),
-                        }),
+                        on_input: Some(set_single_line),
                         ..Default::default()
                     }
                     .into(),
@@ -93,10 +90,7 @@ impl From<TextLabContent> for Widget {
                         semantics_identifier: Some("text-lab.multiline".into()),
                         value: view.state().multiline.clone(),
                         placeholder: Some("Multiline editing area".into()),
-                        on_change: Some(ActionEnvelope {
-                            id: set_multiline_id,
-                            payload: Vec::new(),
-                        }),
+                        on_input: Some(set_multiline),
                         multiline: true,
                         height: Some(MULTILINE_HEIGHT),
                         ..Default::default()
@@ -118,10 +112,7 @@ impl From<TextLabContent> for Widget {
                             && !inline_has_exact,
                         width: None,
                         max_popup_height: Some(POPUP_MAX_HEIGHT),
-                        on_change: Some(ActionEnvelope {
-                            id: set_inline_combobox_id,
-                            payload: Vec::new(),
-                        }),
+                        on_input: Some(set_inline_combobox),
                         on_select: Some(Arc::new(move |value| ActionEnvelope {
                             id: set_inline_combobox_id,
                             payload: serde_json::to_vec(&SetInlineCombobox(value)).unwrap(),

--- a/examples/text-lab/src/text_lab_modal.rs
+++ b/examples/text-lab/src/text_lab_modal.rs
@@ -18,10 +18,10 @@ impl From<TextLabModal> for Widget {
         let (ctx, view) = fission::build::current::<TextLabState>();
         let tokens = &view.env().theme.tokens;
 
-        let set_modal_to_id = with_reducer!(ctx, SetModalTo(String::new()), set_modal_to).id;
-        let set_modal_subject_id =
-            with_reducer!(ctx, SetModalSubject(String::new()), set_modal_subject).id;
-        let set_modal_body_id = with_reducer!(ctx, SetModalBody(String::new()), set_modal_body).id;
+        let set_modal_to = with_reducer!(ctx, SetModalTo(String::new()), set_modal_to);
+        let set_modal_to_id = set_modal_to.id;
+        let set_modal_subject = with_reducer!(ctx, SetModalSubject, set_modal_subject);
+        let set_modal_body = with_reducer!(ctx, SetModalBody, set_modal_body);
         let set_show_modal_id = with_reducer!(ctx, SetShowModal(false), set_show_modal).id;
         let apply_modal = with_reducer!(ctx, ApplyModal, apply_modal);
 
@@ -61,10 +61,7 @@ impl From<TextLabModal> for Widget {
                                     && !modal_has_exact,
                                 width: None,
                                 max_popup_height: Some(POPUP_MAX_HEIGHT),
-                                on_change: Some(ActionEnvelope {
-                                    id: set_modal_to_id,
-                                    payload: Vec::new(),
-                                }),
+                                on_input: Some(set_modal_to),
                                 on_select: Some(Arc::new(move |value| ActionEnvelope {
                                     id: set_modal_to_id,
                                     payload: serde_json::to_vec(&SetModalTo(value)).unwrap(),
@@ -85,10 +82,7 @@ impl From<TextLabModal> for Widget {
                                 semantics_identifier: Some("text-lab.modal.subject".into()),
                                 value: view.state().modal_subject.clone(),
                                 placeholder: Some("Subject".into()),
-                                on_change: Some(ActionEnvelope {
-                                    id: set_modal_subject_id,
-                                    payload: Vec::new(),
-                                }),
+                                on_input: Some(set_modal_subject),
                                 ..Default::default()
                             }
                             .into(),
@@ -107,10 +101,7 @@ impl From<TextLabModal> for Widget {
                                 semantics_identifier: Some("text-lab.modal.body".into()),
                                 value: view.state().modal_body.clone(),
                                 placeholder: Some("Type a longer message".into()),
-                                on_change: Some(ActionEnvelope {
-                                    id: set_modal_body_id,
-                                    payload: Vec::new(),
-                                }),
+                                on_input: Some(set_modal_body),
                                 multiline: true,
                                 height: Some(MODAL_BODY_HEIGHT),
                                 ..Default::default()

--- a/examples/todo-design-system/Cargo.toml
+++ b/examples/todo-design-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-design-system"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/todo-design-system/src/lib.rs
+++ b/examples/todo-design-system/src/lib.rs
@@ -47,8 +47,11 @@ impl Default for TodoState {
 impl GlobalState for TodoState {}
 
 #[fission_reducer(UpdateDraft)]
-fn update_draft(state: &mut TodoState, value: String) {
-    state.draft = value;
+fn update_draft(state: &mut TodoState, ctx: &mut ReducerContext<TodoState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.draft = change.new_text.clone();
 }
 
 #[fission_reducer(AddTodo)]
@@ -93,7 +96,7 @@ impl From<TodoApp> for Widget {
         let spacing = &view.env().theme.tokens.spacing;
         let done_count = view.state().items.iter().filter(|item| item.done).count();
         let add = with_reducer!(ctx, AddTodo, add_todo);
-        let update_draft = with_reducer!(ctx, UpdateDraft(String::new()), update_draft);
+        let update_draft = with_reducer!(ctx, UpdateDraft, update_draft);
         let clear_done = with_reducer!(ctx, ClearDone, clear_done);
         let light = with_reducer!(ctx, SetThemeMode(DesignMode::Light), set_theme_mode);
         let dark = with_reducer!(ctx, SetThemeMode(DesignMode::Dark), set_theme_mode);
@@ -202,7 +205,7 @@ impl From<TodoApp> for Widget {
                                 TextInput {
                                     value: view.state().draft.clone(),
                                     placeholder: Some("Add a task".into()),
-                                    on_change: Some(update_draft),
+                                    on_input: Some(update_draft),
                                     width: Some(360.0),
                                     ..Default::default()
                                 }

--- a/examples/web-smoke/Cargo.toml
+++ b/examples/web-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-smoke"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/examples/web-smoke/fission.toml
+++ b/examples/web-smoke/fission.toml
@@ -10,13 +10,13 @@ targets = [
 [app]
 name = "web-smoke"
 app_id = "com.example.web_smoke"
-version = "0.10.1"
+version = "0.11.0"
 build = 1
 
 [package.android]
 package_name = "com.example.web_smoke"
 version_code = 1
-version_name = "0.10.1"
+version_name = "0.11.0"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -27,13 +27,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.example.web_smoke"
-marketing_version = "0.10.1"
+marketing_version = "0.11.0"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.example.web.smoke"
 publisher = "CN=Fission Developer"
-version = "0.10.1"
+version = "0.11.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "widget-gallery"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/widget-gallery/src/colour_picker_section.rs
+++ b/examples/widget-gallery/src/colour_picker_section.rs
@@ -47,8 +47,11 @@ fn set_gallery_colour_alpha(state: &mut GalleryState, alpha: f32) {
 }
 
 #[fission_reducer(SetGalleryColourHex)]
-fn set_gallery_colour_hex(state: &mut GalleryState, value: String) {
-    if let Some(colour) = parse_gallery_hex(&value) {
+fn set_gallery_colour_hex(state: &mut GalleryState, ctx: &mut ReducerContext<GalleryState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    if let Some(colour) = parse_gallery_hex(&change.new_text) {
         state.colour_value = colour;
     }
 }
@@ -158,9 +161,9 @@ impl From<ColourPickerSection> for Widget {
                         SetGalleryColourAlpha(1.0),
                         set_gallery_colour_alpha
                     )),
-                    on_hex_change: Some(with_reducer!(
+                    on_hex_input: Some(with_reducer!(
                         ctx,
-                        SetGalleryColourHex(String::new()),
+                        SetGalleryColourHex,
                         set_gallery_colour_hex
                     )),
                     ..Default::default()

--- a/examples/widget-gallery/src/input_section.rs
+++ b/examples/widget-gallery/src/input_section.rs
@@ -23,8 +23,11 @@ fn toggle_switch(state: &mut GalleryState) {
 }
 
 #[fission_reducer(UpdateText)]
-fn update_text(state: &mut GalleryState, value: String) {
-    state.text_value = value;
+fn update_text(state: &mut GalleryState, ctx: &mut ReducerContext<GalleryState>) {
+    let Some(change) = ctx.input.text_change() else {
+        return;
+    };
+    state.text_value = change.new_text.clone();
 }
 
 #[fission_reducer(IncrementNumber)]
@@ -49,7 +52,7 @@ impl From<InputSection> for Widget {
         let tokens = &view.env().theme.tokens;
 
         let noop = with_reducer!(ctx, Noop, noop);
-        let update_text = with_reducer!(ctx, UpdateText(String::new()), update_text);
+        let update_text = with_reducer!(ctx, UpdateText, update_text);
         let toggle_checked = with_reducer!(ctx, ToggleChecked, toggle_checked);
         let toggle_switch = with_reducer!(ctx, ToggleSwitch, toggle_switch);
         let set_slider = with_reducer!(ctx, SetSlider(0.0), set_slider);
@@ -96,7 +99,7 @@ impl From<InputSection> for Widget {
                     semantics_identifier: Some("gallery.text_input".into()),
                     value: state.text_value.clone(),
                     placeholder: Some("Type something...".into()),
-                    on_change: Some(update_text),
+                    on_input: Some(update_text),
                     ..Default::default()
                 })
                 .width_length(Length::clamp(


### PR DESCRIPTION
## Summary

- replace payload-rewriting text input with a universal `on_input` contract
- preserve bound action context and expose text, widget ID, caret, and anchor through `ctx.input.text_change()`
- apply the contract to native/IME, accessibility, Web, interactive SSR islands, widgets, tests, examples, and documentation
- make declarative bindings single-handler while preserving explicit multicast registration
- add sanitized, recoverable action-dispatch diagnostics
- bump all first-party crates to 0.11.0 and add release notes

## Breaking changes

- `TextInput::on_change` becomes `TextInput::on_input`
- `Combobox`, `Editable`, and `NumberInput` use `on_input` for typed edits
- `UpdateTextInput` is runtime event data and no longer implements `Action`
- exhaustive matches must handle `ActionInput::TextChanged`, `ActionTrigger::TextChanged`, and `DiagEventKind::ActionDispatchFailed`

## Validation

- formatting, diff, locked metadata, JavaScript runtime tests, and command dependency boundaries
- focused core/IR/diagnostics/widget/shell tests
- full locked workspace all-target tests
- Web/WASM, Android, iOS, CLI, documentation site, package, and publication checks

The release will not be tagged or published unless all required local and platform gates pass.
