### PR TITLE
Web LiveTest support and Fission 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-08-17
+
+### Added
+
+- **Web LiveTest transport** - `LiveTestClient::launch_browser` drives a test-built Fission Web application in Chromium through the same commands, semantic selectors, deterministic clock, text queries, and semantic-tree responses used by native live tests.
+- **Browser screenshots and waits** - Web LiveTests can use bounded selector, text, and motion waits plus browser-page PNG capture without adding Playwright, Selenium, or another test vocabulary.
+
+### Changed
+
+- **Stronger Web target testing** - `fission test --target web` now builds a test-control-enabled WASM application, launches isolated headless Chromium, pumps the real Web event loop, and queries the running Fission semantic tree.
+
+### Fixed
+
+- **Reliable Web test serving** - The temporary browser server serves JavaScript modules with the correct MIME type, accepts renderer diagnostics, keeps accepting after individual request failures, and uses blocking accepted sockets on platforms where listener flags are inherited.
+
+### Migration notes
+
+- Update Fission dependencies and `cargo-fission` to `0.11.1`. Existing native LiveTest code remains source-compatible. Web suites use `LiveTestClient::launch_browser(BrowserTestOptions::new(url).fission_canvas())` against output built by `fission test --target web` or another build with Web test control enabled.
+- The first release targets Chromium. It injects deterministic Fission input events rather than claiming browser-trusted input, exposes the Fission semantic tree rather than DOM selectors, and captures the browser page rather than reading back a WebGPU texture.
+
 ## [0.11.0] - 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "animation-gallery"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fission"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1656,7 +1656,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chart-gallery"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "counter"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "embed-3d"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "embed-video"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "embed-webview"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "example-showcase"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "animation-gallery",
  "anyhow",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "field-inspector"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2695,7 +2695,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fission"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "fission-3d",
  "fission-charts",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "fission-3d"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "fission-charts"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "fission-core",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-package"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-release"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-run"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-command-core",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-server"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "toml 0.8.2",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-site"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-shell-site",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-ui"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "fission-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "fission-design-system-codegen"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "fission-diagnostics"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bitflags 2.13.0",
  "once_cell",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "fission-documentation"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "fission-editor"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -2948,14 +2948,14 @@ dependencies = [
 
 [[package]]
 name = "fission-i18n"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fission-icons"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "heck 0.4.1",
  "serde_json",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "fission-ir"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "blake3",
  "serde",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "fission-layout"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "fission-macros"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-ir",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render-vello"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "fission-semantics"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "fission-ir",
  "serde",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-desktop"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-mobile"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-server"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-site"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-terminal"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-web"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-winit"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test-driver"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3256,14 +3256,14 @@ dependencies = [
 
 [[package]]
 name = "fission-text-engine"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "fission-theme"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "fission-design-system-codegen",
  "fission-ir",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "fission-widgets"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "icons_gallery"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -4760,7 +4760,7 @@ checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "inbox"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-smoke"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "motion-memory-repro"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -6528,7 +6528,7 @@ dependencies = [
 
 [[package]]
 name = "pokemon-card-store"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "product-browser"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "text-lab"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -8640,7 +8640,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todo-design-system"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",
@@ -9370,7 +9370,7 @@ dependencies = [
 
 [[package]]
 name = "web-smoke"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "widget-gallery"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "fission",

--- a/crates/authoring/fission-charts/Cargo.toml
+++ b/crates/authoring/fission-charts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-charts"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 license = "MIT"
@@ -16,9 +16,9 @@ platforms = ["android", "ios", "linux", "macos", "windows", "web", "static-site"
 readme = "README.md"
 [dependencies]
 chrono = "0.4.44"
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-widgets = { path = "../fission-widgets", version = "0.11.0" }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-widgets = { path = "../fission-widgets", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/authoring/fission-charts/README.md
+++ b/crates/authoring/fission-charts/README.md
@@ -6,7 +6,7 @@ Chart widgets and data-visualization primitives for Fission applications.
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["desktop", "charts"] }
+fission = { version = "0.11.1", features = ["desktop", "charts"] }
 ```
 
 Most application code should import from `fission::prelude::*` and `fission::charts::*` rather than depending on this crate directly. Depend on `fission-charts` only when you are extending the chart layer itself.

--- a/crates/authoring/fission-icons/Cargo.toml
+++ b/crates/authoring/fission-icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-icons"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-macros/Cargo.toml
+++ b/crates/authoring/fission-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-macros"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-widgets"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -24,22 +24,22 @@ terminal = [
 ]
 
 [dependencies]
-fission-macros = { path = "../fission-macros", version = "0.11.0" }
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
-fission-icons = { path = "../fission-icons", version = "0.11.0" }
+fission-macros = { path = "../fission-macros", version = "0.11.1" }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
+fission-icons = { path = "../fission-icons", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 
 [dev-dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -50,30 +50,30 @@ video = [
 web = ["dep:fission-shell-web"]
 
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-3d = { path = "../../core/fission-3d", version = "0.11.0", optional = true }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-text-engine = { path = "../../core/fission-text-engine", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.11.0" }
-fission-widgets = { path = "../fission-widgets", version = "0.11.0" }
-fission-macros = { path = "../fission-macros", version = "0.11.0" }
-fission-icons = { path = "../fission-icons", version = "0.11.0" }
-fission-charts = { path = "../fission-charts", version = "0.11.0", optional = true }
-fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.11.0", optional = true }
-fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.11.0", optional = true }
-fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.11.0", optional = true }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.0", optional = true }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-3d = { path = "../../core/fission-3d", version = "0.11.1", optional = true }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-text-engine = { path = "../../core/fission-text-engine", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.11.1" }
+fission-widgets = { path = "../fission-widgets", version = "0.11.1" }
+fission-macros = { path = "../fission-macros", version = "0.11.1" }
+fission-icons = { path = "../fission-icons", version = "0.11.1" }
+fission-charts = { path = "../fission-charts", version = "0.11.1", optional = true }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.11.1", optional = true }
+fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.11.1", optional = true }
+fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.11.1", optional = true }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.11.0", optional = true }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.11.1", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.11.0", optional = true }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.11.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.11.0", optional = true }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.11.1", optional = true }

--- a/crates/authoring/fission/README.md
+++ b/crates/authoring/fission/README.md
@@ -15,7 +15,7 @@ This crate is the public facade. Application code should normally depend on `fis
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["desktop"] }
+fission = { version = "0.11.1", features = ["desktop"] }
 ```
 
 For the full developer workflow, install the Fission command:

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
+//! fission = { version = "0.11.1", default-features = false, features = ["desktop"] }
 //! ```
 //!
 //! Then use via:

--- a/crates/core/fission-3d/Cargo.toml
+++ b/crates/core/fission-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-3d"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 license = "MIT"
@@ -15,8 +15,8 @@ keywords = ["fission", "3d", "gpu-accelerated", "rendering", "cross-platform"]
 platforms = ["android", "ios", "linux", "macos", "windows", "web"]
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../fission-core", version = "0.11.0" }
-fission-ir = { path = "../fission-ir", version = "0.11.0" }
+fission-core = { path = "../fission-core", version = "0.11.1" }
+fission-ir = { path = "../fission-ir", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 wgpu = "26.0"
 bytemuck = { version = "1.18", features = ["derive"] }

--- a/crates/core/fission-3d/README.md
+++ b/crates/core/fission-3d/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["desktop", "three-d"] }
+fission = { version = "0.11.1", features = ["desktop", "three-d"] }
 ```
 
 Use this crate directly only when you are extending the framework's 3D model or renderer integration.

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-core"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,13 +15,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.11.0" }
-fission-layout = { path = "../fission-layout", version = "0.11.0" }
-fission-semantics = { path = "../fission-semantics", version = "0.11.0" }
-fission-theme = { path = "../fission-theme", version = "0.11.0" }
-fission-i18n = { path = "../fission-i18n", version = "0.11.0" }
-fission-text-engine = { path = "../fission-text-engine", version = "0.11.0" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
+fission-ir = { path = "../fission-ir", version = "0.11.1" }
+fission-layout = { path = "../fission-layout", version = "0.11.1" }
+fission-semantics = { path = "../fission-semantics", version = "0.11.1" }
+fission-theme = { path = "../fission-theme", version = "0.11.1" }
+fission-i18n = { path = "../fission-i18n", version = "0.11.1" }
+fission-text-engine = { path = "../fission-text-engine", version = "0.11.1" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -32,6 +32,6 @@ lazy_static = "1.4"
 blake3 = "1.5"
 unicode-segmentation = "1.10"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
 
 [dev-dependencies]

--- a/crates/core/fission-i18n/Cargo.toml
+++ b/crates/core/fission-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-i18n"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-ir/Cargo.toml
+++ b/crates/core/fission-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-ir"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-layout"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.11.0" }
+fission-ir = { path = "../fission-ir", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/Cargo.toml
+++ b/crates/core/fission-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-semantics"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,7 +15,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.11.0" }
+fission-ir = { path = "../fission-ir", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/core/fission-text-engine/Cargo.toml
+++ b/crates/core/fission-text-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-text-engine"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 license = "MIT"

--- a/crates/core/fission-theme/Cargo.toml
+++ b/crates/core/fission-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-theme"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -27,8 +27,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.11.0" }
+fission-ir = { path = "../fission-ir", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.11.0" }
+fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.11.1" }

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-vello"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,13 +15,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-render = { path = "../fission-render", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
 anyhow = "1.0"
 vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2", features = ["wgpu"] }
 parley = "0.7.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
 image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"

--- a/crates/rendering/fission-render-wgpu2d/Cargo.toml
+++ b/crates/rendering/fission-render-wgpu2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-wgpu2d"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -14,7 +14,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.11.0" }
+fission-render = { path = "../fission-render", version = "0.11.1" }
 anyhow = "1.0"
 bytemuck = { version = "1.16", features = ["derive"] }
 wgpu = { version = "26.0.1", default-features = false, features = ["std", "wgsl"] }

--- a/crates/rendering/fission-render/Cargo.toml
+++ b/crates/rendering/fission-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,8 +15,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-desktop"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 license = "MIT"
@@ -21,19 +21,19 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.11.0" }
-fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.11.0" }
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-shell = { path = "../fission-shell", version = "0.11.1" }
+fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.11.1" }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
 winit = { package = "fission-winit", version = "0.30.13-fission.2" }
 anyhow = "1.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.1" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.1" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.1" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.1" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-mobile"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -20,10 +20,10 @@ three-d = ["fission-shell-winit/three-d"]
 video = ["fission-shell-winit/video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.11.0" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.11.0", default-features = false }
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-shell = { path = "../fission-shell", version = "0.11.1" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.11.1", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/shell/fission-shell-mobile/README.md
+++ b/crates/shell/fission-shell-mobile/README.md
@@ -8,9 +8,9 @@ Most application developers should use the public facade instead of depending on
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["android"] }
+fission = { version = "0.11.1", features = ["android"] }
 # or
-fission = { version = "0.11.0", features = ["ios"] }
+fission = { version = "0.11.1", features = ["ios"] }
 ```
 
 ## What it provides

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-server"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -28,12 +28,12 @@ axum = { version = "0.7", optional = true, default-features = false }
 base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-shell-site = { path = "../fission-shell-site", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-shell-site = { path = "../fission-shell-site", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
 getrandom = { version = "0.2", features = ["std"] }
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 moka = { version = "0.12", features = ["sync"] }
@@ -44,4 +44,4 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0", default-features = false }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.1", default-features = false }

--- a/crates/shell/fission-shell-server/README.md
+++ b/crates/shell/fission-shell-server/README.md
@@ -19,7 +19,7 @@ Most applications should depend on the public `fission` facade with the
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["server"] }
+fission = { version = "0.11.1", features = ["server"] }
 ```
 
 Enable adapter features through the facade when you want to host the renderer
@@ -27,7 +27,7 @@ inside an existing HTTP stack:
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["server", "server-axum"] }
+fission = { version = "0.11.1", features = ["server", "server-axum"] }
 ```
 
 See the guides and reference at <https://fission.rs> for the server app model,

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-site"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -17,13 +17,13 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-icons = { path = "../../authoring/fission-icons", version = "0.11.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-icons = { path = "../../authoring/fission-icons", version = "0.11.1" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -6,7 +6,7 @@ Static site shell for Fission applications and documentation sites.
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["site"] }
+fission = { version = "0.11.1", features = ["site"] }
 ```
 
 ```sh

--- a/crates/shell/fission-shell-terminal/Cargo.toml
+++ b/crates/shell/fission-shell-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-terminal"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -21,9 +21,9 @@ crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["png"] }
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.0" }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.1" }
 base64 = "0.22"

--- a/crates/shell/fission-shell-terminal/README.md
+++ b/crates/shell/fission-shell-terminal/README.md
@@ -8,7 +8,7 @@ Application developers normally enable it through the facade crate:
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["terminal-shell"] }
+fission = { version = "0.11.1", features = ["terminal-shell"] }
 ```
 
 ## What it contains

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-web"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -21,9 +21,9 @@ video = ["fission-shell-winit/video"]
 
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
-fission-shell = { path = "../fission-shell", version = "0.11.0" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.11.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
+fission-shell = { path = "../fission-shell", version = "0.11.1" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.11.1", default-features = false }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-web/README.md
+++ b/crates/shell/fission-shell-web/README.md
@@ -13,11 +13,12 @@ What is ready today:
 - runnable `WebApp` wrapper backed by the shared winit runtime
 - checked-in `examples/web-smoke/` browser example
 - first-party `fission add-target web` launcher output
+- Chromium live testing through `fission test --target web` and `LiveTestClient`
 
 What is still missing:
 
-- host-side browser test control equivalent to the desktop/mobile TCP server
 - richer browser integration for clipboard, drag-and-drop, and IME edge cases
+- Firefox and WebKit live-test drivers
 
 ## WASM prerequisites
 

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-winit"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Shared winit shell runtime for desktop and mobile Fission hosts"
 categories = ["gui", "rendering"]
@@ -21,18 +21,18 @@ three-d = ["dep:fission-3d"]
 video = ["dep:gstreamer", "dep:gstreamer-video"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.11.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.0" }
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
-fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.11.0" }
+fission-shell = { path = "../fission-shell", version = "0.11.1" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.1" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.1" }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
+fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.11.1" }
 winit = { package = "fission-winit", version = "0.30.13-fission.2" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.0" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.11.1" }
 image = "0.25"
 tiny-skia = "0.11.4"
 fontdue = "0.9.3"
@@ -108,6 +108,6 @@ dispatch = "0.2"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.1" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.1" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -156,6 +156,8 @@ mod ios_capabilities;
 mod macos_capabilities;
 #[cfg(target_arch = "wasm32")]
 mod web_capabilities;
+#[cfg(target_arch = "wasm32")]
+mod web_test_control;
 
 type EffectResult = AsyncMessage;
 
@@ -4947,7 +4949,7 @@ where
             })
             .unwrap_or(false);
         #[cfg(target_arch = "wasm32")]
-        let test_control_enabled = false;
+        let test_control_enabled = web_test_control::install(event_proxy.clone());
         #[cfg(not(target_os = "android"))]
         let _ = test_control_enabled;
         // Pending screenshot/pump: path + whether it needs a screenshot (vs pump).
@@ -7716,8 +7718,21 @@ where
                                             !pending_capture_settle || resize_settled;
                                         if capture_ready {
                                             pending_capture_settle = false;
-                                            let _ = pending_screenshot_path.take();
-                                            let _ = pending_screenshot_response_tx.take();
+                                            if let Some(path) = pending_screenshot_path.take() {
+                                                if let Some(response_tx) =
+                                                    pending_screenshot_response_tx.take()
+                                                {
+                                                    let response = if path == "__pump__" {
+                                                        fission_test_driver::TestResponse::Ok {}
+                                                    } else {
+                                                        fission_test_driver::TestResponse::Error {
+                                                            message: "Web renderer screenshots are captured by the browser test host"
+                                                                .into(),
+                                                        }
+                                                    };
+                                                    let _ = response_tx.send(response);
+                                                }
+                                            }
                                         }
 
                                         pending_resize = None;

--- a/crates/shell/fission-shell-winit/src/web_test_control.rs
+++ b/crates/shell/fission-shell-winit/src/web_test_control.rs
@@ -1,0 +1,322 @@
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+
+use fission_test_driver::{TestCommand, TestEvent, TestResponse};
+use js_sys::{Object, Reflect};
+use wasm_bindgen::prelude::*;
+use winit::event_loop::EventLoopProxy;
+
+enum PendingResponse {
+    Ready(TestResponse),
+    Waiting(Receiver<TestResponse>),
+}
+
+thread_local! {
+    static NEXT_REQUEST_ID: Cell<u32> = const { Cell::new(1) };
+    static RESPONSES: RefCell<HashMap<u32, PendingResponse>> = RefCell::new(HashMap::new());
+}
+
+pub(crate) fn install(proxy: EventLoopProxy<TestEvent>) -> bool {
+    if option_env!("FISSION_WEB_TEST_CONTROL").is_none() {
+        return false;
+    }
+
+    let submit_proxy = proxy.clone();
+    let submit = Closure::wrap(Box::new(move |command_json: String| -> u32 {
+        let request_id = NEXT_REQUEST_ID.with(|next| {
+            let request_id = next.get();
+            next.set(request_id.wrapping_add(1).max(1));
+            request_id
+        });
+        let response = match serde_json::from_str::<TestCommand>(&command_json) {
+            Ok(command) => dispatch(command, &submit_proxy),
+            Err(error) => PendingResponse::Ready(TestResponse::Error {
+                message: format!("parse error: {error}"),
+            }),
+        };
+        RESPONSES.with(|responses| {
+            responses.borrow_mut().insert(request_id, response);
+        });
+        request_id
+    }) as Box<dyn FnMut(String) -> u32>);
+
+    let poll = Closure::wrap(Box::new(move |request_id: u32| -> JsValue {
+        let response = RESPONSES.with(|responses| {
+            let mut responses = responses.borrow_mut();
+            let completed = match responses.get(&request_id) {
+                Some(PendingResponse::Ready(response)) => Some(response.clone()),
+                Some(PendingResponse::Waiting(receiver)) => match receiver.try_recv() {
+                    Ok(response) => Some(response),
+                    Err(TryRecvError::Empty) => None,
+                    Err(TryRecvError::Disconnected) => Some(TestResponse::Error {
+                        message: "browser test response channel closed".into(),
+                    }),
+                },
+                None => Some(TestResponse::Error {
+                    message: format!("unknown browser test request {request_id}"),
+                }),
+            };
+            if completed.is_some() {
+                responses.remove(&request_id);
+            }
+            completed
+        });
+
+        match response {
+            Some(response) => serde_json::to_string(&response)
+                .map(|response| JsValue::from_str(&response))
+                .unwrap_or_else(|error| {
+                    JsValue::from_str(
+                        &serde_json::json!({
+                            "status": "Error",
+                            "message": format!("response serialization failed: {error}")
+                        })
+                        .to_string(),
+                    )
+                }),
+            None => JsValue::NULL,
+        }
+    }) as Box<dyn FnMut(u32) -> JsValue>);
+
+    let bridge = Object::new();
+    if Reflect::set(&bridge, &JsValue::from_str("submit"), submit.as_ref()).is_err()
+        || Reflect::set(&bridge, &JsValue::from_str("poll"), poll.as_ref()).is_err()
+        || Reflect::set(
+            &js_sys::global(),
+            &JsValue::from_str("__FISSION_TEST__"),
+            &bridge,
+        )
+        .is_err()
+    {
+        return false;
+    }
+
+    submit.forget();
+    poll.forget();
+    true
+}
+
+fn dispatch(command: TestCommand, proxy: &EventLoopProxy<TestEvent>) -> PendingResponse {
+    match command {
+        TestCommand::Tap { x, y } => ready_after(
+            proxy,
+            [
+                TestEvent::MouseMove { x, y },
+                TestEvent::MouseDown { x, y, button: 0 },
+                TestEvent::MouseUp { x, y, button: 0 },
+            ],
+        ),
+        TestCommand::Drag {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            steps,
+        } => {
+            let steps = steps.max(1);
+            let mut events = Vec::with_capacity(steps as usize + 3);
+            events.push(TestEvent::MouseMove {
+                x: start_x,
+                y: start_y,
+            });
+            events.push(TestEvent::MouseDown {
+                x: start_x,
+                y: start_y,
+                button: 0,
+            });
+            for step in 1..=steps {
+                let progress = step as f32 / steps as f32;
+                events.push(TestEvent::MouseMove {
+                    x: start_x + (end_x - start_x) * progress,
+                    y: start_y + (end_y - start_y) * progress,
+                });
+            }
+            events.push(TestEvent::MouseUp {
+                x: end_x,
+                y: end_y,
+                button: 0,
+            });
+            ready_after(proxy, events)
+        }
+        TestCommand::TapText { text } => query(proxy, |response_tx| TestEvent::TapText {
+            text,
+            response_tx,
+        }),
+        TestCommand::ResolveSelector { query: selector } => {
+            query(proxy, |response_tx| TestEvent::ResolveSelector {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::TapSelector { query: selector } => {
+            query(proxy, |response_tx| TestEvent::TapSelector {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::ActivateSelector { query: selector } => {
+            query(proxy, |response_tx| TestEvent::ActivateSelector {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::FocusSelector { query: selector } => {
+            query(proxy, |response_tx| TestEvent::FocusSelector {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::HoverSelector { query: selector } => {
+            query(proxy, |response_tx| TestEvent::HoverSelector {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::RightClickSelector { query: selector } => {
+            query(proxy, |response_tx| TestEvent::RightClickSelector {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::ScrollIntoView { query: selector } => {
+            query(proxy, |response_tx| TestEvent::ScrollIntoView {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::FillText {
+            query: selector,
+            text,
+        } => query(proxy, |response_tx| TestEvent::FillText {
+            query: selector,
+            text,
+            response_tx,
+        }),
+        TestCommand::ClearText { query: selector } => {
+            query(proxy, |response_tx| TestEvent::ClearText {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::Toggle { query: selector } => query(proxy, |response_tx| TestEvent::Toggle {
+            query: selector,
+            response_tx,
+        }),
+        TestCommand::SelectOption { query: selector } => {
+            query(proxy, |response_tx| TestEvent::SelectOption {
+                query: selector,
+                response_tx,
+            })
+        }
+        TestCommand::Scroll { x, y, dx, dy } => {
+            ready_after(proxy, [TestEvent::Scroll { x, y, dx, dy }])
+        }
+        TestCommand::ExternalFileHover { x, y, paths } => {
+            ready_after(proxy, [TestEvent::ExternalFileHover { x, y, paths }])
+        }
+        TestCommand::ExternalFileDrop { x, y, paths } => {
+            ready_after(proxy, [TestEvent::ExternalFileDrop { x, y, paths }])
+        }
+        TestCommand::ExternalFileCancel {} => ready_after(proxy, [TestEvent::ExternalFileCancel]),
+        TestCommand::TypeText { text } => ready_after(proxy, [TestEvent::TextInput { text }]),
+        TestCommand::ImePreedit {
+            text,
+            cursor_start,
+            cursor_end,
+        } => ready_after(
+            proxy,
+            [TestEvent::ImePreedit {
+                text,
+                cursor: cursor_start.zip(cursor_end),
+            }],
+        ),
+        TestCommand::ImeCommit { text } => ready_after(proxy, [TestEvent::ImeCommit { text }]),
+        TestCommand::ImeCancel {} => ready_after(proxy, [TestEvent::ImeCancel]),
+        TestCommand::PressKey { key, modifiers } => ready_after(
+            proxy,
+            [
+                TestEvent::KeyDown {
+                    key_code: key.clone(),
+                    modifiers,
+                },
+                TestEvent::KeyUp {
+                    key_code: key,
+                    modifiers,
+                },
+            ],
+        ),
+        TestCommand::PauseAnimations {} => query(proxy, |response_tx| TestEvent::PauseAnimations {
+            response_tx,
+        }),
+        TestCommand::ResumeAnimations {} => query(proxy, |response_tx| {
+            TestEvent::ResumeAnimations { response_tx }
+        }),
+        TestCommand::AdvanceClock { ms } => query(proxy, |response_tx| TestEvent::AdvanceClock {
+            ms,
+            response_tx,
+        }),
+        TestCommand::WaitForIdle { .. } => {
+            query(proxy, |response_tx| TestEvent::MotionStatus { response_tx })
+        }
+        TestCommand::GetText {} => query(proxy, |response_tx| TestEvent::GetText { response_tx }),
+        TestCommand::GetTree {} => query(proxy, |response_tx| TestEvent::GetTree { response_tx }),
+        TestCommand::Pump {} => query(proxy, |response_tx| TestEvent::Pump { response_tx }),
+        TestCommand::Quit {} => ready_after(proxy, [TestEvent::Quit]),
+        TestCommand::SimulateMouseMove { x, y } => {
+            ready_after(proxy, [TestEvent::MouseMove { x, y }])
+        }
+        TestCommand::SimulateRightClick { x, y } => ready_after(
+            proxy,
+            [
+                TestEvent::MouseMove { x, y },
+                TestEvent::MouseDown { x, y, button: 1 },
+                TestEvent::MouseUp { x, y, button: 1 },
+            ],
+        ),
+        TestCommand::SimulateResize { width, height } => {
+            ready_after(proxy, [TestEvent::Resize { width, height }])
+        }
+        TestCommand::WaitForSelector { .. }
+        | TestCommand::WaitForVisible { .. }
+        | TestCommand::WaitForEnabled { .. }
+        | TestCommand::WaitForDisabled { .. }
+        | TestCommand::WaitForValue { .. }
+        | TestCommand::WaitForText { .. }
+        | TestCommand::WaitForGone { .. }
+        | TestCommand::Wait { .. }
+        | TestCommand::Screenshot { .. }
+        | TestCommand::CaptureScreenshot {}
+        | TestCommand::CaptureAt { .. } => PendingResponse::Ready(TestResponse::Error {
+            message: "command is handled by the browser test host".into(),
+        }),
+    }
+}
+
+fn ready_after(
+    proxy: &EventLoopProxy<TestEvent>,
+    events: impl IntoIterator<Item = TestEvent>,
+) -> PendingResponse {
+    for event in events {
+        if proxy.send_event(event).is_err() {
+            return PendingResponse::Ready(TestResponse::Error {
+                message: "Fission browser event loop is closed".into(),
+            });
+        }
+    }
+    PendingResponse::Ready(TestResponse::Ok {})
+}
+
+fn query(
+    proxy: &EventLoopProxy<TestEvent>,
+    make_event: impl FnOnce(mpsc::Sender<TestResponse>) -> TestEvent,
+) -> PendingResponse {
+    let (response_tx, response_rx) = mpsc::channel();
+    if proxy.send_event(make_event(response_tx)).is_err() {
+        PendingResponse::Ready(TestResponse::Error {
+            message: "Fission browser event loop is closed".into(),
+        })
+    } else {
+        PendingResponse::Waiting(response_rx)
+    }
+}

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.11.0" } # Corrected path
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.1" } # Corrected path
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/tools/cargo-fission/Cargo.toml
+++ b/crates/tools/cargo-fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fission"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -29,10 +29,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.11.0" }
-fission-command-release = { path = "../fission-command-release", version = "0.11.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.11.0" }
-fission-command-server = { path = "../fission-command-server", version = "0.11.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.11.0" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.11.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.1" }
+fission-command-package = { path = "../fission-command-package", version = "0.11.1" }
+fission-command-release = { path = "../fission-command-release", version = "0.11.1" }
+fission-command-run = { path = "../fission-command-run", version = "0.11.1" }
+fission-command-server = { path = "../fission-command-server", version = "0.11.1" }
+fission-command-site = { path = "../fission-command-site", version = "0.11.1" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.11.1" }

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -1517,7 +1517,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
+fission = { version = "0.11.1", default-features = false, features = ["desktop"] }
 "#,
         )
         .unwrap();
@@ -1544,7 +1544,7 @@ edition = "2021"
 anyhow = "1"
 
 [dependencies.fission]
-version = "0.11.0"
+version = "0.11.1"
 default-features = true
 features = ["desktop"]
 "#,

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-core"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-core/assets/AGENTS.md
+++ b/crates/tools/fission-command-core/assets/AGENTS.md
@@ -217,7 +217,7 @@ Outside the Fission source workspace, prefer the published crate pinned to the s
 
 ```toml
 [build-dependencies]
-fission-design-system-codegen = { version = "0.11.0" }
+fission-design-system-codegen = { version = "0.11.1" }
 ```
 
 Generate a typed design system from the copied DSP file in `build.rs`:

--- a/crates/tools/fission-command-package/Cargo.toml
+++ b/crates/tools/fission-command-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-package"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -20,9 +20,9 @@ aws-config = "1"
 aws-sdk-s3 = "1"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.11.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.11.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.1" }
+fission-command-run = { path = "../fission-command-run", version = "0.11.1" }
+fission-command-site = { path = "../fission-command-site", version = "0.11.1" }
 flate2 = "1.0"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-release/Cargo.toml
+++ b/crates/tools/fission-command-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-release"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -18,9 +18,9 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.11.0" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.11.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.1" }
+fission-command-package = { path = "../fission-command-package", version = "0.11.1" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.11.1" }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 jsonwebtoken = "9"
 md-5 = "0.10"

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-run"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,10 +16,10 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
-fission-command-server = { path = "../fission-command-server", version = "0.11.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.11.0" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.11.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.11.1" }
+fission-command-server = { path = "../fission-command-server", version = "0.11.1" }
+fission-command-site = { path = "../fission-command-site", version = "0.11.1" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ureq = "2"

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -386,17 +386,23 @@ pub fn site_serve(
 }
 
 fn browser_test_web(project_dir: &Path) -> Result<()> {
-    build_web(project_dir, false)?;
+    build_web_for_test(project_dir)?;
     let server = StaticTestServer::start(project_dir.to_path_buf())?;
     let url = format!("{}/platforms/web/", server.base_url());
-    let report = fission_test_driver::run_browser_smoke(
+    let client = fission_test_driver::LiveTestClient::launch_browser(
         fission_test_driver::BrowserTestOptions::new(url).fission_canvas(),
     )?;
+    client.pump()?;
+    let semantic_nodes = client.get_tree()?.len();
+    let report = client
+        .browser_report()
+        .context("browser test client did not return a readiness report")?;
     println!(
-        "Web browser smoke passed: renderer={} canvas={}x{}",
+        "Web browser live test passed: renderer={} canvas={}x{} semantic_nodes={}",
         report.renderer.unwrap_or_else(|| "unknown".into()),
         report.width,
-        report.height
+        report.height,
+        semantic_nodes
     );
     Ok(())
 }
@@ -1118,6 +1124,18 @@ fn tail_log_file(path: &Path, follow: bool) -> Result<()> {
 }
 
 fn build_web(project_dir: &Path, release: bool) -> Result<()> {
+    build_web_with_test_control(project_dir, release, false)
+}
+
+fn build_web_for_test(project_dir: &Path) -> Result<()> {
+    build_web_with_test_control(project_dir, false, true)
+}
+
+fn build_web_with_test_control(
+    project_dir: &Path,
+    release: bool,
+    test_control: bool,
+) -> Result<()> {
     let project_dir = fs::canonicalize(project_dir).with_context(|| {
         format!(
             "failed to resolve project directory {}",
@@ -1134,6 +1152,9 @@ fn build_web(project_dir: &Path, release: bool) -> Result<()> {
         .arg("--out-dir")
         .arg(out_dir);
     command.arg(if release { "--release" } else { "--dev" });
+    if test_control {
+        command.env("FISSION_WEB_TEST_CONTROL", "1");
+    }
     run_status(&mut command, "web build")
 }
 

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -488,12 +488,17 @@ impl StaticTestServer {
             while !thread_stop.load(std::sync::atomic::Ordering::Relaxed) {
                 match listener.accept() {
                     Ok((stream, _)) => {
-                        let _ = serve_static_test_request(stream, &root);
+                        if let Err(error) = serve_static_test_request(stream, &root) {
+                            eprintln!("Web test server request failed: {error}");
+                        }
                     }
                     Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
                         std::thread::sleep(Duration::from_millis(20));
                     }
-                    Err(_) => break,
+                    Err(error) => {
+                        eprintln!("Web test server accept failed: {error}");
+                        std::thread::sleep(Duration::from_millis(20));
+                    }
                 }
             }
         });

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -532,14 +532,24 @@ fn serve_static_test_request(mut stream: TcpStream, root: &Path) -> Result<()> {
     let mut buffer = [0u8; 4096];
     let n = stream.read(&mut buffer)?;
     let request = String::from_utf8_lossy(&buffer[..n]);
-    let path = request
+    let mut request_parts = request
         .lines()
         .next()
-        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or_default()
+        .split_whitespace();
+    let method = request_parts.next().unwrap_or("GET");
+    let path = request_parts
+        .next()
         .unwrap_or("/")
         .split('?')
         .next()
         .unwrap_or("/");
+    if method == "POST" && path == "/__fission/renderer" {
+        stream.write_all(
+            b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        )?;
+        return Ok(());
+    }
     let relative = path.trim_start_matches('/');
     let mut candidate = root.join(relative);
     if path.ends_with('/') || candidate.is_dir() {
@@ -2308,6 +2318,28 @@ mod tests {
             module.into_string().expect("read module"),
             "export const ready = true;"
         );
+
+        drop(server);
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn browser_test_server_accepts_renderer_diagnostics() {
+        let root = env::temp_dir().join(format!(
+            "fission-web-test-server-diagnostics-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create test root");
+
+        let server = StaticTestServer::start(root.clone()).expect("start test server");
+        let response = ureq::post(&format!("{}/__fission/renderer", server.base_url()))
+            .send_string(r#"{"active":"canvas2d-software"}"#)
+            .expect("post renderer diagnostics");
+        assert_eq!(response.status(), 204);
 
         drop(server);
         fs::remove_dir_all(root).expect("remove test root");

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -488,6 +488,10 @@ impl StaticTestServer {
             while !thread_stop.load(std::sync::atomic::Ordering::Relaxed) {
                 match listener.accept() {
                     Ok((stream, _)) => {
+                        if let Err(error) = stream.set_nonblocking(false) {
+                            eprintln!("Web test server connection setup failed: {error}");
+                            continue;
+                        }
                         if let Err(error) = serve_static_test_request(stream, &root) {
                             eprintln!("Web test server request failed: {error}");
                         }
@@ -2272,6 +2276,41 @@ mod tests {
             static_content_type(Path::new("platforms/web/bootstrap.mjs")),
             "text/javascript; charset=utf-8"
         );
+    }
+
+    #[test]
+    fn browser_test_server_serves_multiple_resources() {
+        let root = env::temp_dir().join(format!(
+            "fission-web-test-server-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create test root");
+        fs::write(root.join("index.html"), "ready").expect("write index");
+        fs::write(root.join("bootstrap.mjs"), "export const ready = true;").expect("write module");
+
+        let server = StaticTestServer::start(root.clone()).expect("start test server");
+        let index = ureq::get(&format!("{}/", server.base_url()))
+            .call()
+            .expect("fetch index");
+        assert_eq!(index.into_string().expect("read index"), "ready");
+        let module = ureq::get(&format!("{}/bootstrap.mjs", server.base_url()))
+            .call()
+            .expect("fetch module");
+        assert_eq!(
+            module.header("content-type"),
+            Some("text/javascript; charset=utf-8")
+        );
+        assert_eq!(
+            module.into_string().expect("read module"),
+            "export const ready = true;"
+        );
+
+        drop(server);
+        fs::remove_dir_all(root).expect("remove test root");
     }
 
     #[test]

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -562,7 +562,7 @@ fn static_content_type(path: &Path) -> &'static str {
     {
         "html" => "text/html; charset=utf-8",
         "css" => "text/css; charset=utf-8",
-        "js" => "text/javascript; charset=utf-8",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
         "wasm" => "application/wasm",
         "json" => "application/json; charset=utf-8",
         "svg" => "image/svg+xml",
@@ -2259,6 +2259,14 @@ mod tests {
             capabilities: BTreeSet::new(),
             native: Default::default(),
         }
+    }
+
+    #[test]
+    fn browser_test_server_serves_javascript_modules() {
+        assert_eq!(
+            static_content_type(Path::new("platforms/web/bootstrap.mjs")),
+            "text/javascript; charset=utf-8"
+        );
     }
 
     #[test]

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-server"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-site"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,6 +16,6 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.11.0" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.11.1" }
 serde_json = "1"
 toml = "0.8"

--- a/crates/tools/fission-command-ui/Cargo.toml
+++ b/crates/tools/fission-command-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-ui"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -16,11 +16,11 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../authoring/fission", version = "0.11.0", default-features = false, features = ["desktop", "terminal-shell"] }
-fission-command-core = { path = "../fission-command-core", version = "0.11.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.11.0" }
-fission-command-release = { path = "../fission-command-release", version = "0.11.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.11.0" }
+fission = { path = "../../authoring/fission", version = "0.11.1", default-features = false, features = ["desktop", "terminal-shell"] }
+fission-command-core = { path = "../fission-command-core", version = "0.11.1" }
+fission-command-package = { path = "../fission-command-package", version = "0.11.1" }
+fission-command-release = { path = "../fission-command-release", version = "0.11.1" }
+fission-command-run = { path = "../fission-command-run", version = "0.11.1" }
 rfd = { version = "0.14.1", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 toml_edit = "0.23"

--- a/crates/tools/fission-design-system-codegen/Cargo.toml
+++ b/crates/tools/fission-design-system-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-design-system-codegen"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-diagnostics"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test-driver/Cargo.toml
+++ b/crates/tools/fission-test-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test-driver"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test-driver/README.md
+++ b/crates/tools/fission-test-driver/README.md
@@ -2,21 +2,22 @@
 
 Automated UI testing client and protocol for Fission applications.
 
-This crate provides both the JSON protocol types (shared between the test client and the desktop shell server) and a `LiveTestClient` that drives a running Fission application over HTTP.
+This crate provides the shared JSON protocol and a `LiveTestClient` that drives a running native or Web Fission application.
 
 ## Architecture
 
 ```
-Test process                        Application process
-+-----------------+                 +-------------------------+
-| LiveTestClient  | ---HTTP/JSON--> | test_control server     |
-|   .tap(x, y)    |                 |   (fission-shell-desktop)|
-|   .type_text()  |                 |   dispatches to Runtime |
-|   .screenshot() | <--HTTP/JSON--- |   returns TestResponse  |
-+-----------------+                 +-------------------------+
+Test process                         Application
++-----------------+                  +------------------------+
+| LiveTestClient  | -- native HTTP ->| native test control    |
+|                 | -- Chromium CDP ->| Web test-only bridge   |
++-----------------+                  +-----------+------------+
+                                                |
+                                                v
+                                          TestEvent / Runtime
 ```
 
-The application must be launched with `FISSION_TEST_CONTROL_PORT=<port>` to enable the test control server. The `LiveTestClient` connects to `http://127.0.0.1:<port>` and sends `TestCommand` JSON payloads to `/cmd`.
+Native applications use `FISSION_TEST_CONTROL_PORT=<port>`. Web applications use a test-only bridge included by `fission test --target web` or a WASM build with `FISSION_WEB_TEST_CONTROL=1`.
 
 ## Protocol types
 
@@ -91,6 +92,19 @@ use fission_test_driver::LiveTestClient;
 let client = LiveTestClient::connect(9876);
 client.wait_for_ready(5000)?; // Wait up to 5s for the app to start
 ```
+
+For a served Web test build:
+
+```rust
+use fission_test_driver::{BrowserTestOptions, LiveTestClient};
+
+let client = LiveTestClient::launch_browser(
+    BrowserTestOptions::new("http://127.0.0.1:8123/platforms/web/")
+        .fission_canvas(),
+)?;
+```
+
+The initial Web transport uses Chromium. Its screenshots capture the composited page, and its input commands exercise Fission's deterministic event path rather than claiming trusted browser-event coverage.
 
 ### Low-level methods
 

--- a/crates/tools/fission-test-driver/src/browser.rs
+++ b/crates/tools/fission-test-driver/src/browser.rs
@@ -818,7 +818,12 @@ impl CdpClient {
                         .and_then(Value::as_str)
                         .unwrap_or("unknown browser log error");
                     if !text.contains("/__fission/renderer") {
-                        self.errors.push(format!("browser log error: {text}"));
+                        let url = message
+                            .pointer("/params/entry/url")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown URL");
+                        self.errors
+                            .push(format!("browser log error at {url}: {text}"));
                     }
                 }
             }

--- a/crates/tools/fission-test-driver/src/browser.rs
+++ b/crates/tools/fission-test-driver/src/browser.rs
@@ -22,6 +22,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tungstenite::{connect, Message};
 
 #[cfg(not(target_arch = "wasm32"))]
+use crate::{
+    SelectorCandidate, SelectorFailure, SelectorFailureKind, SelectorQuery, TestCommand,
+    TestResponse, VisibilityState,
+};
+
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BrowserSmokeMode {
     Dom,
@@ -115,71 +121,410 @@ pub fn detect_chrome() -> Option<PathBuf> {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn run_browser_smoke(options: BrowserTestOptions) -> Result<BrowserSmokeReport> {
-    let chrome = options
-        .chrome_path
-        .clone()
-        .or_else(detect_chrome)
-        .context("Chrome/Chromium was not found; set FISSION_CHROME=/path/to/chrome")?;
-    let cdp_port = options.cdp_port.unwrap_or_else(free_port);
-    let mut session = ChromeSession::launch(&chrome, cdp_port, &options)?;
-    let ws_url = wait_for_target(
-        cdp_port,
-        &options.url,
-        Duration::from_millis(options.timeout_ms),
-    )?;
-    let mut client = CdpClient::connect(&ws_url)?;
-    client.send("Runtime.enable", json!({}))?;
-    client.send("Log.enable", json!({}))?;
-    client.send("Page.enable", json!({}))?;
-    client.send(
-        "Emulation.setDeviceMetricsOverride",
-        json!({
-            "width": options.viewport_width,
-            "height": options.viewport_height,
-            "deviceScaleFactor": 1,
-            "mobile": false
-        }),
-    )?;
-
-    let deadline = Instant::now() + Duration::from_millis(options.timeout_ms);
-    let mut last_status = None;
-    while Instant::now() < deadline {
-        client.drain_events(Duration::from_millis(25))?;
-        if !client.errors.is_empty() {
-            return Err(anyhow!(
-                "browser reported errors:\n{}",
-                client.errors.join("\n")
-            ));
-        }
-        let status = read_runtime_status(&mut client)?;
-        let ready = match options.mode {
-            BrowserSmokeMode::Dom => status.ready_dom,
-            BrowserSmokeMode::FissionCanvas => status.ready_canvas && status.renderer.is_some(),
-        };
-        if ready {
-            if let Some(path) = &options.screenshot_path {
-                capture_screenshot(&mut client, path)?;
-            }
-            let report = BrowserSmokeReport {
-                url: options.url.clone(),
-                title: status.title,
-                width: status.width,
-                height: status.height,
-                renderer: status.renderer,
-                body_text_len: status.body_text_len,
-                screenshot_path: options.screenshot_path.clone(),
-            };
-            session.kill();
-            return Ok(report);
-        }
-        last_status = Some(status);
-        std::thread::sleep(Duration::from_millis(100));
+    let mut controller = BrowserController::launch(options.clone(), false)?;
+    if let Some(path) = &options.screenshot_path {
+        let bytes = controller.capture_page_screenshot()?;
+        write_screenshot(path, &bytes)?;
     }
-    Err(anyhow!(
-        "browser smoke test timed out for {}; last status: {:?}",
-        options.url,
-        last_status
-    ))
+    Ok(controller.report.clone())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct BrowserController {
+    _session: ChromeSession,
+    client: CdpClient,
+    report: BrowserSmokeReport,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl BrowserController {
+    pub(crate) fn launch(options: BrowserTestOptions, require_live_control: bool) -> Result<Self> {
+        let chrome = options
+            .chrome_path
+            .clone()
+            .or_else(detect_chrome)
+            .context("Chrome/Chromium was not found; set FISSION_CHROME=/path/to/chrome")?;
+        let cdp_port = options.cdp_port.unwrap_or_else(free_port);
+        let session = ChromeSession::launch(&chrome, cdp_port, &options)?;
+        let ws_url = wait_for_target(
+            cdp_port,
+            &options.url,
+            Duration::from_millis(options.timeout_ms),
+        )?;
+        let mut client = CdpClient::connect(&ws_url)?;
+        client.send("Runtime.enable", json!({}))?;
+        client.send("Log.enable", json!({}))?;
+        client.send("Page.enable", json!({}))?;
+        client.send(
+            "Emulation.setDeviceMetricsOverride",
+            json!({
+                "width": options.viewport_width,
+                "height": options.viewport_height,
+                "deviceScaleFactor": 1,
+                "mobile": false
+            }),
+        )?;
+
+        let deadline = Instant::now() + Duration::from_millis(options.timeout_ms);
+        let mut last_status = None;
+        while Instant::now() < deadline {
+            client.drain_events(Duration::from_millis(25))?;
+            if !client.errors.is_empty() {
+                return Err(anyhow!(
+                    "browser reported errors:\n{}",
+                    client.errors.join("\n")
+                ));
+            }
+            let status = read_runtime_status(&mut client)?;
+            let ready = match options.mode {
+                BrowserSmokeMode::Dom => status.ready_dom,
+                BrowserSmokeMode::FissionCanvas => status.ready_canvas && status.renderer.is_some(),
+            } && (!require_live_control || status.test_bridge_ready);
+            if ready {
+                let report = BrowserSmokeReport {
+                    url: options.url.clone(),
+                    title: status.title,
+                    width: status.width,
+                    height: status.height,
+                    renderer: status.renderer,
+                    body_text_len: status.body_text_len,
+                    screenshot_path: options.screenshot_path.clone(),
+                };
+                return Ok(Self {
+                    _session: session,
+                    client,
+                    report,
+                });
+            }
+            last_status = Some(status);
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Err(anyhow!(
+            "browser{} test timed out for {}; last status: {:?}",
+            if require_live_control {
+                " live-control"
+            } else {
+                " smoke"
+            },
+            options.url,
+            last_status
+        ))
+    }
+
+    pub(crate) fn report(&self) -> BrowserSmokeReport {
+        self.report.clone()
+    }
+
+    pub(crate) fn send_test_command(&mut self, command: TestCommand) -> Result<TestResponse> {
+        match command {
+            TestCommand::Wait { ms } => {
+                std::thread::sleep(Duration::from_millis(ms));
+                Ok(TestResponse::Ok {})
+            }
+            TestCommand::WaitForSelector { query, timeout_ms } => {
+                self.wait_for_selector(query, timeout_ms, SelectorWaitCondition::Present)
+            }
+            TestCommand::WaitForVisible { query, timeout_ms } => {
+                self.wait_for_selector(query, timeout_ms, SelectorWaitCondition::Visible)
+            }
+            TestCommand::WaitForEnabled { query, timeout_ms } => {
+                self.wait_for_selector(query, timeout_ms, SelectorWaitCondition::Enabled)
+            }
+            TestCommand::WaitForDisabled { query, timeout_ms } => {
+                self.wait_for_selector(query, timeout_ms, SelectorWaitCondition::Disabled)
+            }
+            TestCommand::WaitForValue {
+                query,
+                value,
+                timeout_ms,
+            } => self.wait_for_selector(query, timeout_ms, SelectorWaitCondition::Value(value)),
+            TestCommand::WaitForGone { query, timeout_ms } => {
+                self.wait_for_selector(query, timeout_ms, SelectorWaitCondition::Gone)
+            }
+            TestCommand::WaitForText { text, timeout_ms } => self.wait_for_text(&text, timeout_ms),
+            TestCommand::WaitForIdle {
+                timeout_ms,
+                ignore_repeating_motion,
+            } => self.wait_for_idle(timeout_ms, ignore_repeating_motion),
+            TestCommand::TapSelector { query } => {
+                self.selector_action(query.clone(), TestCommand::TapSelector { query })
+            }
+            TestCommand::ActivateSelector { query } => {
+                self.selector_action(query.clone(), TestCommand::ActivateSelector { query })
+            }
+            TestCommand::FocusSelector { query } => {
+                self.selector_action(query.clone(), TestCommand::FocusSelector { query })
+            }
+            TestCommand::HoverSelector { query } => {
+                self.selector_action(query.clone(), TestCommand::HoverSelector { query })
+            }
+            TestCommand::RightClickSelector { query } => {
+                self.selector_action(query.clone(), TestCommand::RightClickSelector { query })
+            }
+            TestCommand::FillText { query, text } => {
+                self.selector_action(query.clone(), TestCommand::FillText { query, text })
+            }
+            TestCommand::ClearText { query } => {
+                self.selector_action(query.clone(), TestCommand::ClearText { query })
+            }
+            TestCommand::Toggle { query } => {
+                self.selector_action(query.clone(), TestCommand::Toggle { query })
+            }
+            TestCommand::SelectOption { query } => {
+                self.selector_action(query.clone(), TestCommand::SelectOption { query })
+            }
+            TestCommand::Screenshot { path } => {
+                let bytes = self.capture_page_screenshot()?;
+                write_screenshot(&PathBuf::from(path), &bytes)?;
+                Ok(TestResponse::Ok {})
+            }
+            TestCommand::CaptureScreenshot {} => self.capture_page_response(),
+            TestCommand::CaptureAt { ms } => {
+                ensure_response_ok(self.send_bridge_command(TestCommand::AdvanceClock { ms })?)?;
+                ensure_response_ok(self.send_bridge_command(TestCommand::Pump {})?)?;
+                self.capture_page_response()
+            }
+            command => self.send_bridge_command(command),
+        }
+    }
+
+    fn selector_action(
+        &mut self,
+        query: SelectorQuery,
+        command: TestCommand,
+    ) -> Result<TestResponse> {
+        let scroll = self.send_bridge_command(TestCommand::ScrollIntoView {
+            query: query.include_hidden(),
+        })?;
+        ensure_response_ok(scroll)?;
+        ensure_response_ok(self.send_bridge_command(TestCommand::Pump {})?)?;
+        self.send_bridge_command(command)
+    }
+
+    fn wait_for_selector(
+        &mut self,
+        query: SelectorQuery,
+        timeout_ms: u64,
+        condition: SelectorWaitCondition,
+    ) -> Result<TestResponse> {
+        let started = Instant::now();
+        let timeout = Duration::from_millis(timeout_ms);
+        loop {
+            let response = self.send_bridge_command(TestCommand::ResolveSelector {
+                query: query.clone(),
+            })?;
+            if selector_wait_matches(&condition, &response) {
+                return Ok(TestResponse::Ok {});
+            }
+            if started.elapsed() >= timeout {
+                let candidates = match response {
+                    TestResponse::SelectorResolved { node } => vec![SelectorCandidate {
+                        node,
+                        rejected_reason: Some("wait condition did not pass".into()),
+                    }],
+                    TestResponse::SelectorError { failure } => failure.candidates,
+                    _ => Vec::new(),
+                };
+                return Ok(TestResponse::SelectorError {
+                    failure: SelectorFailure {
+                        kind: SelectorFailureKind::Timeout,
+                        selector: query,
+                        candidates,
+                        message: format!(
+                            "timed out after {timeout_ms}ms waiting for browser selector"
+                        ),
+                    },
+                });
+            }
+            let _ = self.send_bridge_command(TestCommand::Pump {})?;
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn wait_for_text(&mut self, text: &str, timeout_ms: u64) -> Result<TestResponse> {
+        let started = Instant::now();
+        let timeout = Duration::from_millis(timeout_ms);
+        loop {
+            match self.send_bridge_command(TestCommand::GetText {})? {
+                TestResponse::Text { items }
+                    if items.iter().any(|item| item.text.contains(text)) =>
+                {
+                    return Ok(TestResponse::Ok {});
+                }
+                TestResponse::Error { message } => {
+                    return Ok(TestResponse::Error { message });
+                }
+                _ => {}
+            }
+            if started.elapsed() >= timeout {
+                return Ok(TestResponse::Error {
+                    message: format!(
+                        "timed out after {timeout_ms}ms waiting for browser text `{text}`"
+                    ),
+                });
+            }
+            let _ = self.send_bridge_command(TestCommand::Pump {})?;
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn wait_for_idle(
+        &mut self,
+        timeout_ms: u64,
+        ignore_repeating_motion: bool,
+    ) -> Result<TestResponse> {
+        let started = Instant::now();
+        let timeout = Duration::from_millis(timeout_ms);
+        loop {
+            match self.send_bridge_command(TestCommand::WaitForIdle {
+                timeout_ms: 0,
+                ignore_repeating_motion,
+            })? {
+                TestResponse::MotionStatus {
+                    finite,
+                    repeating,
+                    ripples,
+                } if finite == 0 && ripples == 0 && (ignore_repeating_motion || repeating == 0) => {
+                    return Ok(TestResponse::Ok {});
+                }
+                TestResponse::Error { message } => {
+                    return Ok(TestResponse::Error { message });
+                }
+                _ => {}
+            }
+            if started.elapsed() >= timeout {
+                return Ok(TestResponse::Error {
+                    message: format!(
+                        "timed out after {timeout_ms}ms waiting for browser motion to become idle"
+                    ),
+                });
+            }
+            std::thread::sleep(Duration::from_millis(8));
+        }
+    }
+
+    fn send_bridge_command(&mut self, command: TestCommand) -> Result<TestResponse> {
+        let command_json = serde_json::to_string(&command)?;
+        let argument = serde_json::to_string(&command_json)?;
+        let submit = format!("globalThis.__FISSION_TEST__.submit({argument})");
+        let result = self.client.send(
+            "Runtime.evaluate",
+            json!({ "expression": submit, "returnByValue": true }),
+        )?;
+        runtime_exception(&result)?;
+        let request_id = result
+            .pointer("/result/value")
+            .and_then(Value::as_u64)
+            .context("Fission browser test bridge returned no request id")?;
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            self.client.drain_events(Duration::from_millis(5))?;
+            self.fail_on_browser_errors()?;
+            let poll = self.client.send(
+                "Runtime.evaluate",
+                json!({
+                    "expression": format!(
+                        "globalThis.__FISSION_TEST__.poll({request_id})"
+                    ),
+                    "returnByValue": true
+                }),
+            )?;
+            runtime_exception(&poll)?;
+            if let Some(response_json) = poll.pointer("/result/value").and_then(Value::as_str) {
+                return serde_json::from_str(response_json)
+                    .context("failed to decode Fission browser test response");
+            }
+            if Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "timed out waiting for Fission browser test request {request_id}"
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn capture_page_response(&mut self) -> Result<TestResponse> {
+        let bytes = self.capture_page_screenshot()?;
+        let status = read_runtime_status(&mut self.client)?;
+        Ok(TestResponse::Screenshot {
+            png_base64: base64::engine::general_purpose::STANDARD.encode(bytes),
+            width: status.width,
+            height: status.height,
+        })
+    }
+
+    fn capture_page_screenshot(&mut self) -> Result<Vec<u8>> {
+        let result = self.client.send(
+            "Page.captureScreenshot",
+            json!({ "format": "png", "captureBeyondViewport": true }),
+        )?;
+        let data = result
+            .get("data")
+            .and_then(Value::as_str)
+            .context("Page.captureScreenshot returned no data")?;
+        base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .context("Chrome returned invalid screenshot base64")
+    }
+
+    fn fail_on_browser_errors(&self) -> Result<()> {
+        if self.client.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "browser reported errors:\n{}",
+                self.client.errors.join("\n")
+            ))
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+enum SelectorWaitCondition {
+    Present,
+    Visible,
+    Enabled,
+    Disabled,
+    Value(String),
+    Gone,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn selector_wait_matches(condition: &SelectorWaitCondition, response: &TestResponse) -> bool {
+    match (condition, response) {
+        (SelectorWaitCondition::Gone, TestResponse::SelectorError { failure }) => {
+            failure.kind == SelectorFailureKind::NoMatch
+        }
+        (SelectorWaitCondition::Present, TestResponse::SelectorResolved { .. }) => true,
+        (SelectorWaitCondition::Visible, TestResponse::SelectorResolved { node }) => {
+            node.visibility != VisibilityState::Hidden
+        }
+        (SelectorWaitCondition::Enabled, TestResponse::SelectorResolved { node }) => !node.disabled,
+        (SelectorWaitCondition::Disabled, TestResponse::SelectorResolved { node }) => node.disabled,
+        (SelectorWaitCondition::Value(expected), TestResponse::SelectorResolved { node }) => {
+            node.value.as_deref() == Some(expected.as_str())
+        }
+        _ => false,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn ensure_response_ok(response: TestResponse) -> Result<()> {
+    match response {
+        TestResponse::Error { message } => Err(anyhow!(message)),
+        TestResponse::SelectorError { failure } => Err(anyhow!(failure.message)),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn runtime_exception(result: &Value) -> Result<()> {
+    if let Some(details) = result.get("exceptionDetails") {
+        Err(anyhow!("browser runtime evaluation failed: {details}"))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -192,6 +537,7 @@ struct RuntimeStatus {
     height: u32,
     body_text_len: usize,
     renderer: Option<String>,
+    test_bridge_ready: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -209,6 +555,9 @@ fn read_runtime_status(client: &mut CdpClient) -> Result<RuntimeStatus> {
         height: Math.round(rect.height || window.innerHeight || 0),
         body_text_len: body ? body.innerText.trim().length : 0,
         renderer: renderer ? renderer.active : null,
+        test_bridge_ready: !!globalThis.__FISSION_TEST__
+          && typeof globalThis.__FISSION_TEST__.submit === 'function'
+          && typeof globalThis.__FISSION_TEST__.poll === 'function',
       };
     })()"#;
     let result = client.send(
@@ -227,18 +576,7 @@ fn read_runtime_status(client: &mut CdpClient) -> Result<RuntimeStatus> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn capture_screenshot(client: &mut CdpClient, path: &PathBuf) -> Result<()> {
-    let result = client.send(
-        "Page.captureScreenshot",
-        json!({ "format": "png", "captureBeyondViewport": true }),
-    )?;
-    let data = result
-        .get("data")
-        .and_then(|value| value.as_str())
-        .context("Page.captureScreenshot returned no data")?;
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(data)
-        .context("Chrome returned invalid screenshot base64")?;
+fn write_screenshot(path: &PathBuf, bytes: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -486,5 +824,116 @@ impl CdpClient {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Bounds, SemanticNode};
+
+    fn resolved_node(
+        visibility: VisibilityState,
+        disabled: bool,
+        value: Option<&str>,
+    ) -> TestResponse {
+        TestResponse::SelectorResolved {
+            node: SemanticNode {
+                identifier: Some("test.field".into()),
+                widget_id: "1".into(),
+                stable_node_id: "node-1".into(),
+                parent: None,
+                children: Vec::new(),
+                role: "text_input".into(),
+                label: Some("Field".into()),
+                value: value.map(str::to_owned),
+                value_present: value.is_some(),
+                focusable: true,
+                disabled,
+                read_only: false,
+                checked: None,
+                actions: vec!["focus".into()],
+                text_selection: None,
+                masked: false,
+                scrollable_x: false,
+                scrollable_y: false,
+                logical_bounds: Bounds {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 40.0,
+                },
+                visible_bounds: Some(Bounds {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 40.0,
+                }),
+                visibility,
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 40.0,
+            },
+        }
+    }
+
+    #[test]
+    fn browser_selector_waits_use_native_semantics() {
+        let visible = resolved_node(VisibilityState::FullyVisible, false, Some("ready"));
+        assert!(selector_wait_matches(
+            &SelectorWaitCondition::Present,
+            &visible
+        ));
+        assert!(selector_wait_matches(
+            &SelectorWaitCondition::Visible,
+            &visible
+        ));
+        assert!(selector_wait_matches(
+            &SelectorWaitCondition::Enabled,
+            &visible
+        ));
+        assert!(selector_wait_matches(
+            &SelectorWaitCondition::Value("ready".into()),
+            &visible
+        ));
+        assert!(!selector_wait_matches(
+            &SelectorWaitCondition::Value("pending".into()),
+            &visible
+        ));
+
+        let disabled = resolved_node(VisibilityState::PartiallyVisible, true, None);
+        assert!(selector_wait_matches(
+            &SelectorWaitCondition::Disabled,
+            &disabled
+        ));
+
+        let gone = TestResponse::SelectorError {
+            failure: SelectorFailure {
+                kind: SelectorFailureKind::NoMatch,
+                selector: SelectorQuery::label("missing"),
+                candidates: Vec::new(),
+                message: "not found".into(),
+            },
+        };
+        assert!(selector_wait_matches(&SelectorWaitCondition::Gone, &gone));
+    }
+
+    #[test]
+    fn browser_status_requires_explicit_live_bridge_signal() {
+        let status: RuntimeStatus = serde_json::from_value(serde_json::json!({
+            "ready_dom": true,
+            "ready_canvas": true,
+            "title": "Fission",
+            "width": 1280,
+            "height": 900,
+            "body_text_len": 0,
+            "renderer": "webgpu-vello",
+            "test_bridge_ready": true
+        }))
+        .expect("decode browser status");
+
+        assert!(status.test_bridge_ready);
+        assert_eq!(status.renderer.as_deref(), Some("webgpu-vello"));
     }
 }

--- a/crates/tools/fission-test-driver/src/lib.rs
+++ b/crates/tools/fission-test-driver/src/lib.rs
@@ -1,14 +1,14 @@
 //! Automated UI testing client and protocol for Fission applications.
 //!
-//! This crate provides the JSON protocol types (shared between the test client
-//! and the desktop shell server) and a [`LiveTestClient`] that drives a running
-//! Fission application over HTTP.
+//! This crate provides the JSON protocol types shared by the test client and
+//! platform shells, plus a [`LiveTestClient`] that drives a running native or
+//! Web Fission application.
 //!
 //! # Architecture
 //!
-//! The application must be launched with `FISSION_TEST_CONTROL_PORT=<port>`.
-//! The [`LiveTestClient`] connects to `http://127.0.0.1:<port>` and sends
-//! [`TestCommand`] JSON payloads to `/cmd`, receiving [`TestResponse`] replies.
+//! Native applications expose the loopback test-control server. Web
+//! applications built through `fission test --target web` expose a test-only
+//! in-page bridge driven through Chromium.
 
 #[cfg(not(target_arch = "wasm32"))]
 use anyhow::{anyhow, Result};
@@ -607,22 +607,52 @@ pub type TestResponseSender = std::sync::mpsc::Sender<TestResponse>;
 /// ```
 #[cfg(not(target_arch = "wasm32"))]
 pub struct LiveTestClient {
-    base_url: String,
+    transport: LiveTestTransport,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+enum LiveTestTransport {
+    Http { base_url: String },
+    Browser(std::sync::Mutex<browser::BrowserController>),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl LiveTestClient {
     pub fn connect(port: u16) -> Self {
         Self {
-            base_url: format!("http://127.0.0.1:{}", port),
+            transport: LiveTestTransport::Http {
+                base_url: format!("http://127.0.0.1:{port}"),
+            },
+        }
+    }
+
+    /// Launches Chromium and connects to a Web application built with
+    /// Fission's test-only browser bridge.
+    pub fn launch_browser(options: BrowserTestOptions) -> Result<Self> {
+        let controller = browser::BrowserController::launch(options, true)?;
+        Ok(Self {
+            transport: LiveTestTransport::Browser(std::sync::Mutex::new(controller)),
+        })
+    }
+
+    /// Returns browser readiness details for a Web client.
+    pub fn browser_report(&self) -> Option<BrowserSmokeReport> {
+        match &self.transport {
+            LiveTestTransport::Http { .. } => None,
+            LiveTestTransport::Browser(controller) => {
+                controller.lock().ok().map(|controller| controller.report())
+            }
         }
     }
 
     pub fn wait_for_ready(&self, timeout_ms: u64) -> Result<()> {
+        let LiveTestTransport::Http { base_url } = &self.transport else {
+            return Ok(());
+        };
         let start = std::time::Instant::now();
         let timeout = std::time::Duration::from_millis(timeout_ms);
         loop {
-            match ureq::get(&format!("{}/health", self.base_url)).call() {
+            match ureq::get(&format!("{base_url}/health")).call() {
                 Ok(_) => return Ok(()),
                 Err(_) => {
                     if start.elapsed() > timeout {
@@ -635,15 +665,22 @@ impl LiveTestClient {
     }
 
     fn send(&self, cmd: TestCommand) -> Result<TestResponse> {
-        let body = serde_json::to_string(&cmd)?;
-        let resp = ureq::post(&format!("{}/cmd", self.base_url))
-            .set("Content-Type", "application/json")
-            .send_string(&body)
-            .map_err(|e| anyhow!("request failed: {}", e))?;
-        let text = resp.into_string()?;
-        let response: TestResponse = serde_json::from_str(&text)?;
+        let response = match &self.transport {
+            LiveTestTransport::Http { base_url } => {
+                let body = serde_json::to_string(&cmd)?;
+                let response = ureq::post(&format!("{base_url}/cmd"))
+                    .set("Content-Type", "application/json")
+                    .send_string(&body)
+                    .map_err(|error| anyhow!("request failed: {error}"))?;
+                serde_json::from_str(&response.into_string()?)?
+            }
+            LiveTestTransport::Browser(controller) => controller
+                .lock()
+                .map_err(|_| anyhow!("browser test controller lock is poisoned"))?
+                .send_test_command(cmd)?,
+        };
         if let TestResponse::Error { message } = &response {
-            return Err(anyhow!("server error: {}", message));
+            return Err(anyhow!("test host error: {message}"));
         }
         if let TestResponse::SelectorError { failure } = &response {
             return Err(anyhow!("selector error: {}", failure.message));

--- a/crates/tools/fission-test/Cargo.toml
+++ b/crates/tools/fission-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fission-ui/fission"
@@ -15,23 +15,23 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.11.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.11.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.11.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.11.0" }
-fission-shell = { path = "../../shell/fission-shell", version = "0.11.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.0" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.11.0" }
+fission-core = { path = "../../core/fission-core", version = "0.11.1" }
+fission-ir = { path = "../../core/fission-ir", version = "0.11.1" }
+fission-layout = { path = "../../core/fission-layout", version = "0.11.1" }
+fission-render = { path = "../../rendering/fission-render", version = "0.11.1" }
+fission-shell = { path = "../../shell/fission-shell", version = "0.11.1" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.11.1" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.11.1" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
-fission-macros = { path = "../../authoring/fission-macros", version = "0.11.0" }
-fission-diagnostics = { path = "../fission-diagnostics", version = "0.11.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.11.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.11.1" }
+fission-diagnostics = { path = "../fission-diagnostics", version = "0.11.1" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.11.1" }
+fission-theme = { path = "../../core/fission-theme", version = "0.11.1" }
 fontique = "0.7"
 read-fonts = "0.35"
 serde_json = "1.0"
 
 [dev-dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.11.0" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.11.1" }

--- a/docs/rfc-web-testing.md
+++ b/docs/rfc-web-testing.md
@@ -1,0 +1,188 @@
+# RFC: Web Live Testing
+
+Status: Accepted for implementation
+
+## Summary
+
+Fission will let the existing `LiveTestClient` drive a running Web application
+in Chromium. Web tests will use the same `TestCommand`, semantic selectors,
+runtime events, deterministic clock, text queries, and semantic-tree responses
+as native live tests.
+
+The implementation adds a test-only bridge between the browser host and the
+existing Winit `TestEvent` loop. It does not add a second Web-specific widget
+query model, a DOM selector layer, or a new browser automation framework.
+
+## Problem
+
+Fission has two testing layers:
+
+1. `fission-test` exercises the shared runtime headlessly and deterministically.
+2. `LiveTestClient` drives a real native shell through the test command protocol.
+
+The first layer already covers shared application behavior for Web. The second
+does not. `fission test --target web` currently builds and serves the
+application, launches Chromium through the existing CDP driver, checks that a
+canvas and renderer become ready, and reports browser errors. It cannot query
+the Fission semantic tree or drive the running application.
+
+This leaves browser-host regressions dependent on smoke coverage or bespoke
+automation even though the Web shell already receives `TestEvent` user events.
+
+## Goals
+
+- Drive a running Fission Web application with `LiveTestClient`.
+- Preserve the existing test command and selector semantics.
+- Support semantic queries, input, text editing, deterministic time, pumping,
+  resize, waits, and screenshots for the initial Chromium implementation.
+- Make `fission test --target web` prove that live control is operational, not
+  only that a canvas appeared.
+- Keep the bridge out of normal production Web builds.
+- Preserve all existing native test APIs and behavior.
+
+## Non-goals for the initial release
+
+- Firefox, WebKit, or branded-browser matrices.
+- Playwright, Selenium, or WebDriver integration.
+- Browser DOM selectors for canvas-rendered widgets.
+- Browser accessibility-tree assertions. The Fission semantic tree remains
+  available through `GetTree`.
+- Real browser clipboard permissions, file objects, drag-and-drop, or IME
+  composition automation. Existing deterministic Fission input commands remain
+  usable where applicable.
+- Renderer readback on WebGPU. Initial Web screenshots capture the browser page,
+  including the Fission canvas and browser-composited content.
+- Trace recording, video recording, network interception, or service-worker
+  control.
+
+These are useful later improvements, but none is required to establish a
+coherent first-party Web live-testing path.
+
+## Design
+
+### One protocol
+
+`TestCommand`, `SelectorQuery`, `TestEvent`, and `TestResponse` remain the
+authoritative testing vocabulary. Web does not translate widget tests into DOM
+queries because most Fission UI is rendered into a canvas.
+
+The public client remains `LiveTestClient`. Native callers continue to use:
+
+```rust
+let client = LiveTestClient::connect(port);
+```
+
+Web callers use an additive constructor:
+
+```rust
+let client = LiveTestClient::launch_browser(
+    BrowserTestOptions::new(url).fission_canvas(),
+)?;
+```
+
+All existing high-level methods, including `tap_selector`, `fill_text_selector`,
+`get_tree`, `wait_for_text`, `advance_clock`, and `capture_screenshot_png`, are
+then available on the same client type.
+
+### Test-only browser bridge
+
+`fission test --target web` marks its WASM build as a test-control build. The
+Web shell installs `globalThis.__FISSION_TEST__` only in that build. Normal
+`fission build` and `fission run` Web output do not install the bridge.
+
+The bridge has two small operations:
+
+- submit a serialized `TestCommand` and return a request identifier;
+- poll a request identifier for a serialized `TestResponse`.
+
+Submitting a command enqueues the corresponding `TestEvent` through the
+existing Winit `EventLoopProxy`. Query events retain their existing per-command
+response channel. Polling is necessary because browser WASM runs on the browser
+event-loop thread: blocking that thread while waiting for a response would
+prevent Winit from handling the event.
+
+The bridge is intentionally private implementation detail. Tests use the Rust
+client rather than calling the JavaScript object directly.
+
+### Browser transport
+
+`LiveTestClient` gains a browser transport backed by the existing Chromium CDP
+connection. The transport submits commands through the bridge and polls while
+allowing the browser event loop to continue.
+
+Operations that are inherently host-side remain in the host driver:
+
+- wait commands poll semantic/text/motion queries with a bounded timeout;
+- selector interactions perform the same scroll, pump, and action sequence as
+  the native server;
+- sleeps occur in the host process;
+- screenshots use CDP page capture and are returned as PNG bytes;
+- closing the client terminates its isolated browser process.
+
+This preserves behavior without putting blocking timers or filesystem paths in
+WASM.
+
+### CLI behavior
+
+For the Web target, `fission test` will:
+
+1. build WASM with the test bridge enabled;
+2. serve the generated Web host on an ephemeral loopback port;
+3. launch an isolated headless Chromium session;
+4. wait for the Fission canvas, renderer, and test bridge;
+5. pump the application and query its semantic tree;
+6. fail on build, browser, bridge, protocol, or runtime errors.
+
+This remains a smoke/conformance check. Application-specific suites can launch
+`LiveTestClient` against their served test application and use the same API as
+native live tests.
+
+## Command support
+
+The initial browser transport supports the existing command set with these
+bounded differences:
+
+- `CaptureScreenshot` and `CaptureAt` use a browser page screenshot instead of
+  renderer texture readback.
+- External file commands inject Fission's deterministic external-drag events;
+  they do not create browser `File` objects.
+- Pointer, keyboard, text, and IME commands enter through `TestEvent`; they do
+  not claim to verify browser-generated trusted events.
+- `Quit` closes the test application/browser session; it does not expose a
+  network control endpoint.
+
+These differences will be documented as limitations rather than hidden behind
+unsupported parity claims.
+
+## Safety and production cost
+
+- The bridge is selected at Web test build time and is absent from ordinary
+  Web builds.
+- It opens no TCP port and makes no cross-origin request.
+- The browser uses the existing isolated temporary profile and loopback CDP
+  port.
+- Dropping the browser client terminates Chromium and removes its profile.
+- No new direct dependency is required.
+
+## Validation
+
+The release must prove:
+
+- native `LiveTestClient::connect` behavior remains compatible;
+- the Web bridge is absent from a normal Web build configuration;
+- command serialization and malformed-command errors are stable;
+- asynchronous query completion cannot deadlock the browser event loop;
+- semantic tree and visible text can be queried in a real Chromium run;
+- selector interaction updates the running application;
+- text input, pump, resize, deterministic clock, and bounded waits work;
+- browser screenshots return valid PNG bytes;
+- `fission test --target web` exercises the bridge through the public client;
+- formatting, focused tests, the locked workspace test suite, and release
+  publication gates pass for the release candidate.
+
+## Deferred work
+
+The browser controller will remain isolated behind the test client so future
+Firefox, WebKit, WebDriver BiDi, or Playwright adapters do not change Fission's
+selector and command contract. No such abstraction or dependency is added until
+there is a concrete second browser implementation.

--- a/documentation/Cargo.toml
+++ b/documentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-documentation"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 default-run = "fission-documentation"
 

--- a/documentation/content/blog/2026-08-17-fission-0-11-1-web-live-testing.mdx
+++ b/documentation/content/blog/2026-08-17-fission-0-11-1-web-live-testing.mdx
@@ -1,0 +1,86 @@
+---
+title: Fission 0.11.1: Web LiveTest
+description: Drive real Fission Web applications in Chromium with the same semantic test contract used by native shells.
+authors:
+  - fission
+categories:
+  - Releases
+tags:
+  - release
+  - testing
+  - web
+  - chromium
+  - accessibility
+show_adjacent_posts: true
+---
+
+# Fission 0.11.1: Web LiveTest
+
+Fission 0.11.1 extends the existing LiveTest contract to real Web applications.
+Tests can now launch Chromium, query the Fission semantic tree, use semantic
+selectors, inject deterministic input, control time, wait for application state,
+and capture PNG screenshots through the same `LiveTestClient` used by native
+shells.
+
+## One testing vocabulary
+
+Web testing reuses `TestCommand`, `SelectorQuery`, `TestEvent`, and
+`TestResponse`. Canvas-rendered widgets are selected through Fission semantics,
+not a parallel DOM-selector model:
+
+```rust
+let client = LiveTestClient::launch_browser(
+    BrowserTestOptions::new("http://127.0.0.1:8080/").fission_canvas(),
+)?;
+
+client.wait_for_text("Inbox", 5_000)?;
+client.tap_semantic_identifier("inbox.compose")?;
+client.fill_text_semantic_identifier("message.subject", "Hello from Web")?;
+client.wait_for_idle(5_000, true)?;
+let screenshot = client.capture_screenshot_png()?;
+```
+
+Native callers continue to use `LiveTestClient::connect(port)`. The client API
+above is additive, and the existing native transport is unchanged.
+
+## The CLI proves live control
+
+`fission test --target web` now performs more than a canvas-ready smoke check.
+It builds test-control-enabled WASM, serves it on an ephemeral loopback port,
+launches an isolated headless Chromium profile, pumps the Web event loop, and
+queries the running Fission semantic tree. Build failures, browser errors,
+bridge failures, and protocol errors fail the command.
+
+Ordinary Web builds do not install the test bridge. The bridge opens no
+application control port and is selected only when producing a Web test build.
+
+## Intentionally bounded
+
+This first release supports Chromium without adding Playwright, Selenium, or
+WebDriver. Its input commands enter through Fission's deterministic event path;
+they do not claim to be browser-generated trusted events. Screenshots capture
+the browser page, including the canvas and browser-composited surfaces, rather
+than reading back a WebGPU texture. Tests inspect the Fission semantic tree,
+while browser accessibility-tree assertions and Firefox/WebKit drivers remain
+future work.
+
+These limits keep the implementation small and make the native and Web testing
+models genuinely consistent. The transport boundary leaves room for another
+browser driver later without changing application tests.
+
+## Upgrade
+
+Update the application dependency:
+
+```toml
+fission = { version = "0.11.1", default-features = false, features = ["web"] }
+```
+
+Install the matching CLI for `fission test --target web`:
+
+```sh
+cargo install cargo-fission --version 0.11.1 --locked
+```
+
+The complete design and deferred scope are recorded in
+[`docs/rfc-web-testing.md`](https://github.com/fission-ui/fission/blob/main/docs/rfc-web-testing.md).

--- a/documentation/content/docs/guides/design-system.mdx
+++ b/documentation/content/docs/guides/design-system.mdx
@@ -69,10 +69,10 @@ Add the generator as a build dependency:
 
 ```toml title="Cargo.toml"
 [dependencies]
-fission = { version = "0.11.0", default-features = false, features = ["desktop"] }
+fission = { version = "0.11.1", default-features = false, features = ["desktop"] }
 
 [build-dependencies]
-fission-design-system-codegen = "0.11.0"
+fission-design-system-codegen = "0.11.1"
 ```
 
 ## What you should have working

--- a/documentation/content/docs/guides/platform-shells-cli-and-testing.mdx
+++ b/documentation/content/docs/guides/platform-shells-cli-and-testing.mdx
@@ -142,7 +142,7 @@ This is the most important distinction on the page.
 
 Fission's cross-platform production story rests on the shared runtime and real host paths that already exist across the public target set. That is the framework-readiness claim.
 
-Testing-tooling differences are a different category. For example, desktop and mobile currently expose `with_test_control_port(...)`, which opens a live shell-control endpoint over transmission control protocol (TCP), the standard reliable transport used for local network connections. The browser wrapper does not yet expose that same live-control path publicly. That is a limitation in the current browser testing API. It is not evidence that browser apps built with Fission are not viable.
+Testing transport differs by host. Desktop and mobile expose `with_test_control_port(...)`, which opens a loopback live shell-control endpoint. Web test builds expose the same LiveTest command contract through a test-only Chromium bridge without opening another network listener.
 
 Target caveats are a third category. Browser clipboard behavior, drag-and-drop details, and input method editor edge cases still need direct browser validation. Mobile touch handling, safe-area behavior, soft-keyboard behavior, and some mobile lifecycle integration still deserve direct Android and iOS validation. Terminal layout must be checked against terminal cells and supported interaction modes. Static site output must be checked as static HTML. SSR output must be checked under request, cache, action, worker, and island behavior. Those caveats are about proving host-specific behavior where it actually lives.
 
@@ -152,7 +152,7 @@ When those categories stay separate, the platform story becomes much clearer. Th
 
 Desktop is a strong host for fast iteration because it offers native windows, a short local run loop, and the richest current live-testing API. That makes it convenient, but convenience is not the same thing as legitimacy.
 
-Web runs through the browser shell and WebAssembly, which is the compiled format that lets Rust run in the browser. The checked-in web shell, browser smoke example, and generated browser target are real host paths today. The current missing browser live-control hook is a testing-tooling gap. Richer browser integration around clipboard, drag-and-drop, and input method editor handling is a host integration area to validate carefully. Neither point changes the fact that the browser target itself is real.
+Web runs through the browser shell and WebAssembly, which is the compiled format that lets Rust run in the browser. The checked-in Web shell, browser smoke example, generated browser target, and Chromium LiveTest path are real host paths today. Richer browser integration around clipboard, drag-and-drop, trusted browser input, and input method editor handling remains host-specific work.
 
 Android runs through generated or checked-in mobile hosts and currently has a verified emulator path. Android development adds the usual host setup, including the Android software development kit (SDK) for platform tooling and the Android native development kit (NDK) for the native toolchain used by this Rust-based path. Those are normal Android-host concerns, not signs that the shared runtime is less serious there.
 

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -89,7 +89,7 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["server", "server-redis"] }
+fission = { version = "0.11.1", features = ["server", "server-redis"] }
 ```
 
 ## Invalidate cached pages after writes

--- a/documentation/content/docs/guides/server-site-security.mdx
+++ b/documentation/content/docs/guides/server-site-security.mdx
@@ -78,14 +78,14 @@ Hyper is available with the normal `server` feature:
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["server"] }
+fission = { version = "0.11.1", features = ["server"] }
 ```
 
 Axum and Actix adapters are feature-gated to avoid pulling those dependencies into projects that do not use them:
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["server", "server-axum"] }
+fission = { version = "0.11.1", features = ["server", "server-axum"] }
 tower = "0.5"
 ```
 

--- a/documentation/content/docs/guides/terminal-user-interfaces.mdx
+++ b/documentation/content/docs/guides/terminal-user-interfaces.mdx
@@ -21,7 +21,7 @@ Use the Fission facade crate and enable the terminal shell feature for tools tha
 
 ```toml
 [dependencies]
-fission = { version = "0.11.0", features = ["terminal-shell"] }
+fission = { version = "0.11.1", features = ["terminal-shell"] }
 ```
 
 ## What you should have working

--- a/documentation/content/docs/guides/testing-and-diagnostics.mdx
+++ b/documentation/content/docs/guides/testing-and-diagnostics.mdx
@@ -92,7 +92,7 @@ Live shell tests are for the cases where the headless harness is no longer enoug
 
 Sometimes you need a real shell. Maybe you care about overlay behavior in a real presented window. Maybe you want screenshots from the live host. Maybe you are validating shell-managed input flow or a target launch path.
 
-That is where `fission-test-driver::LiveTestClient` fits. It talks to a running app over the shell's Hypertext Transfer Protocol test-control server.
+That is where `fission-test-driver::LiveTestClient` fits. Native shells use the loopback Hypertext Transfer Protocol test-control server. Web tests use the same client and command protocol through a test-only Chromium bridge.
 
 In practice, the app is launched with `FISSION_TEST_CONTROL_PORT=<port>`, and the live client sends commands such as tap, type, scroll, screenshot, get visible text, get the semantic tree, pump, or simulate a resize.
 
@@ -102,7 +102,7 @@ Use live tests when you need confidence that the app behaves correctly in a runn
 
 Do not use live tests for logic that a reducer or harness test can already prove. Real shells are slower, more operationally involved, and more expensive to maintain.
 
-Also remember the current platform boundary: desktop and mobile public shells expose the test-control hook today, while the current web shell documentation still calls out browser-side live control as missing.
+The Web bridge is present only in Web test builds. The initial browser driver supports Chromium and deterministic Fission input; other browsers and trusted browser clipboard, file, accessibility, and IME integration remain separate host-specific work.
 
 A common mistake is using live tests as the first answer to every user interface question. They should sit above simpler layers, not replace them.
 

--- a/documentation/content/docs/test-and-debug/live-test-api.mdx
+++ b/documentation/content/docs/test-and-debug/live-test-api.mdx
@@ -1,11 +1,11 @@
 ---
 title: LiveTest API
-description: Drive a real Fission app with /health, /cmd, semantic selectors, screenshots, and wait commands.
+description: Drive a real native or Web Fission app with semantic selectors, screenshots, and wait commands.
 ---
 
 # LiveTest API
 
-LiveTest is the runtime control surface for real Fission hosts. It lets tests and manual QA drive the current frame without calculating coordinates by hand.
+LiveTest is the runtime control surface for real Fission hosts. It lets tests and manual QA drive the current frame without calculating coordinates by hand. Native hosts expose `/health` and `/cmd`; Web test builds expose the same command contract through Chromium.
 
 Enable the server by launching an app with `FISSION_TEST_CONTROL_PORT`.
 
@@ -28,6 +28,21 @@ curl -s http://127.0.0.1:9876/cmd   -H 'content-type: application/json'   -d '{"
 ```
 
 Prefer `LiveTestClient` in Rust tests and `curl` for quick manual QA or screenshot capture.
+
+For Web, build and serve the application with `fission test --target web`, or set `FISSION_WEB_TEST_CONTROL=1` while building WASM, then connect to the served URL:
+
+```rust
+use fission_test_driver::{BrowserTestOptions, LiveTestClient};
+
+let client = LiveTestClient::launch_browser(
+    BrowserTestOptions::new("http://127.0.0.1:8123/platforms/web/")
+        .fission_canvas(),
+)?;
+client.pump()?;
+client.assert_text_visible("Ready")?;
+```
+
+Web screenshots are composited Chromium page captures. The initial driver does not claim Firefox/WebKit coverage or trusted browser clipboard, file, accessibility, and IME event coverage.
 
 ## Selector-driven actions
 

--- a/documentation/content/reference/platform/testing.mdx
+++ b/documentation/content/reference/platform/testing.mdx
@@ -41,18 +41,30 @@ This is a tooling advantage, not a statement that desktop is the only serious ta
 
 ## Web
 
-The browser target is real and runnable today, with checked-in smoke coverage and generated browser host output. The current difference is the testing API, not the target's legitimacy.
+The browser target supports checked-in smoke coverage, generated browser host output, and first-party Chromium live control. `fission test --target web` builds the application with a test-only bridge, launches an isolated Chromium session, pumps the running Fission shell, and queries its semantic tree.
 
-Today the browser wrapper does not expose a public live-control endpoint equivalent to the desktop and mobile shells. That means browser automation is not yet using the same first-party `LiveTestClient` path.
+Application-specific browser tests can use the same `LiveTestClient` methods and semantic selectors as native tests:
 
-What you can still test reliably on browser targets today is substantial:
+```rust
+use fission_test_driver::{BrowserTestOptions, LiveTestClient, SelectorQuery};
+
+let client = LiveTestClient::launch_browser(
+    BrowserTestOptions::new("http://127.0.0.1:8123/platforms/web/")
+        .fission_canvas(),
+)?;
+client.tap_selector(SelectorQuery::test_id("settings.save"))?;
+client.assert_text_visible("Saved")?;
+```
+
+The application must be served before `launch_browser` is called and must have been built by `fission test --target web`, or with `FISSION_WEB_TEST_CONTROL=1` set for the WASM build. Ordinary Web builds do not expose the bridge.
+
+Browser tests cover:
 
 - shared app behavior through headless deterministic tests
-- browser build and serve paths through the checked-in and generated launcher scripts
-- real browser presentation, layout, and interaction checks in the actual browser host
-- browser-specific validation for viewport sizing, packaging, rendering, and integration details that only the browser can prove
+- semantic selectors, visible text, the semantic tree, Fission input, resize, pump, waits, and deterministic time through `LiveTestClient`
+- browser build, serving, canvas presentation, renderer readiness, console errors, and page screenshots through Chromium
 
-So the practical browser strategy is not "wait until browser tooling catches up." It is "prove shared behavior headlessly, then validate browser-specific behavior in the real browser host." The missing live-control hook is a testing-tooling gap, not evidence that browser apps are not production-capable.
+The initial implementation deliberately uses Chromium and Fission's deterministic `TestEvent` input path. Firefox, WebKit, trusted browser input, browser clipboard permissions, browser `File` objects, and the browser accessibility tree are deferred. Web screenshots capture the composited browser page rather than renderer texture readback.
 
 ## Android
 
@@ -93,8 +105,6 @@ Start with headless tests for shared behavior.
 Add live-driver tests where the current shell exposes that API and the interaction really needs a running host.
 
 Use Web, Android, iOS, Terminal, Static site, and SSR host paths to validate the target-specific behavior only those hosts can prove.
-
-That approach keeps the browser target in the same serious testing story as every other target while still being honest about the current difference in first-party live-control tooling.
 
 ## Related reference pages
 

--- a/documentation/content/reference/widgets/widget-pages/video.mdx
+++ b/documentation/content/reference/widgets/widget-pages/video.mdx
@@ -118,7 +118,7 @@ In the winit shell path, macOS and iOS use AVFoundation player layers, Windows u
 Native Linux video is behind the `video` Cargo feature so ordinary desktop apps do not need GStreamer development packages unless they use embedded video:
 
 ```toml
-fission = { version = "0.11.0", default-features = false, features = ["desktop", "video"] }
+fission = { version = "0.11.1", default-features = false, features = ["desktop", "video"] }
 ```
 
 On Debian or Ubuntu, enabling that feature requires:

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -126,7 +126,7 @@ impl From<FooterIdentity> for Widget {
                     ..Default::default()
                 }
                 .into(),
-                Text::new("Fission 0.11.0")
+                Text::new("Fission 0.11.1")
                     .size(tokens.typography.font_size_sm)
                     .family(tokens.typography.font_family_mono.clone())
                     .color(tokens.colors.text_muted)

--- a/examples/animation-gallery/Cargo.toml
+++ b/examples/animation-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animation-gallery"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/chart-gallery/Cargo.toml
+++ b/examples/chart-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chart-gallery"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "counter"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-editor"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/embed-3d/Cargo.toml
+++ b/examples/embed-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-3d"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [lib]

--- a/examples/embed-video/Cargo.toml
+++ b/examples/embed-video/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-video"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [lib]

--- a/examples/embed-webview/Cargo.toml
+++ b/examples/embed-webview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-webview"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/Cargo.toml
+++ b/examples/field-inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-inspector"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [lib]

--- a/examples/field-inspector/fission.toml
+++ b/examples/field-inspector/fission.toml
@@ -24,13 +24,13 @@ capabilities = [
 [app]
 name = "field-inspector"
 app_id = "com.fission.examples.fieldinspector"
-version = "0.11.0"
+version = "0.11.1"
 build = 1
 
 [package.android]
 package_name = "com.fission.examples.fieldinspector"
 version_code = 1
-version_name = "0.11.0"
+version_name = "0.11.1"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -41,13 +41,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.fission.examples.fieldinspector"
-marketing_version = "0.11.0"
+marketing_version = "0.11.1"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.fission.examples.fieldinspector"
 publisher = "CN=Fission Developer"
-version = "0.11.0"
+version = "0.11.1"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/icons_gallery/Cargo.toml
+++ b/examples/icons_gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icons_gallery"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/inbox/Cargo.toml
+++ b/examples/inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inbox"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/mobile-smoke/Cargo.toml
+++ b/examples/mobile-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-smoke"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [lib]

--- a/examples/motion-memory-repro/Cargo.toml
+++ b/examples/motion-memory-repro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion-memory-repro"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/pokemon-card-store/Cargo.toml
+++ b/examples/pokemon-card-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pokemon-card-store"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 publish = false
 

--- a/examples/pokemon-card-store/fission.toml
+++ b/examples/pokemon-card-store/fission.toml
@@ -19,7 +19,7 @@ preload = "route"
 
 [package.docker]
 port = 8080
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.11.0"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.11.1"]
 
 [distribution.docker_registry.production]
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.11.0"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.11.1"]

--- a/examples/product-browser/Cargo.toml
+++ b/examples/product-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product-browser"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/showcase/Cargo.toml
+++ b/examples/showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-showcase"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [lib]

--- a/examples/showcase/fission.toml
+++ b/examples/showcase/fission.toml
@@ -8,19 +8,19 @@ targets = [
 [app]
 name = "example-showcase"
 app_id = "rs.fission.examples.showcase"
-version = "0.11.0"
+version = "0.11.1"
 build = 1
 
 [package.macos]
 bundle_id = "rs.fission.examples.showcase"
-marketing_version = "0.11.0"
+marketing_version = "0.11.1"
 build_number = "1"
 minimum_os = "13.0"
 
 [package.windows]
 identity_name = "rs.fission.examples.showcase"
 publisher = "CN=Fission Developer"
-version = "0.11.0"
+version = "0.11.1"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/text-lab/Cargo.toml
+++ b/examples/text-lab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-lab"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/todo-design-system/Cargo.toml
+++ b/examples/todo-design-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-design-system"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/examples/web-smoke/Cargo.toml
+++ b/examples/web-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-smoke"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [lib]

--- a/examples/web-smoke/fission.toml
+++ b/examples/web-smoke/fission.toml
@@ -10,13 +10,13 @@ targets = [
 [app]
 name = "web-smoke"
 app_id = "com.example.web_smoke"
-version = "0.11.0"
+version = "0.11.1"
 build = 1
 
 [package.android]
 package_name = "com.example.web_smoke"
 version_code = 1
-version_name = "0.11.0"
+version_name = "0.11.1"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -27,13 +27,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.example.web_smoke"
-marketing_version = "0.11.0"
+marketing_version = "0.11.1"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.example.web.smoke"
 publisher = "CN=Fission Developer"
-version = "0.11.0"
+version = "0.11.1"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "widget-gallery"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- add the accepted Web LiveTest RFC
- reuse the native `TestCommand`/semantic selector contract through a test-only browser bridge
- add a Chromium transport to `LiveTestClient` and make `fission test --target web` prove live control
- document the bounded Chromium-first capability and prepare Fission 0.11.1

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked -j 1`
- `FISSION_WEB_TEST_CONTROL=1 cargo check --locked -p fission-shell-web --target wasm32-unknown-unknown`
- `fission test --target web --project-dir examples/web-smoke` in real Chrome on macOS
- `fission site check --project-dir documentation --release`
- `fission package --project-dir documentation --target site --format static --release`
