### PR TITLE
Expose widget traversal and scoped action resolution

### DIFF
--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -62,7 +62,7 @@ fission-macros = { path = "../fission-macros", version = "0.11.1" }
 fission-icons = { path = "../fission-icons", version = "0.11.1" }
 fission-charts = { path = "../fission-charts", version = "0.11.1", optional = true }
 fission-render = { path = "../../rendering/fission-render", version = "0.11.1" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1", default-features = false }
 fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.11.1", optional = true }
 fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.11.1", optional = true }
 fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.11.1", optional = true }

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -32,6 +32,6 @@ lazy_static = "1.4"
 blake3 = "1.5"
 unicode-segmentation = "1.10"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1", default-features = false }
 
 [dev-dependencies]

--- a/crates/core/fission-core/src/effect.rs
+++ b/crates/core/fission-core/src/effect.rs
@@ -187,7 +187,7 @@ pub struct EffectEnvelope {
 ///     }
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ActionInput {
     /// No extra input.
     None,
@@ -303,6 +303,17 @@ pub enum ActionInput {
 }
 
 impl ActionInput {
+    /// Encodes this runtime input into an opaque representation suitable for
+    /// storage or transport.
+    pub fn encode_opaque(&self) -> Result<Vec<u8>, ActionInputCodecError> {
+        serde_json::to_vec(self).map_err(ActionInputCodecError)
+    }
+
+    /// Decodes an input previously produced by [`Self::encode_opaque`].
+    pub fn decode_opaque(bytes: &[u8]) -> Result<Self, ActionInputCodecError> {
+        serde_json::from_slice(bytes).map_err(ActionInputCodecError)
+    }
+
     pub fn scoped_raw(scope_id: u128, target: WidgetId, input: ActionInput) -> Self {
         Self::ScopedRaw {
             scope_id,
@@ -561,5 +572,43 @@ impl ActionInput {
             | ActionInput::ServiceCommandErr { instance_id, .. } => Some(*instance_id),
             _ => None,
         }
+    }
+}
+
+/// Failure to encode or decode an opaque [`ActionInput`] representation.
+#[derive(Debug)]
+pub struct ActionInputCodecError(serde_json::Error);
+
+impl std::fmt::Display for ActionInputCodecError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("action input codec failed")
+    }
+}
+
+impl std::error::Error for ActionInputCodecError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod action_input_codec_tests {
+    use super::*;
+
+    #[test]
+    fn opaque_codec_round_trips_full_width_scope_ids() {
+        let input = ActionInput::scoped_raw(
+            u128::MAX - 1,
+            WidgetId::from_u128(u128::MAX - 2),
+            ActionInput::TextChanged(UpdateTextInput {
+                node_id: WidgetId::from_u128(7),
+                new_text: "hello".into(),
+                new_caret: 4,
+                new_anchor: 1,
+            }),
+        );
+        let bytes = input.encode_opaque().expect("input should encode");
+        let decoded = ActionInput::decode_opaque(&bytes).expect("input should decode");
+        assert_eq!(decoded, input);
     }
 }

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -218,8 +218,8 @@ pub mod public {
         FissionDataStreamErrorKind,
     };
     pub use crate::effect::{
-        ActionInput, Effect, EffectEnvelope, RuntimeEffect, ScrollAlignment, ScrollAxis,
-        ScrollBehavior, ScrollIntoViewRequest,
+        ActionInput, ActionInputCodecError, Effect, EffectEnvelope, RuntimeEffect, ScrollAlignment,
+        ScrollAxis, ScrollBehavior, ScrollIntoViewRequest,
     };
     pub use crate::env::{
         Clipboard, DragSessionPayload, DragSessionState, Env, ImeHandler, InteractionStateMap,
@@ -345,6 +345,7 @@ pub mod public {
         ResourceRegistry, RuntimeResourceDeclaration, RuntimeResourceKind, ServiceResource,
         TimerResource, VideoRegistration,
     };
+    pub use crate::scoped_action_handlers::ScopedActionResolution;
     pub use crate::time::{Clock, CurrentTime};
     pub use crate::ui::{
         provider, ActionScope, BadgeTone, Button, ButtonHierarchy, ButtonMotion, CardPattern,
@@ -352,7 +353,7 @@ pub mod public {
         IosAudioSessionCategoryOption, IosAudioSessionMode, IosVideoAudioOptions, Pressable,
         PressableRole, PressableStyle, Provider, Responsive, ResponsiveCase, ResponsiveQuery, Row,
         Text, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource,
-        Widget, WidgetIdExt,
+        Widget, WidgetIdExt, WidgetKind,
     };
     pub use crate::view::{ComputedView, FissionViewField, Selector, ValueView, View};
     pub use crate::{
@@ -398,8 +399,8 @@ pub use data_stream::{
     FissionDataStreamErrorKind,
 };
 pub use effect::{
-    ActionInput, Effect, EffectEnvelope, RuntimeEffect, ScrollAlignment, ScrollAxis,
-    ScrollBehavior, ScrollIntoViewRequest,
+    ActionInput, ActionInputCodecError, Effect, EffectEnvelope, RuntimeEffect, ScrollAlignment,
+    ScrollAxis, ScrollBehavior, ScrollIntoViewRequest,
 };
 pub use env::{
     Clipboard, DragSessionPayload, DragSessionState, Env, ImeHandler, InteractionStateMap,
@@ -530,6 +531,7 @@ pub use registry::{
     ResourceRegistry, RuntimeResourceDeclaration, RuntimeResourceKind, ServiceResource,
     TimerResource, VideoRegistration,
 };
+pub use scoped_action_handlers::ScopedActionResolution;
 pub use time::{Clock, CurrentTime};
 pub use ui::{
     provider, ActionScope, BadgeTone, Button, ButtonHierarchy, ButtonMotion, CardPattern, Column,
@@ -537,7 +539,7 @@ pub use ui::{
     IosAudioSessionCategoryOption, IosAudioSessionMode, IosVideoAudioOptions, Pressable,
     PressableRole, PressableStyle, Provider, Responsive, ResponsiveCase, ResponsiveQuery, Row,
     Text, Video, VideoAudioActivation, VideoAudioOptions, VideoAudioPolicy, VideoSource, Widget,
-    WidgetIdExt,
+    WidgetIdExt, WidgetKind,
 };
 pub use view::{ComputedView, FissionViewField, Selector, ValueView, View};
 

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -534,18 +534,24 @@ impl Runtime {
             return Ok(());
         }
 
-        let action_id = action.id;
-
-        if let Some(resolution) =
+        let action = if let Some(resolution) =
             crate::scoped_action_handlers::dispatch_scoped_action_handler(&action, target, input)?
         {
             match resolution {
                 crate::scoped_action_handlers::ScopedActionResolution::Handled => return Ok(()),
                 crate::scoped_action_handlers::ScopedActionResolution::Forward(forwarded) => {
-                    return self.try_dispatch_node_with_input(forwarded, target, input);
+                    if crate::media::handle_video_action(&mut self.runtime_state.video, &forwarded)?
+                    {
+                        return Ok(());
+                    }
+                    forwarded
                 }
             }
-        }
+        } else {
+            action
+        };
+
+        let action_id = action.id;
 
         // Collect effects from this dispatch (both persistent and per-frame reducers).
         let mut effects = Vec::new();

--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -536,8 +536,15 @@ impl Runtime {
 
         let action_id = action.id;
 
-        if crate::scoped_action_handlers::dispatch_scoped_action_handler(&action, target, input)? {
-            return Ok(());
+        if let Some(resolution) =
+            crate::scoped_action_handlers::dispatch_scoped_action_handler(&action, target, input)?
+        {
+            match resolution {
+                crate::scoped_action_handlers::ScopedActionResolution::Handled => return Ok(()),
+                crate::scoped_action_handlers::ScopedActionResolution::Forward(forwarded) => {
+                    return self.try_dispatch_node_with_input(forwarded, target, input);
+                }
+            }
         }
 
         // Collect effects from this dispatch (both persistent and per-frame reducers).

--- a/crates/core/fission-core/src/scoped_action_handlers.rs
+++ b/crates/core/fission-core/src/scoped_action_handlers.rs
@@ -73,20 +73,27 @@ pub(crate) fn dispatch_scoped_action_handler(
     let Some(scoped_handlers) = handlers.get_mut(&(scope_id, action.id)) else {
         return Ok(None);
     };
-    let mut resolution = ScopedActionResolution::Handled;
+    let mut forwarded = None;
     for handler in scoped_handlers {
-        let next = handler(action, target, input)?;
-        if matches!(next, ScopedActionResolution::Forward(_)) {
-            resolution = next;
+        if let ScopedActionResolution::Forward(envelope) = handler(action, target, input)? {
+            if forwarded.replace(envelope).is_some() {
+                return Err(anyhow!(
+                    "multiple scoped action handlers attempted to forward one action"
+                ));
+            }
         }
     }
-    Ok(Some(resolution))
+    Ok(Some(
+        forwarded
+            .map(ScopedActionResolution::Forward)
+            .unwrap_or(ScopedActionResolution::Handled),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ActionInput;
+    use crate::{ActionInput, GlobalState, Runtime};
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -161,6 +168,108 @@ mod tests {
         assert_eq!(forwarded.id, forwarded_action);
         assert_eq!(forwarded.payload, b"forwarded");
 
+        clear_scoped_action_handlers(scope).unwrap();
+    }
+
+    #[derive(Debug, Default)]
+    struct ForwardState {
+        reducer_calls: usize,
+    }
+
+    impl GlobalState for ForwardState {}
+
+    fn count_forwarded_action(
+        state: &mut ForwardState,
+        _action: &ActionEnvelope,
+        _target: WidgetId,
+    ) -> Result<()> {
+        state.reducer_calls += 1;
+        Ok(())
+    }
+
+    #[test]
+    fn forwarding_the_same_action_bypasses_the_scoped_handler() {
+        let scope = ActionScopeId::from_name("test.forwarding.same-action.scope");
+        let action_id = ActionId::from_name("test.forwarding.same-action");
+        clear_scoped_action_handlers(scope).unwrap();
+        let handler_calls = Arc::new(Mutex::new(0usize));
+        let calls_for_handler = handler_calls.clone();
+        register_scoped_action_handler(
+            scope,
+            action_id,
+            Box::new(move |action, _, _| {
+                *calls_for_handler.lock().unwrap() += 1;
+                Ok(ScopedActionResolution::Forward(action.clone()))
+            }),
+        )
+        .unwrap();
+
+        let mut runtime = Runtime::default();
+        runtime
+            .add_app_state(Box::new(ForwardState::default()))
+            .unwrap();
+        runtime
+            .register_reducer::<ForwardState>(action_id, count_forwarded_action)
+            .unwrap();
+        let target = WidgetId::from_u128(13);
+        let input = ActionInput::scoped_raw(scope.as_u128(), target, ActionInput::None);
+        runtime
+            .dispatch_with_input(
+                ActionEnvelope {
+                    id: action_id,
+                    payload: Vec::new(),
+                },
+                target,
+                &input,
+            )
+            .unwrap();
+
+        assert_eq!(*handler_calls.lock().unwrap(), 1);
+        assert_eq!(
+            runtime
+                .get_app_state::<ForwardState>()
+                .expect("forward state")
+                .reducer_calls,
+            1
+        );
+        clear_scoped_action_handlers(scope).unwrap();
+    }
+
+    #[test]
+    fn multiple_forwarding_handlers_are_rejected() {
+        let scope = ActionScopeId::from_name("test.forwarding.ambiguous.scope");
+        let action_id = ActionId::from_name("test.forwarding.ambiguous");
+        clear_scoped_action_handlers(scope).unwrap();
+        for payload in [b"first".as_slice(), b"second".as_slice()] {
+            let payload = payload.to_vec();
+            register_scoped_action_handler(
+                scope,
+                action_id,
+                Box::new(move |_, _, _| {
+                    Ok(ScopedActionResolution::Forward(ActionEnvelope {
+                        id: action_id,
+                        payload: payload.clone(),
+                    }))
+                }),
+            )
+            .unwrap();
+        }
+
+        let target = WidgetId::from_u128(17);
+        let input = ActionInput::scoped_raw(scope.as_u128(), target, ActionInput::None);
+        let error = dispatch_scoped_action_handler(
+            &ActionEnvelope {
+                id: action_id,
+                payload: Vec::new(),
+            },
+            target,
+            &input,
+        )
+        .expect_err("ambiguous forwarding must fail");
+
+        assert!(error
+            .to_string()
+            .contains("multiple scoped action handlers"));
         clear_scoped_action_handlers(scope).unwrap();
     }
 }

--- a/crates/core/fission-core/src/scoped_action_handlers.rs
+++ b/crates/core/fission-core/src/scoped_action_handlers.rs
@@ -11,8 +11,22 @@ use anyhow::{anyhow, Result};
 
 use crate::{ActionEnvelope, ActionId, ActionInput, ActionScopeId, WidgetId};
 
-pub type ScopedActionHandler =
-    Box<dyn FnMut(&ActionEnvelope, WidgetId, &ActionInput) -> Result<()> + Send + 'static>;
+/// Result of handling an action emitted inside an [`ActionScope`](crate::ui::ActionScope).
+///
+/// Handlers can consume the action directly or forward it as a new envelope for
+/// normal reducer and effect processing. The original target and input are
+/// preserved when forwarding.
+#[derive(Clone, Debug)]
+pub enum ScopedActionResolution {
+    Handled,
+    Forward(ActionEnvelope),
+}
+
+pub type ScopedActionHandler = Box<
+    dyn FnMut(&ActionEnvelope, WidgetId, &ActionInput) -> Result<ScopedActionResolution>
+        + Send
+        + 'static,
+>;
 
 type ScopedActionHandlerMap = BTreeMap<(u128, ActionId), Vec<ScopedActionHandler>>;
 
@@ -49,20 +63,24 @@ pub(crate) fn dispatch_scoped_action_handler(
     action: &ActionEnvelope,
     target: WidgetId,
     input: &ActionInput,
-) -> Result<bool> {
+) -> Result<Option<ScopedActionResolution>> {
     let Some(scope_id) = input.action_scope_id() else {
-        return Ok(false);
+        return Ok(None);
     };
     let mut handlers = handlers()
         .lock()
         .map_err(|_| anyhow!("scoped action handler registry is poisoned"))?;
     let Some(scoped_handlers) = handlers.get_mut(&(scope_id, action.id)) else {
-        return Ok(false);
+        return Ok(None);
     };
+    let mut resolution = ScopedActionResolution::Handled;
     for handler in scoped_handlers {
-        handler(action, target, input)?;
+        let next = handler(action, target, input)?;
+        if matches!(next, ScopedActionResolution::Forward(_)) {
+            resolution = next;
+        }
     }
-    Ok(true)
+    Ok(Some(resolution))
 }
 
 #[cfg(test)]
@@ -83,7 +101,7 @@ mod tests {
             action,
             Box::new(move |_, _, _| {
                 *calls_for_handler.lock().unwrap() += 1;
-                Ok(())
+                Ok(ScopedActionResolution::Handled)
             }),
         )
         .unwrap();
@@ -94,14 +112,54 @@ mod tests {
         };
         let target = WidgetId::from_u128(7);
         assert!(
-            !dispatch_scoped_action_handler(&envelope, target, &ActionInput::None).unwrap(),
+            dispatch_scoped_action_handler(&envelope, target, &ActionInput::None)
+                .unwrap()
+                .is_none(),
             "unscoped input must not invoke scoped action handlers"
         );
         assert_eq!(*calls.lock().unwrap(), 0);
 
         let scoped = ActionInput::scoped_raw(scope.as_u128(), target, ActionInput::None);
-        assert!(dispatch_scoped_action_handler(&envelope, target, &scoped).unwrap());
+        assert!(matches!(
+            dispatch_scoped_action_handler(&envelope, target, &scoped).unwrap(),
+            Some(ScopedActionResolution::Handled)
+        ));
         assert_eq!(*calls.lock().unwrap(), 1);
+
+        clear_scoped_action_handlers(scope).unwrap();
+    }
+
+    #[test]
+    fn scoped_handler_can_forward_a_rewritten_envelope() {
+        let scope = ActionScopeId::from_name("test.forwarding.scope");
+        let emitted_action = ActionId::from_name("test.emitted.action");
+        let forwarded_action = ActionId::from_name("test.forwarded.action");
+        clear_scoped_action_handlers(scope).unwrap();
+        register_scoped_action_handler(
+            scope,
+            emitted_action,
+            Box::new(move |_, _, _| {
+                Ok(ScopedActionResolution::Forward(ActionEnvelope {
+                    id: forwarded_action,
+                    payload: b"forwarded".to_vec(),
+                }))
+            }),
+        )
+        .unwrap();
+
+        let emitted = ActionEnvelope {
+            id: emitted_action,
+            payload: b"emitted".to_vec(),
+        };
+        let target = WidgetId::from_u128(11);
+        let input = ActionInput::scoped_raw(scope.as_u128(), target, ActionInput::None);
+        let resolution = dispatch_scoped_action_handler(&emitted, target, &input).unwrap();
+
+        let Some(ScopedActionResolution::Forward(forwarded)) = resolution else {
+            panic!("scoped handler should forward a rewritten envelope");
+        };
+        assert_eq!(forwarded.id, forwarded_action);
+        assert_eq!(forwarded.payload, b"forwarded");
 
         clear_scoped_action_handlers(scope).unwrap();
     }

--- a/crates/core/fission-core/src/ui/mod.rs
+++ b/crates/core/fission-core/src/ui/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod node;
 pub(crate) mod traits;
 pub mod widgets;
 
-pub use node::{CustomWidget, Widget, WidgetIdExt};
+pub use node::{CustomWidget, Widget, WidgetIdExt, WidgetKind};
 pub use widgets::{
     provider, ActionScope, Align, BadgeTone, Builder, Button, ButtonContentAlign, ButtonHierarchy,
     ButtonMotion, ButtonVariant, CardPattern, Checkbox, Column, ComponentSize, ComponentState,

--- a/crates/core/fission-core/src/ui/node.rs
+++ b/crates/core/fission-core/src/ui/node.rs
@@ -1,14 +1,15 @@
 use super::custom_render::CustomRenderObject;
 use super::traits::{InternalLower, InternalLowerer};
 use super::widgets::{
-    ActionScope, Align, Button, Checkbox, Clip, Column, Composite, Container, ContextMenuRegion,
-    FocusScope, GestureDetector, Grid, GridItem, Icon, Image, LazyColumn, Overlay, Positioned,
-    Pressable, Radio, Responsive, RichText, Row, SafeArea, Scroll, SemanticsRegion, Slider, Spacer,
-    Switch, Text, TextInput, Transform, Video, ZStack,
+    ActionScope, Align, Button, Checkbox, Clip, Column, Composite, Container, ContextMenuEntry,
+    ContextMenuRegion, FocusScope, GestureDetector, Grid, GridItem, Icon, Image, LazyColumn,
+    Overlay, Positioned, Pressable, Radio, Responsive, RichText, Row, SafeArea, Scroll,
+    SemanticsRegion, Slider, Spacer, Switch, Text, TextInput, Transform, Video, ZStack,
 };
 use crate::lowering::InternalLoweringCx;
 use fission_ir::{Op, StructuralOp, WidgetId};
 use serde::{Deserialize, Serialize};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -17,7 +18,7 @@ pub struct Widget {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-enum WidgetKind {
+pub enum WidgetKind {
     Identified { id: WidgetId, child: Widget },
     ActionScope(ActionScope),
     Row(Row),
@@ -57,6 +58,88 @@ enum WidgetKind {
 }
 
 impl Widget {
+    /// Returns the concrete kind represented by this type-erased widget.
+    pub fn kind(&self) -> &WidgetKind {
+        self.kind.as_ref()
+    }
+
+    /// Visits this widget and every descendant in depth-first order.
+    ///
+    /// Returning [`ControlFlow::Break`] stops traversal immediately. The
+    /// visitor is read-only; callers that need to transform a tree should
+    /// construct a new widget tree through the normal authoring API.
+    pub fn visit(&self, visitor: &mut impl FnMut(&Widget) -> ControlFlow<()>) -> ControlFlow<()> {
+        visitor(self)?;
+        match self.kind.as_ref() {
+            WidgetKind::Identified { child, .. }
+            | WidgetKind::ActionScope(ActionScope { child, .. })
+            | WidgetKind::Align(Align { child, .. })
+            | WidgetKind::Clip(Clip { child, .. })
+            | WidgetKind::Transform(Transform { child, .. })
+            | WidgetKind::Pressable(Pressable { child, .. })
+            | WidgetKind::GestureDetector(GestureDetector { child, .. })
+            | WidgetKind::GridItem(GridItem { child, .. })
+            | WidgetKind::SafeArea(SafeArea { child, .. })
+            | WidgetKind::Composite(Composite { child, .. }) => child.visit(visitor),
+            WidgetKind::Row(Row { children, .. })
+            | WidgetKind::Column(Column { children, .. })
+            | WidgetKind::FocusScope(FocusScope { children, .. })
+            | WidgetKind::ZStack(ZStack { children, .. })
+            | WidgetKind::Grid(Grid { children, .. })
+            | WidgetKind::LazyColumn(LazyColumn { children, .. }) => {
+                for child in children {
+                    child.visit(visitor)?;
+                }
+                ControlFlow::Continue(())
+            }
+            WidgetKind::Button(Button { child, .. })
+            | WidgetKind::Scroll(Scroll { child, .. })
+            | WidgetKind::SemanticsRegion(SemanticsRegion { child, .. })
+            | WidgetKind::Container(Container { child, .. })
+            | WidgetKind::Positioned(Positioned { child, .. }) => {
+                if let Some(child) = child {
+                    child.visit(visitor)?;
+                }
+                ControlFlow::Continue(())
+            }
+            WidgetKind::Overlay(Overlay {
+                content, overlay, ..
+            }) => {
+                content.visit(visitor)?;
+                overlay.visit(visitor)
+            }
+            WidgetKind::ContextMenuRegion(ContextMenuRegion { child, menu, .. }) => {
+                child.visit(visitor)?;
+                for entry in &menu.items {
+                    if let ContextMenuEntry::Item(item) = entry {
+                        item.child.visit(visitor)?;
+                    }
+                }
+                ControlFlow::Continue(())
+            }
+            WidgetKind::Responsive(Responsive {
+                cases, fallback, ..
+            }) => {
+                for case in cases {
+                    case.child.visit(visitor)?;
+                }
+                fallback.visit(visitor)
+            }
+            WidgetKind::Custom(_)
+            | WidgetKind::Text(_)
+            | WidgetKind::RichText(_)
+            | WidgetKind::TextInput(_)
+            | WidgetKind::Image(_)
+            | WidgetKind::Video(_)
+            | WidgetKind::Checkbox(_)
+            | WidgetKind::Switch(_)
+            | WidgetKind::Radio(_)
+            | WidgetKind::Spacer(_)
+            | WidgetKind::Slider(_)
+            | WidgetKind::Icon(_) => ControlFlow::Continue(()),
+        }
+    }
+
     pub(crate) fn with_id(self, id: WidgetId) -> Self {
         let kind = match *self.kind {
             WidgetKind::Identified { child, .. } => WidgetKind::Identified { id, child },
@@ -749,5 +832,30 @@ pub type CustomWidget = InternalRenderNode;
 impl From<CustomWidget> for Widget {
     fn from(node: CustomWidget) -> Self {
         Widget::custom(node)
+    }
+}
+
+#[cfg(test)]
+mod visitor_tests {
+    use super::*;
+
+    #[test]
+    fn visitor_walks_nested_widgets_and_can_stop() {
+        let root: Widget = Column {
+            children: vec![Text::new("first").into(), Text::new("second").into()],
+            ..Default::default()
+        }
+        .into();
+        let mut visited = 0;
+        let result = root.visit(&mut |widget| {
+            visited += 1;
+            if matches!(widget.kind(), WidgetKind::Text(_)) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        });
+        assert!(matches!(result, ControlFlow::Break(())));
+        assert_eq!(visited, 2);
     }
 }

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -18,6 +18,6 @@ readme = "README.md"
 fission-ir = { path = "../fission-ir", version = "0.11.1" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.11.1", default-features = false }
 
 [dev-dependencies]

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -18,9 +18,11 @@ readme = "README.md"
 path = "src/lib.rs"
 
 [features]
+default = ["web-console"]
 # When disabled, emission macros become near no-ops at runtime (still compiled).
 # We can later make this a true compile-time gate across the workspace.
 fission_diagnostics = []
+web-console = ["dep:wasm-bindgen", "dep:web-sys"]
 
 [dependencies]
 once_cell = "1"
@@ -30,5 +32,5 @@ parking_lot = "0.12"
 bitflags = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["console"] }
+wasm-bindgen = { version = "0.2", optional = true }
+web-sys = { version = "0.3", features = ["console"], optional = true }

--- a/crates/tools/fission-diagnostics/src/lib.rs
+++ b/crates/tools/fission-diagnostics/src/lib.rs
@@ -383,7 +383,7 @@ fn write_stdout(_level: DiagLevel, line: &str) {
     println!("{line}");
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "web-console"))]
 fn write_stdout(level: DiagLevel, line: &str) {
     let line = wasm_bindgen::JsValue::from_str(line);
     if matches!(level, DiagLevel::Error) {
@@ -392,6 +392,9 @@ fn write_stdout(level: DiagLevel, line: &str) {
         web_sys::console::log_1(&line);
     }
 }
+
+#[cfg(all(target_arch = "wasm32", not(feature = "web-console")))]
+fn write_stdout(_level: DiagLevel, _line: &str) {}
 
 struct FileSinkImpl {
     file: RwLock<File>,

--- a/crates/tools/fission-test-driver/src/browser.rs
+++ b/crates/tools/fission-test-driver/src/browser.rs
@@ -547,14 +547,12 @@ impl BrowserController {
             .context("Chrome returned invalid screenshot base64")
     }
 
-    fn fail_on_browser_errors(&self) -> Result<()> {
+    fn fail_on_browser_errors(&mut self) -> Result<()> {
         if self.client.errors.is_empty() {
             Ok(())
         } else {
-            Err(anyhow!(
-                "browser reported errors:\n{}",
-                self.client.errors.join("\n")
-            ))
+            let errors = std::mem::take(&mut self.client.errors);
+            Err(anyhow!("browser reported errors:\n{}", errors.join("\n")))
         }
     }
 }

--- a/examples/showcase/src/mounted_example.rs
+++ b/examples/showcase/src/mounted_example.rs
@@ -5,7 +5,7 @@ use fission_core::scoped_action_handlers::{
 };
 use fission_core::{
     build, ActionEnvelope, ActionScopeId, ReducerContext, ResourceKey, Runtime,
-    RuntimeResourceKind, View,
+    RuntimeResourceKind, ScopedActionResolution, View,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -197,7 +197,7 @@ fn install_action_handlers(
                     .expect("mounted example runtime mutex poisoned");
                 runtime.dispatch_with_input(action.clone(), target, input.unscoped())?;
                 runtime.pending_effects.clear();
-                Ok(())
+                Ok(ScopedActionResolution::Handled)
             }),
         )
         .expect("mounted example action handler must register");


### PR DESCRIPTION
## Summary

Expose generic runtime primitives for inspecting widget trees, preserving action inputs across opaque boundaries, and resolving scoped actions through normal reducer/effect processing.

## Changes

- make `WidgetKind` public and add read-only depth-first `Widget::visit` traversal
- add opaque `ActionInput` encode/decode helpers with full-width identifier coverage
- allow scoped action handlers to consume an action or forward a rewritten envelope
- make WebAssembly console diagnostics an explicit feature that downstream crates can disable
- drain captured browser errors after reporting them so subsequent test-driver checks see only new failures

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p fission-core -p fission-diagnostics -p fission-test-driver --lib` (75 tests passed)
- [x] New focused tests added for widget traversal, opaque action input round trips, and scoped action forwarding
- [ ] `cargo test --workspace` (not run)

## Screenshots

No user-interface changes.
