### PR TITLE
Fix scroll state lifecycle before layout

### DIFF
--- a/crates/core/fission-core/src/runtime.rs
+++ b/crates/core/fission-core/src/runtime.rs
@@ -1062,18 +1062,13 @@ impl Runtime {
         );
     }
 
-    /// Runs runtime work that depends on a freshly computed layout snapshot.
+    /// Reconciles runtime-owned widget state against the current lowered tree.
     ///
-    /// Returns `true` when the hook changed runtime state and the shell should
-    /// schedule another frame.
-    pub fn post_layout_hook(&mut self, ir: &CoreIR, layout: &LayoutSnapshot) -> bool {
-        let mut needs_follow_up_frame = self.apply_pending_scroll_into_view(ir, layout);
+    /// Shells must call this after replacing the IR and before computing layout
+    /// so an unmounted widget's state cannot affect the replacement tree's
+    /// first frame.
+    pub fn reconcile_ir(&mut self, ir: &CoreIR) {
         self.runtime_state.viewport.reconcile(ir);
-        let current_time = self.clock().current_time();
-        needs_follow_up_frame |=
-            self.runtime_state
-                .viewport
-                .advance_inertia(ir, layout, current_time);
         let active_scroll_nodes: HashSet<WidgetId> = ir
             .nodes
             .iter()
@@ -1093,6 +1088,23 @@ impl Runtime {
         {
             self.runtime_state.gesture.scrollbar_drag = None;
         }
+    }
+
+    /// Runs runtime work that depends on a freshly computed layout snapshot.
+    ///
+    /// Returns `true` when the hook changed runtime state and the shell should
+    /// schedule another frame.
+    pub fn post_layout_hook(&mut self, ir: &CoreIR, layout: &LayoutSnapshot) -> bool {
+        // Preserve correct behavior for direct Runtime embedders that have not
+        // yet adopted the pre-layout reconciliation hook. Production shells
+        // call `reconcile_ir` before layout, making this pass idempotent.
+        self.reconcile_ir(ir);
+        let mut needs_follow_up_frame = self.apply_pending_scroll_into_view(ir, layout);
+        let current_time = self.clock().current_time();
+        needs_follow_up_frame |=
+            self.runtime_state
+                .viewport
+                .advance_inertia(ir, layout, current_time);
 
         let mut current_heroes = HashMap::new();
 

--- a/crates/core/fission-core/tests/scroll_state.rs
+++ b/crates/core/fission-core/tests/scroll_state.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
-use fission_core::ScrollStateMap;
-use fission_ir::WidgetId;
+use fission_core::ui::{Container, Scroll};
+use fission_core::{Runtime, ScrollStateMap, WidgetIdExt};
+use fission_ir::{CoreIR, FlexDirection, LayoutOp, Op, WidgetId};
 
 #[test]
 fn scroll_state_discards_unmounted_scroll_nodes() {
@@ -15,4 +16,74 @@ fn scroll_state_discards_unmounted_scroll_nodes() {
 
     assert_eq!(scroll.get_offset(active), 40.0);
     assert_eq!(scroll.get_offset(inactive), 0.0);
+}
+
+#[test]
+fn runtime_reconciles_replacement_scroll_state_before_layout() {
+    let review = WidgetId::explicit("flow.review.scroll");
+    let installing = WidgetId::explicit("flow.installing.scroll");
+    let mut runtime = Runtime::default();
+
+    runtime.runtime_state.scroll.set_offset(review, 640.0);
+    runtime.reconcile_ir(&scroll_ir(review));
+    assert_eq!(runtime.runtime_state.scroll.get_offset(review), 640.0);
+
+    runtime.reconcile_ir(&scroll_ir(installing));
+
+    assert_eq!(runtime.runtime_state.scroll.get_offset(review), 0.0);
+    assert_eq!(runtime.runtime_state.scroll.get_offset(installing), 0.0);
+}
+
+#[test]
+fn runtime_preserves_scroll_state_for_the_same_mounted_identity() {
+    let scroll = WidgetId::explicit("flow.review.scroll");
+    let mut runtime = Runtime::default();
+    runtime.runtime_state.scroll.set_offset(scroll, 320.0);
+
+    runtime.reconcile_ir(&scroll_ir(scroll));
+    runtime.reconcile_ir(&scroll_ir(scroll));
+
+    assert_eq!(runtime.runtime_state.scroll.get_offset(scroll), 320.0);
+}
+
+#[test]
+fn explicit_screen_scope_changes_implicit_descendant_scroll_identity() {
+    let review = scoped_scroll_id("flow.review");
+    let installing = scoped_scroll_id("flow.installing");
+
+    assert_ne!(review, installing);
+}
+
+fn scoped_scroll_id(scope: &str) -> WidgetId {
+    let widget = Container::new(Scroll::default()).id(WidgetId::explicit(scope));
+    let ir = fission_core::internal::lower_widget_to_ir(&widget);
+    ir.nodes
+        .iter()
+        .find_map(|(id, node)| {
+            matches!(node.op, Op::Layout(LayoutOp::Scroll { .. })).then_some(*id)
+        })
+        .expect("scoped screen should contain a scroll node")
+}
+
+fn scroll_ir(scroll: WidgetId) -> CoreIR {
+    let mut ir = CoreIR::new();
+    ir.add_node(
+        scroll,
+        Op::Layout(LayoutOp::Scroll {
+            direction: FlexDirection::Column,
+            show_scrollbar: false,
+            width: None,
+            height: None,
+            min_width: None,
+            max_width: None,
+            min_height: None,
+            max_height: None,
+            padding: [0.0; 4],
+            flex_grow: 1.0,
+            flex_shrink: 0.0,
+        }),
+        Vec::new(),
+    );
+    ir.set_root(scroll);
+    ir
 }

--- a/crates/shell/fission-shell-terminal/src/app.rs
+++ b/crates/shell/fission-shell-terminal/src/app.rs
@@ -204,6 +204,7 @@ where
         };
         verify_terminal_ir(&ir).context("terminal shell support check failed")?;
         self.runtime.reconcile_focus(&ir)?;
+        self.runtime.reconcile_ir(&ir);
 
         let layout_input_nodes = build_layout_tree(&ir, &self.env);
         self.layout_engine.update(&layout_input_nodes);

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -8079,6 +8079,10 @@ where
                                 last_built_viewport = Some(build_viewport);
                             }
 
+                            if let Some(ir) = pipeline.prev_ir.as_ref() {
+                                runtime.reconcile_ir(ir);
+                            }
+
                             let _layout_updates = match pipeline.ensure_layout(
                                 LayoutRect::new(
                                     0.0,


### PR DESCRIPTION
## Summary

- reconcile runtime-owned scroll and viewport state against the current IR before layout
- discard scroll offsets and scrollbar drag state when their widget identity unmounts
- preserve the post-layout reconciliation as an idempotent compatibility fallback for direct Runtime embedders
- apply the same lifecycle in the shared winit shell and Terminal
- add coverage for replacement screens, stable mounted identities, and explicit screen scopes

## Why

A replacement screen could receive the previous screen scroll offset during its first layout because stale state was pruned only after layout. This was visible in Worka when moving from the scrolled "Install <N> packs" review screen to the installation progress screen.

## Validation

- `cargo test -p fission-core --test scroll_state`
- `cargo test -p fission-core --test scroll_into_view --test viewport_input --test canvas_input`
- `cargo test -p fission-shell-terminal`
- `cargo check -p fission-shell-winit`
- `cargo fmt --all -- --check`
- `git diff --check`