### PR TITLE
Derive stable widget identities automatically

### DIFF
--- a/crates/core/fission-core/src/build.rs
+++ b/crates/core/fission-core/src/build.rs
@@ -22,9 +22,10 @@ struct BuildScope {
     runtime: *const crate::RuntimeState,
     env: *const crate::Env,
     layout: Option<*const crate::LayoutSnapshot>,
-    local_state_ordinals: HashMap<(&'static str, &'static str), usize>,
+    local_state_ordinals: HashMap<(crate::WidgetId, &'static str, &'static str), usize>,
     local_state_seen: HashSet<crate::state::LocalStateKey>,
     widget_id_stack: Vec<crate::WidgetId>,
+    identity_stack: Vec<crate::WidgetId>,
     implicit_widget_seq: u32,
     providers: HashMap<TypeId, Vec<Box<dyn Any + Send + Sync>>>,
 }
@@ -64,6 +65,23 @@ pub fn enter<S, R>(ctx: &mut BuildCtx<S>, view: &View<'_, S>, f: impl FnOnce() -
 where
     S: GlobalState,
 {
+    enter_with_root(ctx, view, crate::WidgetId::app_root(), f)
+}
+
+/// Runs an authoring pass beneath a deterministic application mount identity.
+///
+/// First-party shells use this to pass their configured root. Embedders hosting
+/// multiple independent trees in one runtime must provide distinct root ids.
+#[doc(hidden)]
+pub fn enter_with_root<S, R>(
+    ctx: &mut BuildCtx<S>,
+    view: &View<'_, S>,
+    root_id: crate::WidgetId,
+    f: impl FnOnce() -> R,
+) -> R
+where
+    S: GlobalState,
+{
     BUILD_SCOPES.with(|scopes| {
         scopes.borrow_mut().push(BuildScope {
             state_type: TypeId::of::<S>(),
@@ -85,6 +103,7 @@ where
             local_state_ordinals: HashMap::new(),
             local_state_seen: HashSet::new(),
             widget_id_stack: Vec::new(),
+            identity_stack: vec![root_id],
             implicit_widget_seq: 0,
             providers: HashMap::new(),
         });
@@ -147,20 +166,31 @@ where
         };
 
         let key_path = scope
-            .widget_id_stack
+            .identity_stack
             .iter()
             .map(|id| id.as_u128().to_string())
             .collect::<Vec<_>>();
-        let ordinal = if key_path.is_empty() {
-            let next = scope
+        let identity = scope
+            .identity_stack
+            .last()
+            .copied()
+            .unwrap_or_else(crate::WidgetId::app_root);
+        if scope.widget_id_stack.last().copied() == Some(identity)
+            && scope.identity_stack.len() > 1
+        {
+            let parent = scope.identity_stack[scope.identity_stack.len() - 2];
+            scope
                 .local_state_ordinals
-                .entry((component, field))
+                .entry((parent, component, field))
                 .and_modify(|next| *next += 1)
                 .or_insert(0);
-            *next
-        } else {
-            0
-        };
+        }
+        let next = scope
+            .local_state_ordinals
+            .entry((identity, component, field))
+            .and_modify(|next| *next += 1)
+            .or_insert(0);
+        let ordinal = *next;
         let key = crate::state::LocalStateKey::new_scoped(component, field, key_path, ordinal);
         if !scope.local_state_seen.insert(key.clone()) {
             panic!(
@@ -181,6 +211,7 @@ pub fn with_widget_id<R>(id: crate::WidgetId, f: impl FnOnce() -> R) -> R {
         let mut scopes = scopes.borrow_mut();
         if let Some(scope) = scopes.last_mut() {
             scope.widget_id_stack.push(id);
+            scope.identity_stack.push(id);
             true
         } else {
             false
@@ -194,6 +225,7 @@ pub fn with_widget_id<R>(id: crate::WidgetId, f: impl FnOnce() -> R) -> R {
                 BUILD_SCOPES.with(|scopes| {
                     if let Some(scope) = scopes.borrow_mut().last_mut() {
                         scope.widget_id_stack.pop();
+                        scope.identity_stack.pop();
                     }
                 });
             }
@@ -202,6 +234,57 @@ pub fn with_widget_id<R>(id: crate::WidgetId, f: impl FnOnce() -> R) -> R {
 
     let _guard = PopGuard(pushed);
     f()
+}
+
+/// Runs child construction beneath an automatically derived structural scope.
+///
+/// The scope participates in local-state identity but is not an explicit
+/// application-visible widget id.
+#[doc(hidden)]
+pub fn with_implicit_widget_id<R>(id: crate::WidgetId, f: impl FnOnce() -> R) -> R {
+    let pushed = BUILD_SCOPES.with(|scopes| {
+        let mut scopes = scopes.borrow_mut();
+        if let Some(scope) = scopes.last_mut() {
+            scope.identity_stack.push(id);
+            true
+        } else {
+            false
+        }
+    });
+
+    struct PopGuard(bool);
+    impl Drop for PopGuard {
+        fn drop(&mut self) {
+            if self.0 {
+                BUILD_SCOPES.with(|scopes| {
+                    if let Some(scope) = scopes.borrow_mut().last_mut() {
+                        scope.identity_stack.pop();
+                    }
+                });
+            }
+        }
+    }
+
+    let _guard = PopGuard(pushed);
+    f()
+}
+
+/// Returns the current structural identity used by authoring helpers.
+#[doc(hidden)]
+pub fn current_identity() -> Option<crate::WidgetId> {
+    BUILD_SCOPES.with(|scopes| {
+        scopes
+            .borrow()
+            .last()
+            .and_then(|scope| scope.identity_stack.last().copied())
+    })
+}
+
+/// Derives a stable scope for one invocation of `widgets!`.
+#[doc(hidden)]
+pub fn collection_scope(file: &str, line: u32, column: u32) -> crate::WidgetId {
+    let parent = current_identity().unwrap_or_else(crate::WidgetId::app_root);
+    crate::WidgetId::scoped_location(parent.as_u128(), file, line, column)
 }
 
 pub fn current_widget_id() -> Option<crate::WidgetId> {
@@ -218,7 +301,7 @@ pub(crate) fn next_implicit_widget_id(salt: u32) -> Option<crate::WidgetId> {
         let mut scopes = scopes.borrow_mut();
         let scope = scopes.last_mut()?;
         let parent = scope
-            .widget_id_stack
+            .identity_stack
             .last()
             .map(|id| id.as_u128())
             .unwrap_or(0x1337_C0DE_0000_0000);

--- a/crates/core/fission-core/src/lib.rs
+++ b/crates/core/fission-core/src/lib.rs
@@ -101,15 +101,41 @@ pub mod internal {
     }
 
     pub fn lower_widget(widget: &Widget, cx: &mut InternalLoweringCx) -> WidgetId {
-        widget.lower(cx)
+        let root = cx.next_widget_root();
+        lower_widget_with_root(widget, cx, root)
+    }
+
+    pub fn lower_widget_with_root(
+        widget: &Widget,
+        cx: &mut InternalLoweringCx,
+        root: WidgetId,
+    ) -> WidgetId {
+        widget.clone().resolve_identities(root).lower(cx)
     }
 
     pub fn lower_widget_to_ir(widget: &Widget) -> fission_ir::CoreIR {
+        lower_widget_to_ir_with_root(widget, WidgetId::app_root())
+    }
+
+    pub fn lower_widget_to_ir_with_root(widget: &Widget, root: WidgetId) -> fission_ir::CoreIR {
         let env = crate::Env::default();
         let runtime_state = crate::RuntimeState::default();
         let mut cx = InternalLoweringCx::new(&env, &runtime_state, None, None);
-        widget.lower(&mut cx);
+        let root_id = widget.clone().resolve_identities(root).lower(&mut cx);
+        cx.ir.root = Some(root_id);
         cx.ir
+    }
+
+    pub fn resolve_widget_identities(widget: &Widget, root: WidgetId) -> Widget {
+        widget.clone().resolve_identities(root)
+    }
+
+    pub fn shell_root_id(authored_root: WidgetId) -> WidgetId {
+        WidgetId::derived(authored_root.as_u128(), &[0xF155_5E11])
+    }
+
+    pub fn widget_id(widget: &Widget) -> Option<WidgetId> {
+        widget.declared_id()
     }
 
     pub fn widget_kind_name(widget: &Widget) -> &'static str {
@@ -586,15 +612,25 @@ macro_rules! reduce {
 /// Builds a `Vec<Widget>` from widget expressions without repeated `.into()` calls.
 ///
 /// Dynamic children may still be produced with normal iterators and
-/// `collect::<Vec<Widget>>()`; this macro is only syntax sugar for
-/// literal child lists.
+/// `collect::<Vec<Widget>>()`. In both forms, children without explicit IDs
+/// receive deterministic position-based identity. Set an explicit ID on a
+/// logical collection item when retained state should follow the item through
+/// reordering.
 #[macro_export]
 macro_rules! widgets {
     ($($widget:expr),* $(,)?) => {
         {
             let mut widgets = ::std::vec::Vec::<$crate::Widget>::new();
+            let collection_scope = $crate::build::collection_scope(file!(), line!(), column!());
             $(
-                widgets.push($crate::Widget::from($widget));
+                let child_index = widgets.len() as u32;
+                let child_scope = $crate::WidgetId::derived(
+                    collection_scope.as_u128(),
+                    &[child_index],
+                );
+                widgets.push($crate::build::with_implicit_widget_id(child_scope, || {
+                    $crate::Widget::from($widget)
+                }));
             )*
             widgets
         }

--- a/crates/core/fission-core/src/lowering.rs
+++ b/crates/core/fission-core/src/lowering.rs
@@ -47,6 +47,14 @@ impl<'a> InternalLoweringCx<'a> {
         }
     }
 
+    pub(crate) fn next_widget_root(&mut self) -> WidgetId {
+        if self.ir.nodes.is_empty() && self.id_stack.is_empty() && self.global_seq == 0 {
+            WidgetId::app_root()
+        } else {
+            self.next_node_id()
+        }
+    }
+
     pub fn push_scope(&mut self, node_id: WidgetId) {
         self.id_stack.push((node_id, 0));
     }

--- a/crates/core/fission-core/src/ui/node.rs
+++ b/crates/core/fission-core/src/ui/node.rs
@@ -65,6 +65,8 @@ pub enum WidgetKind {
 }
 
 impl Widget {
+    const CHILD_ROLE: u32 = 0xF155_2000;
+
     /// Returns the concrete kind represented by this type-erased widget.
     pub fn kind(&self) -> &WidgetKind {
         self.kind.as_ref()
@@ -132,12 +134,25 @@ impl Widget {
                 }
                 fallback.visit(visitor)
             }
+            WidgetKind::RichText(RichText { inline_widgets, .. }) => {
+                for inline in inline_widgets {
+                    inline.widget.visit(visitor)?;
+                }
+                ControlFlow::Continue(())
+            }
+            WidgetKind::TextInput(TextInput { prefix, suffix, .. }) => {
+                if let Some(prefix) = prefix {
+                    prefix.visit(visitor)?;
+                }
+                if let Some(suffix) = suffix {
+                    suffix.visit(visitor)?;
+                }
+                ControlFlow::Continue(())
+            }
             #[cfg(feature = "interactive-canvas")]
             WidgetKind::InteractiveViewer(InteractiveViewer { child, .. }) => child.visit(visitor),
             WidgetKind::Custom(_)
             | WidgetKind::Text(_)
-            | WidgetKind::RichText(_)
-            | WidgetKind::TextInput(_)
             | WidgetKind::Image(_)
             | WidgetKind::Video(_)
             | WidgetKind::Checkbox(_)
@@ -378,6 +393,273 @@ impl Widget {
         }
     }
 
+    fn kind_discriminator(&self) -> u32 {
+        // These values are part of structural identity. Never renumber an
+        // existing kind; append a new value even when variants move.
+        match &*self.kind {
+            WidgetKind::Identified { .. } => 1,
+            WidgetKind::ActionScope(_) => 2,
+            WidgetKind::Row(_) => 3,
+            WidgetKind::Column(_) => 4,
+            WidgetKind::Align(_) => 5,
+            WidgetKind::FocusScope(_) => 6,
+            WidgetKind::Clip(_) => 7,
+            WidgetKind::Text(_) => 8,
+            WidgetKind::RichText(_) => 9,
+            WidgetKind::Transform(_) => 10,
+            #[cfg(feature = "interactive-canvas")]
+            WidgetKind::InteractiveViewer(_) => 11,
+            WidgetKind::Button(_) => 12,
+            WidgetKind::Pressable(_) => 13,
+            WidgetKind::TextInput(_) => 14,
+            WidgetKind::Scroll(_) => 15,
+            WidgetKind::SemanticsRegion(_) => 16,
+            WidgetKind::Image(_) => 17,
+            WidgetKind::Video(_) => 18,
+            WidgetKind::ZStack(_) => 19,
+            WidgetKind::Overlay(_) => 20,
+            WidgetKind::Container(_) => 21,
+            WidgetKind::ContextMenuRegion(_) => 22,
+            WidgetKind::GestureDetector(_) => 23,
+            WidgetKind::Grid(_) => 24,
+            WidgetKind::GridItem(_) => 25,
+            WidgetKind::Responsive(_) => 26,
+            WidgetKind::Checkbox(_) => 27,
+            WidgetKind::Switch(_) => 28,
+            WidgetKind::Radio(_) => 29,
+            WidgetKind::SafeArea(_) => 30,
+            WidgetKind::Positioned(_) => 31,
+            WidgetKind::Spacer(_) => 32,
+            WidgetKind::Slider(_) => 33,
+            WidgetKind::LazyColumn(_) => 34,
+            WidgetKind::Icon(_) => 35,
+            WidgetKind::Composite(_) => 36,
+            WidgetKind::Custom(_) => 37,
+        }
+    }
+
+    pub(crate) fn declared_id(&self) -> Option<WidgetId> {
+        match &*self.kind {
+            WidgetKind::Identified { id, .. } => Some(*id),
+            WidgetKind::ActionScope(_) => None,
+            WidgetKind::Custom(widget) => widget
+                .lowerer
+                .as_ref()
+                .and_then(|lowerer| lowerer.widget_id()),
+            WidgetKind::Row(widget) => widget.id,
+            WidgetKind::Column(widget) => widget.id,
+            WidgetKind::Align(widget) => widget.id,
+            WidgetKind::FocusScope(widget) => widget.id,
+            WidgetKind::Clip(widget) => widget.id,
+            WidgetKind::Text(widget) => widget.id,
+            WidgetKind::RichText(widget) => widget.id,
+            WidgetKind::Transform(widget) => widget.id,
+            #[cfg(feature = "interactive-canvas")]
+            WidgetKind::InteractiveViewer(widget) => widget.id,
+            WidgetKind::Button(widget) => widget.id,
+            WidgetKind::Pressable(widget) => widget.id,
+            WidgetKind::TextInput(widget) => widget.id,
+            WidgetKind::Scroll(widget) => widget.id,
+            WidgetKind::SemanticsRegion(widget) => widget.id,
+            WidgetKind::Image(widget) => widget.id,
+            WidgetKind::Video(widget) => widget.id,
+            WidgetKind::ZStack(widget) => widget.id,
+            WidgetKind::Overlay(widget) => widget.id,
+            WidgetKind::Container(widget) => widget.id,
+            WidgetKind::ContextMenuRegion(widget) => widget.id,
+            WidgetKind::GestureDetector(widget) => widget.id,
+            WidgetKind::Grid(widget) => widget.id,
+            WidgetKind::GridItem(widget) => widget.id,
+            WidgetKind::Responsive(widget) => widget.id,
+            WidgetKind::Checkbox(widget) => widget.id,
+            WidgetKind::Switch(widget) => widget.id,
+            WidgetKind::Radio(widget) => widget.id,
+            WidgetKind::SafeArea(widget) => widget.id,
+            WidgetKind::Positioned(widget) => widget.id,
+            WidgetKind::Spacer(widget) => widget.id,
+            WidgetKind::Slider(widget) => widget.id,
+            WidgetKind::LazyColumn(widget) => widget.id,
+            WidgetKind::Icon(widget) => widget.id,
+            WidgetKind::Composite(widget) => widget.id,
+        }
+    }
+
+    pub(crate) fn resolve_identities(self, root: WidgetId) -> Self {
+        self.resolve_identity(root)
+    }
+
+    fn resolve_identity(self, automatic_id: WidgetId) -> Self {
+        let resolved = if self.declared_id().is_some() {
+            self
+        } else {
+            self.with_id(automatic_id)
+        };
+        let parent = resolved.declared_id().unwrap_or(automatic_id);
+        resolved.resolve_descendants(parent)
+    }
+
+    fn resolve_descendants(self, parent: WidgetId) -> Self {
+        let child = |widget: Widget, slot: u32| {
+            let id = WidgetId::derived(
+                parent.as_u128(),
+                &[Self::CHILD_ROLE, slot, widget.kind_discriminator()],
+            );
+            widget.resolve_identity(id)
+        };
+        let children = |widgets: Vec<Widget>, first_slot: u32| {
+            widgets
+                .into_iter()
+                .enumerate()
+                .map(|(index, widget)| child(widget, first_slot + index as u32))
+                .collect()
+        };
+
+        let kind = match *self.kind {
+            WidgetKind::Identified {
+                id,
+                child: identified_child,
+            } => WidgetKind::Identified {
+                id,
+                // The structural wrapper is the logical identity for widget
+                // kinds that cannot store an id directly (ActionScope and
+                // Custom). Re-resolving that child would create wrappers
+                // recursively; only its descendants need identities here.
+                child: identified_child.resolve_descendants(id),
+            },
+            WidgetKind::ActionScope(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::ActionScope(widget)
+            }
+            WidgetKind::Row(mut widget) => {
+                widget.children = children(widget.children, 0);
+                WidgetKind::Row(widget)
+            }
+            WidgetKind::Column(mut widget) => {
+                widget.children = children(widget.children, 0);
+                WidgetKind::Column(widget)
+            }
+            WidgetKind::Align(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::Align(widget)
+            }
+            WidgetKind::FocusScope(mut widget) => {
+                widget.children = children(widget.children, 0);
+                WidgetKind::FocusScope(widget)
+            }
+            WidgetKind::Clip(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::Clip(widget)
+            }
+            WidgetKind::Text(widget) => WidgetKind::Text(widget),
+            WidgetKind::RichText(mut widget) => {
+                for (index, inline) in widget.inline_widgets.iter_mut().enumerate() {
+                    inline.widget = child(inline.widget.clone(), index as u32);
+                }
+                WidgetKind::RichText(widget)
+            }
+            WidgetKind::Transform(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::Transform(widget)
+            }
+            #[cfg(feature = "interactive-canvas")]
+            WidgetKind::InteractiveViewer(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::InteractiveViewer(widget)
+            }
+            WidgetKind::Button(mut widget) => {
+                widget.child = widget.child.map(|value| child(value, 0));
+                WidgetKind::Button(widget)
+            }
+            WidgetKind::Pressable(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::Pressable(widget)
+            }
+            WidgetKind::TextInput(mut widget) => {
+                widget.prefix = widget.prefix.map(|value| child(value, 0));
+                widget.suffix = widget.suffix.map(|value| child(value, 1));
+                WidgetKind::TextInput(widget)
+            }
+            WidgetKind::Scroll(mut widget) => {
+                widget.child = widget.child.map(|value| child(value, 0));
+                WidgetKind::Scroll(widget)
+            }
+            WidgetKind::SemanticsRegion(mut widget) => {
+                widget.child = widget.child.map(|value| child(value, 0));
+                WidgetKind::SemanticsRegion(widget)
+            }
+            WidgetKind::Image(widget) => WidgetKind::Image(widget),
+            WidgetKind::Video(widget) => WidgetKind::Video(widget),
+            WidgetKind::ZStack(mut widget) => {
+                widget.children = children(widget.children, 0);
+                WidgetKind::ZStack(widget)
+            }
+            WidgetKind::Overlay(mut widget) => {
+                widget.content = child(widget.content, 0);
+                widget.overlay = child(widget.overlay, 1);
+                WidgetKind::Overlay(widget)
+            }
+            WidgetKind::Container(mut widget) => {
+                widget.child = widget.child.map(|value| child(value, 0));
+                WidgetKind::Container(widget)
+            }
+            WidgetKind::ContextMenuRegion(mut widget) => {
+                widget.child = child(widget.child, 0);
+                for (index, entry) in widget.menu.items.iter_mut().enumerate() {
+                    if let ContextMenuEntry::Item(item) = entry {
+                        item.child = child(item.child.clone(), 1 + index as u32);
+                    }
+                }
+                WidgetKind::ContextMenuRegion(widget)
+            }
+            WidgetKind::GestureDetector(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::GestureDetector(widget)
+            }
+            WidgetKind::Grid(mut widget) => {
+                widget.children = children(widget.children, 0);
+                WidgetKind::Grid(widget)
+            }
+            WidgetKind::GridItem(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::GridItem(widget)
+            }
+            WidgetKind::Responsive(mut widget) => {
+                for (index, case) in widget.cases.iter_mut().enumerate() {
+                    case.child = child(case.child.clone(), index as u32);
+                }
+                widget.fallback = child(widget.fallback, u32::MAX);
+                WidgetKind::Responsive(widget)
+            }
+            WidgetKind::Checkbox(widget) => WidgetKind::Checkbox(widget),
+            WidgetKind::Switch(widget) => WidgetKind::Switch(widget),
+            WidgetKind::Radio(widget) => WidgetKind::Radio(widget),
+            WidgetKind::SafeArea(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::SafeArea(widget)
+            }
+            WidgetKind::Positioned(mut widget) => {
+                widget.child = widget.child.map(|value| child(value, 0));
+                WidgetKind::Positioned(widget)
+            }
+            WidgetKind::Spacer(widget) => WidgetKind::Spacer(widget),
+            WidgetKind::Slider(widget) => WidgetKind::Slider(widget),
+            WidgetKind::LazyColumn(mut widget) => {
+                widget.children = children(widget.children, 0);
+                WidgetKind::LazyColumn(widget)
+            }
+            WidgetKind::Icon(widget) => WidgetKind::Icon(widget),
+            WidgetKind::Composite(mut widget) => {
+                widget.child = child(widget.child, 0);
+                WidgetKind::Composite(widget)
+            }
+            WidgetKind::Custom(widget) => WidgetKind::Custom(widget),
+        };
+
+        Self {
+            kind: Box::new(kind),
+        }
+    }
+
     pub(crate) fn as_row(&self) -> Option<&Row> {
         match &*self.kind {
             WidgetKind::Identified { child, .. } => child.as_row(),
@@ -468,6 +750,12 @@ impl Widget {
     }
 }
 
+/// Overrides Fission's automatic structural identity for a widget.
+///
+/// Explicit IDs are normally only needed for logical items in dynamic
+/// collections or for code that must address a particular widget. An explicit
+/// ID also scopes all automatically identified descendants, so a stateful
+/// subtree follows its logical item when reordered.
 pub trait WidgetIdExt: Into<Widget> + Sized {
     fn id<I>(self, id: I) -> Widget
     where
@@ -487,7 +775,9 @@ impl Widget {
     pub(crate) fn lower(&self, cx: &mut InternalLoweringCx) -> WidgetId {
         match &*self.kind {
             WidgetKind::Identified { id, child } => {
+                cx.push_scope(*id);
                 let child_id = child.lower(cx);
+                cx.pop_scope();
                 let mut builder = crate::lowering::InternalIrBuilder::new(
                     (*id).into(),
                     Op::Structural(StructuralOp::Group {
@@ -538,8 +828,10 @@ impl Widget {
                     .lowerer
                     .as_ref()
                     .expect("CustomWidget lowerer must be set");
-                let child_id = lowerer.lower_dyn(cx);
                 let wrapper = lowerer.widget_id().unwrap_or_else(|| cx.next_node_id());
+                cx.push_scope(wrapper);
+                let child_id = lowerer.lower_dyn(cx);
+                cx.pop_scope();
                 let mut builder = crate::lowering::InternalIrBuilder::new(
                     wrapper,
                     Op::Structural(StructuralOp::Group {

--- a/crates/core/fission-core/tests/automatic_widget_identity.rs
+++ b/crates/core/fission-core/tests/automatic_widget_identity.rs
@@ -1,0 +1,714 @@
+use std::ops::ControlFlow;
+
+use fission_core::internal::{self, BuildCtx};
+use fission_core::ui::widgets::text::InlineWidgetSpan;
+use fission_core::ui::{Container, Overlay, RichText, Scroll, TextContent, TextInput, ZStack};
+use fission_core::{
+    build, reduce, widgets, ActionEnvelope, ActionScope, ActionScopeId, Button, Column, Env,
+    Runtime, Text, View, Widget, WidgetId, WidgetIdExt,
+};
+use fission_ir::op::Color;
+use fission_ir::Op;
+use fission_macros::{fission_component, fission_reducer};
+
+fn resolved(widget: Widget) -> Widget {
+    internal::resolve_widget_identities(&widget, WidgetId::app_root())
+}
+
+fn identity_snapshot(widget: &Widget) -> Vec<(&'static str, WidgetId)> {
+    let mut snapshot = Vec::new();
+    let _ = widget.visit(&mut |node| {
+        let id = internal::widget_id(node).expect("every built-in widget should be identified");
+        snapshot.push((internal::widget_kind_name(node), id));
+        ControlFlow::Continue(())
+    });
+    snapshot
+}
+
+fn text_identities(widget: &Widget) -> Vec<(String, WidgetId)> {
+    let mut identities = Vec::new();
+    let _ = widget.visit(&mut |node| {
+        if let Some(text) = internal::widget_as_text(node) {
+            if let TextContent::Literal(value) = &text.content {
+                identities.push((
+                    value.clone(),
+                    internal::widget_id(node).expect("resolved text should have an id"),
+                ));
+            }
+        }
+        ControlFlow::Continue(())
+    });
+    identities
+}
+
+fn typical_developer_tree(decorated: bool) -> Widget {
+    let background = decorated.then_some(Color {
+        r: 20,
+        g: 30,
+        b: 40,
+        a: 255,
+    });
+
+    Column {
+        children: widgets![
+            Text::new("Dashboard"),
+            Container {
+                child: Some(Text::new("Summary").into()),
+                background_color: background,
+                ..Default::default()
+            },
+            Scroll {
+                child: Some(
+                    Column {
+                        children: vec![
+                            Text::new("First row").into(),
+                            Text::new("Second row").into(),
+                        ],
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
+                ..Default::default()
+            },
+            TextInput {
+                value: "search".into(),
+                ..Default::default()
+            },
+            Button {
+                child: Some(Text::new("Continue").into()),
+                ..Default::default()
+            }
+            .id(WidgetId::explicit("developer-randomly-identified-button")),
+        ],
+        ..Default::default()
+    }
+    .into()
+}
+
+#[test]
+fn identical_developer_trees_receive_identical_complete_identity_snapshots() {
+    let first = resolved(typical_developer_tree(false));
+    let second = resolved(typical_developer_tree(false));
+
+    let first_snapshot = identity_snapshot(&first);
+    let second_snapshot = identity_snapshot(&second);
+
+    assert_eq!(first_snapshot, second_snapshot);
+    let unique = first_snapshot
+        .iter()
+        .map(|(_, id)| *id)
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(unique.len(), first_snapshot.len());
+}
+
+#[test]
+fn embedded_widget_surfaces_receive_automatic_identities() {
+    let tree = resolved(
+        Column {
+            children: vec![
+                TextInput {
+                    prefix: Some(Text::new("prefix").into()),
+                    suffix: Some(Text::new("suffix").into()),
+                    ..Default::default()
+                }
+                .into(),
+                RichText {
+                    inline_widgets: vec![InlineWidgetSpan::new(Text::new("inline"), 20.0, 20.0)],
+                    ..Default::default()
+                }
+                .into(),
+            ],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let embedded = text_identities(&tree);
+    assert_eq!(
+        embedded
+            .iter()
+            .map(|(text, _)| text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["prefix", "suffix", "inline"]
+    );
+    let unique = embedded
+        .iter()
+        .map(|(_, id)| *id)
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(unique.len(), embedded.len());
+}
+
+#[test]
+fn optional_sibling_slots_do_not_renumber_present_widgets() {
+    let with_prefix = resolved(
+        TextInput {
+            prefix: Some(Text::new("prefix").into()),
+            suffix: Some(Text::new("suffix").into()),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let without_prefix = resolved(
+        TextInput {
+            suffix: Some(Text::new("suffix").into()),
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let suffix_with_prefix = text_identities(&with_prefix)
+        .into_iter()
+        .find(|(label, _)| label == "suffix")
+        .unwrap();
+    let suffix_without_prefix = text_identities(&without_prefix)
+        .into_iter()
+        .find(|(label, _)| label == "suffix")
+        .unwrap();
+    assert_eq!(suffix_with_prefix.1, suffix_without_prefix.1);
+}
+
+#[test]
+fn internal_decoration_does_not_change_authored_widget_identities() {
+    let plain = resolved(typical_developer_tree(false));
+    let decorated = resolved(typical_developer_tree(true));
+
+    assert_eq!(identity_snapshot(&plain), identity_snapshot(&decorated));
+
+    let plain_ir = internal::lower_widget_to_ir(&plain);
+    let decorated_ir = internal::lower_widget_to_ir(&decorated);
+    for (_, id) in identity_snapshot(&plain) {
+        assert!(plain_ir.nodes.contains_key(&id));
+        assert!(decorated_ir.nodes.contains_key(&id));
+    }
+}
+
+#[test]
+fn shell_overlay_has_a_separate_root_without_reidentifying_the_authored_tree() {
+    let authored_root = WidgetId::explicit("authored-app-root");
+    let shell_root = internal::shell_root_id(authored_root);
+    let authored = internal::resolve_widget_identities(
+        &Column {
+            children: vec![Text::new("content").into()],
+            ..Default::default()
+        }
+        .into(),
+        authored_root,
+    );
+    let shell: Widget = Overlay {
+        content: authored,
+        overlay: ZStack::default().into(),
+        ..Default::default()
+    }
+    .into();
+    let ir = internal::lower_widget_to_ir_with_root(&shell, shell_root);
+
+    assert_eq!(ir.root, Some(shell_root));
+    assert!(ir.nodes.contains_key(&authored_root));
+    assert_ne!(shell_root, authored_root);
+}
+
+#[test]
+fn identical_identity_trees_produce_an_empty_frame_diff() {
+    let first = internal::lower_widget_to_ir(&typical_developer_tree(false));
+    let second = internal::lower_widget_to_ir(&typical_developer_tree(false));
+    let diff = fission_core::diff::diff_ir(&first, &second);
+
+    assert!(diff.dirty_layout.is_empty());
+    assert!(diff.dirty_paint.is_empty());
+    assert!(diff.dirty_composite.is_empty());
+}
+
+#[test]
+fn changing_one_leaf_does_not_change_an_unrelated_sibling_identity() {
+    let before = resolved(
+        Column {
+            children: vec![Text::new("before").into(), Text::new("stable").into()],
+            ..Default::default()
+        }
+        .into(),
+    );
+    let after = resolved(
+        Column {
+            children: vec![Text::new("after").into(), Text::new("stable").into()],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let before_text = text_identities(&before);
+    let after_text = text_identities(&after);
+    assert_eq!(before_text[0].1, after_text[0].1);
+    assert_eq!(before_text[1], after_text[1]);
+
+    let before_ir = internal::lower_widget_to_ir(&before);
+    let after_ir = internal::lower_widget_to_ir(&after);
+    let diff = fission_core::diff::diff_ir(&before_ir, &after_ir);
+    assert!(!diff.dirty_layout.contains(&before_text[1].1));
+    assert!(!diff.dirty_paint.contains(&before_text[1].1));
+}
+
+#[test]
+fn resolved_widget_identity_survives_serialization() {
+    let tree = resolved(typical_developer_tree(false));
+    let encoded = serde_json::to_vec(&tree).expect("resolved widget tree should serialize");
+    let decoded: Widget =
+        serde_json::from_slice(&encoded).expect("resolved widget tree should deserialize");
+    assert_eq!(identity_snapshot(&tree), identity_snapshot(&decoded));
+}
+
+#[test]
+fn duplicate_manual_ids_are_rejected() {
+    let duplicate = WidgetId::explicit("duplicate-manual-id");
+    let tree: Widget = Column {
+        children: vec![
+            Text::new("first").id(duplicate),
+            Text::new("second").id(duplicate),
+        ],
+        ..Default::default()
+    }
+    .into();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        internal::lower_widget_to_ir(&tree)
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn explicit_identity_is_preserved_while_automatic_siblings_are_generated() {
+    let explicit = WidgetId::explicit("only-widget-the-developer-cared-about");
+    let tree = resolved(
+        Column {
+            children: vec![
+                Text::new("automatic-before").into(),
+                Text::new("manual").id(explicit),
+                Text::new("automatic-after").into(),
+            ],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let identities = text_identities(&tree);
+    assert_eq!(identities[1], ("manual".to_string(), explicit));
+    assert_ne!(identities[0].1, explicit);
+    assert_ne!(identities[2].1, explicit);
+    assert_ne!(identities[0].1, identities[2].1);
+}
+
+#[test]
+fn root_identity_namespaces_automatic_ids_but_not_explicit_ids() {
+    let explicit = WidgetId::explicit("portable-explicit-child");
+    let widget: Widget = Column {
+        children: vec![
+            Text::new("automatic").into(),
+            Text::new("explicit").id(explicit),
+        ],
+        ..Default::default()
+    }
+    .into();
+
+    let first = internal::resolve_widget_identities(&widget, WidgetId::explicit("mount-a"));
+    let second = internal::resolve_widget_identities(&widget, WidgetId::explicit("mount-b"));
+    let first_text = text_identities(&first);
+    let second_text = text_identities(&second);
+
+    assert_ne!(first_text[0].1, second_text[0].1);
+    assert_eq!(first_text[1].1, explicit);
+    assert_eq!(second_text[1].1, explicit);
+}
+
+#[test]
+fn configured_root_is_the_authored_root_widget_identity() {
+    let root = WidgetId::explicit("developer-chosen-app-root");
+    let widget = internal::resolve_widget_identities(&Text::new("root").into(), root);
+
+    assert_eq!(internal::widget_id(&widget), Some(root));
+}
+
+#[test]
+fn explicit_root_widget_identity_overrides_the_app_namespace() {
+    let explicit = WidgetId::explicit("root-widget-explicit-id");
+    let widget = Text::new("root").id(explicit);
+    let resolved = internal::resolve_widget_identities(
+        &widget,
+        WidgetId::explicit("configured-app-namespace"),
+    );
+
+    assert_eq!(internal::widget_id(&resolved), Some(explicit));
+}
+
+#[test]
+fn explicit_subtree_identity_keeps_automatic_descendants_stable_when_reordered() {
+    fn tree(order: &[&str]) -> Widget {
+        Column {
+            children: order
+                .iter()
+                .map(|label| {
+                    Container::new(Text::new(format!("child-of-{label}")))
+                        .id(WidgetId::explicit(&format!("subtree.{label}")))
+                })
+                .collect(),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    let before = text_identities(&resolved(tree(&["a", "b"])));
+    let after = text_identities(&resolved(tree(&["b", "a"])));
+
+    for (label, id) in before {
+        let after_id = after
+            .iter()
+            .find_map(|(candidate, candidate_id)| (candidate == &label).then_some(*candidate_id))
+            .unwrap();
+        assert_eq!(id, after_id);
+    }
+}
+
+#[test]
+fn automatic_subtree_identity_and_descendants_follow_the_structural_position() {
+    fn tree(order: &[&str]) -> Widget {
+        Column {
+            children: order
+                .iter()
+                .map(|label| Container::new(Text::new(format!("child-of-{label}"))).into())
+                .collect(),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    let before = text_identities(&resolved(tree(&["a", "b"])));
+    let after = text_identities(&resolved(tree(&["b", "a"])));
+
+    assert_eq!(before[0].1, after[0].1);
+    assert_eq!(before[1].1, after[1].1);
+    assert_ne!(before[0].0, after[0].0);
+}
+
+#[test]
+fn explicit_identity_stabilizes_internal_nodes_of_wrapper_widgets() {
+    let scope = ActionScopeId::from_name("stable-action-scope");
+    let explicit = WidgetId::explicit("stable-action-scope-widget");
+    let make_tree = |scope_first: bool| {
+        let scoped = ActionScope::new(scope, Text::new("scoped child")).id(explicit);
+        let sibling: Widget = Text::new("ordinary sibling").into();
+        Column {
+            children: if scope_first {
+                vec![scoped, sibling]
+            } else {
+                vec![sibling, scoped]
+            },
+            ..Default::default()
+        }
+        .into()
+    };
+    let scope_node = |ir: &fission_ir::CoreIR| {
+        ir.nodes
+            .iter()
+            .find_map(|(id, node)| match &node.op {
+                Op::Semantics(semantics) if semantics.action_scope_id == Some(scope.as_u128()) => {
+                    Some(*id)
+                }
+                _ => None,
+            })
+            .expect("action scope semantics node should be lowered")
+    };
+
+    let before = internal::lower_widget_to_ir(&make_tree(true));
+    let after = internal::lower_widget_to_ir(&make_tree(false));
+    assert_eq!(scope_node(&before), scope_node(&after));
+}
+
+#[test]
+fn widget_kind_participates_in_automatic_identity() {
+    let text = resolved(
+        Column {
+            children: vec![Text::new("same-slot").into()],
+            ..Default::default()
+        }
+        .into(),
+    );
+    let container = resolved(
+        Column {
+            children: vec![Container::new(Text::new("same-slot")).into()],
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let text_child = internal::widget_as_column(&text).unwrap().children[0].clone();
+    let container_child = internal::widget_as_column(&container).unwrap().children[0].clone();
+    assert_ne!(
+        internal::widget_id(&text_child),
+        internal::widget_id(&container_child)
+    );
+}
+
+fn unkeyed_text_collection(labels: &[&str]) -> Widget {
+    Column {
+        children: labels
+            .iter()
+            .map(|label| Text::new(*label).into())
+            .collect(),
+        ..Default::default()
+    }
+    .into()
+}
+
+fn identified_text_collection(labels: &[&str]) -> Widget {
+    Column {
+        children: labels
+            .iter()
+            .map(|label| Text::new(*label).id(WidgetId::explicit(&format!("item.{label}"))))
+            .collect(),
+        ..Default::default()
+    }
+    .into()
+}
+
+#[test]
+fn unkeyed_collection_identity_is_stable_and_position_based() {
+    let original = text_identities(&resolved(unkeyed_text_collection(&["a", "b", "c"])));
+    let rebuilt = text_identities(&resolved(unkeyed_text_collection(&["a", "b", "c"])));
+    let reordered = text_identities(&resolved(unkeyed_text_collection(&["c", "b", "a"])));
+
+    assert_eq!(original, rebuilt);
+    assert_eq!(
+        original.iter().map(|(_, id)| *id).collect::<Vec<_>>(),
+        reordered.iter().map(|(_, id)| *id).collect::<Vec<_>>()
+    );
+    assert_eq!(reordered[0].0, "c");
+    assert_eq!(reordered[0].1, original[0].1);
+}
+
+#[test]
+fn explicitly_identified_collection_items_follow_data_across_reorder() {
+    let original = text_identities(&resolved(identified_text_collection(&["a", "b", "c"])));
+    let reordered = text_identities(&resolved(identified_text_collection(&["c", "b", "a"])));
+
+    for (label, id) in original {
+        let reordered_id = reordered
+            .iter()
+            .find_map(|(candidate, candidate_id)| (candidate == &label).then_some(*candidate_id))
+            .expect("the same logical item should remain present");
+        assert_eq!(id, reordered_id);
+    }
+}
+
+#[test]
+fn inserted_unkeyed_items_keep_identity_with_positions() {
+    let original = text_identities(&resolved(unkeyed_text_collection(&["a", "b"])));
+    let inserted = text_identities(&resolved(unkeyed_text_collection(&["new", "a", "b"])));
+
+    assert_eq!(inserted[0].1, original[0].1);
+    assert_eq!(inserted[1].1, original[1].1);
+    assert_ne!(inserted[2].1, original[1].1);
+}
+
+#[fission_reducer(IncrementCounter)]
+fn increment_counter(value: &mut u32) {
+    *value += 1;
+}
+
+#[fission_component]
+struct StatefulItem {
+    label: String,
+
+    #[local_state(default = 0)]
+    value: u32,
+}
+
+impl From<StatefulItem> for Widget {
+    fn from(item: StatefulItem) -> Self {
+        let (ctx, _) = build::current::<()>();
+        let value = item.value();
+        let increment = ctx.bind_local(IncrementCounter, value.clone(), reduce!(increment_counter));
+        Column {
+            children: widgets![
+                Text::new(item.label),
+                Text::new(format!("value={}", value.get())),
+                Button {
+                    child: Some(Text::new("increment").into()),
+                    on_press: Some(increment),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+fn build_stateful_collection(
+    runtime: &Runtime,
+    labels: &[&str],
+    explicitly_identified: &[&str],
+    root: WidgetId,
+) -> (Widget, BuildCtx<()>) {
+    let env = Env::default();
+    let view = View::new(&(), &runtime.runtime_state, &env, None);
+    let mut context = BuildCtx::new();
+    let widget = build::enter_with_root(&mut context, &view, root, || {
+        Column {
+            children: labels
+                .iter()
+                .map(|label| {
+                    let item = StatefulItem {
+                        label: (*label).to_string(),
+                    };
+                    if explicitly_identified.contains(label) {
+                        item.id(WidgetId::explicit(&format!("stateful-item.{label}")))
+                    } else {
+                        item.into()
+                    }
+                })
+                .collect(),
+            ..Default::default()
+        }
+        .into()
+    });
+    (widget, context)
+}
+
+fn button_actions(widget: &Widget) -> Vec<ActionEnvelope> {
+    let mut actions = Vec::new();
+    let _ = widget.visit(&mut |node| {
+        if let Some(action) =
+            internal::widget_as_button(node).and_then(|button| button.on_press.clone())
+        {
+            actions.push(action);
+        }
+        ControlFlow::Continue(())
+    });
+    actions
+}
+
+fn item_values(widget: &Widget) -> Vec<(String, u32)> {
+    let texts = text_identities(&resolved(widget.clone()))
+        .into_iter()
+        .map(|(text, _)| text)
+        .collect::<Vec<_>>();
+    texts
+        .chunks(3)
+        .map(|chunk| {
+            let value = chunk[1].strip_prefix("value=").unwrap().parse().unwrap();
+            (chunk[0].clone(), value)
+        })
+        .collect()
+}
+
+fn dispatch_action(runtime: &mut Runtime, context: BuildCtx<()>, action: ActionEnvelope) {
+    runtime.clear_reducers();
+    runtime.absorb_registry(context.registry);
+    runtime
+        .dispatch(action, WidgetId::from_u128(0))
+        .expect("local-state action should dispatch");
+}
+
+#[test]
+fn local_state_in_unidentified_collections_is_stable_by_position() {
+    let mut runtime = Runtime::default();
+    let root = WidgetId::explicit("unkeyed-state-root");
+    let (widget, context) = build_stateful_collection(&runtime, &["a", "b"], &[], root);
+    let second = button_actions(&widget).remove(1);
+    dispatch_action(&mut runtime, context, second);
+
+    let (same_order, _) = build_stateful_collection(&runtime, &["a", "b"], &[], root);
+    assert_eq!(
+        item_values(&same_order),
+        vec![("a".into(), 0), ("b".into(), 1)]
+    );
+
+    let (reordered, _) = build_stateful_collection(&runtime, &["b", "a"], &[], root);
+    assert_eq!(
+        item_values(&reordered),
+        vec![("b".into(), 0), ("a".into(), 1)]
+    );
+}
+
+#[test]
+fn local_state_in_explicitly_identified_collections_follows_the_item() {
+    let mut runtime = Runtime::default();
+    let root = WidgetId::explicit("identified-state-root");
+    let identified = ["a", "b"];
+    let (widget, context) = build_stateful_collection(&runtime, &["a", "b"], &identified, root);
+    let second = button_actions(&widget).remove(1);
+    dispatch_action(&mut runtime, context, second);
+
+    let (reordered, _) = build_stateful_collection(&runtime, &["b", "a"], &identified, root);
+    assert_eq!(
+        item_values(&reordered),
+        vec![("b".into(), 1), ("a".into(), 0)]
+    );
+}
+
+#[test]
+fn one_randomly_identified_collection_item_coexists_with_automatic_items() {
+    let mut runtime = Runtime::default();
+    let root = WidgetId::explicit("mixed-state-root");
+    let (widget, context) = build_stateful_collection(&runtime, &["a", "b", "c"], &["b"], root);
+    let middle = button_actions(&widget).remove(1);
+    dispatch_action(&mut runtime, context, middle);
+
+    let (reordered, _) = build_stateful_collection(&runtime, &["b", "a", "c"], &["b"], root);
+    assert_eq!(
+        item_values(&reordered),
+        vec![("b".into(), 1), ("a".into(), 0), ("c".into(), 0)]
+    );
+}
+
+#[test]
+fn automatic_local_state_remains_position_based_around_a_random_explicit_item() {
+    let mut runtime = Runtime::default();
+    let root = WidgetId::explicit("mixed-positional-state-root");
+    let (widget, context) = build_stateful_collection(&runtime, &["a", "b", "c"], &["b"], root);
+    let actions = button_actions(&widget);
+    dispatch_action(&mut runtime, context, actions[0].clone());
+
+    let (widget, context) = build_stateful_collection(&runtime, &["a", "b", "c"], &["b"], root);
+    let actions = button_actions(&widget);
+    dispatch_action(&mut runtime, context, actions[2].clone());
+
+    let (reordered, _) = build_stateful_collection(&runtime, &["b", "a", "c"], &["b"], root);
+    assert_eq!(
+        item_values(&reordered),
+        vec![("b".into(), 0), ("a".into(), 0), ("c".into(), 1)]
+    );
+}
+
+#[test]
+fn changing_the_app_root_resets_automatic_local_state_namespace() {
+    let mut runtime = Runtime::default();
+    let root_a = WidgetId::explicit("local-state-mount-a");
+    let root_b = WidgetId::explicit("local-state-mount-b");
+    let (widget, context) = build_stateful_collection(&runtime, &["a"], &[], root_a);
+    let action = button_actions(&widget).remove(0);
+    dispatch_action(&mut runtime, context, action);
+
+    let (same_root, _) = build_stateful_collection(&runtime, &["a"], &[], root_a);
+    assert_eq!(item_values(&same_root), vec![("a".into(), 1)]);
+
+    let (other_root, _) = build_stateful_collection(&runtime, &["a"], &[], root_b);
+    assert_eq!(item_values(&other_root), vec![("a".into(), 0)]);
+}
+
+#[test]
+fn removing_an_item_prunes_its_local_state_before_reinsertion() {
+    let mut runtime = Runtime::default();
+    let root = WidgetId::explicit("pruned-item-state-root");
+    let identified = ["a", "b"];
+    let (widget, context) = build_stateful_collection(&runtime, &["a", "b"], &identified, root);
+    let second = button_actions(&widget).remove(1);
+    dispatch_action(&mut runtime, context, second);
+
+    let (without_b, _) = build_stateful_collection(&runtime, &["a"], &identified, root);
+    assert_eq!(item_values(&without_b), vec![("a".into(), 0)]);
+
+    let (reinserted, _) = build_stateful_collection(&runtime, &["a", "b"], &identified, root);
+    assert_eq!(
+        item_values(&reinserted),
+        vec![("a".into(), 0), ("b".into(), 0)]
+    );
+}

--- a/crates/core/fission-ir/src/widget_id.rs
+++ b/crates/core/fission-ir/src/widget_id.rs
@@ -11,8 +11,14 @@ use std::fmt;
 
 /// A stable 128-bit identity for widgets and lowered IR nodes.
 ///
-/// `WidgetId` values are derived from BLAKE3 hashes. Two construction strategies
-/// are available:
+/// Fission assigns every widget a deterministic identity from the application
+/// root and its structural child path. Most application code therefore does
+/// not need to set IDs. Unidentified collection items intentionally retain
+/// identity by position; give each logical item an explicit ID when state must
+/// follow the item through insertion, removal, filtering, or reordering.
+///
+/// `WidgetId` values are derived from BLAKE3 hashes. Two public construction
+/// strategies are available:
 ///
 /// * [`WidgetId::explicit`] hashes a user-provided stable key.
 /// * [`WidgetId::derived`] hashes a parent identity plus a child-index path.
@@ -30,6 +36,12 @@ use std::fmt;
 pub struct WidgetId(u128);
 
 impl WidgetId {
+    /// Returns the deterministic identity seed used for an application's root
+    /// widget when the embedding shell does not provide a mount-specific id.
+    pub fn app_root() -> Self {
+        Self::explicit("fission.app.root")
+    }
+
     /// Creates a `WidgetId` from a raw 128-bit value.
     ///
     /// This is intended for internal use or deserialization. In normal code use
@@ -76,6 +88,37 @@ impl WidgetId {
             hash.as_bytes()[0..16].try_into().unwrap(),
         ))
     }
+
+    /// Creates an identity scoped to a parent and a stable string key.
+    ///
+    /// This is used for authoring locations and keyed collection items where a
+    /// numeric child position is not the logical identity authority.
+    pub fn scoped(parent: u128, key: &str) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"scoped:");
+        hasher.update(&parent.to_le_bytes());
+        hasher.update(key.as_bytes());
+        let hash = hasher.finalize();
+        Self(u128::from_le_bytes(
+            hash.as_bytes()[0..16].try_into().unwrap(),
+        ))
+    }
+
+    /// Creates an identity scoped to a source location without allocating a
+    /// temporary location string.
+    #[doc(hidden)]
+    pub fn scoped_location(parent: u128, file: &str, line: u32, column: u32) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"source-location:");
+        hasher.update(&parent.to_le_bytes());
+        hasher.update(file.as_bytes());
+        hasher.update(&line.to_le_bytes());
+        hasher.update(&column.to_le_bytes());
+        let hash = hasher.finalize();
+        Self(u128::from_le_bytes(
+            hash.as_bytes()[0..16].try_into().unwrap(),
+        ))
+    }
 }
 
 impl fmt::Debug for WidgetId {
@@ -87,5 +130,74 @@ impl fmt::Debug for WidgetId {
 impl fmt::Display for WidgetId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:032x}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WidgetId;
+
+    #[test]
+    fn all_identity_domains_are_deterministic_and_distinct() {
+        let parent = WidgetId::explicit("parent");
+        let explicit = WidgetId::explicit("child");
+        let derived = WidgetId::derived(parent.as_u128(), &[4, 2]);
+        let scoped = WidgetId::scoped(parent.as_u128(), "child");
+
+        assert_eq!(explicit, WidgetId::explicit("child"));
+        assert_eq!(derived, WidgetId::derived(parent.as_u128(), &[4, 2]));
+        assert_eq!(scoped, WidgetId::scoped(parent.as_u128(), "child"));
+        assert_ne!(explicit, derived);
+        assert_ne!(explicit, scoped);
+        assert_ne!(derived, scoped);
+    }
+
+    #[test]
+    fn structural_path_segments_and_order_are_significant() {
+        let parent = WidgetId::explicit("parent");
+        assert_ne!(
+            WidgetId::derived(parent.as_u128(), &[1, 2]),
+            WidgetId::derived(parent.as_u128(), &[2, 1])
+        );
+        assert_ne!(
+            WidgetId::derived(parent.as_u128(), &[1, 2]),
+            WidgetId::derived(parent.as_u128(), &[1, 2, 0])
+        );
+    }
+
+    #[test]
+    fn parent_identity_namespaces_structural_and_scoped_children() {
+        let first = WidgetId::explicit("first-parent");
+        let second = WidgetId::explicit("second-parent");
+        assert_ne!(
+            WidgetId::derived(first.as_u128(), &[0]),
+            WidgetId::derived(second.as_u128(), &[0])
+        );
+        assert_ne!(
+            WidgetId::scoped(first.as_u128(), "item"),
+            WidgetId::scoped(second.as_u128(), "item")
+        );
+    }
+
+    #[test]
+    fn source_location_identity_includes_every_input() {
+        let parent = WidgetId::explicit("parent");
+        let base = WidgetId::scoped_location(parent.as_u128(), "src/app.rs", 10, 4);
+        assert_eq!(
+            base,
+            WidgetId::scoped_location(parent.as_u128(), "src/app.rs", 10, 4)
+        );
+        assert_ne!(
+            base,
+            WidgetId::scoped_location(parent.as_u128(), "src/other.rs", 10, 4)
+        );
+        assert_ne!(
+            base,
+            WidgetId::scoped_location(parent.as_u128(), "src/app.rs", 11, 4)
+        );
+        assert_ne!(
+            base,
+            WidgetId::scoped_location(parent.as_u128(), "src/app.rs", 10, 5)
+        );
     }
 }

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 use anyhow::Result;
-use fission_core::{Action, ActionId, Env, GlobalState, Widget};
+use fission_core::{Action, ActionId, Env, GlobalState, Widget, WidgetId};
 use fission_shell::{async_host::AsyncRegistry, NativeSurfaceHandler};
 use fission_shell_winit::WinitApp;
 
@@ -50,6 +50,11 @@ where
 
     pub fn with_global_state(mut self, global_state: S) -> Self {
         self.inner = self.inner.with_global_state(global_state);
+        self
+    }
+
+    pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
+        self.inner = self.inner.with_root_id(root_id);
         self
     }
 

--- a/crates/shell/fission-shell-mobile/src/lib.rs
+++ b/crates/shell/fission-shell-mobile/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use fission_core::{Action, ActionRegistry, Env, GlobalState, Widget};
+use fission_core::{Action, ActionRegistry, Env, GlobalState, Widget, WidgetId};
 use fission_shell::{async_host::AsyncRegistry, NativeSurfaceHandler};
 use fission_shell_winit::WinitApp;
 
@@ -44,6 +44,11 @@ where
 
     pub fn with_global_state(mut self, global_state: S) -> Self {
         self.inner = self.inner.with_global_state(global_state);
+        self
+    }
+
+    pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
+        self.inner = self.inner.with_root_id(root_id);
         self
     }
 

--- a/crates/shell/fission-shell-terminal/src/app.rs
+++ b/crates/shell/fission-shell-terminal/src/app.rs
@@ -21,8 +21,8 @@ use fission_core::internal::InternalLoweringCx;
 use fission_core::ui::{Container, Overlay, Widget, ZStack};
 use fission_core::{
     Env, GlobalState, InputEvent, KeyCode, KeyEvent, LayoutEngine, LayoutPoint, LayoutSize,
-    LayoutSnapshot, PointerButton, PointerEvent, Runtime, RuntimeState, View, WidgetIdExt,
-    WindowTitle,
+    LayoutSnapshot, PointerButton, PointerEvent, Runtime, RuntimeState, View, WidgetId,
+    WidgetIdExt, WindowTitle,
 };
 use fission_ir::CoreIR;
 use fission_layout::TextMeasurer;
@@ -58,6 +58,7 @@ where
     W: Clone + Into<Widget>,
 {
     root: W,
+    root_id: WidgetId,
     runtime: Runtime,
     layout_engine: LayoutEngine,
     env: Env,
@@ -97,6 +98,7 @@ where
         env.viewport_size = LayoutSize::new(100.0, 32.0);
         Self {
             root,
+            root_id: WidgetId::app_root(),
             runtime,
             layout_engine: LayoutEngine::new().with_measurer(measurer.clone()),
             env,
@@ -121,6 +123,11 @@ where
         *self.runtime.get_global_state_mut::<S>().expect(
             "Fission global state must be registered before TerminalApp::with_global_state is called",
         ) = global_state;
+        self
+    }
+
+    pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
+        self.root_id = root_id;
         self
     }
 
@@ -198,7 +205,9 @@ where
                 Some(&self.measurer),
                 self.last_snapshot.as_ref(),
             );
-            let root_id = fission_core::internal::lower_widget(&node_tree, &mut cx);
+            let shell_root_id = fission_core::internal::shell_root_id(self.root_id);
+            let root_id =
+                fission_core::internal::lower_widget_with_root(&node_tree, &mut cx, shell_root_id);
             cx.ir.root = Some(root_id);
             (cx.ir, root_id)
         };
@@ -394,7 +403,10 @@ where
             self.last_snapshot.as_ref(),
         );
         let mut ctx = BuildCtx::<S>::new();
-        let tree = fission_core::build::enter(&mut ctx, &view, || self.root.clone().into());
+        let tree = fission_core::build::enter_with_root(&mut ctx, &view, self.root_id, || {
+            self.root.clone().into()
+        });
+        let tree = fission_core::internal::resolve_widget_identities(&tree, self.root_id);
 
         self.runtime.clear_reducers();
         let motion_declarations = ctx.take_motion_declarations();

--- a/crates/shell/fission-shell-web/src/lib.rs
+++ b/crates/shell/fission-shell-web/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use fission_core::{Action, ActionRegistry, Env, GlobalState, Widget};
+use fission_core::{Action, ActionRegistry, Env, GlobalState, Widget, WidgetId};
 use fission_shell::async_host::AsyncRegistry;
 use fission_shell_winit::WinitApp;
 
@@ -41,6 +41,11 @@ where
 
     pub fn with_global_state(mut self, global_state: S) -> Self {
         self.inner = self.inner.with_global_state(global_state);
+        self
+    }
+
+    pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
+        self.inner = self.inner.with_root_id(root_id);
         self
     }
 

--- a/crates/shell/fission-shell-winit/src/lib.rs
+++ b/crates/shell/fission-shell-winit/src/lib.rs
@@ -4611,6 +4611,7 @@ where
     runtime: Runtime,
     layout_engine: LayoutEngine,
     root_widget: W,
+    root_widget_id: WidgetId,
     env: Env,
     pipeline: Pipeline,
     measurer: Arc<VelloTextMeasurer>,
@@ -4685,6 +4686,7 @@ where
             runtime,
             layout_engine,
             root_widget,
+            root_widget_id: WidgetId::app_root(),
             env,
             pipeline: Pipeline::new(),
             measurer,
@@ -4716,6 +4718,15 @@ where
         *self.runtime.get_global_state_mut::<S>().expect(
             "Fission global state must be registered before WinitApp::with_global_state is called",
         ) = global_state;
+        self
+    }
+
+    /// Sets the stable identity namespace for the application's authored root.
+    ///
+    /// The default is [`WidgetId::app_root`]. An explicit ID set directly on
+    /// the root widget remains authoritative.
+    pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
+        self.root_widget_id = root_id;
         self
     }
 
@@ -5299,6 +5310,7 @@ where
         }
         let mut layout_engine = self.layout_engine;
         let root_widget = self.root_widget;
+        let root_widget_id = self.root_widget_id;
         let mut env = self.env;
         env.window.title = fission_core::WindowTitle::plain(window_title.clone());
         let mut applied_window_title = window_title.clone();
@@ -7953,9 +7965,16 @@ where
                                         pipeline.last_snapshot.as_ref(),
                                     );
                                     let mut ctx = BuildCtx::new();
-                                    let node = fission_core::build::enter(&mut ctx, &view, || {
-                                        root_widget.clone().into()
-                                    });
+                                    let node = fission_core::build::enter_with_root(
+                                        &mut ctx,
+                                        &view,
+                                        root_widget_id,
+                                        || root_widget.clone().into(),
+                                    );
+                                    let node = fission_core::internal::resolve_widget_identities(
+                                        &node,
+                                        root_widget_id,
+                                    );
                                     let resources = ctx.take_resources();
                                     let motion_declarations = ctx.take_motion_declarations();
                                     let videos = ctx.take_video_registrations();
@@ -8058,9 +8077,12 @@ where
                                         runtime.measurer.as_ref(),
                                         pipeline.last_snapshot.as_ref(),
                                     );
-                                    let root_id = fission_core::internal::lower_widget(
+                                    let shell_root_id =
+                                        fission_core::internal::shell_root_id(root_widget_id);
+                                    let root_id = fission_core::internal::lower_widget_with_root(
                                         &final_root,
                                         &mut lower_cx,
+                                        shell_root_id,
                                     );
                                     lower_cx.ir.root = Some(root_id);
                                     lower_cx.ir


### PR DESCRIPTION
## Summary

- derive every authored widget identity from a stable application root and structural child path
- keep explicit widget IDs authoritative, including keyed collection subtrees
- align retained local state with automatic, explicit, and mixed collection identity
- expose configurable root IDs across retained runtime shells
- add comprehensive identity, diff, serialization, wrapper, collection, and local-state lifecycle coverage

## Collection contract

- unkeyed items retain identity by structural position
- explicitly identified items and their descendants follow the logical item through reorder
- mixed lists preserve both rules without requiring IDs on unrelated widgets

## Validation

- `cargo test -p fission-core --test automatic_widget_identity` (26 passed)
- `cargo test -p fission-ir -p fission-core --tests` (full core/IR regression suite passed; one pre-existing ignored text test)
- `cargo test -p fission-widgets --features interactive-canvas --lib` (11 passed)
- `cargo check -p fission-shell-winit -p fission-shell-desktop -p fission-shell-web -p fission-shell-mobile -p fission-shell-terminal`
- `cargo fmt --all`
- `git diff --check`
