### PR TITLE
Fix WebGPU rendering, web input parity, and intrinsic flyouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,8 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3197,6 +3199,7 @@ dependencies = [
  "jni 0.21.1",
  "js-sys",
  "lazy_static",
+ "log",
  "ndk-context",
  "objc",
  "pollster",
@@ -3207,6 +3210,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tiny-skia",
+ "tracing-wasm",
  "tray-icon",
  "ureq",
  "wasm-bindgen",
@@ -7760,6 +7764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8532,6 +8545,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8889,6 +8911,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "fission-winit"
 version = "0.30.13-fission.2"
-source = "git+https://github.com/worka-ai/winit.git?rev=95888ea5adf62ecd160a2df4652ddfffd0310bcf#95888ea5adf62ecd160a2df4652ddfffd0310bcf"
+source = "git+https://github.com/worka-ai/winit.git?rev=4ceafb8ea25505de329238e4edc4f0a7187b92c8#4ceafb8ea25505de329238e4edc4f0a7187b92c8"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ panic = "abort"
 
 [patch.crates-io]
 android-activity = { path = "third_party/android-activity/android-activity" }
-fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "95888ea5adf62ecd160a2df4652ddfffd0310bcf" }
+fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "4ceafb8ea25505de329238e4edc4f0a7187b92c8" }

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -362,12 +362,12 @@ pub use fission_shell_terminal::TerminalApp;
     target_arch = "wasm32"
 ))]
 pub use fission_shell_web::{
-    BarcodeScannerHost, BiometricHost, BluetoothHost, CameraHost, ClipboardHost, GeolocationHost,
-    HapticHost, MemoryBarcodeScannerHost, MemoryBiometricHost, MemoryBluetoothHost,
-    MemoryCameraHost, MemoryClipboardHost, MemoryGeolocationHost, MemoryHapticHost,
-    MemoryMicrophoneHost, MemoryNfcHost, MemoryNotificationHost, MemoryPasskeyHost,
-    MemoryVolumeHost, MemoryWifiHost, MicrophoneHost, NfcHost, NotificationHost, PasskeyHost,
-    UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedBluetoothHost,
+    BarcodeScannerHost, BiometricHost, BluetoothHost, BrowserDefaults, CameraHost, ClipboardHost,
+    GeolocationHost, HapticHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
+    MemoryBluetoothHost, MemoryCameraHost, MemoryClipboardHost, MemoryGeolocationHost,
+    MemoryHapticHost, MemoryMicrophoneHost, MemoryNfcHost, MemoryNotificationHost,
+    MemoryPasskeyHost, MemoryVolumeHost, MemoryWifiHost, MicrophoneHost, NfcHost, NotificationHost,
+    PasskeyHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedBluetoothHost,
     UnsupportedCameraHost, UnsupportedGeolocationHost, UnsupportedHapticHost,
     UnsupportedMicrophoneHost, UnsupportedNfcHost, UnsupportedNotificationHost,
     UnsupportedPasskeyHost, UnsupportedVolumeHost, UnsupportedWifiHost, VolumeHost, WebApp,
@@ -610,8 +610,8 @@ pub mod prelude {
         target_arch = "wasm32"
     ))]
     pub use fission_shell_web::{
-        BarcodeScannerHost, BiometricHost, BluetoothHost, CameraHost, ClipboardHost,
-        GeolocationHost, HapticHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
+        BarcodeScannerHost, BiometricHost, BluetoothHost, BrowserDefaults, CameraHost,
+        ClipboardHost, GeolocationHost, HapticHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
         MemoryBluetoothHost, MemoryCameraHost, MemoryClipboardHost, MemoryGeolocationHost,
         MemoryHapticHost, MemoryMicrophoneHost, MemoryNfcHost, MemoryNotificationHost,
         MemoryPasskeyHost, MemoryVolumeHost, MemoryWifiHost, MicrophoneHost, NfcHost,

--- a/crates/core/fission-core/src/event.rs
+++ b/crates/core/fission-core/src/event.rs
@@ -127,6 +127,20 @@ pub enum KeyEvent {
     Up { key_code: KeyCode, modifiers: u8 },
 }
 
+/// Semantic text-editing commands produced by a platform shell.
+///
+/// Browser shells should translate trusted `copy`, `cut`, and `paste` events
+/// into these commands instead of synthesizing platform-specific key chords.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EditingCommand {
+    Copy,
+    Cut,
+    Paste(String),
+    SelectAll,
+    Undo,
+    Redo,
+}
+
 /// Application lifecycle events.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum LifecycleEvent {
@@ -199,6 +213,8 @@ pub enum InputEvent {
     Keyboard(KeyEvent),
     /// Input Method Editor (IME) events for CJK and composed text.
     Ime(ImeEvent),
+    /// A platform-native semantic text-editing command.
+    Editing(EditingCommand),
     /// High-level gesture events.
     Gesture(GestureEvent),
     /// Desktop shell drag-and-drop events from outside the app.

--- a/crates/core/fission-core/src/event.rs
+++ b/crates/core/fission-core/src/event.rs
@@ -215,6 +215,12 @@ pub enum InputEvent {
     Ime(ImeEvent),
     /// A platform-native semantic text-editing command.
     Editing(EditingCommand),
+    /// A platform requested Fission's contextual action at this position.
+    ContextMenuRequested {
+        point: LayoutPoint,
+        /// Modifier bitmask (Shift=1, Alt=2, Ctrl=4, Super=8).
+        modifiers: u8,
+    },
     /// High-level gesture events.
     Gesture(GestureEvent),
     /// Desktop shell drag-and-drop events from outside the app.

--- a/crates/core/fission-core/src/input/editing_convention.rs
+++ b/crates/core/fission-core/src/input/editing_convention.rs
@@ -1,0 +1,72 @@
+use crate::event::{MOD_ALT, MOD_CTRL, MOD_SUPER};
+
+/// Host text-editing conventions used by platform input controllers.
+///
+/// This is supplied by the runtime rather than inferred from the Rust target:
+/// a WebAssembly application can be running on either an Apple or non-Apple
+/// host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TextEditingConvention {
+    /// Control is the primary shortcut and word-navigation modifier.
+    #[default]
+    Standard,
+    /// Command is the primary shortcut, Option navigates by word, and the
+    /// conventional Control-based line-editing commands are available.
+    Apple,
+}
+
+impl TextEditingConvention {
+    pub const fn is_apple(self) -> bool {
+        matches!(self, Self::Apple)
+    }
+
+    pub const fn primary_shortcut_modifier(self) -> u8 {
+        match self {
+            Self::Standard => MOD_CTRL,
+            Self::Apple => MOD_SUPER,
+        }
+    }
+
+    pub const fn has_primary_shortcut(self, modifiers: u8) -> bool {
+        (modifiers & self.primary_shortcut_modifier()) != 0
+    }
+
+    pub const fn has_word_modifier(self, modifiers: u8) -> bool {
+        match self {
+            Self::Standard => (modifiers & MOD_CTRL) != 0,
+            Self::Apple => (modifiers & MOD_ALT) != 0,
+        }
+    }
+
+    /// Ctrl+Alt represents AltGr on common non-Apple keyboard layouts. The
+    /// resulting character is text input, not a Control shortcut.
+    pub const fn is_alt_gr(self, modifiers: u8) -> bool {
+        matches!(self, Self::Standard)
+            && (modifiers & (MOD_CTRL | MOD_ALT)) == (MOD_CTRL | MOD_ALT)
+            && (modifiers & MOD_SUPER) == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conventions_define_host_shortcuts_without_compile_target_checks() {
+        assert!(TextEditingConvention::Apple.has_primary_shortcut(MOD_SUPER));
+        assert!(!TextEditingConvention::Apple.has_primary_shortcut(MOD_CTRL));
+        assert!(TextEditingConvention::Apple.has_word_modifier(MOD_ALT));
+
+        assert!(TextEditingConvention::Standard.has_primary_shortcut(MOD_CTRL));
+        assert!(!TextEditingConvention::Standard.has_primary_shortcut(MOD_SUPER));
+        assert!(TextEditingConvention::Standard.has_word_modifier(MOD_CTRL));
+    }
+
+    #[test]
+    fn only_standard_ctrl_alt_is_alt_gr() {
+        assert!(TextEditingConvention::Standard.is_alt_gr(MOD_CTRL | MOD_ALT));
+        assert!(!TextEditingConvention::Apple.is_alt_gr(MOD_CTRL | MOD_ALT));
+        assert!(!TextEditingConvention::Standard.is_alt_gr(MOD_CTRL));
+        assert!(!TextEditingConvention::Standard.is_alt_gr(MOD_CTRL | MOD_ALT | MOD_SUPER));
+    }
+}

--- a/crates/core/fission-core/src/input/gesture.rs
+++ b/crates/core/fission-core/src/input/gesture.rs
@@ -17,6 +17,13 @@ impl InputController for GestureController {
             InputEvent::Pointer(pe) => {
                 match pe {
                     PointerEvent::Down { point, button, .. } => {
+                        // GestureState currently models one active pointer-button
+                        // sequence. Do not let an additional button press replace
+                        // the button that must match the eventual release.
+                        if ctx.gesture.pressed_button.is_some() {
+                            return true;
+                        }
+
                         ctx.gesture.start_point = Some(*point);
                         ctx.gesture.last_point = Some(*point);
                         ctx.gesture.is_panning = false;
@@ -52,13 +59,23 @@ impl InputController for GestureController {
                             ctx.ir, ctx.layout, ctx.scroll, *point,
                         ) {
                             ctx.gesture.target_node = Some(hit);
-                            ctx.gesture.dragging_payload = self.find_drag_payload(ctx, hit);
+                            ctx.gesture.dragging_payload =
+                                matches!(button, crate::event::PointerButton::Primary)
+                                    .then(|| self.find_drag_payload(ctx, hit))
+                                    .flatten();
                         } else {
                             ctx.gesture.target_node = None;
                             ctx.gesture.dragging_payload = None;
                         }
                     }
                     PointerEvent::Move { point, .. } => {
+                        if !matches!(
+                            ctx.gesture.pressed_button,
+                            Some(crate::event::PointerButton::Primary)
+                        ) {
+                            return false;
+                        }
+
                         if let Some(drag) = ctx.gesture.scrollbar_drag {
                             if let Some(geometry) = scrollbar_geometry_for_node(
                                 ctx.ir,
@@ -154,15 +171,25 @@ impl InputController for GestureController {
                         }
                     }
                     PointerEvent::Up {
-                        point, modifiers, ..
+                        point,
+                        button,
+                        modifiers,
                     } => {
                         let scrollbar_drag = ctx.gesture.scrollbar_drag.take();
                         let mut handled = false;
-                        let was_secondary = matches!(
-                            ctx.gesture.pressed_button,
-                            Some(crate::event::PointerButton::Secondary)
-                        );
-                        if ctx.gesture.is_panning {
+                        let pressed_button = ctx.gesture.pressed_button.clone();
+                        let buttons_match = pressed_button.as_ref() == Some(button);
+                        let was_primary =
+                            matches!(pressed_button, Some(crate::event::PointerButton::Primary));
+                        let was_secondary =
+                            matches!(pressed_button, Some(crate::event::PointerButton::Secondary));
+
+                        if pressed_button.is_some() && !buttons_match {
+                            self.reset_pointer_sequence(ctx, *point);
+                            return true;
+                        }
+
+                        if buttons_match && ctx.gesture.is_panning {
                             // Internal Drop
                             if let Some(payload) = ctx.gesture.dragging_payload.take() {
                                 if let Some(up_hit) = crate::hit_test::hit_test_with_scroll(
@@ -184,7 +211,7 @@ impl InputController for GestureController {
                                 );
                             }
                             handled = true;
-                        } else if was_secondary {
+                        } else if buttons_match && was_secondary {
                             // Secondary click (right-click)
                             if let Some(target) = ctx.gesture.target_node {
                                 if let Some(up_hit) = crate::hit_test::hit_test_with_scroll(
@@ -234,7 +261,7 @@ impl InputController for GestureController {
                                     }
                                 }
                             }
-                        } else {
+                        } else if buttons_match && was_primary {
                             // Tap (primary click)
                             if let Some(target) = ctx.gesture.target_node {
                                 if let Some(up_hit) = crate::hit_test::hit_test_with_scroll(
@@ -280,12 +307,7 @@ impl InputController for GestureController {
                         if !was_secondary {
                             ctx.context_menu.close();
                         }
-                        ctx.gesture.start_point = None;
-                        ctx.gesture.is_panning = false;
-                        ctx.gesture.dragging_payload = None;
-                        self.clear_drag_target(ctx, *point);
-                        ctx.gesture.drag_session = None;
-                        ctx.gesture.pressed_button = None;
+                        self.reset_pointer_sequence(ctx, *point);
                         if scrollbar_drag.is_some() {
                             ctx.gesture.target_node = None;
                             return true;
@@ -375,6 +397,15 @@ impl InputController for GestureController {
 }
 
 impl GestureController {
+    fn reset_pointer_sequence(&self, ctx: &mut ControllerContext, point: LayoutPoint) {
+        ctx.gesture.start_point = None;
+        ctx.gesture.is_panning = false;
+        ctx.gesture.dragging_payload = None;
+        self.clear_drag_target(ctx, point);
+        ctx.gesture.drag_session = None;
+        ctx.gesture.pressed_button = None;
+    }
+
     fn path_for_node(&self, ctx: &ControllerContext, node_id: WidgetId) -> Vec<WidgetId> {
         let mut path = Vec::new();
         let mut curr = Some(node_id);

--- a/crates/core/fission-core/src/input/gesture.rs
+++ b/crates/core/fission-core/src/input/gesture.rs
@@ -390,6 +390,9 @@ impl InputController for GestureController {
                     return true;
                 }
             },
+            InputEvent::ContextMenuRequested { point, .. } => {
+                return self.handle_context_menu_request(ctx, *point);
+            }
             _ => {}
         }
         false
@@ -397,6 +400,37 @@ impl InputController for GestureController {
 }
 
 impl GestureController {
+    fn handle_context_menu_request(
+        &mut self,
+        ctx: &mut ControllerContext,
+        point: LayoutPoint,
+    ) -> bool {
+        let Some(hit) =
+            crate::hit_test::hit_test_with_scroll(ctx.ir, ctx.layout, ctx.scroll, point)
+        else {
+            return false;
+        };
+        if let Some(menu_owner) = self.find_context_menu_owner(ctx, hit) {
+            ctx.context_menu.open(menu_owner, point);
+            return true;
+        }
+        let rich_text_path = self.path_for_node(ctx, hit);
+        if let Some((annotation_node_id, annotation)) =
+            crate::input::hover::resolve_rich_text_annotation_at_point(ctx, &rich_text_path, point)
+        {
+            if self.dispatch_annotation_trigger(
+                ctx,
+                annotation_node_id,
+                &annotation,
+                ActionTrigger::SecondaryClick,
+                point,
+            ) {
+                return true;
+            }
+        }
+        self.dispatch_trigger(ctx, hit, ActionTrigger::SecondaryClick, point, None)
+    }
+
     fn reset_pointer_sequence(&self, ctx: &mut ControllerContext, point: LayoutPoint) {
         ctx.gesture.start_point = None;
         ctx.gesture.is_panning = false;

--- a/crates/core/fission-core/src/input/mod.rs
+++ b/crates/core/fission-core/src/input/mod.rs
@@ -15,6 +15,9 @@ pub mod selectable_text;
 pub mod slider;
 pub mod text;
 
+mod editing_convention;
+pub use editing_convention::TextEditingConvention;
+
 pub struct ControllerContext<'a> {
     pub ir: &'a CoreIR,
     pub layout: &'a LayoutSnapshot,
@@ -24,6 +27,7 @@ pub struct ControllerContext<'a> {
     pub interaction: &'a mut InteractionStateMap,
     pub scroll: &'a mut ScrollStateMap,
     pub gesture: &'a mut crate::env::GestureState,
+    pub editing_convention: TextEditingConvention,
     pub clipboard: Option<&'a Arc<dyn Clipboard>>,
     pub measurer: Option<&'a Arc<dyn TextMeasurer>>,
     // We queue actions here instead of dispatching immediately to keep Controller pure logic

--- a/crates/core/fission-core/src/input/selectable_text.rs
+++ b/crates/core/fission-core/src/input/selectable_text.rs
@@ -1,5 +1,5 @@
 use super::{ControllerContext, InputController};
-use crate::event::{InputEvent, KeyCode, KeyEvent, PointerEvent, MOD_CTRL, MOD_SUPER};
+use crate::event::{EditingCommand, InputEvent, KeyCode, KeyEvent, PointerEvent};
 use crate::ui::widgets::context_menu::{text_context_menu_button_id, TextContextMenuAction};
 use fission_ir::{op::LayoutOp, Op, Semantics, WidgetId};
 use fission_layout::{LayoutNodeGeometry, LayoutPoint};
@@ -13,6 +13,7 @@ impl InputController for SelectableTextController {
                 key_code,
                 modifiers,
             }) => self.handle_key(ctx, key_code.clone(), *modifiers),
+            InputEvent::Editing(command) => self.handle_editing_command(ctx, command),
             InputEvent::Pointer(PointerEvent::Down {
                 point,
                 button,
@@ -82,11 +83,10 @@ impl InputController for SelectableTextController {
 }
 
 impl SelectableTextController {
-    fn handle_key(
+    fn handle_editing_command(
         &mut self,
         ctx: &mut ControllerContext,
-        key_code: KeyCode,
-        modifiers: u8,
+        command: &EditingCommand,
     ) -> bool {
         let Some(owner) = ctx.interaction.focused else {
             return false;
@@ -94,11 +94,8 @@ impl SelectableTextController {
         let Some(semantics) = Self::selectable_text_semantics(ctx, owner) else {
             return false;
         };
-        if !Self::has_primary_shortcut(modifiers) {
-            return false;
-        }
-        match key_code {
-            KeyCode::Char('c') | KeyCode::Char('C') => {
+        match command {
+            EditingCommand::Copy => {
                 if let Some(selected) = Self::selected_text(ctx, owner, &semantics) {
                     if let Some(clipboard) = ctx.clipboard {
                         clipboard.set_text(&selected);
@@ -106,15 +103,37 @@ impl SelectableTextController {
                 }
                 true
             }
-            KeyCode::Char('a') | KeyCode::Char('A') => {
+            EditingCommand::SelectAll => {
                 let len = semantics.value.as_deref().unwrap_or("").len();
                 let state = ctx.selectable_text.get_mut_or_default(owner);
                 state.anchor = 0;
                 state.caret = len;
                 true
             }
-            _ => false,
+            EditingCommand::Cut
+            | EditingCommand::Paste(_)
+            | EditingCommand::Undo
+            | EditingCommand::Redo => false,
         }
+    }
+
+    fn handle_key(
+        &mut self,
+        ctx: &mut ControllerContext,
+        key_code: KeyCode,
+        modifiers: u8,
+    ) -> bool {
+        if !ctx.editing_convention.has_primary_shortcut(modifiers)
+            || ctx.editing_convention.is_alt_gr(modifiers)
+        {
+            return false;
+        }
+        let command = match key_code {
+            KeyCode::Char('c') | KeyCode::Char('C') => Some(EditingCommand::Copy),
+            KeyCode::Char('a') | KeyCode::Char('A') => Some(EditingCommand::SelectAll),
+            _ => None,
+        };
+        command.is_some_and(|command| self.handle_editing_command(ctx, &command))
     }
 
     fn selectable_text_at_hit(
@@ -344,13 +363,5 @@ impl SelectableTextController {
 
     fn has_shift(modifiers: u8) -> bool {
         (modifiers & crate::event::MOD_SHIFT) != 0
-    }
-
-    fn has_primary_shortcut(modifiers: u8) -> bool {
-        if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
-            (modifiers & MOD_SUPER) != 0
-        } else {
-            (modifiers & MOD_CTRL) != 0
-        }
     }
 }

--- a/crates/core/fission-core/src/input/slider.rs
+++ b/crates/core/fission-core/src/input/slider.rs
@@ -9,7 +9,9 @@ pub struct SliderController;
 impl InputController for SliderController {
     fn handle_event(&mut self, ctx: &mut ControllerContext, event: &InputEvent) -> bool {
         match event {
-            InputEvent::Pointer(PointerEvent::Down { point, .. }) => {
+            InputEvent::Pointer(PointerEvent::Down { point, button, .. })
+                if matches!(button, crate::event::PointerButton::Primary) =>
+            {
                 if let Some(hit_id) =
                     crate::hit_test::hit_test_with_scroll(ctx.ir, ctx.layout, ctx.scroll, *point)
                 {

--- a/crates/core/fission-core/src/input/text.rs
+++ b/crates/core/fission-core/src/input/text.rs
@@ -1,7 +1,8 @@
 use super::{ControllerContext, InputController};
 use crate::env::TextSelectionHandleKind;
 use crate::event::{
-    InputEvent, KeyCode, KeyEvent, PointerEvent, MOD_ALT, MOD_CTRL, MOD_SHIFT, MOD_SUPER,
+    EditingCommand, InputEvent, KeyCode, KeyEvent, PointerEvent, MOD_ALT, MOD_CTRL, MOD_SHIFT,
+    MOD_SUPER,
 };
 use crate::ui::widgets::context_menu::TextContextMenuAction;
 use crate::ui::widgets::text_input::{
@@ -28,6 +29,7 @@ impl InputController for TextInputController {
                 key_code,
                 modifiers,
             }) => self.handle_key(ctx, key_code.clone(), *modifiers),
+            InputEvent::Editing(command) => self.handle_editing_command(ctx, command),
             InputEvent::Ime(ime) => self.handle_ime(ctx, ime),
             InputEvent::Pointer(PointerEvent::Down {
                 point,
@@ -565,6 +567,129 @@ impl InputController for TextInputController {
 }
 
 impl TextInputController {
+    fn handle_editing_command(
+        &mut self,
+        ctx: &mut ControllerContext,
+        command: &EditingCommand,
+    ) -> bool {
+        let Some(focused_id) = ctx.interaction.focused else {
+            return false;
+        };
+        let Some(semantics) = Self::text_input_semantics(ctx, focused_id) else {
+            return false;
+        };
+        if semantics.disabled {
+            return false;
+        }
+
+        let (value, caret, anchor) =
+            Self::resolve_editing_value(ctx, focused_id, semantics.value.as_deref().unwrap_or(""));
+        let caret = Self::clamp_caret_to_value(&value, caret);
+        let anchor = Self::clamp_caret_to_value(&value, anchor);
+        let selection = (caret != anchor).then_some((caret.min(anchor), caret.max(anchor)));
+
+        match command {
+            EditingCommand::Copy => {
+                if let (Some((start, end)), Some(clipboard)) = (selection, ctx.clipboard) {
+                    clipboard.set_text(&value[start..end]);
+                }
+            }
+            EditingCommand::Cut => {
+                if let Some((start, end)) = selection {
+                    if let Some(clipboard) = ctx.clipboard {
+                        clipboard.set_text(&value[start..end]);
+                    }
+                    if !semantics.read_only {
+                        let next = ctx.text_edit.get_mut_or_default(focused_id).apply_edit(
+                            start..end,
+                            "",
+                            start,
+                            start,
+                        );
+                        self.dispatch_change(ctx, &semantics, focused_id, next);
+                        Self::dispatch_cursor_change(ctx, &semantics, focused_id, start, start);
+                    }
+                }
+            }
+            EditingCommand::Paste(text) => {
+                if !semantics.read_only && !text.is_empty() {
+                    let (start, end) = selection.unwrap_or((caret, caret));
+                    if let Some(inserted) =
+                        Self::prepare_inserted_text(&semantics, &value, start, end, text)
+                    {
+                        let next_caret = start + inserted.len();
+                        let next = ctx.text_edit.get_mut_or_default(focused_id).apply_edit(
+                            start..end,
+                            &inserted,
+                            next_caret,
+                            next_caret,
+                        );
+                        self.dispatch_change(ctx, &semantics, focused_id, next);
+                        Self::dispatch_cursor_change(
+                            ctx, &semantics, focused_id, next_caret, next_caret,
+                        );
+                    }
+                }
+            }
+            EditingCommand::SelectAll => {
+                let state = ctx.text_edit.get_mut_or_default(focused_id);
+                state.caret = value.len();
+                state.anchor = 0;
+                state.clear_preedit();
+                Self::dispatch_cursor_change(ctx, &semantics, focused_id, value.len(), 0);
+            }
+            EditingCommand::Undo | EditingCommand::Redo => {
+                let edit = {
+                    let state = ctx.text_edit.get_mut_or_default(focused_id);
+                    match command {
+                        EditingCommand::Undo => state.undo(),
+                        EditingCommand::Redo => state.redo(),
+                        _ => unreachable!(),
+                    }
+                };
+                if let Some((next, next_caret, next_anchor)) = edit {
+                    self.dispatch_change(ctx, &semantics, focused_id, next);
+                    Self::dispatch_cursor_change(
+                        ctx,
+                        &semantics,
+                        focused_id,
+                        next_caret,
+                        next_anchor,
+                    );
+                }
+            }
+        }
+
+        let displayed_value = ctx
+            .text_edit
+            .get(focused_id)
+            .map(|state| state.committed_text().to_owned())
+            .unwrap_or(value);
+        Self::sync_text_input_affordances(
+            ctx,
+            focused_id,
+            &semantics,
+            displayed_value.as_str(),
+            false,
+            None,
+        );
+        true
+    }
+
+    fn text_input_semantics(ctx: &ControllerContext, focused_id: WidgetId) -> Option<Semantics> {
+        let mut current_id = Some(focused_id);
+        while let Some(node_id) = current_id {
+            let node = ctx.ir.nodes.get(&node_id)?;
+            if let Op::Semantics(semantics) = &node.op {
+                if semantics.role == fission_ir::semantics::Role::TextInput {
+                    return Some(semantics.clone());
+                }
+            }
+            current_id = node.parent;
+        }
+        None
+    }
+
     fn handle_key(
         &mut self,
         ctx: &mut ControllerContext,
@@ -620,14 +745,14 @@ impl TextInputController {
         let mut next_edit: Option<(std::ops::Range<usize>, String)> = None;
         let mut handled = false;
 
-        // Undo/Redo logic result
-        let mut undo_redo_result: Option<(String, usize, usize)> = None;
         let read_only = semantics.read_only;
         let disabled = semantics.disabled;
-        let is_apple = Self::is_apple_platform();
+        let convention = ctx.editing_convention;
+        let is_apple = convention.is_apple();
         let shift = Self::has_shift(modifiers);
-        let primary_shortcut = Self::has_primary_shortcut(modifiers);
-        let word_modifier = Self::has_word_modifier(modifiers);
+        let primary_shortcut =
+            convention.has_primary_shortcut(modifiers) && !convention.is_alt_gr(modifiers);
+        let word_modifier = convention.has_word_modifier(modifiers);
 
         if disabled {
             return false;
@@ -652,82 +777,22 @@ impl TextInputController {
             KeyCode::Char(ch) => {
                 let lower = ch.to_ascii_lowercase();
                 if primary_shortcut {
-                    let (s, e) = sel.unwrap_or((caret, caret));
-                    match lower {
-                        'a' => {
-                            next_caret = value.len();
-                            next_anchor = 0;
-                            handled = true;
-                        }
-                        'c' => {
-                            if s != e {
-                                let txt = value[s..e].to_string();
-                                if let Some(cb) = ctx.clipboard {
-                                    cb.set_text(&txt);
-                                }
-                            }
-                            handled = true;
-                        }
-                        'x' => {
-                            if s != e {
-                                let txt = value[s..e].to_string();
-                                if let Some(cb) = ctx.clipboard {
-                                    cb.set_text(&txt);
-                                }
-                                if !read_only {
-                                    next_edit = Some((s..e, String::new()));
-                                    next_caret = s;
-                                    next_anchor = s;
-                                }
-                            }
-                            handled = true;
-                        }
-                        'v' => {
-                            handled = true;
-                            if !read_only {
-                                let text_to_paste = if let Some(cb) = ctx.clipboard {
-                                    cb.get_text().unwrap_or_default()
-                                } else {
-                                    String::new()
-                                };
-                                if !text_to_paste.is_empty() {
-                                    if let Some(inserted) = Self::prepare_inserted_text(
-                                        semantics,
-                                        &value,
-                                        s,
-                                        e,
-                                        &text_to_paste,
-                                    ) {
-                                        next_caret = s + inserted.len();
-                                        next_anchor = next_caret;
-                                        next_edit = Some((s..e, inserted));
-                                    }
-                                }
-                            }
-                        }
-                        'z' => {
-                            let st = ctx.text_edit.get_mut_or_default(focused_id);
-                            if shift {
-                                if let Some((v, c, a)) = st.redo() {
-                                    undo_redo_result = Some((v, c, a));
-                                }
-                            } else if let Some((v, c, a)) = st.undo() {
-                                undo_redo_result = Some((v, c, a));
-                            }
-                            handled = true;
-                        }
-                        'y' if !is_apple => {
-                            let st = ctx.text_edit.get_mut_or_default(focused_id);
-                            if let Some((v, c, a)) = st.redo() {
-                                undo_redo_result = Some((v, c, a));
-                            }
-                            handled = true;
-                        }
-                        _ => {}
-                    }
-                    if handled {
-                        // Skip plain text insertion when a primary shortcut matched.
-                    }
+                    let command = match lower {
+                        'a' => Some(EditingCommand::SelectAll),
+                        'c' => Some(EditingCommand::Copy),
+                        'x' => Some(EditingCommand::Cut),
+                        'v' => Some(EditingCommand::Paste(
+                            ctx.clipboard
+                                .and_then(|clipboard| clipboard.get_text())
+                                .unwrap_or_default(),
+                        )),
+                        'z' if shift => Some(EditingCommand::Redo),
+                        'z' => Some(EditingCommand::Undo),
+                        'y' if !is_apple => Some(EditingCommand::Redo),
+                        _ => None,
+                    };
+                    return command
+                        .map_or(true, |command| self.handle_editing_command(ctx, &command));
                 }
 
                 if !handled
@@ -1013,21 +1078,6 @@ impl TextInputController {
             _ => {}
         }
 
-        if let Some((v, c, a)) = undo_redo_result {
-            // Apply undo/redo result
-            self.dispatch_change(ctx, semantics, focused_id, v);
-            Self::dispatch_cursor_change(ctx, semantics, focused_id, c, a);
-            Self::sync_text_input_affordances(
-                ctx,
-                focused_id,
-                semantics,
-                value.as_str(),
-                false,
-                None,
-            );
-            return true;
-        }
-
         if let Some((range, replacement)) = next_edit {
             // Apply text change
             let st = ctx.text_edit.get_mut_or_default(focused_id);
@@ -1061,10 +1111,6 @@ impl TextInputController {
         }
 
         handled
-    }
-
-    fn is_apple_platform() -> bool {
-        cfg!(target_os = "macos") || cfg!(target_os = "ios")
     }
 
     fn runtime_config(
@@ -1122,30 +1168,6 @@ impl TextInputController {
 
     fn has_super(modifiers: u8) -> bool {
         (modifiers & MOD_SUPER) != 0
-    }
-
-    fn has_primary_shortcut(modifiers: u8) -> bool {
-        if Self::is_apple_platform() {
-            Self::has_super(modifiers)
-        } else {
-            Self::has_ctrl(modifiers)
-        }
-    }
-
-    fn has_word_modifier(modifiers: u8) -> bool {
-        if Self::is_apple_platform() {
-            Self::has_alt(modifiers)
-        } else {
-            Self::has_ctrl(modifiers)
-        }
-    }
-
-    fn primary_shortcut_modifier() -> u8 {
-        if Self::is_apple_platform() {
-            MOD_SUPER
-        } else {
-            MOD_CTRL
-        }
     }
 
     fn node_or_ancestor_matches(
@@ -1211,20 +1233,17 @@ impl TextInputController {
         ctx: &mut ControllerContext,
         action: TextContextMenuAction,
     ) -> bool {
-        match action {
-            TextContextMenuAction::Copy => {
-                self.handle_key(ctx, KeyCode::Char('c'), Self::primary_shortcut_modifier())
-            }
-            TextContextMenuAction::Cut => {
-                self.handle_key(ctx, KeyCode::Char('x'), Self::primary_shortcut_modifier())
-            }
-            TextContextMenuAction::Paste => {
-                self.handle_key(ctx, KeyCode::Char('v'), Self::primary_shortcut_modifier())
-            }
-            TextContextMenuAction::SelectAll => {
-                self.handle_key(ctx, KeyCode::Char('a'), Self::primary_shortcut_modifier())
-            }
-        }
+        let command = match action {
+            TextContextMenuAction::Copy => EditingCommand::Copy,
+            TextContextMenuAction::Cut => EditingCommand::Cut,
+            TextContextMenuAction::Paste => EditingCommand::Paste(
+                ctx.clipboard
+                    .and_then(|clipboard| clipboard.get_text())
+                    .unwrap_or_default(),
+            ),
+            TextContextMenuAction::SelectAll => EditingCommand::SelectAll,
+        };
+        self.handle_editing_command(ctx, &command)
     }
 
     fn input_wrapper_geometry<'a>(

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -127,6 +127,8 @@ pub struct Runtime {
     pub clipboard_backend: Option<Arc<dyn Clipboard>>,
     /// Platform-provided IME (Input Method Editor) handler.
     pub ime_handler: Option<Arc<dyn ImeHandler>>,
+    /// Text-editing conventions for the host that owns this runtime.
+    pub editing_convention: crate::input::TextEditingConvention,
     /// Effects emitted by reducers, awaiting platform execution.
     pub pending_effects: Vec<EffectEnvelope>,
     /// Post-layout scroll requests that need computed geometry before applying.
@@ -152,6 +154,7 @@ impl Default for Runtime {
             measurer: None,
             clipboard_backend: None,
             ime_handler: None,
+            editing_convention: crate::input::TextEditingConvention::default(),
             pending_effects: Vec::new(),
             pending_scroll_into_view: Vec::new(),
             focus_barriers: Vec::new(),
@@ -1164,6 +1167,7 @@ impl Runtime {
                     interaction: &mut self.runtime_state.interaction,
                     scroll: &mut self.runtime_state.scroll,
                     gesture: &mut self.runtime_state.gesture,
+                    editing_convention: self.editing_convention,
                     clipboard: self.clipboard_backend.as_ref(),
                     measurer: self.measurer.as_ref(),
                     dispatched_actions: Vec::new(),
@@ -1261,7 +1265,13 @@ impl Runtime {
                             let result = render_obj.handle_event(nid, &event, node_rect);
                             if result.handled {
                                 // Set focus to this node so keyboard events route here
-                                if matches!(event, InputEvent::Pointer(PointerEvent::Down { .. })) {
+                                if matches!(
+                                    event,
+                                    InputEvent::Pointer(PointerEvent::Down {
+                                        button: PointerButton::Primary,
+                                        ..
+                                    })
+                                ) {
                                     let old_focused_id = self.runtime_state.interaction.focused;
                                     if Some(nid) != old_focused_id {
                                         self.clear_text_pending_on_blur(old_focused_id, Some(nid));
@@ -1298,7 +1308,10 @@ impl Runtime {
         // (if any) and walk up its ancestor chain looking for a custom render
         // object.  This allows custom editor nodes to handle arrow keys,
         // typing, etc. before the framework's default focus-navigation logic.
-        if matches!(event, InputEvent::Keyboard(_) | InputEvent::Ime(_)) {
+        if matches!(
+            event,
+            InputEvent::Keyboard(_) | InputEvent::Ime(_) | InputEvent::Editing(_)
+        ) {
             if let Some(focused_id) = self.runtime_state.interaction.focused {
                 let mut walk_id = Some(focused_id);
                 while let Some(nid) = walk_id {
@@ -1332,6 +1345,7 @@ impl Runtime {
                 interaction: &mut self.runtime_state.interaction,
                 scroll: &mut self.runtime_state.scroll,
                 gesture: &mut self.runtime_state.gesture,
+                editing_convention: self.editing_convention,
                 clipboard: self.clipboard_backend.as_ref(),
                 measurer: self.measurer.as_ref(),
                 dispatched_actions: Vec::new(),
@@ -1551,7 +1565,11 @@ impl Runtime {
                 }
                 _ => {}
             },
-            InputEvent::Pointer(PointerEvent::Down { point, .. }) => {
+            InputEvent::Pointer(PointerEvent::Down {
+                point,
+                button: PointerButton::Primary,
+                ..
+            }) => {
                 if let Some(hit_node_id) =
                     hit_test_with_scroll(ir, layout, &self.runtime_state.scroll, point)
                 {
@@ -1657,51 +1675,63 @@ impl Runtime {
                     self.runtime_state.interaction.set_focused(None);
                 }
             }
-            InputEvent::Pointer(PointerEvent::Up { point, .. }) => {
+            InputEvent::Pointer(PointerEvent::Up {
+                point,
+                button: PointerButton::Primary,
+                ..
+            }) => {
                 self.runtime_state.interaction.pressed.clear();
-                self.runtime_state.interaction.last_down_point = None;
-                if let Some(hit_node_id) =
-                    hit_test_with_scroll(ir, layout, &self.runtime_state.scroll, point)
-                {
-                    let mut current_id = Some(hit_node_id);
-                    while let Some(node_id) = current_id {
-                        if let Some(node) = ir.nodes.get(&node_id) {
-                            if let Op::Semantics(semantics) = &node.op {
-                                if semantics.role == fission_ir::semantics::Role::TextInput {
-                                    // No action
-                                } else if let Some(action_entry) =
-                                    semantics.actions.entries.iter().find(|entry| {
-                                        entry.trigger
-                                            == fission_ir::semantics::ActionTrigger::Default
-                                    })
-                                {
-                                    if let Some(payload) = &action_entry.payload_data {
-                                        let envelope = ActionEnvelope {
-                                            id: ActionId::from_u128(action_entry.action_id),
-                                            payload: payload.clone(),
-                                        };
-                                        diag::emit(
-                                            diag::DiagCategory::Input,
-                                            diag::DiagLevel::Debug,
-                                            diag::DiagEventKind::InputEvent {
-                                                kind: "pointer_up_dispatch".into(),
-                                                target: Some(node_id.as_u128()),
-                                                position: Some((point.x, point.y)),
-                                            },
-                                        );
-                                        let input = crate::input::scoped_action_input(
-                                            ir,
-                                            node_id,
-                                            ActionInput::None,
-                                        );
-                                        return self
-                                            .dispatch_node_with_input(envelope, node_id, &input);
+                let had_primary_down = self
+                    .runtime_state
+                    .interaction
+                    .last_down_point
+                    .take()
+                    .is_some();
+                if had_primary_down {
+                    if let Some(hit_node_id) =
+                        hit_test_with_scroll(ir, layout, &self.runtime_state.scroll, point)
+                    {
+                        let mut current_id = Some(hit_node_id);
+                        while let Some(node_id) = current_id {
+                            if let Some(node) = ir.nodes.get(&node_id) {
+                                if let Op::Semantics(semantics) = &node.op {
+                                    if semantics.role == fission_ir::semantics::Role::TextInput {
+                                        // No action
+                                    } else if let Some(action_entry) =
+                                        semantics.actions.entries.iter().find(|entry| {
+                                            entry.trigger
+                                                == fission_ir::semantics::ActionTrigger::Default
+                                        })
+                                    {
+                                        if let Some(payload) = &action_entry.payload_data {
+                                            let envelope = ActionEnvelope {
+                                                id: ActionId::from_u128(action_entry.action_id),
+                                                payload: payload.clone(),
+                                            };
+                                            diag::emit(
+                                                diag::DiagCategory::Input,
+                                                diag::DiagLevel::Debug,
+                                                diag::DiagEventKind::InputEvent {
+                                                    kind: "pointer_up_dispatch".into(),
+                                                    target: Some(node_id.as_u128()),
+                                                    position: Some((point.x, point.y)),
+                                                },
+                                            );
+                                            let input = crate::input::scoped_action_input(
+                                                ir,
+                                                node_id,
+                                                ActionInput::None,
+                                            );
+                                            return self.dispatch_node_with_input(
+                                                envelope, node_id, &input,
+                                            );
+                                        }
                                     }
                                 }
+                                current_id = node.parent;
+                            } else {
+                                break;
                             }
-                            current_id = node.parent;
-                        } else {
-                            break;
                         }
                     }
                 }
@@ -1727,6 +1757,7 @@ impl Runtime {
                 interaction: &mut self.runtime_state.interaction,
                 scroll: &mut self.runtime_state.scroll,
                 gesture: &mut self.runtime_state.gesture,
+                editing_convention: self.editing_convention,
                 clipboard: self.clipboard_backend.as_ref(),
                 measurer: self.measurer.as_ref(),
                 dispatched_actions: Vec::new(),
@@ -1800,6 +1831,7 @@ impl Runtime {
                     interaction: &mut self.runtime_state.interaction,
                     scroll: &mut self.runtime_state.scroll,
                     gesture: &mut self.runtime_state.gesture,
+                    editing_convention: self.editing_convention,
                     clipboard: self.clipboard_backend.as_ref(),
                     measurer: self.measurer.as_ref(),
                     dispatched_actions: Vec::new(),

--- a/crates/core/fission-core/tests/input_controller_tests.rs
+++ b/crates/core/fission-core/tests/input_controller_tests.rs
@@ -3,11 +3,11 @@ use fission_core::env::{
     SelectableTextStateMap, TextEditStateMap,
 };
 use fission_core::event::{
-    ImeEvent, InputEvent, KeyCode, KeyEvent, PointerButton, PointerEvent, MOD_ALT, MOD_CTRL,
-    MOD_SHIFT, MOD_SUPER,
+    EditingCommand, ImeEvent, InputEvent, KeyCode, KeyEvent, PointerButton, PointerEvent, MOD_ALT,
+    MOD_CTRL, MOD_SHIFT, MOD_SUPER,
 };
 use fission_core::input::text::TextInputController;
-use fission_core::input::{ControllerContext, InputController};
+use fission_core::input::{ControllerContext, InputController, TextEditingConvention};
 use fission_core::ui::widgets::text_input::{
     DragStartBehavior, TextInputRuntimeConfig, TextUndoController,
 };
@@ -49,19 +49,11 @@ impl Clipboard for MockClipboard {
 }
 
 fn primary_shortcut_modifier() -> u8 {
-    if cfg!(any(target_os = "macos", target_os = "ios")) {
-        MOD_SUPER
-    } else {
-        MOD_CTRL
-    }
+    MOD_CTRL
 }
 
 fn word_navigation_modifier() -> u8 {
-    if cfg!(any(target_os = "macos", target_os = "ios")) {
-        MOD_ALT
-    } else {
-        MOD_CTRL
-    }
+    MOD_CTRL
 }
 
 #[derive(Default)]
@@ -372,6 +364,31 @@ fn setup_ctx<'a>(
     clipboard: &'a Arc<dyn Clipboard>,
     measurer: Option<&'a Arc<dyn TextMeasurer>>,
 ) -> ControllerContext<'a> {
+    setup_ctx_with_convention(
+        ir,
+        layout,
+        text_edit,
+        interaction,
+        scroll,
+        gesture,
+        clipboard,
+        measurer,
+        TextEditingConvention::Standard,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn setup_ctx_with_convention<'a>(
+    ir: &'a CoreIR,
+    layout: &'a LayoutSnapshot,
+    text_edit: &'a mut TextEditStateMap,
+    interaction: &'a mut InteractionStateMap,
+    scroll: &'a mut ScrollStateMap,
+    gesture: &'a mut fission_core::env::GestureState,
+    clipboard: &'a Arc<dyn Clipboard>,
+    measurer: Option<&'a Arc<dyn TextMeasurer>>,
+    editing_convention: TextEditingConvention,
+) -> ControllerContext<'a> {
     let selectable_text = Box::leak(Box::new(SelectableTextStateMap::default()));
     let context_menu = Box::leak(Box::new(ContextMenuState::default()));
     ControllerContext {
@@ -383,6 +400,7 @@ fn setup_ctx<'a>(
         interaction,
         scroll,
         gesture,
+        editing_convention,
         clipboard: Some(clipboard),
         measurer,
         dispatched_actions: Vec::new(),
@@ -1519,21 +1537,204 @@ fn test_primary_shortcut_select_all() {
         Some(&measurer),
     );
 
-    let primary_mod = if cfg!(any(target_os = "macos", target_os = "ios")) {
-        MOD_SUPER
-    } else {
-        MOD_CTRL
-    };
-
     let event = InputEvent::Keyboard(KeyEvent::Down {
         key_code: KeyCode::Char('a'),
-        modifiers: primary_mod,
+        modifiers: MOD_CTRL,
     });
     assert!(controller.handle_event(&mut ctx, &event));
 
     let st = ctx.text_edit.get(node_id).unwrap();
     assert_eq!(st.anchor, 0);
     assert_eq!(st.caret, initial_text.len());
+}
+
+#[test]
+fn test_apple_primary_shortcut_is_runtime_selected() {
+    let node_id = WidgetId::derived(201, &[0]);
+    let initial_text = "Select everything";
+    let ir = create_text_node(node_id, initial_text, false);
+    let layout = LayoutSnapshot::new(LayoutSize::new(200.0, 100.0));
+    let mut text_edit = TextEditStateMap::default();
+    let mut interaction = InteractionStateMap::default();
+    let mut scroll = ScrollStateMap::default();
+    let mut gesture = fission_core::env::GestureState::default();
+    let clipboard: Arc<dyn Clipboard> = Arc::new(MockClipboard::new());
+    let measurer: Arc<dyn TextMeasurer> = Arc::new(MockTextMeasurer);
+
+    interaction.set_focused(Some(node_id));
+    text_edit.set_caret(node_id, 3, Some(3));
+    let mut ctx = setup_ctx_with_convention(
+        &ir,
+        &layout,
+        &mut text_edit,
+        &mut interaction,
+        &mut scroll,
+        &mut gesture,
+        &clipboard,
+        Some(&measurer),
+        TextEditingConvention::Apple,
+    );
+
+    assert!(TextInputController.handle_event(
+        &mut ctx,
+        &InputEvent::Keyboard(KeyEvent::Down {
+            key_code: KeyCode::Char('a'),
+            modifiers: MOD_SUPER,
+        }),
+    ));
+    let state = ctx.text_edit.get(node_id).expect("text edit state");
+    assert_eq!((state.anchor, state.caret), (0, initial_text.len()));
+}
+
+#[test]
+fn test_unhandled_primary_chord_is_not_inserted() {
+    for (convention, modifier) in [
+        (TextEditingConvention::Standard, MOD_CTRL),
+        (TextEditingConvention::Apple, MOD_SUPER),
+    ] {
+        let node_id = WidgetId::derived(202, &[modifier as u32]);
+        let ir = create_text_node(node_id, "", false);
+        let layout = LayoutSnapshot::new(LayoutSize::new(100.0, 40.0));
+        let mut text_edit = TextEditStateMap::default();
+        let mut interaction = InteractionStateMap::default();
+        let mut scroll = ScrollStateMap::default();
+        let mut gesture = fission_core::env::GestureState::default();
+        let clipboard: Arc<dyn Clipboard> = Arc::new(MockClipboard::new());
+        let measurer: Arc<dyn TextMeasurer> = Arc::new(MockTextMeasurer);
+        interaction.set_focused(Some(node_id));
+
+        let mut ctx = setup_ctx_with_convention(
+            &ir,
+            &layout,
+            &mut text_edit,
+            &mut interaction,
+            &mut scroll,
+            &mut gesture,
+            &clipboard,
+            Some(&measurer),
+            convention,
+        );
+        assert!(TextInputController.handle_event(
+            &mut ctx,
+            &InputEvent::Keyboard(KeyEvent::Down {
+                key_code: KeyCode::Char('q'),
+                modifiers: modifier,
+            }),
+        ));
+        assert!(ctx.dispatched_actions.is_empty());
+        assert_eq!(
+            ctx.text_edit
+                .get(node_id)
+                .expect("text edit state")
+                .committed_text(),
+            ""
+        );
+    }
+}
+
+#[test]
+fn test_standard_alt_gr_character_remains_text_input() {
+    let node_id = WidgetId::derived(203, &[0]);
+    let ir = create_text_node(node_id, "", false);
+    let layout = LayoutSnapshot::new(LayoutSize::new(100.0, 40.0));
+    let mut text_edit = TextEditStateMap::default();
+    let mut interaction = InteractionStateMap::default();
+    let mut scroll = ScrollStateMap::default();
+    let mut gesture = fission_core::env::GestureState::default();
+    let clipboard: Arc<dyn Clipboard> = Arc::new(MockClipboard::new());
+    let measurer: Arc<dyn TextMeasurer> = Arc::new(MockTextMeasurer);
+    interaction.set_focused(Some(node_id));
+
+    let mut ctx = setup_ctx(
+        &ir,
+        &layout,
+        &mut text_edit,
+        &mut interaction,
+        &mut scroll,
+        &mut gesture,
+        &clipboard,
+        Some(&measurer),
+    );
+    assert!(TextInputController.handle_event(
+        &mut ctx,
+        &InputEvent::Keyboard(KeyEvent::Down {
+            key_code: KeyCode::Char('€'),
+            modifiers: MOD_CTRL | MOD_ALT,
+        }),
+    ));
+    assert_eq!(
+        ctx.dispatched_actions[0].2.text_change().unwrap().new_text,
+        "€"
+    );
+}
+
+#[test]
+fn test_semantic_editing_commands_share_text_input_state() {
+    let node_id = WidgetId::derived(204, &[0]);
+    let ir = create_text_node(node_id, "abc", false);
+    let layout = LayoutSnapshot::new(LayoutSize::new(100.0, 40.0));
+    let mut text_edit = TextEditStateMap::default();
+    let mut interaction = InteractionStateMap::default();
+    let mut scroll = ScrollStateMap::default();
+    let mut gesture = fission_core::env::GestureState::default();
+    let clipboard: Arc<dyn Clipboard> = Arc::new(MockClipboard::new());
+    let measurer: Arc<dyn TextMeasurer> = Arc::new(MockTextMeasurer);
+    interaction.set_focused(Some(node_id));
+    let mut ctx = setup_ctx(
+        &ir,
+        &layout,
+        &mut text_edit,
+        &mut interaction,
+        &mut scroll,
+        &mut gesture,
+        &clipboard,
+        Some(&measurer),
+    );
+    let mut controller = TextInputController;
+
+    for command in [EditingCommand::SelectAll, EditingCommand::Copy] {
+        assert!(controller.handle_event(&mut ctx, &InputEvent::Editing(command)));
+    }
+    assert_eq!(clipboard.get_text().as_deref(), Some("abc"));
+
+    assert!(controller.handle_event(&mut ctx, &InputEvent::Editing(EditingCommand::Cut),));
+    assert_eq!(
+        ctx.text_edit
+            .get(node_id)
+            .expect("text edit state")
+            .committed_text(),
+        ""
+    );
+
+    assert!(controller.handle_event(
+        &mut ctx,
+        &InputEvent::Editing(EditingCommand::Paste("xyz".into())),
+    ));
+    assert_eq!(
+        ctx.text_edit
+            .get(node_id)
+            .expect("text edit state")
+            .committed_text(),
+        "xyz"
+    );
+
+    assert!(controller.handle_event(&mut ctx, &InputEvent::Editing(EditingCommand::Undo),));
+    assert_eq!(
+        ctx.text_edit
+            .get(node_id)
+            .expect("text edit state")
+            .committed_text(),
+        ""
+    );
+
+    assert!(controller.handle_event(&mut ctx, &InputEvent::Editing(EditingCommand::Redo),));
+    assert_eq!(
+        ctx.text_edit
+            .get(node_id)
+            .expect("text edit state")
+            .committed_text(),
+        "xyz"
+    );
 }
 
 #[test]
@@ -1581,10 +1782,6 @@ fn test_forward_delete_removes_next_grapheme() {
 
 #[test]
 fn test_apple_ctrl_bindings_cover_line_and_char_navigation() {
-    if !cfg!(any(target_os = "macos", target_os = "ios")) {
-        return;
-    }
-
     let node_id = WidgetId::derived(211, &[0]);
     let initial_text = "hello";
     let ir = create_text_node(node_id, initial_text, false);
@@ -1607,7 +1804,7 @@ fn test_apple_ctrl_bindings_cover_line_and_char_navigation() {
         (KeyCode::Char('a'), 0usize),
         (KeyCode::Char('e'), initial_text.len()),
     ] {
-        let mut ctx = setup_ctx(
+        let mut ctx = setup_ctx_with_convention(
             &ir,
             &layout,
             &mut text_edit,
@@ -1616,6 +1813,7 @@ fn test_apple_ctrl_bindings_cover_line_and_char_navigation() {
             &mut gesture,
             &clipboard,
             Some(&measurer),
+            TextEditingConvention::Apple,
         );
         let event = InputEvent::Keyboard(KeyEvent::Down {
             key_code,
@@ -1630,10 +1828,6 @@ fn test_apple_ctrl_bindings_cover_line_and_char_navigation() {
 
 #[test]
 fn test_apple_meta_delete_shortcuts_trim_current_line() {
-    if !cfg!(any(target_os = "macos", target_os = "ios")) {
-        return;
-    }
-
     let node_id = WidgetId::derived(213, &[0]);
     let initial_text = "hello world";
     let ir = create_text_node(node_id, initial_text, false);
@@ -1651,7 +1845,7 @@ fn test_apple_meta_delete_shortcuts_trim_current_line() {
     let mut controller = TextInputController;
 
     {
-        let mut ctx = setup_ctx(
+        let mut ctx = setup_ctx_with_convention(
             &ir,
             &layout,
             &mut text_edit,
@@ -1660,6 +1854,7 @@ fn test_apple_meta_delete_shortcuts_trim_current_line() {
             &mut gesture,
             &clipboard,
             Some(&measurer),
+            TextEditingConvention::Apple,
         );
         let event = InputEvent::Keyboard(KeyEvent::Down {
             key_code: KeyCode::Backspace,
@@ -1677,7 +1872,7 @@ fn test_apple_meta_delete_shortcuts_trim_current_line() {
     text_edit.set_caret(node_id, 6, Some(6));
 
     {
-        let mut ctx = setup_ctx(
+        let mut ctx = setup_ctx_with_convention(
             &ir,
             &layout,
             &mut text_edit,
@@ -1686,6 +1881,7 @@ fn test_apple_meta_delete_shortcuts_trim_current_line() {
             &mut gesture,
             &clipboard,
             Some(&measurer),
+            TextEditingConvention::Apple,
         );
         let event = InputEvent::Keyboard(KeyEvent::Down {
             key_code: KeyCode::Delete,
@@ -2119,14 +2315,9 @@ fn test_digits_only_formatter_filters_paste() {
         &clipboard,
         Some(&measurer),
     );
-    let paste_mod = if cfg!(any(target_os = "macos", target_os = "ios")) {
-        MOD_SUPER
-    } else {
-        MOD_CTRL
-    };
     let event = InputEvent::Keyboard(KeyEvent::Down {
         key_code: KeyCode::Char('v'),
-        modifiers: paste_mod,
+        modifiers: MOD_CTRL,
     });
     assert!(controller.handle_event(&mut ctx, &event));
     assert_eq!(

--- a/crates/core/fission-core/tests/pointer_button_input.rs
+++ b/crates/core/fission-core/tests/pointer_button_input.rs
@@ -1,0 +1,210 @@
+use fission_core::event::{InputEvent, PointerButton, PointerEvent};
+use fission_core::{ActionEnvelope, ActionId, GlobalState, Runtime};
+use fission_ir::semantics::ActionTrigger;
+use fission_ir::{
+    ActionEntry, ActionSet, CompositeStyle, CoreIR, CoreNode, Op, Role, Semantics, WidgetId,
+};
+use fission_layout::{LayoutNodeGeometry, LayoutPoint, LayoutRect, LayoutSize, LayoutSnapshot};
+
+#[derive(Debug, Default)]
+struct ClickState {
+    primary: usize,
+    secondary: usize,
+}
+
+impl GlobalState for ClickState {}
+
+#[test]
+fn primary_click_dispatches_default_action_only() -> anyhow::Result<()> {
+    let (mut runtime, ir, layout, _) = click_runtime(true)?;
+
+    click(
+        &mut runtime,
+        &ir,
+        &layout,
+        PointerButton::Primary,
+        PointerButton::Primary,
+    )?;
+
+    let state = runtime.get_app_state::<ClickState>().expect("click state");
+    assert_eq!(state.primary, 1);
+    assert_eq!(state.secondary, 0);
+    Ok(())
+}
+
+#[test]
+fn secondary_click_never_falls_through_to_default_action() -> anyhow::Result<()> {
+    let (mut runtime, ir, layout, node_id) = click_runtime(true)?;
+
+    click(
+        &mut runtime,
+        &ir,
+        &layout,
+        PointerButton::Secondary,
+        PointerButton::Secondary,
+    )?;
+
+    let state = runtime.get_app_state::<ClickState>().expect("click state");
+    assert_eq!(state.primary, 0);
+    assert_eq!(state.secondary, 1);
+    assert_eq!(runtime.runtime_state.interaction.focused, None);
+    assert!(!runtime.runtime_state.interaction.is_pressed(node_id));
+    Ok(())
+}
+
+#[test]
+fn secondary_click_without_secondary_action_does_not_activate_default() -> anyhow::Result<()> {
+    let (mut runtime, ir, layout, _) = click_runtime(false)?;
+
+    click(
+        &mut runtime,
+        &ir,
+        &layout,
+        PointerButton::Secondary,
+        PointerButton::Secondary,
+    )?;
+
+    let state = runtime.get_app_state::<ClickState>().expect("click state");
+    assert_eq!(state.primary, 0);
+    assert_eq!(state.secondary, 0);
+    Ok(())
+}
+
+#[test]
+fn mismatched_pointer_buttons_cancel_activation() -> anyhow::Result<()> {
+    let (mut runtime, ir, layout, _) = click_runtime(true)?;
+
+    click(
+        &mut runtime,
+        &ir,
+        &layout,
+        PointerButton::Secondary,
+        PointerButton::Primary,
+    )?;
+
+    let state = runtime.get_app_state::<ClickState>().expect("click state");
+    assert_eq!(state.primary, 0);
+    assert_eq!(state.secondary, 0);
+    Ok(())
+}
+
+#[test]
+fn primary_release_without_primary_press_does_not_activate_default() -> anyhow::Result<()> {
+    let (mut runtime, ir, layout, _) = click_runtime(true)?;
+    let point = LayoutPoint::new(20.0, 20.0);
+
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Up {
+            point,
+            button: PointerButton::Primary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+
+    let state = runtime.get_app_state::<ClickState>().expect("click state");
+    assert_eq!(state.primary, 0);
+    assert_eq!(state.secondary, 0);
+    Ok(())
+}
+
+fn click_runtime(
+    with_secondary_action: bool,
+) -> anyhow::Result<(Runtime, CoreIR, LayoutSnapshot, WidgetId)> {
+    let node_id = WidgetId::explicit("button");
+    let primary_id = ActionId::from_name("pointer_button_test::Primary");
+    let secondary_id = ActionId::from_name("pointer_button_test::Secondary");
+    let mut entries = vec![action_entry(ActionTrigger::Default, primary_id)];
+    if with_secondary_action {
+        entries.push(action_entry(ActionTrigger::SecondaryClick, secondary_id));
+    }
+
+    let mut ir = CoreIR::default();
+    ir.root = Some(node_id);
+    ir.nodes.insert(
+        node_id,
+        CoreNode {
+            id: node_id,
+            op: Op::Semantics(Semantics {
+                role: Role::Button,
+                focusable: true,
+                actions: ActionSet { entries },
+                ..Default::default()
+            }),
+            composite: CompositeStyle::default(),
+            children: Vec::new(),
+            parent: None,
+            hash: 0,
+        },
+    );
+
+    let mut layout = LayoutSnapshot::new(LayoutSize::new(200.0, 100.0));
+    layout.nodes.insert(
+        node_id,
+        LayoutNodeGeometry {
+            rect: LayoutRect::new(10.0, 10.0, 100.0, 40.0),
+            content_size: LayoutSize::new(100.0, 40.0),
+        },
+    );
+
+    let mut runtime = Runtime::default();
+    runtime.add_app_state(Box::new(ClickState::default()))?;
+    runtime.register_reducer::<ClickState>(primary_id, record_primary)?;
+    runtime.register_reducer::<ClickState>(secondary_id, record_secondary)?;
+    Ok((runtime, ir, layout, node_id))
+}
+
+fn action_entry(trigger: ActionTrigger, action_id: ActionId) -> ActionEntry {
+    ActionEntry {
+        trigger,
+        action_id: action_id.as_u128(),
+        payload_data: Some(Vec::new()),
+    }
+}
+
+fn click(
+    runtime: &mut Runtime,
+    ir: &CoreIR,
+    layout: &LayoutSnapshot,
+    down_button: PointerButton,
+    up_button: PointerButton,
+) -> anyhow::Result<()> {
+    let point = LayoutPoint::new(20.0, 20.0);
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Down {
+            point,
+            button: down_button,
+            modifiers: 0,
+        }),
+        ir,
+        layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Up {
+            point,
+            button: up_button,
+            modifiers: 0,
+        }),
+        ir,
+        layout,
+    )
+}
+
+fn record_primary(
+    state: &mut ClickState,
+    _action: &ActionEnvelope,
+    _target: WidgetId,
+) -> anyhow::Result<()> {
+    state.primary += 1;
+    Ok(())
+}
+
+fn record_secondary(
+    state: &mut ClickState,
+    _action: &ActionEnvelope,
+    _target: WidgetId,
+) -> anyhow::Result<()> {
+    state.secondary += 1;
+    Ok(())
+}

--- a/crates/core/fission-core/tests/pointer_button_input.rs
+++ b/crates/core/fission-core/tests/pointer_button_input.rs
@@ -109,6 +109,25 @@ fn primary_release_without_primary_press_does_not_activate_default() -> anyhow::
     Ok(())
 }
 
+#[test]
+fn semantic_context_menu_request_dispatches_secondary_only() -> anyhow::Result<()> {
+    let (mut runtime, ir, layout, _) = click_runtime(true)?;
+
+    runtime.handle_input(
+        InputEvent::ContextMenuRequested {
+            point: LayoutPoint::new(20.0, 20.0),
+            modifiers: 0,
+        },
+        &ir,
+        &layout,
+    )?;
+
+    let state = runtime.get_app_state::<ClickState>().expect("click state");
+    assert_eq!(state.primary, 0);
+    assert_eq!(state.secondary, 1);
+    Ok(())
+}
+
 fn click_runtime(
     with_secondary_action: bool,
 ) -> anyhow::Result<(Runtime, CoreIR, LayoutSnapshot, WidgetId)> {

--- a/crates/core/fission-core/tests/scrollbar_input.rs
+++ b/crates/core/fission-core/tests/scrollbar_input.rs
@@ -4,7 +4,7 @@ use fission_core::env::{
 };
 use fission_core::event::{InputEvent, PointerButton, PointerEvent};
 use fission_core::input::gesture::GestureController;
-use fission_core::input::{ControllerContext, InputController};
+use fission_core::input::{ControllerContext, InputController, TextEditingConvention};
 use fission_core::scrollbar::scrollbar_geometry_for_node;
 use fission_core::Runtime;
 use fission_ir::{CompositeStyle, CoreIR, CoreNode, FlexDirection, LayoutOp, Op, WidgetId};
@@ -50,6 +50,7 @@ fn dragging_scrollbar_thumb_updates_scroll_offset_directly() {
         interaction: &mut interaction,
         scroll: &mut scroll_map,
         gesture: &mut gesture,
+        editing_convention: TextEditingConvention::Standard,
         clipboard: Some(&clipboard),
         measurer: None,
         dispatched_actions: Vec::new(),
@@ -158,6 +159,7 @@ fn dragging_nested_scrollbar_uses_visual_pointer_coordinates() {
         interaction: &mut interaction,
         scroll: &mut scroll_map,
         gesture: &mut gesture,
+        editing_convention: TextEditingConvention::Standard,
         clipboard: Some(&clipboard),
         measurer: None,
         dispatched_actions: Vec::new(),

--- a/crates/core/fission-core/tests/slider_input.rs
+++ b/crates/core/fission-core/tests/slider_input.rs
@@ -50,6 +50,43 @@ fn slider_pointer_up_does_not_replay_template_change_payload() -> anyhow::Result
     Ok(())
 }
 
+#[test]
+fn secondary_click_does_not_change_slider_value() -> anyhow::Result<()> {
+    let action_id = ActionId::from_name("fission_core_test::SliderChanged");
+    let slider_id = WidgetId::explicit("slider");
+    let (ir, layout) = slider_tree(slider_id, action_id);
+    let mut runtime = Runtime::default();
+    runtime.add_app_state(Box::new(SliderState::default()))?;
+    runtime.register_reducer::<SliderState>(action_id, record_slider_change)?;
+
+    let point = LayoutPoint::new(150.0, 20.0);
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Down {
+            point,
+            button: PointerButton::Secondary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+    runtime.handle_input(
+        InputEvent::Pointer(PointerEvent::Up {
+            point,
+            button: PointerButton::Secondary,
+            modifiers: 0,
+        }),
+        &ir,
+        &layout,
+    )?;
+
+    let state = runtime
+        .get_app_state::<SliderState>()
+        .expect("slider state");
+    assert_eq!(state.changes, 0);
+    assert_eq!(state.value, 0.0);
+    Ok(())
+}
+
 fn record_slider_change(
     state: &mut SliderState,
     action: &ActionEnvelope,

--- a/crates/core/fission-core/tests/text_input_contextual_actions.rs
+++ b/crates/core/fission-core/tests/text_input_contextual_actions.rs
@@ -6,7 +6,8 @@ use fission_core::env::{
 use fission_core::event::{ImeEvent, InputEvent, KeyCode, KeyEvent};
 use fission_core::input::text::TextInputController;
 use fission_core::input::{
-    prepare_scoped_text_input_change, prepare_text_input_change, ControllerContext, InputController,
+    prepare_scoped_text_input_change, prepare_text_input_change, ControllerContext,
+    InputController, TextEditingConvention,
 };
 use fission_core::internal::{self, BuildCtx};
 use fission_core::ui::{Column, TextInput, Widget};
@@ -212,6 +213,7 @@ fn dispatch_native_edit(
         interaction: &mut interaction,
         scroll: &mut scroll,
         gesture: &mut gesture,
+        editing_convention: TextEditingConvention::Standard,
         clipboard: None,
         measurer: None,
         dispatched_actions: Vec::new(),

--- a/crates/core/fission-layout/src/lib.rs
+++ b/crates/core/fission-layout/src/lib.rs
@@ -3215,15 +3215,12 @@ impl LayoutEngine {
                             child_constraints.max_w = intrinsic_width;
                         }
                         let tight_width = child_constraints.min_w == child_constraints.max_w;
+                        // Stretch consumes space the box actually owns. A finite maximum on an
+                        // auto-sized axis is only a bound: tightening it here makes intrinsic
+                        // surfaces such as flyouts expand to the viewport.
                         let stretch_width =
                             tight_width && child_width.is_none() && child_max_width.is_none();
-                        if matches!(box_alignment, fission_ir::op::BoxAlignment::Stretch)
-                            && child_width.is_none()
-                            && child_max_width.is_none()
-                            && child_constraints.max_w.is_finite()
-                        {
-                            child_constraints.min_w = child_constraints.max_w;
-                        } else if stretch_width {
+                        if stretch_width {
                             child_constraints.min_w = child_constraints.max_w;
                         } else if tight_width
                             && (child_width.is_some() || child_max_width.is_some())
@@ -3233,13 +3230,7 @@ impl LayoutEngine {
                         let tight_height = child_constraints.min_h == child_constraints.max_h;
                         let stretch_height =
                             tight_height && child_height.is_none() && child_max_height.is_none();
-                        if matches!(box_alignment, fission_ir::op::BoxAlignment::Stretch)
-                            && child_height.is_none()
-                            && child_max_height.is_none()
-                            && child_constraints.max_h.is_finite()
-                        {
-                            child_constraints.min_h = child_constraints.max_h;
-                        } else if stretch_height {
+                        if stretch_height {
                             child_constraints.min_h = child_constraints.max_h;
                         } else if tight_height
                             && (child_height.is_some() || child_max_height.is_some())

--- a/crates/core/fission-layout/tests/box_layout_test.rs
+++ b/crates/core/fission-layout/tests/box_layout_test.rs
@@ -1,3 +1,6 @@
+use fission_ir::op::{
+    AlignItems, BoxAlignment, BoxStyle, FlexDirection, FlexWrap, JustifyContent, Length,
+};
 use fission_ir::{LayoutOp as IrLayoutOp, WidgetId};
 use fission_layout::{LayoutEngine, LayoutInputNode, LayoutSize};
 #[test]
@@ -79,4 +82,102 @@ fn test_box_default_stretch() {
         50.0,
         "Box child should keep fixed height"
     );
+}
+
+#[test]
+fn stretch_box_shrink_wraps_child_on_loose_axis() {
+    let flyout = WidgetId::from_u128(10);
+    let content = WidgetId::from_u128(11);
+    let column = WidgetId::from_u128(12);
+    let first = WidgetId::from_u128(13);
+    let divider = WidgetId::from_u128(14);
+    let second = WidgetId::from_u128(15);
+    let anchor = WidgetId::from_u128(16);
+    let layout_node = |id, parent_id, children_ids, op, width, height| LayoutInputNode {
+        id,
+        parent_id,
+        op,
+        children_ids,
+        debug_name: format!("node-{}", id.as_u128()),
+        width,
+        height,
+        flex_grow: 0.0,
+        flex_shrink: 1.0,
+        rich_text: None,
+    };
+    let fixed_box = |id, height| {
+        layout_node(
+            id,
+            Some(column),
+            vec![],
+            IrLayoutOp::Box {
+                width: Some(150.0),
+                height: Some(height),
+                min_width: None,
+                max_width: None,
+                min_height: None,
+                max_height: None,
+                padding: [0.0; 4],
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+                aspect_ratio: None,
+            },
+            Some(150.0),
+            Some(height),
+        )
+    };
+    let nodes = vec![
+        layout_node(
+            flyout,
+            None,
+            vec![content],
+            IrLayoutOp::Flyout { anchor, content },
+            None,
+            None,
+        ),
+        layout_node(
+            content,
+            Some(flyout),
+            vec![column],
+            IrLayoutOp::StyledBox {
+                style: BoxStyle {
+                    width: Some(Length::points(158.0)),
+                    padding: Some(Length::all(Length::points(4.0))),
+                    alignment: BoxAlignment::Stretch,
+                    ..Default::default()
+                },
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+            },
+            None,
+            None,
+        ),
+        layout_node(
+            column,
+            Some(content),
+            vec![first, divider, second],
+            IrLayoutOp::Flex {
+                direction: FlexDirection::Column,
+                wrap: FlexWrap::NoWrap,
+                flex_grow: 0.0,
+                flex_shrink: 1.0,
+                padding: [0.0; 4],
+                gap: Some(2.0),
+                align_items: AlignItems::Stretch,
+                justify_content: JustifyContent::Start,
+            },
+            None,
+            None,
+        ),
+        fixed_box(first, 36.0),
+        fixed_box(divider, 1.0),
+        fixed_box(second, 36.0),
+    ];
+    let mut engine = LayoutEngine::new();
+    let snapshot = engine
+        .compute_layout(&nodes, flyout, LayoutSize::new(1440.0, 757.0), &|_| 0.0)
+        .expect("intrinsic flyout layout");
+
+    assert_eq!(snapshot.nodes[&column].rect.height(), 77.0);
+    assert_eq!(snapshot.nodes[&content].rect.height(), 85.0);
 }

--- a/crates/shell/fission-shell-web/README.md
+++ b/crates/shell/fission-shell-web/README.md
@@ -14,11 +14,31 @@ What is ready today:
 - checked-in `examples/web-smoke/` browser example
 - first-party `fission add-target web` launcher output
 - Chromium live testing through `fission test --target web` and `LiveTestClient`
+- Fission-owned keyboard shortcuts, clipboard events, contextual actions, and
+  IME composition
+- deny-by-default browser behavior with explicit `BrowserDefaults` opt-ins
 
 What is still missing:
 
-- richer browser integration for clipboard, drag-and-drop, and IME edge cases
+- browser autocorrect/autofill and soft-keyboard replacement edge cases
 - Firefox and WebKit live-test drivers
+
+## Browser defaults
+
+Fission suppresses browser behavior by default so application input is
+consistent with native targets. Delegate only the categories your application
+intentionally wants the browser to own:
+
+```rust
+WebApp::new(App)
+    .with_browser_defaults(
+        BrowserDefaults::CONTEXT_MENU | BrowserDefaults::WHEEL,
+    )
+    .run()
+```
+
+Categories not included in the allowlist remain Fission-owned. The default is
+`BrowserDefaults::NONE`.
 
 ## WASM prerequisites
 

--- a/crates/shell/fission-shell-web/src/lib.rs
+++ b/crates/shell/fission-shell-web/src/lib.rs
@@ -4,12 +4,12 @@ use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
 pub use fission_shell_winit::{
-    BarcodeScannerHost, BiometricHost, BluetoothHost, CameraHost, ClipboardHost, GeolocationHost,
-    HapticHost, MemoryBarcodeScannerHost, MemoryBiometricHost, MemoryBluetoothHost,
-    MemoryCameraHost, MemoryClipboardHost, MemoryGeolocationHost, MemoryHapticHost,
-    MemoryMicrophoneHost, MemoryNfcHost, MemoryNotificationHost, MemoryPasskeyHost,
-    MemoryVolumeHost, MemoryWifiHost, MicrophoneHost, NfcHost, NotificationHost, PasskeyHost,
-    UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedBluetoothHost,
+    BarcodeScannerHost, BiometricHost, BluetoothHost, BrowserDefaults, CameraHost, ClipboardHost,
+    GeolocationHost, HapticHost, MemoryBarcodeScannerHost, MemoryBiometricHost,
+    MemoryBluetoothHost, MemoryCameraHost, MemoryClipboardHost, MemoryGeolocationHost,
+    MemoryHapticHost, MemoryMicrophoneHost, MemoryNfcHost, MemoryNotificationHost,
+    MemoryPasskeyHost, MemoryVolumeHost, MemoryWifiHost, MicrophoneHost, NfcHost, NotificationHost,
+    PasskeyHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost, UnsupportedBluetoothHost,
     UnsupportedCameraHost, UnsupportedGeolocationHost, UnsupportedHapticHost,
     UnsupportedMicrophoneHost, UnsupportedNfcHost, UnsupportedNotificationHost,
     UnsupportedPasskeyHost, UnsupportedVolumeHost, UnsupportedWifiHost, VolumeHost, WifiHost,
@@ -51,6 +51,13 @@ where
 
     pub fn with_mount_selector(mut self, selector: impl Into<String>) -> Self {
         self.inner = self.inner.with_mount_selector(selector);
+        self
+    }
+
+    /// Selectively permits browser-owned defaults. Fission owns every browser
+    /// input category unless it is explicitly included here.
+    pub fn with_browser_defaults(mut self, defaults: BrowserDefaults) -> Self {
+        self.inner = self.inner.with_browser_defaults(defaults);
         self
     }
 

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -49,6 +49,7 @@ bincode = "1.3"
 base64 = "0.22"
 tray-icon = { version = "0.24", optional = true }
 futures-core = "0.3"
+log = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = "2"
@@ -92,6 +93,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 web-time = "1.1"
+tracing-wasm = "0.2.1"
 web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "console", "CssStyleDeclaration", "Document", "Element", "Headers", "HtmlCanvasElement", "HtmlElement", "HtmlMediaElement", "HtmlVideoElement", "ImageData", "Location", "Node", "Request", "RequestInit", "RequestMode", "Response", "Window"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -96,7 +96,7 @@ use vello::util::{RenderContext, RenderSurface};
 use vello::wgpu;
 use vello::{AaSupport, Renderer as VelloSceneRenderer, RendererOptions, Scene};
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen::{Clamped, JsCast};
+use wasm_bindgen::{Clamped, JsCast, JsValue};
 #[cfg(target_arch = "wasm32")]
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, ImageData};
 #[cfg(target_arch = "wasm32")]
@@ -1045,6 +1045,29 @@ fn preferred_surface_alpha_mode(
         .unwrap_or(wgpu::CompositeAlphaMode::Opaque)
 }
 
+fn preferred_web_surface_alpha_mode(
+    supported: &[wgpu::CompositeAlphaMode],
+) -> wgpu::CompositeAlphaMode {
+    supported
+        .iter()
+        .copied()
+        .find(|mode| *mode == wgpu::CompositeAlphaMode::Opaque)
+        .or_else(|| {
+            supported
+                .iter()
+                .copied()
+                .find(|mode| *mode == wgpu::CompositeAlphaMode::PreMultiplied)
+        })
+        .or_else(|| {
+            supported
+                .iter()
+                .copied()
+                .find(|mode| *mode == wgpu::CompositeAlphaMode::PostMultiplied)
+        })
+        .or_else(|| supported.first().copied())
+        .unwrap_or(wgpu::CompositeAlphaMode::Opaque)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SurfaceAcquireRecovery {
@@ -1115,7 +1138,17 @@ async fn create_webgpu_presenter(
 
     let device_handle = &render_cx.devices[surface.dev_id];
     let surface_caps = surface.surface.get_capabilities(device_handle.adapter());
-    surface.config.alpha_mode = preferred_surface_alpha_mode(&surface_caps.alpha_modes);
+    surface.config.alpha_mode = preferred_web_surface_alpha_mode(&surface_caps.alpha_modes);
+    surface.blitter =
+        wgpu::util::TextureBlitterBuilder::new(&device_handle.device, surface.config.format)
+            .blend_state(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING)
+            .build();
+    log::info!(
+        "Fission WebGPU canvas surface: format={:?}, alpha_mode={:?}, supported_alpha_modes={:?}",
+        surface.config.format,
+        surface.config.alpha_mode,
+        surface_caps.alpha_modes,
+    );
     surface
         .surface
         .configure(&device_handle.device, &surface.config);
@@ -1167,6 +1200,7 @@ async fn create_webgpu_presenter(
 fn create_webgpu_main_renderer(
     device_handle: &vello::util::DeviceHandle,
     request: RendererRequest,
+    use_indirect_dispatch: bool,
 ) -> anyhow::Result<MainRenderer> {
     if matches!(request, RendererRequest::Canvas2dSoftware) {
         return Err(anyhow::anyhow!(
@@ -1177,7 +1211,7 @@ fn create_webgpu_main_renderer(
         &device_handle.device,
         RendererOptions {
             use_cpu: false,
-            use_indirect_dispatch: true,
+            use_indirect_dispatch,
             antialiasing_support: AaSupport::all(),
             num_init_threads: None,
             pipeline_cache: None,
@@ -1198,33 +1232,61 @@ async fn create_validated_webgpu_main_renderer(
     request: RendererRequest,
 ) -> anyhow::Result<MainRenderer> {
     let device = &device_handle.device;
-    device.push_error_scope(wgpu::ErrorFilter::Validation);
-    device.push_error_scope(wgpu::ErrorFilter::OutOfMemory);
-    device.push_error_scope(wgpu::ErrorFilter::Internal);
+    let mut failures = Vec::new();
 
-    let result = create_webgpu_main_renderer(device_handle, request).and_then(|mut renderer| {
-        preflight_webgpu_main_renderer(device_handle, &mut renderer)?;
-        Ok(renderer)
-    });
+    for use_indirect_dispatch in [true, false] {
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+        device.push_error_scope(wgpu::ErrorFilter::OutOfMemory);
+        device.push_error_scope(wgpu::ErrorFilter::Internal);
 
-    let mut gpu_errors = Vec::new();
-    for stage in ["internal", "out-of-memory", "validation"] {
-        if let Some(error) = device.pop_error_scope().await {
-            gpu_errors.push(format!("{stage}: {error}"));
+        let result =
+            match create_webgpu_main_renderer(device_handle, request, use_indirect_dispatch) {
+                Ok(mut renderer) => preflight_webgpu_main_renderer(device_handle, &mut renderer)
+                    .await
+                    .map(|()| renderer),
+                Err(error) => Err(error),
+            };
+
+        let mut gpu_errors = Vec::new();
+        for stage in ["internal", "out-of-memory", "validation"] {
+            if let Some(error) = device.pop_error_scope().await {
+                gpu_errors.push(format!("{stage}: {error}"));
+            }
+        }
+
+        match (result, gpu_errors.is_empty()) {
+            (Ok(renderer), true) => {
+                log::info!(
+                    "Fission WebGPU Vello pixel preflight passed: indirect_dispatch={use_indirect_dispatch}"
+                );
+                return Ok(renderer);
+            }
+            (result, _) => {
+                let mode = if use_indirect_dispatch {
+                    "indirect"
+                } else {
+                    "direct"
+                };
+                let mut reasons = Vec::new();
+                if let Err(error) = result {
+                    reasons.push(error.to_string());
+                }
+                reasons.extend(gpu_errors);
+                let failure = format!("{mode} dispatch: {}", reasons.join("; "));
+                log::warn!("Fission WebGPU Vello pixel preflight failed: {failure}");
+                failures.push(failure);
+            }
         }
     }
-    if !gpu_errors.is_empty() {
-        return Err(anyhow::anyhow!(
-            "webgpu Vello preflight failed: {}",
-            gpu_errors.join("; ")
-        ));
-    }
 
-    result
+    Err(anyhow::anyhow!(
+        "webgpu Vello pixel preflight failed: {}",
+        failures.join(" | ")
+    ))
 }
 
 #[cfg(target_arch = "wasm32")]
-fn preflight_webgpu_main_renderer(
+async fn preflight_webgpu_main_renderer(
     device_handle: &vello::util::DeviceHandle,
     renderer: &mut MainRenderer,
 ) -> anyhow::Result<()> {
@@ -1244,7 +1306,9 @@ fn preflight_webgpu_main_renderer(
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
+            usage: wgpu::TextureUsages::STORAGE_BINDING
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
             view_formats: &[],
         });
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -1256,8 +1320,34 @@ fn preflight_webgpu_main_renderer(
         None,
         &vello::kurbo::Rect::new(0.0, 0.0, 16.0, 16.0),
     );
+    let workload_profile = vello::RenderWorkloadProfile {
+        target: vello::TargetProfile {
+            width_px: 16,
+            height_px: 16,
+            scale_factor: 1.0,
+            dirty_tiles: None,
+        },
+        coverage: vello::TileCoverageProfile {
+            tile_width: 16,
+            tile_height: 16,
+            target_tiles: 1,
+            visible_tiles: 1,
+            total_draw_tile_coverage: 1,
+            total_path_tile_coverage: 1,
+            max_ops_per_tile: 1,
+            max_blend_depth: 0,
+        },
+        scene: vello::SceneComplexityProfile {
+            draw_ops: 1,
+            path_ops: 1,
+            path_points: 4,
+            estimated_path_segments: 4,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
     renderer
-        .render_to_texture(
+        .render_to_texture_with_workload_profile(
             &device_handle.device,
             &device_handle.queue,
             &scene,
@@ -1268,8 +1358,89 @@ fn preflight_webgpu_main_renderer(
                 height: 16,
                 antialiasing_method: vello::AaConfig::Area,
             },
+            Some(&workload_profile),
         )
-        .map_err(|error| anyhow::anyhow!("webgpu Vello preflight submission failed: {error}"))
+        .map_err(|error| {
+            anyhow::anyhow!("webgpu profiled Vello preflight submission failed: {error}")
+        })?;
+
+    const BYTES_PER_ROW: u32 = 256;
+    const HEIGHT: u32 = 16;
+    let readback = device_handle.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Fission WebGPU Vello preflight readback"),
+        size: u64::from(BYTES_PER_ROW * HEIGHT),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder =
+        device_handle
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Fission WebGPU Vello preflight readback encoder"),
+            });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(BYTES_PER_ROW),
+                rows_per_image: Some(HEIGHT),
+            },
+        },
+        wgpu::Extent3d {
+            width: 16,
+            height: HEIGHT,
+            depth_or_array_layers: 1,
+        },
+    );
+    device_handle.queue.submit(Some(encoder.finish()));
+
+    let promise = js_sys::Promise::new(&mut |resolve, reject| {
+        let resolve = resolve.clone();
+        let reject = reject.clone();
+        readback
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |result| match result {
+                Ok(()) => {
+                    let _ = resolve.call0(&JsValue::UNDEFINED);
+                }
+                Err(error) => {
+                    let _ =
+                        reject.call1(&JsValue::UNDEFINED, &JsValue::from_str(&error.to_string()));
+                }
+            });
+    });
+    wasm_bindgen_futures::JsFuture::from(promise)
+        .await
+        .map_err(|error| anyhow::anyhow!("webgpu Vello preflight readback failed: {error:?}"))?;
+
+    let mapped = readback.slice(..).get_mapped_range();
+    let mut non_black = 0_u32;
+    let mut non_transparent = 0_u32;
+    for row in mapped
+        .chunks_exact(BYTES_PER_ROW as usize)
+        .take(HEIGHT as usize)
+    {
+        for pixel in row[..16 * 4].chunks_exact(4) {
+            non_black = non_black.saturating_add(u32::from(pixel[..3] != [0, 0, 0]));
+            non_transparent = non_transparent.saturating_add(u32::from(pixel[3] != 0));
+        }
+    }
+    drop(mapped);
+    readback.unmap();
+
+    if non_black == 0 || non_transparent == 0 {
+        return Err(anyhow::anyhow!(
+            "webgpu Vello preflight produced an empty texture (non_black={non_black}, non_transparent={non_transparent})"
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -7850,6 +8021,31 @@ where
                                                             label: Some("WebGPU Surface Blit"),
                                                         },
                                                     );
+                                                {
+                                                    let _pass = encoder.begin_render_pass(
+                                                        &wgpu::RenderPassDescriptor {
+                                                            label: Some(
+                                                                "Fission WebGPU Surface Clear",
+                                                            ),
+                                                            color_attachments: &[Some(
+                                                                wgpu::RenderPassColorAttachment {
+                                                                    view: &surface_view,
+                                                                    resolve_target: None,
+                                                                    depth_slice: None,
+                                                                    ops: wgpu::Operations {
+                                                                        load: wgpu::LoadOp::Clear(
+                                                                            clear_color,
+                                                                        ),
+                                                                        store: wgpu::StoreOp::Store,
+                                                                    },
+                                                                },
+                                                            )],
+                                                            depth_stencil_attachment: None,
+                                                            timestamp_writes: None,
+                                                            occlusion_query_set: None,
+                                                        },
+                                                    );
+                                                }
                                                 presenter.render_state.surface.blitter.copy(
                                                     &device_handle.device,
                                                     &mut encoder,
@@ -9263,9 +9459,9 @@ mod tests {
         native_window_size_for_logical_viewport, normalize_scale_factor,
         normalize_winit_scroll_delta, physical_position_to_layout_point,
         physical_size_to_layout_size, preferred_native_present_mode, preferred_surface_alpha_mode,
-        present_frame_with_winit_coordination, rect_visible_in_scroll_ancestors,
-        repeating_animation_redraw_interval, resize_is_unsettled, resolve_build_viewport,
-        resolve_selector_record, should_auto_select_native_software,
+        preferred_web_surface_alpha_mode, present_frame_with_winit_coordination,
+        rect_visible_in_scroll_ancestors, repeating_animation_redraw_interval, resize_is_unsettled,
+        resolve_build_viewport, resolve_selector_record, should_auto_select_native_software,
         should_present_startup_clear_frame, surface_acquire_recovery,
         sync_tracked_target_texture_size_to_surface, texture_plans_fit_device_limits,
         visual_rect_for_node, window_insets_from_safe_area_frames, windows_shell_execute_succeeded,
@@ -9425,6 +9621,22 @@ mod tests {
             PostMultiplied
         );
         assert_eq!(preferred_surface_alpha_mode(&[]), Opaque);
+    }
+
+    #[test]
+    fn web_surface_prefers_opaque_composition() {
+        use super::wgpu::CompositeAlphaMode::{Inherit, Opaque, PostMultiplied, PreMultiplied};
+
+        assert_eq!(
+            preferred_web_surface_alpha_mode(&[PreMultiplied, Opaque, PostMultiplied]),
+            Opaque
+        );
+        assert_eq!(
+            preferred_web_surface_alpha_mode(&[PostMultiplied, PreMultiplied]),
+            PreMultiplied
+        );
+        assert_eq!(preferred_web_surface_alpha_mode(&[Inherit]), Inherit);
+        assert_eq!(preferred_web_surface_alpha_mode(&[]), Opaque);
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -1234,11 +1234,7 @@ async fn create_validated_webgpu_main_renderer(
     let device = &device_handle.device;
     let mut failures = Vec::new();
 
-    // BrowserWebGpu can successfully execute a trivial indirect workload while
-    // silently producing an empty target for a real retained scene. Prefer the
-    // conservative direct-dispatch recording on the web; it remains fully GPU
-    // accelerated and avoids depending on GPU-written dispatch counts.
-    for use_indirect_dispatch in [false, true] {
+    for use_indirect_dispatch in [true, false] {
         device.push_error_scope(wgpu::ErrorFilter::Validation);
         device.push_error_scope(wgpu::ErrorFilter::OutOfMemory);
         device.push_error_scope(wgpu::ErrorFilter::Internal);
@@ -7943,14 +7939,6 @@ where
                                                                     .expect(
                                                                         "failed to encode retained scene",
                                                                     );
-                                                            let workload_profile =
-                                                                workload_profile_for_encoded_scene(
-                                                                    retained_scene,
-                                                                    &presenter.scene,
-                                                                    render_target_size.0,
-                                                                    render_target_size.1,
-                                                                    scale_factor,
-                                                                );
                                                             if web_rendered_frames == 0 {
                                                                 let encoding =
                                                                     presenter.scene.encoding();
@@ -7966,20 +7954,19 @@ where
                                                                 );
                                                             }
                                                             renderer
-                                                                    .render_to_texture_with_workload_profile(
-                                                                        &device_handle.device,
-                                                                        &device_handle.queue,
-                                                                        &presenter.scene,
-                                                                        &presenter
-                                                                            .render_state
-                                                                            .surface
-                                                                            .target_view,
-                                                                        &render_params,
-                                                                        Some(&workload_profile),
-                                                                    )
-                                                                    .expect(
-                                                                        "failed to render webgpu frame",
-                                                                    );
+                                                                .render_to_texture(
+                                                                    &device_handle.device,
+                                                                    &device_handle.queue,
+                                                                    &presenter.scene,
+                                                                    &presenter
+                                                                        .render_state
+                                                                        .surface
+                                                                        .target_view,
+                                                                    &render_params,
+                                                                )
+                                                                .expect(
+                                                                    "failed to render webgpu frame",
+                                                                );
                                                         } else {
                                                             let force_full_compositor_redraw =
                                                                 invalidations.build

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -4,6 +4,22 @@
     allow(dead_code, unused_imports, unused_variables)
 )]
 
+macro_rules! eprintln {
+    () => {{
+        #[cfg(target_arch = "wasm32")]
+        crate::web_console::error("");
+        #[cfg(not(target_arch = "wasm32"))]
+        std::eprintln!();
+    }};
+    ($($arg:tt)*) => {{
+        let message = format!($($arg)*);
+        #[cfg(target_arch = "wasm32")]
+        crate::web_console::error(&message);
+        #[cfg(not(target_arch = "wasm32"))]
+        std::eprintln!("{message}");
+    }};
+}
+
 use anyhow::Result;
 use base64::Engine;
 use fission_core::internal::BuildCtx;
@@ -98,6 +114,8 @@ use renderer_diagnostics::renderer_request_from_value;
 use renderer_diagnostics::{emit_renderer_report, RendererReport, RendererRequest};
 mod software_fonts;
 mod software_renderer;
+#[cfg(target_arch = "wasm32")]
+mod web_console;
 use software_renderer::SoftwareRenderer;
 mod native_surface;
 use native_surface::NativeSurfaceRegistry;
@@ -1055,6 +1073,29 @@ async fn create_webgpu_presenter(
     canvas.set_width(viewport.physical_size.width.max(1));
     canvas.set_height(viewport.physical_size.height.max(1));
     let mut render_cx = RenderContext::new();
+
+    // Acquire the adapter/device and construct Vello before asking the visible
+    // canvas for its WebGPU context. A failed `getContext("webgpu")` ownership
+    // transition cannot be undone; Canvas2D fallback must still be able to use
+    // this canvas when GPU initialization fails.
+    let dev_id = match render_cx.device_result(None).await {
+        Ok(dev_id) => dev_id,
+        Err(first_error) => {
+            eprintln!(
+                "webgpu device initialization failed; retrying once before software fallback: {first_error}"
+            );
+            render_cx.device_result(None).await.map_err(|second_error| {
+                anyhow::anyhow!(
+                    "webgpu device initialization failed twice; first: {first_error}; second: {second_error}"
+                )
+            })?
+        }
+    };
+    let main_renderer = {
+        let device_handle = &render_cx.devices[dev_id];
+        create_webgpu_main_renderer(device_handle, request)?
+    };
+
     let surface = render_cx
         .instance
         .create_surface(wgpu::SurfaceTarget::Canvas(canvas))
@@ -1083,7 +1124,6 @@ async fn create_webgpu_presenter(
         target_texture_size.0,
         target_texture_size.1,
     );
-    let main_renderer = create_webgpu_main_renderer(device_handle, request)?;
     let active_renderer = match &main_renderer {
         MainRenderer::Vello { .. } => "webgpu-vello",
         MainRenderer::Software => "webgpu-software",
@@ -1174,7 +1214,7 @@ struct WebInputLatency<'a> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn publish_web_frame_perf(renderer: &str, total_ms: f64) {
+fn publish_web_frame_perf(renderer: &str, total_ms: f64, presented_frames: u64) {
     let perf = WebFramePerf { renderer, total_ms };
     append_web_perf_sample("frames", total_ms);
     diag::emit(
@@ -1186,6 +1226,7 @@ fn publish_web_frame_perf(renderer: &str, total_ms: f64) {
         },
     );
     set_web_global_json("__FISSION_LAST_FRAME_PERF", &perf);
+    set_web_global_json("__FISSION_RENDERED_FRAME_COUNT", &presented_frames);
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -4705,12 +4746,16 @@ where
         mut self,
         #[cfg(target_os = "android")] android_app: Option<AndroidApp>,
     ) -> Result<()> {
+        #[cfg(target_arch = "wasm32")]
+        web_console::install();
+        diag::init_from_env();
+        #[cfg(target_arch = "wasm32")]
+        set_web_global_json("__FISSION_RENDERED_FRAME_COUNT", &0_u64);
         diag::emit(
             diag::DiagCategory::Frame,
             diag::DiagLevel::Info,
             diag::DiagEventKind::FrameStart { root: None },
         );
-        diag::init_from_env();
 
         // Build event loop with TestEvent as the user event type.
         // This allows the test control server to inject events via EventLoopProxy.
@@ -7749,7 +7794,11 @@ where
                                         );
 
                                         let total_ms = now.elapsed().as_secs_f64() * 1000.0;
-                                        publish_web_frame_perf(&active_renderer, total_ms);
+                                        publish_web_frame_perf(
+                                            &active_renderer,
+                                            total_ms,
+                                            presented_frames,
+                                        );
                                         if let Some(input_at) = pending_web_input_at.take() {
                                             publish_web_input_latency(
                                                 &active_renderer,

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -116,6 +116,7 @@ mod software_fonts;
 mod software_renderer;
 #[cfg(target_arch = "wasm32")]
 mod web_console;
+mod web_input;
 use software_renderer::SoftwareRenderer;
 mod native_surface;
 use native_surface::NativeSurfaceRegistry;
@@ -145,6 +146,7 @@ mod camera;
 pub use camera::{CameraHost, MemoryCameraHost, UnsupportedCameraHost};
 mod ime;
 use ime::{DesktopImeHandler, TextInputConfig};
+pub use web_input::BrowserDefaults;
 mod microphone;
 pub use microphone::{MemoryMicrophoneHost, MicrophoneHost, UnsupportedMicrophoneHost};
 mod notifications;
@@ -1585,6 +1587,7 @@ fn build_window(
     background_test_mode: bool,
     target: &EventLoopWindowTarget,
     _web_mount_selector: Option<&str>,
+    _browser_defaults: BrowserDefaults,
 ) -> anyhow::Result<Arc<Window>> {
     let reported_scale_factor = target
         .primary_monitor()
@@ -1595,6 +1598,7 @@ fn build_window(
         background_test_mode,
         false,
         _web_mount_selector,
+        _browser_defaults,
         reported_scale_factor,
     )?;
     Ok(Arc::new(target.create_window(window_attributes).map_err(
@@ -1610,6 +1614,7 @@ fn build_window_before_run(
     tray_skip_taskbar: bool,
     event_loop: &EventLoop<TestEvent>,
     _web_mount_selector: Option<&str>,
+    _browser_defaults: BrowserDefaults,
 ) -> anyhow::Result<Arc<Window>> {
     let window_attributes = build_window_attributes(
         title,
@@ -1617,6 +1622,7 @@ fn build_window_before_run(
         background_test_mode,
         tray_skip_taskbar,
         _web_mount_selector,
+        _browser_defaults,
         None,
     )?;
     #[allow(deprecated)]
@@ -1638,6 +1644,7 @@ fn build_window_attributes(
     background_test_mode: bool,
     tray_skip_taskbar: bool,
     _web_mount_selector: Option<&str>,
+    _browser_defaults: BrowserDefaults,
     _reported_scale_factor: Option<f64>,
 ) -> anyhow::Result<WindowAttributes> {
     let mut window_attributes = WindowAttributes::default()
@@ -1664,7 +1671,9 @@ fn build_window_attributes(
     }
     #[cfg(target_arch = "wasm32")]
     {
-        window_attributes = window_attributes.with_prevent_default(true);
+        window_attributes = window_attributes
+            .with_prevent_default(true)
+            .with_browser_defaults(web_input::to_winit(_browser_defaults));
         window_attributes = if let Some(selector) = _web_mount_selector {
             window_attributes.with_canvas(Some(canvas_for_mount_selector(selector)?))
         } else {
@@ -4469,6 +4478,8 @@ where
     env: Env,
     pipeline: Pipeline,
     measurer: Arc<VelloTextMeasurer>,
+    #[cfg(target_arch = "wasm32")]
+    clipboard: Arc<DesktopClipboard>,
     sync_env: Option<Arc<dyn Fn(&S, &mut Env) + Send + Sync>>,
     key_handler: Option<KeyHandler<S>>,
     frame_hook: Option<FrameHook<S>>,
@@ -4476,6 +4487,7 @@ where
     title: String,
     initial_maximized: bool,
     web_mount_selector: Option<String>,
+    browser_defaults: BrowserDefaults,
     test_control_port: Option<u16>,
     /// Channel pair for receiving completed background effect results.
     effect_result_tx: mpsc::Sender<AsyncMessage>,
@@ -4501,6 +4513,7 @@ where
 
     pub fn new_with_global_state(root_widget: W, global_state: S) -> Self {
         let mut runtime = Runtime::default();
+        runtime.editing_convention = web_input::host_text_editing_convention();
         runtime.add_global_state(Box::new(global_state)).unwrap();
 
         const DEFAULT_FONT_FAMILY: &str = "Fission Default";
@@ -4521,12 +4534,12 @@ where
             DEFAULT_FONT_FAMILY,
         ));
         let env = Env::new(measurer.clone() as Arc<dyn fission_layout::TextMeasurer>);
-        let clipboard: Arc<dyn fission_core::env::Clipboard> = Arc::new(DesktopClipboard::new());
+        let clipboard = Arc::new(DesktopClipboard::new());
 
         let layout_engine = LayoutEngine::new().with_measurer(measurer.clone());
         let runtime = runtime
             .with_measurer(measurer.clone())
-            .with_clipboard(clipboard);
+            .with_clipboard(clipboard.clone());
 
         let (effect_result_tx, effect_result_rx) = mpsc::channel();
         let mut async_registry = AsyncRegistry::new();
@@ -4539,6 +4552,8 @@ where
             env,
             pipeline: Pipeline::new(),
             measurer,
+            #[cfg(target_arch = "wasm32")]
+            clipboard,
             sync_env: None,
             key_handler: None,
             frame_hook: None,
@@ -4546,6 +4561,7 @@ where
             title: "Fission".into(),
             initial_maximized: false,
             web_mount_selector: None,
+            browser_defaults: BrowserDefaults::NONE,
             test_control_port: None,
             effect_result_tx,
             effect_result_rx,
@@ -4597,6 +4613,13 @@ where
 
     pub fn with_mount_selector(mut self, selector: impl Into<String>) -> Self {
         self.web_mount_selector = Some(selector.into());
+        self
+    }
+
+    /// Selectively delegates browser behavior while Fission continues to own
+    /// all other Web input defaults.
+    pub fn with_browser_defaults(mut self, defaults: BrowserDefaults) -> Self {
+        self.browser_defaults = defaults;
         self
     }
 
@@ -5076,6 +5099,7 @@ where
         let window_title = self.title.clone();
         let initial_maximized = self.initial_maximized;
         let web_mount_selector = self.web_mount_selector;
+        let browser_defaults = self.browser_defaults;
         let ime_handler = Arc::new(DesktopImeHandler::default());
         self.runtime = self.runtime.with_ime_handler(ime_handler.clone());
 
@@ -5087,6 +5111,7 @@ where
             tray_skip_taskbar,
             &event_loop,
             web_mount_selector.as_deref(),
+            browser_defaults,
         )?;
         #[cfg(not(target_os = "android"))]
         ime_handler.set_window(Some(platform_window.clone()));
@@ -5164,6 +5189,8 @@ where
         let mut players: HashMap<WidgetId, ActivePlayer> = HashMap::new();
 
         let mut last_cursor_position: Option<PhysicalPosition<f64>> = None;
+        #[cfg(target_arch = "wasm32")]
+        let mut last_web_secondary_up: Option<(LayoutPoint, Instant)> = None;
         let mut active_primary_touch: Option<u64> = None;
         let mut touch_positions: HashMap<u64, PhysicalPosition<f64>> = HashMap::new();
         let max_fps = std::env::var("FISSION_MAX_FPS")
@@ -6374,6 +6401,7 @@ where
                             background_test_mode,
                             elwt,
                             web_mount_selector.as_deref(),
+                            browser_defaults,
                         ) {
                             Ok(new_window) => {
                                 ime_handler.set_window(Some(new_window.clone()));
@@ -8655,6 +8683,9 @@ where
                                     window_physical_position_to_layout_point(window, position);
                                 if let Some(btn) = map_mouse_button(button) {
                                     let is_pressed = state.is_pressed();
+                                    #[cfg(target_arch = "wasm32")]
+                                    let is_secondary_release =
+                                        !is_pressed && matches!(btn, PointerButton::Secondary);
                                     handle_mouse_button(
                                         point.x,
                                         point.y,
@@ -8682,6 +8713,10 @@ where
                                         &mut frame_trace,
                                         &mut invalidations,
                                     );
+                                    #[cfg(target_arch = "wasm32")]
+                                    if is_secondary_release {
+                                        last_web_secondary_up = Some((point, Instant::now()));
+                                    }
                                 }
                             }
                         }
@@ -8901,7 +8936,7 @@ where
                             pending_web_input_at.get_or_insert_with(Instant::now);
                             if event.state.is_pressed() {
                                 use winit::keyboard::{Key, NamedKey};
-                                let key_code = match event.logical_key {
+                                let key_code = match &event.logical_key {
                                     Key::Named(NamedKey::Space) => Some(KeyCode::Space),
                                     Key::Named(NamedKey::Enter) => Some(KeyCode::Enter),
                                     Key::Named(NamedKey::Escape) => Some(KeyCode::Escape),
@@ -8916,16 +8951,28 @@ where
                                     Key::Named(NamedKey::End) => Some(KeyCode::End),
                                     Key::Named(NamedKey::PageUp) => Some(KeyCode::PageUp),
                                     Key::Named(NamedKey::PageDown) => Some(KeyCode::PageDown),
-                                    _ => {
-                                        if let Some(text) = &event.text {
-                                            text.chars().next().map(KeyCode::Char)
-                                        } else {
-                                            None
-                                        }
-                                    }
+                                    Key::Character(text) => text.chars().next().map(KeyCode::Char),
+                                    _ => event
+                                        .text
+                                        .as_ref()
+                                        .and_then(|text| text.chars().next())
+                                        .map(KeyCode::Char),
                                 };
 
                                 if let Some(code) = key_code {
+                                    #[cfg(target_arch = "wasm32")]
+                                    let browser_clipboard_chord = runtime
+                                        .editing_convention
+                                        .has_primary_shortcut(current_mods)
+                                        && matches!(
+                                            code,
+                                            KeyCode::Char('c' | 'C' | 'x' | 'X' | 'v' | 'V')
+                                        );
+                                    #[cfg(not(target_arch = "wasm32"))]
+                                    let browser_clipboard_chord = false;
+                                    if browser_clipboard_chord {
+                                        return;
+                                    }
                                     handle_key_down::<S>(
                                         code,
                                         current_mods,
@@ -8952,6 +8999,95 @@ where
                                         &mut invalidations,
                                     );
                                 }
+                            }
+                        }
+                        #[cfg(target_arch = "wasm32")]
+                        WindowEvent::WebInput(web_input) => {
+                            use fission_core::env::Clipboard as _;
+                            use fission_core::event::EditingCommand;
+                            use winit::event::{WebClipboardAction, WebInputEvent};
+
+                            pending_web_input_at.get_or_insert_with(Instant::now);
+                            let input_event = match &web_input {
+                                WebInputEvent::ContextMenuRequested { position, .. } => {
+                                    if browser_defaults.contains(BrowserDefaults::CONTEXT_MENU) {
+                                        return;
+                                    }
+                                    let point = window_physical_position_to_layout_point(
+                                        &window, *position,
+                                    );
+                                    let duplicate =
+                                        last_web_secondary_up.is_some_and(|(last_point, at)| {
+                                            at.elapsed() <= Duration::from_millis(500)
+                                                && (last_point.x - point.x).abs() <= 2.0
+                                                && (last_point.y - point.y).abs() <= 2.0
+                                        });
+                                    if duplicate {
+                                        None
+                                    } else {
+                                        Some(InputEvent::ContextMenuRequested {
+                                            point,
+                                            modifiers: current_mods,
+                                        })
+                                    }
+                                }
+                                WebInputEvent::Clipboard(event) => {
+                                    if browser_defaults.contains(BrowserDefaults::CLIPBOARD) {
+                                        return;
+                                    }
+                                    let command = match event.action {
+                                        WebClipboardAction::Copy => EditingCommand::Copy,
+                                        WebClipboardAction::Cut => EditingCommand::Cut,
+                                        WebClipboardAction::Paste => EditingCommand::Paste(
+                                            event.text.clone().unwrap_or_default(),
+                                        ),
+                                    };
+                                    if !matches!(event.action, WebClipboardAction::Paste) {
+                                        self.clipboard.set_text("");
+                                    }
+                                    Some(InputEvent::Editing(command))
+                                }
+                            };
+
+                            if let (Some(input_event), Some(ir), Some(layout)) = (
+                                input_event,
+                                pipeline.prev_ir.as_ref(),
+                                pipeline.last_snapshot.as_ref(),
+                            ) {
+                                if let Err(error) = runtime.handle_input(input_event, ir, layout) {
+                                    eprintln!("Web input handling error: {error:?}");
+                                }
+                                if let WebInputEvent::Clipboard(event) = web_input {
+                                    if !matches!(event.action, WebClipboardAction::Paste) {
+                                        event.set_text(
+                                            self.clipboard.get_text().unwrap_or_default(),
+                                        );
+                                    }
+                                }
+                                invalidations.mark_build();
+                                let _ = process_pending_effects(
+                                    &mut runtime,
+                                    &effect_result_tx,
+                                    &event_proxy,
+                                    &async_registry,
+                                    &mut active_services,
+                                    &mut service_bindings,
+                                    &mut next_service_instance_id,
+                                );
+                                reset_text_input_caret(
+                                    &mut runtime,
+                                    pipeline.prev_ir.as_ref(),
+                                    &mut last_blink_toggle,
+                                );
+                                request_redraw_logged(
+                                    &window,
+                                    elwt,
+                                    &mut last_redraw_at,
+                                    min_frame,
+                                    &mut redraw_pending,
+                                    &mut frame_trace,
+                                    "web_input",
+                                );
                             }
                         }
                         WindowEvent::Ime(ime) => {
@@ -9465,7 +9601,8 @@ mod tests {
         should_present_startup_clear_frame, surface_acquire_recovery,
         sync_tracked_target_texture_size_to_surface, texture_plans_fit_device_limits,
         visual_rect_for_node, window_insets_from_safe_area_frames, windows_shell_execute_succeeded,
-        windows_wide, LiveResizeController, SurfaceAcquireRecovery, WindowViewportState,
+        windows_wide, BrowserDefaults, LiveResizeController, SurfaceAcquireRecovery,
+        WindowViewportState,
     };
     use crate::pipeline::CompositorTexturePlan;
     use crate::renderer_diagnostics::RendererRequest;
@@ -9569,10 +9706,26 @@ mod tests {
 
     #[test]
     fn initial_window_maximization_is_opt_in() {
-        let default_attributes =
-            build_window_attributes("Fission", false, false, false, None, None).unwrap();
-        let maximized_attributes =
-            build_window_attributes("Fission", true, false, false, None, None).unwrap();
+        let default_attributes = build_window_attributes(
+            "Fission",
+            false,
+            false,
+            false,
+            None,
+            BrowserDefaults::NONE,
+            None,
+        )
+        .unwrap();
+        let maximized_attributes = build_window_attributes(
+            "Fission",
+            true,
+            false,
+            false,
+            None,
+            BrowserDefaults::NONE,
+            None,
+        )
+        .unwrap();
 
         assert!(!default_attributes.maximized);
         assert!(maximized_attributes.maximized);

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -7939,6 +7939,14 @@ where
                                                                     .expect(
                                                                         "failed to encode retained scene",
                                                                     );
+                                                            let workload_profile =
+                                                                workload_profile_for_encoded_scene(
+                                                                    retained_scene,
+                                                                    &presenter.scene,
+                                                                    render_target_size.0,
+                                                                    render_target_size.1,
+                                                                    scale_factor,
+                                                                );
                                                             if web_rendered_frames == 0 {
                                                                 let encoding =
                                                                     presenter.scene.encoding();
@@ -7954,7 +7962,7 @@ where
                                                                 );
                                                             }
                                                             renderer
-                                                                .render_to_texture(
+                                                                .render_to_texture_with_workload_profile(
                                                                     &device_handle.device,
                                                                     &device_handle.queue,
                                                                     &presenter.scene,
@@ -7963,6 +7971,7 @@ where
                                                                         .surface
                                                                         .target_view,
                                                                     &render_params,
+                                                                    Some(&workload_profile),
                                                                 )
                                                                 .expect(
                                                                     "failed to render webgpu frame",

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -1093,7 +1093,10 @@ async fn create_webgpu_presenter(
     };
     let main_renderer = {
         let device_handle = &render_cx.devices[dev_id];
-        create_webgpu_main_renderer(device_handle, request)?
+        device_handle.device.on_uncaptured_error(Box::new(|error| {
+            eprintln!("webgpu uncaptured error: {error}");
+        }));
+        create_validated_webgpu_main_renderer(device_handle, request).await?
     };
 
     let surface = render_cx
@@ -1190,6 +1193,86 @@ fn create_webgpu_main_renderer(
 }
 
 #[cfg(target_arch = "wasm32")]
+async fn create_validated_webgpu_main_renderer(
+    device_handle: &vello::util::DeviceHandle,
+    request: RendererRequest,
+) -> anyhow::Result<MainRenderer> {
+    let device = &device_handle.device;
+    device.push_error_scope(wgpu::ErrorFilter::Validation);
+    device.push_error_scope(wgpu::ErrorFilter::OutOfMemory);
+    device.push_error_scope(wgpu::ErrorFilter::Internal);
+
+    let result = create_webgpu_main_renderer(device_handle, request).and_then(|mut renderer| {
+        preflight_webgpu_main_renderer(device_handle, &mut renderer)?;
+        Ok(renderer)
+    });
+
+    let mut gpu_errors = Vec::new();
+    for stage in ["internal", "out-of-memory", "validation"] {
+        if let Some(error) = device.pop_error_scope().await {
+            gpu_errors.push(format!("{stage}: {error}"));
+        }
+    }
+    if !gpu_errors.is_empty() {
+        return Err(anyhow::anyhow!(
+            "webgpu Vello preflight failed: {}",
+            gpu_errors.join("; ")
+        ));
+    }
+
+    result
+}
+
+#[cfg(target_arch = "wasm32")]
+fn preflight_webgpu_main_renderer(
+    device_handle: &vello::util::DeviceHandle,
+    renderer: &mut MainRenderer,
+) -> anyhow::Result<()> {
+    let MainRenderer::Vello { renderer, .. } = renderer else {
+        return Ok(());
+    };
+    let texture = device_handle
+        .device
+        .create_texture(&wgpu::TextureDescriptor {
+            label: Some("Fission WebGPU Vello preflight target"),
+            size: wgpu::Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let mut scene = Scene::new();
+    scene.fill(
+        vello::peniko::Fill::NonZero,
+        vello::kurbo::Affine::IDENTITY,
+        vello::peniko::Color::WHITE,
+        None,
+        &vello::kurbo::Rect::new(0.0, 0.0, 16.0, 16.0),
+    );
+    renderer
+        .render_to_texture(
+            &device_handle.device,
+            &device_handle.queue,
+            &scene,
+            &view,
+            &vello::RenderParams {
+                base_color: vello::peniko::Color::BLACK,
+                width: 16,
+                height: 16,
+                antialiasing_method: vello::AaConfig::Area,
+            },
+        )
+        .map_err(|error| anyhow::anyhow!("webgpu Vello preflight submission failed: {error}"))
+}
+
+#[cfg(target_arch = "wasm32")]
 fn publish_web_renderer_report(report: &RendererReport) {
     let line = report.concise_line();
     web_sys::console::info_1(&wasm_bindgen::JsValue::from_str(&format!(
@@ -1214,7 +1297,7 @@ struct WebInputLatency<'a> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn publish_web_frame_perf(renderer: &str, total_ms: f64, presented_frames: u64) {
+fn publish_web_frame_perf(renderer: &str, total_ms: f64, rendered_frames: u64) {
     let perf = WebFramePerf { renderer, total_ms };
     append_web_perf_sample("frames", total_ms);
     diag::emit(
@@ -1226,7 +1309,7 @@ fn publish_web_frame_perf(renderer: &str, total_ms: f64, presented_frames: u64) 
         },
     );
     set_web_global_json("__FISSION_LAST_FRAME_PERF", &perf);
-    set_web_global_json("__FISSION_RENDERED_FRAME_COUNT", &presented_frames);
+    set_web_global_json("__FISSION_RENDERED_FRAME_COUNT", &rendered_frames);
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -4858,6 +4941,8 @@ where
         let mut webgpu_init_in_flight = false;
         #[cfg(target_arch = "wasm32")]
         let mut web_renderer_reported = false;
+        #[cfg(target_arch = "wasm32")]
+        let mut web_rendered_frames: u64 = 0;
         #[cfg(not(target_arch = "wasm32"))]
         let mut scene = Scene::new();
         #[cfg(not(target_arch = "wasm32"))]
@@ -7487,6 +7572,9 @@ where
                                             return;
                                         };
                                         let active_renderer = renderer.active_name().to_string();
+                                        let web_frame_has_content = pipeline
+                                            .retained_scene()
+                                            .is_some_and(|scene| !scene.roots.is_empty());
                                         match renderer {
                                             WebRenderer::Canvas2d(presenter) => {
                                                 let retained_scene = pipeline
@@ -7688,6 +7776,20 @@ where
                                                                     render_target_size.1,
                                                                     scale_factor,
                                                                 );
+                                                            if web_rendered_frames == 0 {
+                                                                let encoding =
+                                                                    presenter.scene.encoding();
+                                                                log::info!(
+                                                                    "Fission WebGPU first content frame: roots={}, paths={}, draws={}, glyph_runs={}, glyphs={}, target={}x{}",
+                                                                    retained_scene.roots.len(),
+                                                                    encoding.n_paths,
+                                                                    encoding.draw_tags.len(),
+                                                                    encoding.resources.glyph_runs.len(),
+                                                                    encoding.resources.glyphs.len(),
+                                                                    render_target_size.0,
+                                                                    render_target_size.1,
+                                                                );
+                                                            }
                                                             renderer
                                                                     .render_to_texture_with_workload_profile(
                                                                         &device_handle.device,
@@ -7787,6 +7889,10 @@ where
                                         invalidations = InvalidationSet::default();
 
                                         presented_frames = presented_frames.saturating_add(1);
+                                        if web_frame_has_content {
+                                            web_rendered_frames =
+                                                web_rendered_frames.saturating_add(1);
+                                        }
                                         flush_text_traces(
                                             text_trace_enabled,
                                             &mut pending_text_traces,
@@ -7797,7 +7903,7 @@ where
                                         publish_web_frame_perf(
                                             &active_renderer,
                                             total_ms,
-                                            presented_frames,
+                                            web_rendered_frames,
                                         );
                                         if let Some(input_at) = pending_web_input_at.take() {
                                             publish_web_input_latency(

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -1234,7 +1234,11 @@ async fn create_validated_webgpu_main_renderer(
     let device = &device_handle.device;
     let mut failures = Vec::new();
 
-    for use_indirect_dispatch in [true, false] {
+    // BrowserWebGpu can successfully execute a trivial indirect workload while
+    // silently producing an empty target for a real retained scene. Prefer the
+    // conservative direct-dispatch recording on the web; it remains fully GPU
+    // accelerated and avoids depending on GPU-written dispatch counts.
+    for use_indirect_dispatch in [false, true] {
         device.push_error_scope(wgpu::ErrorFilter::Validation);
         device.push_error_scope(wgpu::ErrorFilter::OutOfMemory);
         device.push_error_scope(wgpu::ErrorFilter::Internal);

--- a/crates/shell/fission-shell-winit/src/web_console.rs
+++ b/crates/shell/fission-shell-winit/src/web_console.rs
@@ -1,0 +1,71 @@
+use std::sync::Once;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use wasm_bindgen::JsValue;
+
+static INSTALL: Once = Once::new();
+static LOGGER: BrowserConsoleLogger = BrowserConsoleLogger;
+
+struct BrowserConsoleLogger;
+
+impl Log for BrowserConsoleLogger {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let message = format!("[{} {}] {}", record.level(), record.target(), record.args());
+        match record.level() {
+            Level::Error => error(&message),
+            _ => info(&message),
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub(crate) fn install() {
+    INSTALL.call_once(|| {
+        if log::set_logger(&LOGGER).is_ok() {
+            log::set_max_level(LevelFilter::Trace);
+        }
+        // Respect an application-installed tracing subscriber. Otherwise make
+        // tracing events visible in the same browser console as `log` records.
+        let _ = tracing_wasm::try_set_as_global_default();
+
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            error(&format!("Fission application panic: {panic_info}"));
+            previous(panic_info);
+        }));
+    });
+}
+
+pub(crate) fn info(message: &str) {
+    web_sys::console::log_1(&JsValue::from_str(message));
+}
+
+pub(crate) fn error(message: &str) {
+    web_sys::console::error_1(&JsValue::from_str(message));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_logger_accepts_every_log_level() {
+        for level in [
+            Level::Error,
+            Level::Warn,
+            Level::Info,
+            Level::Debug,
+            Level::Trace,
+        ] {
+            assert!(LOGGER.enabled(&Metadata::builder().level(level).build()));
+        }
+    }
+}

--- a/crates/shell/fission-shell-winit/src/web_input.rs
+++ b/crates/shell/fission-shell-winit/src/web_input.rs
@@ -1,0 +1,129 @@
+use fission_core::input::TextEditingConvention;
+
+/// Browser behavior which a Web application deliberately delegates to the browser.
+///
+/// Fission owns input by default. An empty policy therefore keeps every browser
+/// default suppressed while still delivering the corresponding event to Fission.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BrowserDefaults(u8);
+
+impl BrowserDefaults {
+    pub const NONE: Self = Self(0);
+    pub const KEYBOARD: Self = Self(1 << 0);
+    pub const POINTER: Self = Self(1 << 1);
+    pub const TOUCH: Self = Self(1 << 2);
+    pub const WHEEL: Self = Self(1 << 3);
+    pub const CONTEXT_MENU: Self = Self(1 << 4);
+    pub const CLIPBOARD: Self = Self(1 << 5);
+
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+impl std::ops::BitOr for BrowserDefaults {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for BrowserDefaults {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn to_winit(defaults: BrowserDefaults) -> winit::platform::web::BrowserDefaults {
+    use winit::platform::web::BrowserDefaults as WinitDefaults;
+
+    let mut result = WinitDefaults::NONE;
+    for (fission, winit) in [
+        (BrowserDefaults::KEYBOARD, WinitDefaults::KEYBOARD),
+        (BrowserDefaults::POINTER, WinitDefaults::POINTER),
+        (BrowserDefaults::TOUCH, WinitDefaults::TOUCH),
+        (BrowserDefaults::WHEEL, WinitDefaults::WHEEL),
+        (BrowserDefaults::CONTEXT_MENU, WinitDefaults::CONTEXT_MENU),
+        (BrowserDefaults::CLIPBOARD, WinitDefaults::CLIPBOARD),
+    ] {
+        if defaults.contains(fission) {
+            result |= winit;
+        }
+    }
+    result
+}
+
+pub(crate) fn host_text_editing_convention() -> TextEditingConvention {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let global = js_sys::global();
+        let navigator = js_sys::Reflect::get(&global, &"navigator".into()).ok();
+        let platform = navigator
+            .as_ref()
+            .and_then(|navigator| js_sys::Reflect::get(navigator, &"platform".into()).ok())
+            .and_then(|platform| platform.as_string());
+        let user_agent = navigator
+            .as_ref()
+            .and_then(|navigator| js_sys::Reflect::get(navigator, &"userAgent".into()).ok())
+            .and_then(|user_agent| user_agent.as_string());
+        return convention_for_browser_host(platform.as_deref(), user_agent.as_deref());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if cfg!(any(target_os = "macos", target_os = "ios")) {
+            TextEditingConvention::Apple
+        } else {
+            TextEditingConvention::Standard
+        }
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn convention_for_browser_host(
+    platform: Option<&str>,
+    user_agent: Option<&str>,
+) -> TextEditingConvention {
+    let is_apple = platform.into_iter().chain(user_agent).any(|value| {
+        ["mac", "iphone", "ipad", "ipod"]
+            .iter()
+            .any(|needle| value.to_ascii_lowercase().contains(needle))
+    });
+    if is_apple {
+        TextEditingConvention::Apple
+    } else {
+        TextEditingConvention::Standard
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_host_selects_apple_conventions_without_using_wasm_target_os() {
+        assert_eq!(
+            convention_for_browser_host(Some("MacIntel"), None),
+            TextEditingConvention::Apple
+        );
+        assert_eq!(
+            convention_for_browser_host(None, Some("Mozilla/5.0 (iPhone)")),
+            TextEditingConvention::Apple
+        );
+        assert_eq!(
+            convention_for_browser_host(Some("Win32"), None),
+            TextEditingConvention::Standard
+        );
+    }
+
+    #[test]
+    fn browser_defaults_are_composable_and_deny_by_default() {
+        assert!(!BrowserDefaults::NONE.contains(BrowserDefaults::KEYBOARD));
+        let editing = BrowserDefaults::KEYBOARD | BrowserDefaults::CLIPBOARD;
+        assert!(editing.contains(BrowserDefaults::KEYBOARD));
+        assert!(editing.contains(BrowserDefaults::CLIPBOARD));
+        assert!(!editing.contains(BrowserDefaults::CONTEXT_MENU));
+    }
+}

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["development-tools", "development-tools::debugging"]
 keywords = ["fission", "diagnostics", "debugging", "tracing", "tooling"]
 
 [package.metadata.fission]
-platforms = ["linux", "macos", "windows"]
+platforms = ["linux", "macos", "web", "windows"]
 
 homepage = "https://fission.rs"
 documentation = "https://fission.rs"
@@ -28,3 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 parking_lot = "0.12"
 bitflags = "2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["console"] }

--- a/crates/tools/fission-diagnostics/src/lib.rs
+++ b/crates/tools/fission-diagnostics/src/lib.rs
@@ -372,7 +372,24 @@ struct StdoutSinkImpl;
 impl SinkImpl for StdoutSinkImpl {
     fn write(&self, event: &DiagEvent) {
         // JSONL for stable tooling integration
-        let _ = serde_json::to_string(event).map(|line| println!("{}", line));
+        if let Ok(line) = serde_json::to_string(event) {
+            write_stdout(event.level, &line);
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn write_stdout(_level: DiagLevel, line: &str) {
+    println!("{line}");
+}
+
+#[cfg(target_arch = "wasm32")]
+fn write_stdout(level: DiagLevel, line: &str) {
+    let line = wasm_bindgen::JsValue::from_str(line);
+    if matches!(level, DiagLevel::Error) {
+        web_sys::console::error_1(&line);
+    } else {
+        web_sys::console::log_1(&line);
     }
 }
 

--- a/crates/tools/fission-test-driver/src/browser.rs
+++ b/crates/tools/fission-test-driver/src/browser.rs
@@ -258,9 +258,7 @@ impl BrowserController {
             TestCommand::HoverSelector { query } => {
                 self.selector_action(query.clone(), TestCommand::HoverSelector { query })
             }
-            TestCommand::RightClickSelector { query } => {
-                self.selector_action(query.clone(), TestCommand::RightClickSelector { query })
-            }
+            TestCommand::RightClickSelector { query } => self.right_click_selector(query),
             TestCommand::FillText { query, text } => {
                 self.selector_action(query.clone(), TestCommand::FillText { query, text })
             }
@@ -284,8 +282,89 @@ impl BrowserController {
                 ensure_response_ok(self.send_bridge_command(TestCommand::Pump {})?)?;
                 self.capture_page_response()
             }
+            TestCommand::PressKey { key, modifiers } => self.press_dom_key(&key, modifiers),
             command => self.send_bridge_command(command),
         }
+    }
+
+    fn right_click_selector(&mut self, query: SelectorQuery) -> Result<TestResponse> {
+        ensure_response_ok(self.send_bridge_command(TestCommand::ScrollIntoView {
+            query: query.clone().include_hidden(),
+        })?)?;
+        ensure_response_ok(self.send_bridge_command(TestCommand::Pump {})?)?;
+        let response = self.send_bridge_command(TestCommand::ResolveSelector { query })?;
+        let TestResponse::SelectorResolved { node } = response else {
+            return Ok(response);
+        };
+        let bounds = node.visible_bounds.unwrap_or(node.logical_bounds);
+        let (offset_x, offset_y) = self.canvas_viewport_offset()?;
+        let x = offset_x + f64::from(bounds.x + bounds.width * 0.5);
+        let y = offset_y + f64::from(bounds.y + bounds.height * 0.5);
+        self.client.send(
+            "Input.dispatchMouseEvent",
+            json!({ "type": "mouseMoved", "x": x, "y": y }),
+        )?;
+        self.client.send(
+            "Input.dispatchMouseEvent",
+            json!({
+                "type": "mousePressed",
+                "x": x,
+                "y": y,
+                "button": "right",
+                "buttons": 2,
+                "clickCount": 1
+            }),
+        )?;
+        self.client.send(
+            "Input.dispatchMouseEvent",
+            json!({
+                "type": "mouseReleased",
+                "x": x,
+                "y": y,
+                "button": "right",
+                "buttons": 0,
+                "clickCount": 1
+            }),
+        )?;
+        ensure_response_ok(self.send_bridge_command(TestCommand::Pump {})?)?;
+        Ok(TestResponse::Ok {})
+    }
+
+    fn press_dom_key(&mut self, key: &str, modifiers: u8) -> Result<TestResponse> {
+        let cdp_modifiers = cdp_modifiers(modifiers);
+        let (dom_key, code) = dom_key_and_code(key);
+        for event_type in ["keyDown", "keyUp"] {
+            self.client.send(
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": event_type,
+                    "key": dom_key,
+                    "code": code,
+                    "modifiers": cdp_modifiers
+                }),
+            )?;
+        }
+        ensure_response_ok(self.send_bridge_command(TestCommand::Pump {})?)?;
+        Ok(TestResponse::Ok {})
+    }
+
+    fn canvas_viewport_offset(&mut self) -> Result<(f64, f64)> {
+        let result = self.client.send(
+            "Runtime.evaluate",
+            json!({
+                "expression": "(() => { const r = document.querySelector('canvas')?.getBoundingClientRect(); return r ? [r.left, r.top] : [0, 0]; })()",
+                "returnByValue": true
+            }),
+        )?;
+        runtime_exception(&result)?;
+        let values = result
+            .pointer("/result/value")
+            .and_then(Value::as_array)
+            .context("browser returned no canvas offset")?;
+        Ok((
+            values.first().and_then(Value::as_f64).unwrap_or(0.0),
+            values.get(1).and_then(Value::as_f64).unwrap_or(0.0),
+        ))
     }
 
     fn selector_action(
@@ -515,6 +594,55 @@ fn ensure_response_ok(response: TestResponse) -> Result<()> {
         TestResponse::Error { message } => Err(anyhow!(message)),
         TestResponse::SelectorError { failure } => Err(anyhow!(failure.message)),
         _ => Ok(()),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn cdp_modifiers(fission: u8) -> u8 {
+    let mut cdp = 0;
+    if fission & 1 != 0 {
+        cdp |= 8;
+    }
+    if fission & 2 != 0 {
+        cdp |= 1;
+    }
+    if fission & 4 != 0 {
+        cdp |= 2;
+    }
+    if fission & 8 != 0 {
+        cdp |= 4;
+    }
+    cdp
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn dom_key_and_code(key: &str) -> (String, String) {
+    let named = match key {
+        "Left" => Some(("ArrowLeft", "ArrowLeft")),
+        "Right" => Some(("ArrowRight", "ArrowRight")),
+        "Up" => Some(("ArrowUp", "ArrowUp")),
+        "Down" => Some(("ArrowDown", "ArrowDown")),
+        "Space" => Some((" ", "Space")),
+        "Esc" => Some(("Escape", "Escape")),
+        "Enter" | "Escape" | "Tab" | "Backspace" | "Delete" | "Home" | "End" | "PageUp"
+        | "PageDown" => Some((key, key)),
+        _ => None,
+    };
+    if let Some((dom_key, code)) = named {
+        return (dom_key.to_owned(), code.to_owned());
+    }
+    let mut chars = key.chars();
+    if let (Some(ch), None) = (chars.next(), chars.next()) {
+        let code = if ch.is_ascii_alphabetic() {
+            format!("Key{}", ch.to_ascii_uppercase())
+        } else if ch.is_ascii_digit() {
+            format!("Digit{ch}")
+        } else {
+            String::new()
+        };
+        (ch.to_string(), code)
+    } else {
+        (key.to_owned(), key.to_owned())
     }
 }
 
@@ -940,5 +1068,24 @@ mod tests {
 
         assert!(status.test_bridge_ready);
         assert_eq!(status.renderer.as_deref(), Some("webgpu-vello"));
+    }
+
+    #[test]
+    fn browser_key_events_translate_fission_modifiers_to_cdp() {
+        assert_eq!(cdp_modifiers(1), 8); // Shift
+        assert_eq!(cdp_modifiers(2), 1); // Alt
+        assert_eq!(cdp_modifiers(4), 2); // Control
+        assert_eq!(cdp_modifiers(8), 4); // Meta
+        assert_eq!(cdp_modifiers(1 | 4 | 8), 8 | 2 | 4);
+    }
+
+    #[test]
+    fn browser_key_events_use_dom_key_names() {
+        assert_eq!(
+            dom_key_and_code("Left"),
+            ("ArrowLeft".into(), "ArrowLeft".into())
+        );
+        assert_eq!(dom_key_and_code("a"), ("a".into(), "KeyA".into()));
+        assert_eq!(dom_key_and_code("7"), ("7".into(), "Digit7".into()));
     }
 }

--- a/crates/tools/fission-test/tests/flyout_bounds.rs
+++ b/crates/tools/fission-test/tests/flyout_bounds.rs
@@ -1,8 +1,8 @@
-use fission_core::ui::{Button, Container, Positioned, Text, Widget, ZStack};
+use fission_core::ui::{Button, Column, Container, Positioned, Spacer, Text, Widget, ZStack};
 use fission_core::{GlobalState, WidgetId, WidgetIdExt};
 use fission_render::{DisplayOp, Fill};
 use fission_test::TestHarness;
-use fission_widgets::{Popover, Tooltip};
+use fission_widgets::{flyout, Popover, Tooltip};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -151,5 +151,68 @@ fn tooltip_surface_uses_intrinsic_size_inside_viewport_portal() {
         tooltip_rect.height() < display_list.bounds.height(),
         "tooltip must not fill the viewport height: tooltip={tooltip_rect:?} viewport={:?}",
         display_list.bounds
+    );
+}
+
+#[derive(Clone)]
+struct IntrinsicMenuRoot;
+
+impl From<IntrinsicMenuRoot> for Widget {
+    fn from(_component: IntrinsicMenuRoot) -> Self {
+        let (ctx, view) = fission_core::build::current::<State>();
+        let anchor_id = WidgetId::explicit("intrinsic-menu-anchor");
+        let menu_id = WidgetId::explicit("intrinsic-menu");
+        let menu = Container::new(Column {
+            children: vec![
+                Container::new(Spacer::default())
+                    .width(150.0)
+                    .height(36.0)
+                    .into(),
+                Container::new(Spacer::default())
+                    .width(150.0)
+                    .height(1.0)
+                    .into(),
+                Container::new(Spacer::default())
+                    .width(150.0)
+                    .height(36.0)
+                    .into(),
+            ],
+            gap: Some(2.0),
+            ..Default::default()
+        })
+        .width(158.0)
+        .padding_all(4.0)
+        .bg(view.env().theme.tokens.colors.surface)
+        .id(menu_id)
+        .into();
+        ctx.register_portal_with_layer(
+            fission_core::PortalLayer::Flyout,
+            Some(WidgetId::explicit("intrinsic-menu-portal")),
+            flyout(anchor_id, menu),
+        );
+
+        Container::new(Spacer::default())
+            .width(64.0)
+            .height(24.0)
+            .id(anchor_id)
+            .into()
+    }
+}
+
+#[test]
+fn default_stretch_container_keeps_intrinsic_flyout_height() {
+    let mut harness =
+        TestHarness::new_with_mock_measurer(State::default()).with_root_widget(IntrinsicMenuRoot);
+    harness.pump().expect("intrinsic menu frame");
+
+    let snapshot = harness.last_snapshot.as_ref().expect("snapshot");
+    let menu_id: WidgetId = WidgetId::explicit("intrinsic-menu").into();
+    let menu_rect = snapshot.get_node_rect(menu_id).expect("menu rect");
+
+    assert_eq!(menu_rect.height(), 85.0);
+    assert!(
+        menu_rect.height() < snapshot.viewport_size.height,
+        "intrinsic menu must not fill the viewport: menu={menu_rect:?} viewport={:?}",
+        snapshot.viewport_size
     );
 }

--- a/docs/rfc-web-testing.md
+++ b/docs/rfc-web-testing.md
@@ -146,8 +146,10 @@ bounded differences:
   renderer texture readback.
 - External file commands inject Fission's deterministic external-drag events;
   they do not create browser `File` objects.
-- Pointer, keyboard, text, and IME commands enter through `TestEvent`; they do
-  not claim to verify browser-generated trusted events.
+- `RightClickSelector` and `PressKey` cross the real DOM/CDP boundary before
+  entering Winit, so they cover browser button/modifier translation and the
+  trusted clipboard accelerator path. Deterministic text and IME commands
+  still enter through `TestEvent`; they do not claim to automate browser IME UI.
 - `Quit` closes the test application/browser session; it does not expose a
   network control endpoint.
 


### PR DESCRIPTION
## Summary

- make WebGPU startup and presentation failures observable, preserve fallback diagnostics, and size Vello buffers from actual frame workloads
- bring browser pointer buttons, context menus, keyboard editing shortcuts, clipboard handling, and composition commits into parity with native input while retaining Fission's default browser-event ownership
- expose selective browser-default policy and drive keyboard/right-click browser tests through real DOM input
- preserve intrinsic flyout sizing when an auto-sized `Container` uses its default stretch alignment

## Flyout regression

A finite maximum on an auto-sized box axis is a bound, not space that the box already owns. Tightening that axis caused short dropdowns such as Worka's language menu to fill the viewport. Stretching now applies when the supplied axis is actually tight, preserving explicit-size and flex cross-axis behavior.

Coverage includes both the layout primitive and an authored `Container -> Column -> flyout portal` matching the production menu structure.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p fission-layout`
- `cargo test -p fission-test --test flyout_bounds -- --nocapture`
