### PR TITLE
Improve multiline text input and scrollbar defaults

### DIFF
--- a/crates/core/fission-core/src/scrollbar.rs
+++ b/crates/core/fission-core/src/scrollbar.rs
@@ -5,6 +5,11 @@ use fission_layout::{LayoutPoint, LayoutRect, LayoutSnapshot};
 pub const SCROLLBAR_INSET: f32 = 2.0;
 pub const SCROLLBAR_THICKNESS: f32 = 6.0;
 pub const SCROLLBAR_MIN_THUMB: f32 = 24.0;
+/// Additional inward cross-axis reach for pointer interaction.
+///
+/// Scrollbar chrome stays visually compact while remaining practical to grab
+/// on high-density displays.
+pub const SCROLLBAR_HIT_SLOP: f32 = 4.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScrollbarAxis {
@@ -219,7 +224,9 @@ fn scrollbar_hit_test_recursive(
     }
 
     if let Some(geometry) = scrollbar_geometry_for_node(ir, layout, scroll_map, node_id) {
-        if geometry.thumb_rect.contains(point) {
+        let thumb_hit_rect = interaction_rect(geometry.axis, geometry.thumb_rect);
+        let rail_hit_rect = interaction_rect(geometry.axis, geometry.rail_rect);
+        if thumb_hit_rect.contains(point) {
             return Some(ScrollbarHit {
                 geometry,
                 kind: ScrollbarHitKind::Thumb,
@@ -228,7 +235,7 @@ fn scrollbar_hit_test_recursive(
                 layout_point: point,
             });
         }
-        if geometry.rail_rect.contains(point) {
+        if rail_hit_rect.contains(point) {
             return Some(ScrollbarHit {
                 geometry,
                 kind: ScrollbarHitKind::Rail,
@@ -258,6 +265,23 @@ fn scrollbar_hit_test_recursive(
     None
 }
 
+fn interaction_rect(axis: ScrollbarAxis, rect: LayoutRect) -> LayoutRect {
+    match axis {
+        ScrollbarAxis::Vertical => LayoutRect::new(
+            rect.origin.x - SCROLLBAR_HIT_SLOP,
+            rect.origin.y,
+            rect.size.width + SCROLLBAR_HIT_SLOP,
+            rect.size.height,
+        ),
+        ScrollbarAxis::Horizontal => LayoutRect::new(
+            rect.origin.x,
+            rect.origin.y - SCROLLBAR_HIT_SLOP,
+            rect.size.width,
+            rect.size.height + SCROLLBAR_HIT_SLOP,
+        ),
+    }
+}
+
 fn axis_start(axis: ScrollbarAxis, rect: LayoutRect) -> f32 {
     match axis {
         ScrollbarAxis::Horizontal => rect.origin.x,
@@ -282,8 +306,8 @@ fn point_axis(axis: ScrollbarAxis, point: LayoutPoint) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        scrollbar_drag_offset_with_grab, scrollbar_geometry_for_node, scrollbar_hit_test,
-        scrollbar_point_for_node, ScrollbarAxis, ScrollbarHitKind,
+        scrollbar_drag_offset, scrollbar_drag_offset_with_grab, scrollbar_geometry_for_node,
+        scrollbar_hit_test, scrollbar_point_for_node, ScrollbarAxis, ScrollbarHitKind,
     };
     use crate::env::ScrollStateMap;
     use fission_ir::{CompositeStyle, CoreIR, CoreNode, FlexDirection, LayoutOp, Op, WidgetId};
@@ -308,6 +332,7 @@ mod tests {
         assert_eq!(geometry.axis, ScrollbarAxis::Vertical);
         assert_eq!(geometry.rail_rect.origin.x, 102.0);
         assert_eq!(geometry.rail_rect.origin.y, 22.0);
+        assert!((geometry.thumb_extent() - (196.0 / 3.0)).abs() <= 0.01);
         assert!(geometry.thumb_rect.origin.y > geometry.rail_rect.origin.y);
         assert!(geometry.thumb_rect.bottom() <= geometry.rail_rect.bottom());
     }
@@ -351,6 +376,49 @@ mod tests {
         let offset = scrollbar_drag_offset_with_grab(geometry, LayoutPoint::new(97.0, 198.0), 0.0);
 
         assert!((offset - geometry.max_offset).abs() <= 0.01);
+    }
+
+    #[test]
+    fn scrollbar_rail_click_centres_thumb_at_requested_position() {
+        let (ir, mut layout, scroll) = scroll_tree();
+        layout.nodes.insert(
+            scroll,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(0.0, 0.0, 100.0, 200.0),
+                content_size: LayoutSize::new(100.0, 600.0),
+            },
+        );
+        let geometry =
+            scrollbar_geometry_for_node(&ir, &layout, &ScrollStateMap::default(), scroll).unwrap();
+
+        let offset = scrollbar_drag_offset(geometry, LayoutPoint::new(97.0, 100.0));
+
+        assert!((offset - geometry.max_offset * 0.5).abs() <= 0.01);
+    }
+
+    #[test]
+    fn scrollbar_hit_target_extends_inward_beyond_painted_chrome() {
+        let (ir, mut layout, scroll) = scroll_tree();
+        layout.nodes.insert(
+            scroll,
+            LayoutNodeGeometry {
+                rect: LayoutRect::new(0.0, 0.0, 100.0, 200.0),
+                content_size: LayoutSize::new(100.0, 600.0),
+            },
+        );
+        let scroll_map = ScrollStateMap::default();
+        let geometry =
+            scrollbar_geometry_for_node(&ir, &layout, &scroll_map, scroll).expect("scrollbar");
+        let point = LayoutPoint::new(
+            geometry.rail_rect.x() - super::SCROLLBAR_HIT_SLOP * 0.5,
+            geometry.thumb_rect.bottom() + 4.0,
+        );
+        assert!(!geometry.rail_rect.contains(point));
+
+        let hit = scrollbar_hit_test(&ir, &layout, &scroll_map, point)
+            .expect("inward scrollbar interaction target");
+
+        assert_eq!(hit.kind, ScrollbarHitKind::Rail);
     }
 
     #[test]

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -319,6 +319,8 @@ pub struct TextInput {
     pub wrap_mode: TextWrapMode,
     /// Automatic scrolling and scrollbar visibility policy.
     pub scroll_policy: TextScrollPolicy,
+    /// Whether overflowing multiline content displays a scrollbar.
+    pub show_scrollbar: bool,
     /// User-driven scrolling policy.
     pub scroll_physics: TextScrollPhysics,
     /// Whether selection drags become active on pointer-down or only after slop is crossed.
@@ -585,6 +587,12 @@ impl TextInput {
         self
     }
 
+    /// Controls whether overflowing multiline content displays a scrollbar.
+    pub fn show_scrollbar(mut self, show_scrollbar: bool) -> Self {
+        self.show_scrollbar = show_scrollbar;
+        self
+    }
+
     pub fn magnifier_configuration(
         mut self,
         magnifier_configuration: TextMagnifierConfiguration,
@@ -756,7 +764,7 @@ impl Default for TextInput {
             selection_color: None,
             selection_text_color: None,
             text_align: fission_ir::op::TextAlign::Start,
-            text_align_vertical: TextAlignVertical::Center,
+            text_align_vertical: TextAlignVertical::Auto,
             expands: false,
             cursor_color: None,
             cursor_width: None,
@@ -800,6 +808,7 @@ impl Default for TextInput {
             scroll_padding: None,
             wrap_mode: TextWrapMode::Soft,
             scroll_policy: TextScrollPolicy::Auto,
+            show_scrollbar: true,
             scroll_physics: TextScrollPhysics::Platform,
             drag_start_behavior: DragStartBehavior::Start,
             context_menu: TextContextMenuConfig::editing(),
@@ -1297,7 +1306,9 @@ impl InternalLower for TextInput {
                 } else {
                     FlexDirection::Row
                 },
-                show_scrollbar: self.scroll_policy == TextScrollPolicy::Always,
+                show_scrollbar: self.multiline
+                    && self.show_scrollbar
+                    && self.scroll_policy != TextScrollPolicy::Never,
                 width: None, // Let it fill parent padding box
                 height: None,
                 min_width: None,
@@ -1326,7 +1337,7 @@ impl InternalLower for TextInput {
                 } else {
                     None
                 },
-                align_items: self.text_align_vertical.align_items(),
+                align_items: self.text_align_vertical.align_items(self.multiline),
                 justify_content: fission_ir::op::JustifyContent::Start,
             }),
         );
@@ -1349,7 +1360,7 @@ impl InternalLower for TextInput {
                 padding: [0.0; 4],
                 gap: None,
                 align_items: fission_ir::op::AlignItems::Stretch,
-                justify_content: self.text_align_vertical.justify_content(),
+                justify_content: self.text_align_vertical.justify_content(self.multiline),
             }),
         );
         content_alignment.add_child(content_row_id);
@@ -1395,11 +1406,7 @@ impl InternalLower for TextInput {
                 min_height,
                 max_height,
                 padding: content_padding,
-                flex_grow: if self.width.is_none() || self.expands {
-                    1.0
-                } else {
-                    0.0
-                },
+                flex_grow: if self.expands { 1.0 } else { 0.0 },
                 flex_shrink: 1.0,
                 aspect_ratio: None,
             }),

--- a/crates/core/fission-core/src/ui/widgets/text_input.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input.rs
@@ -1329,7 +1329,11 @@ impl InternalLower for TextInput {
             Op::Layout(LayoutOp::Flex {
                 direction: FlexDirection::Row,
                 wrap: FlexWrap::NoWrap,
-                flex_grow: if self.expands { 1.0 } else { 0.0 },
+                flex_grow: if self.multiline || self.expands {
+                    1.0
+                } else {
+                    0.0
+                },
                 flex_shrink: 1.0,
                 padding: [0.0; 4],
                 gap: if self.prefix.is_some() || self.suffix.is_some() {
@@ -1337,7 +1341,11 @@ impl InternalLower for TextInput {
                 } else {
                     None
                 },
-                align_items: self.text_align_vertical.align_items(self.multiline),
+                align_items: if self.multiline {
+                    fission_ir::op::AlignItems::Stretch
+                } else {
+                    self.text_align_vertical.align_items(false)
+                },
                 justify_content: fission_ir::op::JustifyContent::Start,
             }),
         );

--- a/crates/core/fission-core/src/ui/widgets/text_input/config.rs
+++ b/crates/core/fission-core/src/ui/widgets/text_input/config.rs
@@ -3,26 +3,41 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum TextAlignVertical {
-    Top,
+    /// Centres single-line fields and top-aligns multiline fields.
     #[default]
+    Auto,
+    /// Aligns editable content to the top edge.
+    Top,
+    /// Aligns editable content to the vertical centre.
     Center,
+    /// Aligns editable content to the bottom edge.
     Bottom,
 }
 
 impl TextAlignVertical {
-    pub(crate) fn justify_content(self) -> fission_ir::op::JustifyContent {
+    pub(crate) fn resolve(self, multiline: bool) -> Self {
         match self {
-            Self::Top => fission_ir::op::JustifyContent::Start,
-            Self::Center => fission_ir::op::JustifyContent::Center,
-            Self::Bottom => fission_ir::op::JustifyContent::End,
+            Self::Auto if multiline => Self::Top,
+            Self::Auto => Self::Center,
+            explicit => explicit,
         }
     }
 
-    pub(crate) fn align_items(self) -> fission_ir::op::AlignItems {
-        match self {
+    pub(crate) fn justify_content(self, multiline: bool) -> fission_ir::op::JustifyContent {
+        match self.resolve(multiline) {
+            Self::Top => fission_ir::op::JustifyContent::Start,
+            Self::Center => fission_ir::op::JustifyContent::Center,
+            Self::Bottom => fission_ir::op::JustifyContent::End,
+            Self::Auto => unreachable!("automatic text alignment must resolve before lowering"),
+        }
+    }
+
+    pub(crate) fn align_items(self, multiline: bool) -> fission_ir::op::AlignItems {
+        match self.resolve(multiline) {
             Self::Top => fission_ir::op::AlignItems::Start,
             Self::Center => fission_ir::op::AlignItems::Center,
             Self::Bottom => fission_ir::op::AlignItems::End,
+            Self::Auto => unreachable!("automatic text alignment must resolve before lowering"),
         }
     }
 }
@@ -157,6 +172,7 @@ pub(crate) fn text_input_scroll_physics_for_node(
 pub struct TextSelectionControls {
     #[serde(default = "default_selection_controls_enabled")]
     pub enabled: bool,
+    #[serde(default)]
     pub show_collapsed_handle: bool,
     pub handle_radius: f32,
     pub handle_fill: IrColor,
@@ -172,7 +188,7 @@ impl Default for TextSelectionControls {
     fn default() -> Self {
         Self {
             enabled: true,
-            show_collapsed_handle: true,
+            show_collapsed_handle: false,
             handle_radius: 7.0,
             handle_fill: IrColor {
                 r: 0,

--- a/crates/core/fission-core/tests/scrollbar_input.rs
+++ b/crates/core/fission-core/tests/scrollbar_input.rs
@@ -96,6 +96,57 @@ fn dragging_scrollbar_thumb_updates_scroll_offset_directly() {
 }
 
 #[test]
+fn clicking_scrollbar_rail_jumps_and_starts_dragging() {
+    let (ir, layout, scroll) = scroll_tree(FlexDirection::Column);
+    let mut runtime = Runtime::default();
+    let geometry = scrollbar_geometry_for_node(&ir, &layout, &runtime.runtime_state.scroll, scroll)
+        .expect("scrollbar");
+    let point = LayoutPoint::new(
+        geometry.rail_rect.origin.x + geometry.rail_rect.size.width / 2.0,
+        geometry.rail_rect.origin.y + geometry.rail_rect.size.height * 0.75,
+    );
+
+    runtime
+        .handle_input(
+            InputEvent::Pointer(PointerEvent::Down {
+                pointer_id: Default::default(),
+                kind: Default::default(),
+                point,
+                button: PointerButton::Primary,
+                modifiers: 0,
+            }),
+            &ir,
+            &layout,
+        )
+        .expect("scroll rail pointer down");
+
+    assert!(runtime.runtime_state.scroll.get_offset(scroll) > geometry.max_offset * 0.5);
+    assert_eq!(
+        runtime
+            .runtime_state
+            .gesture
+            .scrollbar_drag
+            .map(|drag| drag.node_id),
+        Some(scroll)
+    );
+
+    runtime
+        .handle_input(
+            InputEvent::Pointer(PointerEvent::Up {
+                pointer_id: Default::default(),
+                kind: Default::default(),
+                point,
+                button: PointerButton::Primary,
+                modifiers: 0,
+            }),
+            &ir,
+            &layout,
+        )
+        .expect("scroll rail pointer up");
+    assert!(runtime.runtime_state.gesture.scrollbar_drag.is_none());
+}
+
+#[test]
 fn dragging_nested_scrollbar_uses_visual_pointer_coordinates() {
     let parent = WidgetId::derived(82, &[0]);
     let child = WidgetId::derived(82, &[1]);

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -74,6 +74,75 @@ fn layout_ops(ir: &CoreIR) -> impl Iterator<Item = &LayoutOp> {
     })
 }
 
+#[test]
+fn text_input_defaults_adapt_single_and_multiline_chrome() {
+    let defaults = TextInput::default();
+    assert_eq!(defaults.text_align_vertical, TextAlignVertical::Auto);
+    assert!(defaults.show_scrollbar);
+    assert!(!defaults.selection_controls.show_collapsed_handle);
+
+    let multiline = lower_node(
+        TextInput {
+            multiline: true,
+            height: Some(160.0),
+            ..Default::default()
+        }
+        .into(),
+    );
+    assert!(layout_ops(&multiline).any(|op| matches!(
+        op,
+        LayoutOp::Scroll {
+            direction: FlexDirection::Column,
+            show_scrollbar: true,
+            ..
+        }
+    )));
+    assert!(layout_ops(&multiline).any(|op| matches!(
+        op,
+        LayoutOp::Flex {
+            direction: FlexDirection::Column,
+            justify_content: fission_ir::op::JustifyContent::Start,
+            ..
+        }
+    )));
+    assert!(!layout_ops(&multiline).any(|op| matches!(
+        op,
+        LayoutOp::Box { flex_grow, .. } if *flex_grow > 0.0
+    )));
+
+    let without_scrollbar = lower_node(
+        TextInput {
+            multiline: true,
+            show_scrollbar: false,
+            ..Default::default()
+        }
+        .into(),
+    );
+    assert!(layout_ops(&without_scrollbar).any(|op| matches!(
+        op,
+        LayoutOp::Scroll {
+            show_scrollbar: false,
+            ..
+        }
+    )));
+
+    let never_scroll = lower_node(
+        TextInput {
+            multiline: true,
+            scroll_policy: fission_core::ui::widgets::text_input::TextScrollPolicy::Never,
+            ..Default::default()
+        }
+        .into(),
+    );
+    assert!(layout_ops(&never_scroll).any(|op| matches!(
+        op,
+        LayoutOp::Scroll {
+            show_scrollbar: false,
+            ..
+        }
+    )));
+}
+
 fn rich_text_annotations(ir: &CoreIR) -> Option<(fission_ir::WidgetId, &Vec<RichTextAnnotation>)> {
     ir.nodes.iter().find_map(|(id, node)| match &node.op {
         Op::Paint(PaintOp::DrawRichText { .. }) => {

--- a/crates/core/fission-core/tests/text_surface_api.rs
+++ b/crates/core/fission-core/tests/text_surface_api.rs
@@ -105,6 +105,15 @@ fn text_input_defaults_adapt_single_and_multiline_chrome() {
             ..
         }
     )));
+    assert!(layout_ops(&multiline).any(|op| matches!(
+        op,
+        LayoutOp::Flex {
+            direction: FlexDirection::Row,
+            flex_grow,
+            align_items: fission_ir::op::AlignItems::Stretch,
+            ..
+        } if *flex_grow == 1.0
+    )));
     assert!(!layout_ops(&multiline).any(|op| matches!(
         op,
         LayoutOp::Box { flex_grow, .. } if *flex_grow > 0.0

--- a/documentation/content/reference/widgets/widget-pages/text-input.mdx
+++ b/documentation/content/reference/widgets/widget-pages/text-input.mdx
@@ -73,6 +73,7 @@ action or carry stable application context such as a field or row identity.
 | `can_request_focus` | `bool` | Whether pointer, traversal, accessibility, autofocus, or controller requests may focus the field. | Defaults to `true`. |
 | `select_all_on_focus` | `bool` | Select the complete value whenever focus enters the field. | Defaults to `false`. |
 | `show_cursor` | `bool` | Whether Fission paints the caret while focused. | Defaults to `true`; selection and editing still work when hidden. |
+| `text_align_vertical` | `TextAlignVertical` | Vertical placement of editable content. | Defaults to `Auto`, which centres a single line and top-aligns multiline content. |
 | `min_lines` | `Option<usize>` | Minimum visible line count for multiline fields. | Defaults to `None`. |
 | `max_lines` | `Option<usize>` | Maximum visible line count for multiline fields. | Defaults to `None`. |
 | `obscure_text` | `bool` | Whether the field masks characters. | Defaults to `false`. Useful for passwords. |
@@ -108,10 +109,11 @@ action or carry stable application context such as a field or row identity.
 | `locale` | `Option<String>` | Locale override for shaping and accessibility. | Defaults to `None`. |
 | `scroll_padding` | `Option<[f32; 4]>` | Extra space kept around the caret during auto-scroll. | Defaults to `None`. |
 | `wrap_mode` | `TextWrapMode` | Soft wrapping, hard wrapping, or no wrapping for multiline content. | Static site and SSR lower the equivalent textarea `wrap` behavior. |
-| `scroll_policy` | `TextScrollPolicy` | Automatic, always-visible, or disabled editable scrolling. | Defaults to `Auto`. |
+| `scroll_policy` | `TextScrollPolicy` | Automatic or disabled editable scrolling. | Defaults to `Auto`; `Never` also suppresses scrollbar chrome. |
+| `show_scrollbar` | `bool` | Whether overflowing multiline content displays scrollbar chrome. | Defaults to `true`; set to `false` without disabling programmatic or user scrolling. |
 | `scroll_physics` | `TextScrollPhysics` | Platform, clamped, or non-scrollable user interaction. | Programmatic caret/range visibility remains explicit through a controller. |
 | `context_menu` | `TextContextMenuConfig` | Configures built-in editing actions shown from the text selection context menu. | Defaults to Copy, Cut, Paste, and Select All. Menu labels use localizable child widgets with English fallbacks. |
-| `selection_controls` | `TextSelectionControls` | Configures caret and selection-handle overlays. | Set `enabled` to `false` for mouse-first editors that should not show touch-style handles. Defaults to enabled. |
+| `selection_controls` | `TextSelectionControls` | Configures caret and selection-handle overlays. | Selection handles are enabled; the collapsed caret handle is hidden by default and can be enabled with `show_collapsed_handle`. |
 
 ## Programmatic editing, scrolling, and forms
 

--- a/examples/inbox/src/features/compose.rs
+++ b/examples/inbox/src/features/compose.rs
@@ -390,6 +390,69 @@ mod tests {
     use fission::core::Action;
     use fission_test::TestHarness;
 
+    fn display_contains(h: &TestHarness<InboxState>, needle: &str) -> bool {
+        h.get_last_display_list().is_some_and(|list| {
+            list.ops.iter().any(|op| match op {
+                fission::render::DisplayOp::DrawText { text, .. } => text.contains(needle),
+                fission::render::DisplayOp::DrawRichText { runs, .. } => runs
+                    .iter()
+                    .map(|run| run.text.as_str())
+                    .collect::<String>()
+                    .contains(needle),
+                _ => false,
+            })
+        })
+    }
+
+    #[test]
+    fn compose_multiline_trailing_newline_keeps_previous_line_visible() -> Result<()> {
+        let mut h = TestHarness::new(InboxState::default()).with_root_widget(ComposeModal);
+        h.pump()?;
+        let body_node_id: fission_ir::WidgetId = WidgetId::explicit("compose_body_input").into();
+        h.runtime
+            .runtime_state
+            .interaction
+            .set_focused(Some(body_node_id));
+
+        for ch in "first".chars() {
+            h.send_event(InputEvent::Keyboard(KeyEvent::Down {
+                key_code: KeyCode::Char(ch),
+                modifiers: 0,
+            }))?;
+            h.pump()?;
+        }
+        assert!(display_contains(&h, "first"));
+
+        h.send_event(InputEvent::Keyboard(KeyEvent::Down {
+            key_code: KeyCode::Enter,
+            modifiers: 0,
+        }))?;
+        h.pump()?;
+
+        assert_eq!(
+            h.runtime
+                .get_app_state::<InboxState>()
+                .expect("inbox state")
+                .compose_body,
+            "first\n"
+        );
+        assert!(
+            display_contains(&h, "first"),
+            "the committed first line must remain in the display list when the value ends in a newline"
+        );
+        assert!(
+            h.runtime
+                .runtime_state
+                .scroll
+                .offsets
+                .values()
+                .all(|offset| offset.abs() <= f32::EPSILON),
+            "a trailing newline that still fits the field must not scroll the first line out of view: {:?}",
+            h.runtime.runtime_state.scroll.offsets
+        );
+        Ok(())
+    }
+
     #[test]
     fn compose_subject_and_body_accept_typing() -> Result<()> {
         let mut h = TestHarness::new(InboxState::default()).with_root_widget(ComposeModal);

--- a/examples/inbox/src/tests/mod.rs
+++ b/examples/inbox/src/tests/mod.rs
@@ -1376,6 +1376,46 @@ fn default_viewport_email_list_scroll_has_positive_height() -> Result<()> {
 }
 
 #[test]
+fn email_detail_scrollbar_is_bounded_proportional_and_interactive() -> Result<()> {
+    let mut h = pump_state_with_viewport(state_detail(), 1200.0, 800.0)?;
+    let ir = h.last_ir.as_ref().expect("inbox IR");
+    let layout = h.last_snapshot.as_ref().expect("inbox layout");
+    let mut current = find_text_node_id(&h, "Details");
+    let scroll = loop {
+        let id = current.expect("email details should have a scroll ancestor");
+        let node = ir.nodes.get(&id).expect("email detail ancestor");
+        if matches!(node.op, Op::Layout(LayoutOp::Scroll { .. })) {
+            break id;
+        }
+        current = node.parent;
+    };
+    let geometry = layout
+        .get_node_geometry(scroll)
+        .expect("email detail scroll geometry");
+    let viewport_height = geometry.rect.height();
+    let content_height = geometry.content_size.height;
+    let rail_height = (viewport_height - 4.0).max(0.0);
+    let proportional_thumb_height = ((viewport_height / content_height) * rail_height)
+        .clamp(24.0_f32.min(rail_height), rail_height);
+    assert!(viewport_height <= 800.0);
+    assert!(content_height > viewport_height);
+    assert!(proportional_thumb_height < rail_height);
+
+    let rail_point = fission::core::LayoutPoint::new(
+        geometry.rect.right() - 5.0,
+        geometry.rect.y() + 2.0 + rail_height * 0.8,
+    );
+    let previous_offset = h.runtime.runtime_state.scroll.get_offset(scroll);
+    click(&mut h, rail_point.x, rail_point.y)?;
+    let jumped_offset = h.runtime.runtime_state.scroll.get_offset(scroll);
+    assert!(
+        jumped_offset > previous_offset,
+        "clicking below the thumb should jump the email detail scroll position"
+    );
+    Ok(())
+}
+
+#[test]
 fn spinner_motion_present_in_default_inbox() -> Result<()> {
     let h = pump_state(state_default())?;
     let base = motion_slot_id(WidgetId::explicit("sync_spinner"), 0x1D1_CA70);


### PR DESCRIPTION
Fission text inputs now use adaptive vertical alignment: single-line fields remain centred while multiline fields begin at the top. Multiline fields display scrollbar chrome by default, applications can disable it with `show_scrollbar(false)`, and the collapsed blue caret handle is hidden unless explicitly enabled through `TextSelectionControls`. The TextInput reference documents these defaults.\n\nGeneral Scroll chrome retains its compact six-point appearance but gains a wider inward interaction target. Clicking above or below the thumb jumps to that rail position and immediately begins a drag. Regression coverage exercises the core runtime controller and the actual opened-email Scroll in the inbox example, including bounded proportional thumb geometry.