### PR TITLE
Prepare Fission 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-08-25
+
+### Added
+
+- **Coherent cross-shell navigation** - Applications can read one `RouteLocation` and push, replace, traverse, or reload history without adopting the built-in `Router`. Web applications support path and hash routes, deployment base paths, initial deep links, and browser back/forward navigation.
+- **Semantic links** - `Link`, `Pressable`, `SemanticsRegion`, and custom widgets can expose a complete `Hyperlink`. Web canvas output projects it to a real DOM anchor, while Static site and SSR emit ordinary `<a>` elements with targets, relationship metadata, downloads, and popover targets.
+- **Opt-in SQLite storage** - The portable Store API provides typed scoped values, prefix listing, and atomic batches. A separate SQL API exposes parameterized statements, typed rows, migrations, and passable multi-step transactions across native, Web/OPFS, Terminal, and SSR targets without adding SQLite to applications that do not enable storage.
+- **Complete text editing model** - `TextEditingValue`, validated positions and ranges, directional selections, composition, commands, formatters, editing and scrolling controllers, forms, validation, autofill metadata, and payload-preserving typed actions now share one cross-platform transaction pipeline.
+- **Coordinated text selection** - `SelectionRegion` selects across retained `Text` and `RichText` nodes with word and paragraph selection, keyboard extension, exclusions, copy, desktop context menus, and adaptive touch handles, magnifier, toolbar, and edge scrolling.
+- **Expanded typography** - Text styles now include fallback families, locale, word spacing, decoration variants, shadows and paints, OpenType features and variable axes, baseline and leading policy, line breaking, hyphenation, and nonlinear accessibility scaling.
+
+### Changed
+
+- **One retained paragraph authority** - Measurement retains final lines, glyph clusters, caret stops, selection rectangles, inline placements, constraints, and size. Painting, hit testing, editing geometry, scrolling, IME placement, and accessibility consume that shared result.
+- **Adaptive multiline input defaults** - Multiline input begins at the top, fills the available field height, shows scrollbar chrome by default, and hides the collapsed touch caret handle unless an application explicitly enables it.
+- **Platform-native text sessions** - Web synchronizes a hidden native control, Android uses GameActivity text input, iOS uses a native text view, and desktop IME and accessibility entry points all feed the same editing pipeline.
+
+### Fixed
+
+- **Scroll lifecycle isolation** - Runtime scroll offsets are reset before layout when a retained scroll identity is reused by content whose declared scroll state has changed, preventing one screen's offset from leaking into the next screen.
+- **Deep-link and history consistency** - Initial Web locations, hash changes, history traversal, external deep links, and custom route handlers now enter the same shell-neutral route contract.
+- **First-frame text layout** - Nested percentage and maximum-width constraints no longer require a viewport resize before text wraps and paints correctly.
+- **Composition and controlled-value fidelity** - Composition commit and cancellation, complete-value correction/autofill, selection, undo/redo, focus changes, secure entry, and multiline caret visibility retain the correct value and context.
+- **Multiline newline visibility** - Pressing Enter no longer scrolls a short multiline editor enough to hide its preceding line before the next character is typed.
+- **Scrollbar interaction** - Scrollbar thumbs use bounded proportional geometry, retain compact visuals with a wider interaction target, and support clicking above or below the thumb to jump and begin dragging.
+
+### Migration notes
+
+- Update Fission dependencies and `cargo-fission` to `0.14.0`.
+- Storage remains opt-in. CLI-managed applications can run `fission add-capability storage`; Cargo-managed applications enable `store-sqlite-native` or `store-sqlite-web` for the intended targets.
+- Existing `with_route_handler` integrations remain supported. Applications may use Fission's `Router`, a custom router, or a third-party router over the shared route and navigation contracts.
+- Existing string-controlled `TextInput::value` fields remain supported. Use `editing_value` when an application must control text, directional selection, and composition atomically.
+
 ## [0.13.0] - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "animation-gallery"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fission"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1679,7 +1679,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chart-gallery"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "counter"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "embed-3d"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "embed-video"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "embed-webview"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "example-showcase"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "animation-gallery",
  "anyhow",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "field-inspector"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2718,7 +2718,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fission"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "fission-3d",
  "fission-charts",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "fission-3d"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "fission-charts"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "fission-core",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-package"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-release"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-run"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-command-core",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "toml 0.8.2",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-site"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-shell-site",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "fission-command-ui"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "fission-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "fission-design-system-codegen"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "fission-diagnostics"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitflags 2.13.0",
  "once_cell",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "fission-documentation"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "fission-editor"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -2979,14 +2979,14 @@ dependencies = [
 
 [[package]]
 name = "fission-i18n"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fission-icons"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "heck 0.4.1",
  "serde_json",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "fission-ir"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "serde",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "fission-layout"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "fission-macros"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-ir",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "fission-render-vello"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-diagnostics",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "fission-semantics"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "fission-ir",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-desktop"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-mobile"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-site"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-terminal"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-web"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "fission-shell-winit"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "fission-store"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "fission-store-sqlite"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "fission-store",
  "futures-lite",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission-core",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "fission-test-driver"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3327,14 +3327,14 @@ dependencies = [
 
 [[package]]
 name = "fission-text-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "fission-theme"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "fission-design-system-codegen",
  "fission-ir",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "fission-widgets"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4628,7 +4628,7 @@ dependencies = [
 
 [[package]]
 name = "icons_gallery"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -4825,7 +4825,7 @@ checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "inbox"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "interactive-canvas-example"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-smoke"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "motion-memory-repro"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "pokemon-card-store"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -6777,7 +6777,7 @@ dependencies = [
 
 [[package]]
 name = "product-browser"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8137,7 +8137,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-sqlite"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8575,7 +8575,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -8607,7 +8607,7 @@ dependencies = [
 
 [[package]]
 name = "text-lab"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -8776,7 +8776,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todo-design-system"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",
@@ -9528,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "web-smoke"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "widget-gallery"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "fission",

--- a/crates/authoring/fission-charts/Cargo.toml
+++ b/crates/authoring/fission-charts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-charts"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -16,9 +16,9 @@ platforms = ["android", "ios", "linux", "macos", "windows", "web", "static-site"
 readme = "README.md"
 [dependencies]
 chrono = "0.4.44"
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-widgets = { path = "../fission-widgets", version = "0.13.0" }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/authoring/fission-charts/README.md
+++ b/crates/authoring/fission-charts/README.md
@@ -6,7 +6,7 @@ Chart widgets and data-visualization primitives for Fission applications.
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["desktop", "charts"] }
+fission = { version = "0.14.0", features = ["desktop", "charts"] }
 ```
 
 Most application code should import from `fission::prelude::*` and `fission::charts::*` rather than depending on this crate directly. Depend on `fission-charts` only when you are extending the chart layer itself.

--- a/crates/authoring/fission-icons/Cargo.toml
+++ b/crates/authoring/fission-icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-icons"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-macros/Cargo.toml
+++ b/crates/authoring/fission-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-macros"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/authoring/fission-widgets/Cargo.toml
+++ b/crates/authoring/fission-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-widgets"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -25,22 +25,22 @@ terminal = [
 ]
 
 [dependencies]
-fission-macros = { path = "../fission-macros", version = "0.13.0" }
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
-fission-icons = { path = "../fission-icons", version = "0.13.0" }
+fission-macros = { path = "../fission-macros", version = "0.14.0" }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
+fission-icons = { path = "../fission-icons", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde_json = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.13.0", default-features = false }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
 rushdown = "0.18.0"
 
 [dev-dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/authoring/fission/Cargo.toml
+++ b/crates/authoring/fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -71,32 +71,32 @@ store-sqlite-web = [
 ]
 
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-3d = { path = "../../core/fission-3d", version = "0.13.0", optional = true }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-text-engine = { path = "../../core/fission-text-engine", version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.13.0" }
-fission-widgets = { path = "../fission-widgets", version = "0.13.0" }
-fission-macros = { path = "../fission-macros", version = "0.13.0" }
-fission-icons = { path = "../fission-icons", version = "0.13.0" }
-fission-charts = { path = "../fission-charts", version = "0.13.0", optional = true }
-fission-store = { path = "../../core/fission-store", version = "0.13.0", optional = true }
-fission-store-sqlite = { path = "../../core/fission-store-sqlite", version = "0.13.0", optional = true, default-features = false }
-fission-render = { path = "../../rendering/fission-render", version = "0.13.0" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.13.0", default-features = false }
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.13.0", optional = true }
-fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.13.0", optional = true }
-fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.13.0", optional = true }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.13.0", optional = true }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-3d = { path = "../../core/fission-3d", version = "0.14.0", optional = true }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-text-engine = { path = "../../core/fission-text-engine", version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.14.0" }
+fission-widgets = { path = "../fission-widgets", version = "0.14.0" }
+fission-macros = { path = "../fission-macros", version = "0.14.0" }
+fission-icons = { path = "../fission-icons", version = "0.14.0" }
+fission-charts = { path = "../fission-charts", version = "0.14.0", optional = true }
+fission-store = { path = "../../core/fission-store", version = "0.14.0", optional = true }
+fission-store-sqlite = { path = "../../core/fission-store-sqlite", version = "0.14.0", optional = true, default-features = false }
+fission-render = { path = "../../rendering/fission-render", version = "0.14.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0", default-features = false }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.14.0", optional = true }
+fission-shell-server = { path = "../../shell/fission-shell-server", version = "0.14.0", optional = true }
+fission-shell-terminal = { path = "../../shell/fission-shell-terminal", version = "0.14.0", optional = true }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.14.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.13.0", optional = true }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.14.0", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.13.0", optional = true }
+fission-shell-mobile = { path = "../../shell/fission-shell-mobile", version = "0.14.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.13.0", optional = true }
+fission-shell-web = { path = "../../shell/fission-shell-web", version = "0.14.0", optional = true }

--- a/crates/authoring/fission/README.md
+++ b/crates/authoring/fission/README.md
@@ -15,7 +15,7 @@ This crate is the public facade. Application code should normally depend on `fis
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["desktop"] }
+fission = { version = "0.14.0", features = ["desktop"] }
 ```
 
 For the full developer workflow, install the Fission command:

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fission = { version = "0.13.0", default-features = false, features = ["desktop"] }
+//! fission = { version = "0.14.0", default-features = false, features = ["desktop"] }
 //! ```
 //!
 //! Then use via:

--- a/crates/core/fission-3d/Cargo.toml
+++ b/crates/core/fission-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-3d"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ keywords = ["fission", "3d", "gpu-accelerated", "rendering", "cross-platform"]
 platforms = ["android", "ios", "linux", "macos", "windows", "web"]
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../fission-core", version = "0.13.0" }
-fission-ir = { path = "../fission-ir", version = "0.13.0" }
+fission-core = { path = "../fission-core", version = "0.14.0" }
+fission-ir = { path = "../fission-ir", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 wgpu = "26.0"
 bytemuck = { version = "1.18", features = ["derive"] }

--- a/crates/core/fission-3d/README.md
+++ b/crates/core/fission-3d/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["desktop", "three-d"] }
+fission = { version = "0.14.0", features = ["desktop", "three-d"] }
 ```
 
 Use this crate directly only when you are extending the framework's 3D model or renderer integration.

--- a/crates/core/fission-core/Cargo.toml
+++ b/crates/core/fission-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-core"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -22,14 +22,14 @@ store = ["dep:fission-store"]
 store-sql = ["store"]
 
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.13.0" }
-fission-layout = { path = "../fission-layout", version = "0.13.0" }
-fission-semantics = { path = "../fission-semantics", version = "0.13.0" }
-fission-theme = { path = "../fission-theme", version = "0.13.0" }
-fission-i18n = { path = "../fission-i18n", version = "0.13.0" }
-fission-text-engine = { path = "../fission-text-engine", version = "0.13.0" }
-fission-store = { path = "../fission-store", version = "0.13.0", optional = true }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.13.0" }
+fission-ir = { path = "../fission-ir", version = "0.14.0" }
+fission-layout = { path = "../fission-layout", version = "0.14.0" }
+fission-semantics = { path = "../fission-semantics", version = "0.14.0" }
+fission-theme = { path = "../fission-theme", version = "0.14.0" }
+fission-i18n = { path = "../fission-i18n", version = "0.14.0" }
+fission-text-engine = { path = "../fission-text-engine", version = "0.14.0" }
+fission-store = { path = "../fission-store", version = "0.14.0", optional = true }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -41,6 +41,6 @@ blake3 = "1.5"
 unicode-segmentation = "1.10"
 regex-lite = "0.1.9"
 glam = "0.29"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.13.0", default-features = false }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/core/fission-i18n/Cargo.toml
+++ b/crates/core/fission-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-i18n"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-ir/Cargo.toml
+++ b/crates/core/fission-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-ir"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-layout/Cargo.toml
+++ b/crates/core/fission-layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-layout"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -15,9 +15,9 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.13.0" }
+fission-ir = { path = "../fission-ir", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.13.0", default-features = false }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/core/fission-semantics/Cargo.toml
+++ b/crates/core/fission-semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-semantics"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -15,7 +15,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.13.0" }
+fission-ir = { path = "../fission-ir", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/core/fission-store-sqlite/Cargo.toml
+++ b/crates/core/fission-store-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-store-sqlite"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -23,7 +23,7 @@ web = [
 ]
 
 [dependencies]
-fission-store = { path = "../fission-store", version = "0.13.0" }
+fission-store = { path = "../fission-store", version = "0.14.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/core/fission-store/Cargo.toml
+++ b/crates/core/fission-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-store"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/core/fission-text-engine/Cargo.toml
+++ b/crates/core/fission-text-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-text-engine"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/crates/core/fission-theme/Cargo.toml
+++ b/crates/core/fission-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-theme"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -27,8 +27,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-ir = { path = "../fission-ir", version = "0.13.0" }
+fission-ir = { path = "../fission-ir", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.13.0" }
+fission-design-system-codegen = { path = "../../tools/fission-design-system-codegen", version = "0.14.0" }

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-vello"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -15,13 +15,13 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
+fission-render = { path = "../fission-render", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
 anyhow = "1.0"
 vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2", features = ["wgpu"] }
 parley = "0.7.0"
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.13.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0" }
 image = "0.24"
 lazy_static = "1.5.0"
 peniko = "0.5"

--- a/crates/rendering/fission-render-wgpu2d/Cargo.toml
+++ b/crates/rendering/fission-render-wgpu2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render-wgpu2d"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -14,7 +14,7 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 
 [dependencies]
-fission-render = { path = "../fission-render", version = "0.13.0" }
+fission-render = { path = "../fission-render", version = "0.14.0" }
 anyhow = "1.0"
 bytemuck = { version = "1.16", features = ["derive"] }
 wgpu = { version = "26.0.1", default-features = false, features = ["std", "wgsl"] }

--- a/crates/rendering/fission-render/Cargo.toml
+++ b/crates/rendering/fission-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-render"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -15,8 +15,8 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 

--- a/crates/shell/fission-shell-desktop/Cargo.toml
+++ b/crates/shell/fission-shell-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-desktop"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -24,20 +24,20 @@ store-sql = ["store", "fission-core/store-sql", "fission-shell-winit/store-sql"]
 store-sqlite-native = ["store-sql", "fission-shell-winit/store-sqlite-native"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.13.0" }
-fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.13.0" }
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-store = { path = "../../core/fission-store", optional = true, version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
+fission-shell = { path = "../fission-shell", version = "0.14.0" }
+fission-shell-winit = { path = "../fission-shell-winit", default-features = false, version = "0.14.0" }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
 winit = { package = "fission-winit", version = "0.30.13-fission.2" }
 anyhow = "1.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.13.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.13.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.13.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.13.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.14.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.14.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.14.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.14.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell-mobile/Cargo.toml
+++ b/crates/shell/fission-shell-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-mobile"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -23,11 +23,11 @@ store-sql = ["store", "fission-core/store-sql", "fission-shell-winit/store-sql"]
 store-sqlite-native = ["store-sql", "fission-shell-winit/store-sqlite-native"]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.13.0" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.13.0", default-features = false }
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-store = { path = "../../core/fission-store", optional = true, version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
+fission-shell = { path = "../fission-shell", version = "0.14.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.14.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/shell/fission-shell-mobile/README.md
+++ b/crates/shell/fission-shell-mobile/README.md
@@ -8,9 +8,9 @@ Most application developers should use the public facade instead of depending on
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["android"] }
+fission = { version = "0.14.0", features = ["android"] }
 # or
-fission = { version = "0.13.0", features = ["ios"] }
+fission = { version = "0.14.0", features = ["ios"] }
 ```
 
 ## What it provides

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-server"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -36,15 +36,15 @@ axum = { version = "0.7", optional = true, default-features = false }
 base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-shell = { path = "../fission-shell", optional = true, version = "0.13.0" }
-fission-store = { path = "../../core/fission-store", optional = true, version = "0.13.0" }
-fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.13.0", default-features = false }
-fission-shell-site = { path = "../fission-shell-site", version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-shell = { path = "../fission-shell", optional = true, version = "0.14.0" }
+fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
+fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.14.0", default-features = false }
+fission-shell-site = { path = "../fission-shell-site", version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
 getrandom = { version = "0.2", features = ["std"] }
 futures-lite = { version = "2", optional = true }
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
@@ -56,4 +56,4 @@ tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 
 [dev-dependencies]
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.13.0", default-features = false }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.14.0", default-features = false }

--- a/crates/shell/fission-shell-server/README.md
+++ b/crates/shell/fission-shell-server/README.md
@@ -19,7 +19,7 @@ Most applications should depend on the public `fission` facade with the
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["server"] }
+fission = { version = "0.14.0", features = ["server"] }
 ```
 
 Enable adapter features through the facade when you want to host the renderer
@@ -27,7 +27,7 @@ inside an existing HTTP stack:
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["server", "server-axum"] }
+fission = { version = "0.14.0", features = ["server", "server-axum"] }
 ```
 
 See the guides and reference at <https://fission.rs> for the server app model,

--- a/crates/shell/fission-shell-site/Cargo.toml
+++ b/crates/shell/fission-shell-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-site"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -17,13 +17,13 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-icons = { path = "../../authoring/fission-icons", version = "0.13.0" }
-fission-i18n = { path = "../../core/fission-i18n", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.13.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-icons = { path = "../../authoring/fission-icons", version = "0.14.0" }
+fission-i18n = { path = "../../core/fission-i18n", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.14.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"

--- a/crates/shell/fission-shell-site/README.md
+++ b/crates/shell/fission-shell-site/README.md
@@ -6,7 +6,7 @@ Static site shell for Fission applications and documentation sites.
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["site"] }
+fission = { version = "0.14.0", features = ["site"] }
 ```
 
 ```sh

--- a/crates/shell/fission-shell-terminal/Cargo.toml
+++ b/crates/shell/fission-shell-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-terminal"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -32,12 +32,12 @@ crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["png"] }
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-shell = { path = "../fission-shell", optional = true, version = "0.13.0" }
-fission-store = { path = "../../core/fission-store", optional = true, version = "0.13.0" }
-fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.13.0", default-features = false }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.13.0" }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-shell = { path = "../fission-shell", optional = true, version = "0.14.0" }
+fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
+fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.14.0", default-features = false }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.14.0" }
 base64 = "0.22"

--- a/crates/shell/fission-shell-terminal/README.md
+++ b/crates/shell/fission-shell-terminal/README.md
@@ -8,7 +8,7 @@ Application developers normally enable it through the facade crate:
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["terminal-shell"] }
+fission = { version = "0.14.0", features = ["terminal-shell"] }
 ```
 
 ## What it contains

--- a/crates/shell/fission-shell-web/Cargo.toml
+++ b/crates/shell/fission-shell-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-web"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -24,10 +24,10 @@ store-sqlite-web = ["store-sql", "fission-shell-winit/store-sqlite-web"]
 
 [dependencies]
 anyhow = "1.0"
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-store = { path = "../../core/fission-store", optional = true, version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
-fission-shell = { path = "../fission-shell", version = "0.13.0" }
-fission-shell-winit = { path = "../fission-shell-winit", version = "0.13.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
+fission-shell = { path = "../fission-shell", version = "0.14.0" }
+fission-shell-winit = { path = "../fission-shell-winit", version = "0.14.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell-winit"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Shared winit shell runtime for desktop and mobile Fission hosts"
 categories = ["gui", "rendering"]
@@ -35,20 +35,20 @@ store-sqlite-web = [
 ]
 
 [dependencies]
-fission-shell = { path = "../fission-shell", version = "0.13.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.13.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.13.0" }
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
-fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.13.0" }
-fission-store = { path = "../../core/fission-store", optional = true, version = "0.13.0" }
-fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.13.0", default-features = false }
+fission-shell = { path = "../fission-shell", version = "0.14.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.14.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.14.0" }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
+fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.14.0" }
+fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
+fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.14.0", default-features = false }
 winit = { package = "fission-winit", version = "0.30.13-fission.2" }
-fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.13.0" }
-fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.13.0" }
+fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0" }
+fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.14.0" }
 image = "0.25"
 tiny-skia = "0.11.4"
 fontdue = "0.9.3"
@@ -129,6 +129,6 @@ dispatch = "0.2"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
-fission-macros = { path = "../../authoring/fission-macros", version = "0.13.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.13.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.14.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.14.0" }
 lazy_static = "1"

--- a/crates/shell/fission-shell/Cargo.toml
+++ b/crates/shell/fission-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-shell"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -29,11 +29,11 @@ store-sqlite-web = [
     "fission-store-sqlite/web",
 ]
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.13.0" } # Corrected path
-fission-store = { path = "../../core/fission-store", optional = true, version = "0.13.0" }
-fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.13.0", default-features = false }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.14.0" } # Corrected path
+fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
+fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.14.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 serde_json = "1.0"

--- a/crates/tools/cargo-fission/Cargo.toml
+++ b/crates/tools/cargo-fission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fission"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -29,10 +29,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.13.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.13.0" }
-fission-command-release = { path = "../fission-command-release", version = "0.13.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.13.0" }
-fission-command-server = { path = "../fission-command-server", version = "0.13.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.13.0" }
-fission-command-ui = { path = "../fission-command-ui", version = "0.13.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.14.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.14.0" }
+fission-command-release = { path = "../fission-command-release", version = "0.14.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.14.0" }
+fission-command-server = { path = "../fission-command-server", version = "0.14.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.14.0" }
+fission-command-ui = { path = "../fission-command-ui", version = "0.14.0" }

--- a/crates/tools/cargo-fission/src/lib.rs
+++ b/crates/tools/cargo-fission/src/lib.rs
@@ -1564,7 +1564,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fission = { version = "0.13.0", default-features = false, features = ["desktop"] }
+fission = { version = "0.14.0", default-features = false, features = ["desktop"] }
 "#,
         )
         .unwrap();
@@ -1591,7 +1591,7 @@ edition = "2021"
 anyhow = "1"
 
 [dependencies.fission]
-version = "0.13.0"
+version = "0.14.0"
 default-features = true
 features = ["desktop"]
 "#,

--- a/crates/tools/fission-command-core/Cargo.toml
+++ b/crates/tools/fission-command-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-core"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-fission-store-sqlite = { path = "../../core/fission-store-sqlite", version = "0.13.0" }
+fission-store-sqlite = { path = "../../core/fission-store-sqlite", version = "0.14.0" }
 plist = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/tools/fission-command-core/assets/AGENTS.md
+++ b/crates/tools/fission-command-core/assets/AGENTS.md
@@ -217,7 +217,7 @@ Outside the Fission source workspace, prefer the published crate pinned to the s
 
 ```toml
 [build-dependencies]
-fission-design-system-codegen = { version = "0.13.0" }
+fission-design-system-codegen = { version = "0.14.0" }
 ```
 
 Generate a typed design system from the copied DSP file in `build.rs`:

--- a/crates/tools/fission-command-package/Cargo.toml
+++ b/crates/tools/fission-command-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-package"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -20,9 +20,9 @@ aws-config = "1"
 aws-sdk-s3 = "1"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.13.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.13.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.13.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.14.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.14.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.14.0" }
 flate2 = "1.0"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls"] }

--- a/crates/tools/fission-command-release/Cargo.toml
+++ b/crates/tools/fission-command-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-release"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -18,9 +18,9 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-fission-command-core = { path = "../fission-command-core", version = "0.13.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.13.0" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.13.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.14.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.14.0" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.14.0" }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 jsonwebtoken = "9"
 md-5 = "0.10"

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-run"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -16,10 +16,10 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-command-core = { path = "../fission-command-core", version = "0.13.0" }
-fission-command-server = { path = "../fission-command-server", version = "0.13.0" }
-fission-command-site = { path = "../fission-command-site", version = "0.13.0" }
-fission-test-driver = { path = "../fission-test-driver", version = "0.13.0" }
+fission-command-core = { path = "../fission-command-core", version = "0.14.0" }
+fission-command-server = { path = "../fission-command-server", version = "0.14.0" }
+fission-command-site = { path = "../fission-command-site", version = "0.14.0" }
+fission-test-driver = { path = "../fission-test-driver", version = "0.14.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ureq = "2"

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-server"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-site"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -16,6 +16,6 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.13.0" }
+fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.14.0" }
 serde_json = "1"
 toml = "0.8"

--- a/crates/tools/fission-command-ui/Cargo.toml
+++ b/crates/tools/fission-command-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-command-ui"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -16,11 +16,11 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
-fission = { path = "../../authoring/fission", version = "0.13.0", default-features = false, features = ["desktop", "terminal-shell"] }
-fission-command-core = { path = "../fission-command-core", version = "0.13.0" }
-fission-command-package = { path = "../fission-command-package", version = "0.13.0" }
-fission-command-release = { path = "../fission-command-release", version = "0.13.0" }
-fission-command-run = { path = "../fission-command-run", version = "0.13.0" }
+fission = { path = "../../authoring/fission", version = "0.14.0", default-features = false, features = ["desktop", "terminal-shell"] }
+fission-command-core = { path = "../fission-command-core", version = "0.14.0" }
+fission-command-package = { path = "../fission-command-package", version = "0.14.0" }
+fission-command-release = { path = "../fission-command-release", version = "0.14.0" }
+fission-command-run = { path = "../fission-command-run", version = "0.14.0" }
 rfd = { version = "0.14.1", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 toml_edit = "0.23"

--- a/crates/tools/fission-design-system-codegen/Cargo.toml
+++ b/crates/tools/fission-design-system-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-design-system-codegen"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-diagnostics/Cargo.toml
+++ b/crates/tools/fission-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-diagnostics"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test-driver/Cargo.toml
+++ b/crates/tools/fission-test-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test-driver"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"

--- a/crates/tools/fission-test/Cargo.toml
+++ b/crates/tools/fission-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-test"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/fission-ui/fission"
@@ -15,23 +15,23 @@ homepage = "https://fission.rs"
 documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
-fission-core = { path = "../../core/fission-core", version = "0.13.0" }
-fission-ir = { path = "../../core/fission-ir", version = "0.13.0" }
-fission-layout = { path = "../../core/fission-layout", version = "0.13.0" }
-fission-render = { path = "../../rendering/fission-render", version = "0.13.0" }
-fission-shell = { path = "../../shell/fission-shell", version = "0.13.0" }
-fission-widgets = { path = "../../authoring/fission-widgets", version = "0.13.0" }
-fission-semantics = { path = "../../core/fission-semantics", version = "0.13.0" }
+fission-core = { path = "../../core/fission-core", version = "0.14.0" }
+fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
+fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
+fission-render = { path = "../../rendering/fission-render", version = "0.14.0" }
+fission-shell = { path = "../../shell/fission-shell", version = "0.14.0" }
+fission-widgets = { path = "../../authoring/fission-widgets", version = "0.14.0" }
+fission-semantics = { path = "../../core/fission-semantics", version = "0.14.0" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
-fission-macros = { path = "../../authoring/fission-macros", version = "0.13.0" }
-fission-diagnostics = { path = "../fission-diagnostics", version = "0.13.0" }
-fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.13.0" }
-fission-theme = { path = "../../core/fission-theme", version = "0.13.0" }
+fission-macros = { path = "../../authoring/fission-macros", version = "0.14.0" }
+fission-diagnostics = { path = "../fission-diagnostics", version = "0.14.0" }
+fission-render-vello = { path = "../../rendering/fission-render-vello", version = "0.14.0" }
+fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
 fontique = "0.7"
 read-fonts = "0.35"
 serde_json = "1.0"
 
 [dev-dependencies]
-fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.13.0" }
+fission-shell-desktop = { path = "../../shell/fission-shell-desktop", version = "0.14.0" }

--- a/documentation/Cargo.toml
+++ b/documentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-documentation"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 default-run = "fission-documentation"

--- a/documentation/content/blog/2026-08-25-fission-0-14-0-navigation-storage-and-text.mdx
+++ b/documentation/content/blog/2026-08-25-fission-0-14-0-navigation-storage-and-text.mdx
@@ -1,0 +1,178 @@
+---
+title: Fission 0.14.0: navigation, SQLite storage, and complete text
+description: Fission 0.14.0 adds coherent deep links and history, opt-in cross-platform SQLite, and a complete retained text subsystem.
+authors:
+  - fission
+categories:
+  - Releases
+tags:
+  - release
+  - navigation
+  - storage
+  - text
+show_adjacent_posts: true
+---
+
+# Fission 0.14.0: navigation, SQLite storage, and complete text
+
+Fission 0.14.0 gives applications three coherent framework-level capabilities:
+deep links and history that behave consistently across shells, opt-in SQLite
+storage without a cost for applications that do not use it, and a text system
+whose editing, layout, rendering, selection, accessibility, and platform input
+all share the same retained authority.
+
+This is a minor release because it adds substantial public APIs and target
+capabilities. Existing route handlers and ordinary string-controlled text inputs
+continue to work.
+
+## Deep links and history without a required router
+
+Every shell now exposes the same logical route and navigation commands. An
+application can use Fission's `Router`, retain an existing `with_route_handler`
+integration, or build a custom or third-party router over `RouteLocation`.
+
+Reducers can navigate through the normal effect pipeline:
+
+```rust
+#[fission_reducer(OpenProject)]
+fn open_project(
+    _state: &mut AppState,
+    action: OpenProject,
+    ctx: &mut ReducerContext<AppState>,
+) {
+    ctx.effects.navigate(format!("/projects/{}", action.id));
+}
+```
+
+On Web, both `/projects/42` and `#/projects/42` can launch the same application
+route. `WebRouteStrategy::Auto` preserves the representation used at launch;
+explicit path and hash strategies remain available, along with deployment base
+paths. Back, forward, hash changes, and initial deep links flow into the same
+route-change contract.
+
+`Link::to("Open project", "/projects/42")` performs internal navigation and
+also behaves as a real link. The semantic hyperlink contract is public, so a
+custom widget can provide an `href`, target, relationship metadata, download,
+or popover target without depending on the built-in `Link`. Web canvas output
+projects these links into DOM anchors, and Static site and SSR output emit
+ordinary `<a>` elements.
+
+Path-based SPA deployments still need their host to serve the application entry
+document for application routes. Fission's development and generated Web
+servers do this while continuing to return `404` for missing assets. Hash routing
+remains the zero-configuration choice for static hosts without rewrite support.
+
+## SQLite is the portable storage direction
+
+Storage is deliberately opt-in. Applications that do not enable it do not
+compile SQLite, start a worker, or ship SQLite Web assets.
+
+CLI-managed projects can add the capability with:
+
+```console
+fission add-capability storage --project-dir .
+```
+
+The high-level Store API owns one reserved `fission` table and provides typed
+keys, application/session/user/named scopes, `get`, `set`, `contains`, `remove`,
+prefix listing, and atomic batches. Storage requests and results follow Fission's
+normal reducer effect and typed input contracts.
+
+The SQL API does not handicap SQLite. It supports parameterized execution,
+typed query rows, ordered migrations through `user_version`, and transactions
+that can be passed between modules while they are assembled:
+
+```rust
+fn append_audit(transaction: &mut SqlTransaction, message: String) {
+    transaction.execute(
+        SqlStatement::new("INSERT INTO audit(message) VALUES (?1)").bind(message),
+    );
+}
+
+let mut transaction = SqlTransaction::new();
+transaction.execute(
+    SqlStatement::new("UPDATE projects SET name = ?1 WHERE id = ?2")
+        .bind(name)
+        .bind(project_id),
+);
+append_audit(&mut transaction, "Project renamed".into());
+ctx.effects.sql().transaction(transaction);
+```
+
+Native graphical targets and Terminal use bundled SQLite in an application-data
+database. Web uses the official SQLite WebAssembly distribution in a worker and
+persists through OPFS. SSR uses a server-side database file. Static-site-only
+projects reject runtime storage because generated files have no storage
+authority. Applications can supply their own Store or SQL provider through the
+same capability traits.
+
+## One complete retained text subsystem
+
+`TextEditingValue` is now the editing authority: text, directional selection
+with affinity, and the composing range move atomically. Validated UTF-8
+`TextPosition` values have named UTF-16 and Unicode-scalar conversions for
+platform boundaries. Keyboard, IME, Web native editing, accessibility,
+clipboard, programmatic controllers, and tests all enter one `TextEditCommand`
+transaction pipeline.
+
+Ordinary `value: String` inputs remain supported. Applications that need full
+control can provide the complete value:
+
+```rust
+TextInput {
+    editing_value: Some(TextEditingValue::from_text("hello")),
+    on_input: Some(update_document),
+    ..Default::default()
+}
+```
+
+Typed input, selection, focus, blur, validation, submission, and completion
+callbacks preserve the bound action payload, so repeated and schema-generated
+forms retain their stable field context. Public controllers cover editing,
+scrolling, coordinated read-only selection, and forms. Validation and autofill
+metadata reach native accessibility and semantic HTML.
+
+Paragraph measurement now retains final lines, Unicode clusters, caret stops,
+selection rectangles, inline placements, constraints, and measured size.
+Painting, hit testing, caret and selection geometry, scrolling, IME candidate
+placement, and accessibility consume that same result. Typography adds fallback
+families, locale, word spacing, complete decoration styles, shadows and paints,
+OpenType features, variable axes, baseline and leading policy, line breaking,
+hyphenation, and nonlinear accessibility scaling across native rendering,
+software rendering, Static site, and SSR.
+
+`SelectionRegion` coordinates selection across several retained `Text` and
+`RichText` nodes. Desktop supports mouse, keyboard, and context-menu workflows;
+touch targets add slop-aware handles, magnification, a selection toolbar, and
+edge auto-scroll.
+
+## Input and scrolling polish
+
+Multiline fields now start at the top, fill the available editor height, and
+show scrollbar chrome by default. Applications can disable that chrome with
+`show_scrollbar(false)`. The collapsed blue touch caret handle is hidden unless
+explicitly enabled.
+
+Scrollbars retain their compact visual width but have a wider inward hit target.
+Clicking the rail above or below the thumb jumps proportionally and immediately
+begins a drag. Scroll-state reconciliation also happens before layout, preventing
+an offset retained by one screen from hiding the content of a different screen
+that reuses the same structural identity.
+
+## Upgrade
+
+Update the framework and CLI:
+
+```toml
+[dependencies]
+fission = { version = "0.14.0", default-features = false, features = ["desktop"] }
+```
+
+```sh
+cargo install cargo-fission --version 0.14.0 --locked
+```
+
+Existing route handlers remain valid. Existing string-controlled text fields
+remain valid. Enable SQLite only in applications that use storage, with the CLI
+capability command above or the `store-sqlite-native` and `store-sqlite-web`
+Cargo features for manually managed projects.

--- a/documentation/content/docs/guides/design-system.mdx
+++ b/documentation/content/docs/guides/design-system.mdx
@@ -69,10 +69,10 @@ Add the generator as a build dependency:
 
 ```toml title="Cargo.toml"
 [dependencies]
-fission = { version = "0.13.0", default-features = false, features = ["desktop"] }
+fission = { version = "0.14.0", default-features = false, features = ["desktop"] }
 
 [build-dependencies]
-fission-design-system-codegen = "0.13.0"
+fission-design-system-codegen = "0.14.0"
 ```
 
 ## What you should have working

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -89,7 +89,7 @@ Enable Redis through the facade feature in the server app's `Cargo.toml`:
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["server", "server-redis"] }
+fission = { version = "0.14.0", features = ["server", "server-redis"] }
 ```
 
 ## Invalidate cached pages after writes

--- a/documentation/content/docs/guides/server-site-security.mdx
+++ b/documentation/content/docs/guides/server-site-security.mdx
@@ -78,14 +78,14 @@ Hyper is available with the normal `server` feature:
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["server"] }
+fission = { version = "0.14.0", features = ["server"] }
 ```
 
 Axum and Actix adapters are feature-gated to avoid pulling those dependencies into projects that do not use them:
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["server", "server-axum"] }
+fission = { version = "0.14.0", features = ["server", "server-axum"] }
 tower = "0.5"
 ```
 

--- a/documentation/content/docs/guides/terminal-user-interfaces.mdx
+++ b/documentation/content/docs/guides/terminal-user-interfaces.mdx
@@ -21,7 +21,7 @@ Use the Fission facade crate and enable the terminal shell feature for tools tha
 
 ```toml
 [dependencies]
-fission = { version = "0.13.0", features = ["terminal-shell"] }
+fission = { version = "0.14.0", features = ["terminal-shell"] }
 ```
 
 ## What you should have working

--- a/documentation/content/reference/widgets/widget-pages/video.mdx
+++ b/documentation/content/reference/widgets/widget-pages/video.mdx
@@ -118,7 +118,7 @@ In the winit shell path, macOS and iOS use AVFoundation player layers, Windows u
 Native Linux video is behind the `video` Cargo feature so ordinary desktop apps do not need GStreamer development packages unless they use embedded video:
 
 ```toml
-fission = { version = "0.13.0", default-features = false, features = ["desktop", "video"] }
+fission = { version = "0.14.0", default-features = false, features = ["desktop", "video"] }
 ```
 
 On Debian or Ubuntu, enabling that feature requires:

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -126,7 +126,7 @@ impl From<FooterIdentity> for Widget {
                     ..Default::default()
                 }
                 .into(),
-                Text::new("Fission 0.13.0")
+                Text::new("Fission 0.14.0")
                     .size(tokens.typography.font_size_sm)
                     .family(tokens.typography.font_family_mono.clone())
                     .color(tokens.colors.text_muted)

--- a/examples/animation-gallery/Cargo.toml
+++ b/examples/animation-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animation-gallery"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/chart-gallery/Cargo.toml
+++ b/examples/chart-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chart-gallery"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "counter"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fission-editor"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/embed-3d/Cargo.toml
+++ b/examples/embed-3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-3d"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/embed-video/Cargo.toml
+++ b/examples/embed-video/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-video"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/embed-webview/Cargo.toml
+++ b/examples/embed-webview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed-webview"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/field-inspector/Cargo.toml
+++ b/examples/field-inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-inspector"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/field-inspector/fission.toml
+++ b/examples/field-inspector/fission.toml
@@ -24,13 +24,13 @@ capabilities = [
 [app]
 name = "field-inspector"
 app_id = "com.fission.examples.fieldinspector"
-version = "0.13.0"
+version = "0.14.0"
 build = 1
 
 [package.android]
 package_name = "com.fission.examples.fieldinspector"
 version_code = 1
-version_name = "0.13.0"
+version_name = "0.14.0"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -41,13 +41,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.fission.examples.fieldinspector"
-marketing_version = "0.13.0"
+marketing_version = "0.14.0"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.fission.examples.fieldinspector"
 publisher = "CN=Fission Developer"
-version = "0.13.0"
+version = "0.14.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/icons_gallery/Cargo.toml
+++ b/examples/icons_gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icons_gallery"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/inbox/Cargo.toml
+++ b/examples/inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inbox"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/interactive-canvas/Cargo.toml
+++ b/examples/interactive-canvas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactive-canvas-example"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/interactive-canvas/fission.toml
+++ b/examples/interactive-canvas/fission.toml
@@ -10,13 +10,13 @@ targets = [
 [app]
 name = "interactive-canvas"
 app_id = "dev.fission.interactive_canvas"
-version = "0.13.0"
+version = "0.14.0"
 build = 1
 
 [package.android]
 package_name = "dev.fission.interactive_canvas"
 version_code = 1
-version_name = "0.13.0"
+version_name = "0.14.0"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -27,13 +27,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "dev.fission.interactive-canvas"
-marketing_version = "0.13.0"
+marketing_version = "0.14.0"
 build_number = "1"
 
 [package.windows]
 identity_name = "dev.fission.interactive.canvas"
 publisher = "CN=Fission Developer"
-version = "0.13.0"
+version = "0.14.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"
@@ -41,7 +41,7 @@ certificate_password_env = "WINDOWS_CERTIFICATE_PASSWORD"
 
 [package.macos]
 bundle_id = "dev.fission.interactive_canvas"
-marketing_version = "0.13.0"
+marketing_version = "0.14.0"
 build_number = "1"
 minimum_os = "13.0"
 

--- a/examples/mobile-smoke/Cargo.toml
+++ b/examples/mobile-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-smoke"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/motion-memory-repro/Cargo.toml
+++ b/examples/motion-memory-repro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motion-memory-repro"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/pokemon-card-store/Cargo.toml
+++ b/examples/pokemon-card-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pokemon-card-store"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/examples/pokemon-card-store/fission.toml
+++ b/examples/pokemon-card-store/fission.toml
@@ -19,7 +19,7 @@ preload = "route"
 
 [package.docker]
 port = 8080
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.13.0"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.14.0"]
 
 [distribution.docker_registry.production]
-tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.13.0"]
+tags = ["ghcr.io/fission-ui/fission-pokemon-card-store:0.14.0"]

--- a/examples/product-browser/Cargo.toml
+++ b/examples/product-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product-browser"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/showcase/Cargo.toml
+++ b/examples/showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-showcase"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/showcase/fission.toml
+++ b/examples/showcase/fission.toml
@@ -8,19 +8,19 @@ targets = [
 [app]
 name = "example-showcase"
 app_id = "rs.fission.examples.showcase"
-version = "0.13.0"
+version = "0.14.0"
 build = 1
 
 [package.macos]
 bundle_id = "rs.fission.examples.showcase"
-marketing_version = "0.13.0"
+marketing_version = "0.14.0"
 build_number = "1"
 minimum_os = "13.0"
 
 [package.windows]
 identity_name = "rs.fission.examples.showcase"
 publisher = "CN=Fission Developer"
-version = "0.13.0"
+version = "0.14.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/store-sqlite/Cargo.toml
+++ b/examples/store-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "store-sqlite"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/text-lab/Cargo.toml
+++ b/examples/text-lab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-lab"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/todo-design-system/Cargo.toml
+++ b/examples/todo-design-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-design-system"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/web-smoke/Cargo.toml
+++ b/examples/web-smoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-smoke"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/web-smoke/fission.toml
+++ b/examples/web-smoke/fission.toml
@@ -10,13 +10,13 @@ targets = [
 [app]
 name = "web-smoke"
 app_id = "com.example.web_smoke"
-version = "0.13.0"
+version = "0.14.0"
 build = 1
 
 [package.android]
 package_name = "com.example.web_smoke"
 version_code = 1
-version_name = "0.13.0"
+version_name = "0.14.0"
 min_sdk = 24
 target_sdk = 35
 keystore_alias = "upload"
@@ -27,13 +27,13 @@ key_password_env = "ANDROID_KEY_PASSWORD"
 
 [package.ios]
 bundle_id = "com.example.web_smoke"
-marketing_version = "0.13.0"
+marketing_version = "0.14.0"
 build_number = "1"
 
 [package.windows]
 identity_name = "com.example.web.smoke"
 publisher = "CN=Fission Developer"
-version = "0.13.0"
+version = "0.14.0"
 installer = "msix"
 certificate_thumbprint_env = "WINDOWS_CERTIFICATE_THUMBPRINT"
 certificate_base64_env = "WINDOWS_CERTIFICATE_BASE64"

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "widget-gallery"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
---
title: Fission 0.14.0: navigation, SQLite storage, and complete text
description: Fission 0.14.0 adds coherent deep links and history, opt-in cross-platform SQLite, and a complete retained text subsystem.
authors:
  - fission
categories:
  - Releases
tags:
  - release
  - navigation
  - storage
  - text
show_adjacent_posts: true
---

# Fission 0.14.0: navigation, SQLite storage, and complete text

Fission 0.14.0 gives applications three coherent framework-level capabilities:
deep links and history that behave consistently across shells, opt-in SQLite
storage without a cost for applications that do not use it, and a text system
whose editing, layout, rendering, selection, accessibility, and platform input
all share the same retained authority.

This is a minor release because it adds substantial public APIs and target
capabilities. Existing route handlers and ordinary string-controlled text inputs
continue to work.

## Deep links and history without a required router

Every shell now exposes the same logical route and navigation commands. An
application can use Fission's `Router`, retain an existing `with_route_handler`
integration, or build a custom or third-party router over `RouteLocation`.

Reducers can navigate through the normal effect pipeline:

```rust
#[fission_reducer(OpenProject)]
fn open_project(
    _state: &mut AppState,
    action: OpenProject,
    ctx: &mut ReducerContext<AppState>,
) {
    ctx.effects.navigate(format!("/projects/{}", action.id));
}
```

On Web, both `/projects/42` and `#/projects/42` can launch the same application
route. `WebRouteStrategy::Auto` preserves the representation used at launch;
explicit path and hash strategies remain available, along with deployment base
paths. Back, forward, hash changes, and initial deep links flow into the same
route-change contract.

`Link::to("Open project", "/projects/42")` performs internal navigation and
also behaves as a real link. The semantic hyperlink contract is public, so a
custom widget can provide an `href`, target, relationship metadata, download,
or popover target without depending on the built-in `Link`. Web canvas output
projects these links into DOM anchors, and Static site and SSR output emit
ordinary `<a>` elements.

Path-based SPA deployments still need their host to serve the application entry
document for application routes. Fission's development and generated Web
servers do this while continuing to return `404` for missing assets. Hash routing
remains the zero-configuration choice for static hosts without rewrite support.

## SQLite is the portable storage direction

Storage is deliberately opt-in. Applications that do not enable it do not
compile SQLite, start a worker, or ship SQLite Web assets.

CLI-managed projects can add the capability with:

```console
fission add-capability storage --project-dir .
```

The high-level Store API owns one reserved `fission` table and provides typed
keys, application/session/user/named scopes, `get`, `set`, `contains`, `remove`,
prefix listing, and atomic batches. Storage requests and results follow Fission's
normal reducer effect and typed input contracts.

The SQL API does not handicap SQLite. It supports parameterized execution,
typed query rows, ordered migrations through `user_version`, and transactions
that can be passed between modules while they are assembled:

```rust
fn append_audit(transaction: &mut SqlTransaction, message: String) {
    transaction.execute(
        SqlStatement::new("INSERT INTO audit(message) VALUES (?1)").bind(message),
    );
}

let mut transaction = SqlTransaction::new();
transaction.execute(
    SqlStatement::new("UPDATE projects SET name = ?1 WHERE id = ?2")
        .bind(name)
        .bind(project_id),
);
append_audit(&mut transaction, "Project renamed".into());
ctx.effects.sql().transaction(transaction);
```

Native graphical targets and Terminal use bundled SQLite in an application-data
database. Web uses the official SQLite WebAssembly distribution in a worker and
persists through OPFS. SSR uses a server-side database file. Static-site-only
projects reject runtime storage because generated files have no storage
authority. Applications can supply their own Store or SQL provider through the
same capability traits.

## One complete retained text subsystem

`TextEditingValue` is now the editing authority: text, directional selection
with affinity, and the composing range move atomically. Validated UTF-8
`TextPosition` values have named UTF-16 and Unicode-scalar conversions for
platform boundaries. Keyboard, IME, Web native editing, accessibility,
clipboard, programmatic controllers, and tests all enter one `TextEditCommand`
transaction pipeline.

Ordinary `value: String` inputs remain supported. Applications that need full
control can provide the complete value:

```rust
TextInput {
    editing_value: Some(TextEditingValue::from_text("hello")),
    on_input: Some(update_document),
    ..Default::default()
}
```

Typed input, selection, focus, blur, validation, submission, and completion
callbacks preserve the bound action payload, so repeated and schema-generated
forms retain their stable field context. Public controllers cover editing,
scrolling, coordinated read-only selection, and forms. Validation and autofill
metadata reach native accessibility and semantic HTML.

Paragraph measurement now retains final lines, Unicode clusters, caret stops,
selection rectangles, inline placements, constraints, and measured size.
Painting, hit testing, caret and selection geometry, scrolling, IME candidate
placement, and accessibility consume that same result. Typography adds fallback
families, locale, word spacing, complete decoration styles, shadows and paints,
OpenType features, variable axes, baseline and leading policy, line breaking,
hyphenation, and nonlinear accessibility scaling across native rendering,
software rendering, Static site, and SSR.

`SelectionRegion` coordinates selection across several retained `Text` and
`RichText` nodes. Desktop supports mouse, keyboard, and context-menu workflows;
touch targets add slop-aware handles, magnification, a selection toolbar, and
edge auto-scroll.

## Input and scrolling polish

Multiline fields now start at the top, fill the available editor height, and
show scrollbar chrome by default. Applications can disable that chrome with
`show_scrollbar(false)`. The collapsed blue touch caret handle is hidden unless
explicitly enabled.

Scrollbars retain their compact visual width but have a wider inward hit target.
Clicking the rail above or below the thumb jumps proportionally and immediately
begins a drag. Scroll-state reconciliation also happens before layout, preventing
an offset retained by one screen from hiding the content of a different screen
that reuses the same structural identity.

## Upgrade

Update the framework and CLI:

```toml
[dependencies]
fission = { version = "0.14.0", default-features = false, features = ["desktop"] }
```

```sh
cargo install cargo-fission --version 0.14.0 --locked
```

Existing route handlers remain valid. Existing string-controlled text fields
remain valid. Enable SQLite only in applications that use storage, with the CLI
capability command above or the `store-sqlite-native` and `store-sqlite-web`
Cargo features for manually managed projects.
