### PR TITLE
Resolve release dependencies exclusively from crates.io

### DIFF
--- a/.github/workflows/platform-checks.yml
+++ b/.github/workflows/platform-checks.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Check CLI dependency boundaries
         run: ./scripts/check_command_dependency_boundaries.sh
 
+      - name: Check published dependency boundaries
+        run: ./scripts/check_published_dependency_boundaries.sh
+
       - name: Test generated platform scripts
         run: cargo test -p cargo-fission
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "fission-vello"
-version = "0.6.0-fission.2"
+version = "0.6.0-fission.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8840ee7e1d9bb6db8d1441d151b368ed1fe7438e9ad4c612991cc2b3cad8f6"
+checksum = "373c8d6ec789c062ce0d8dd3776ee2f8a4959f9ff5c133d88e645efb3557d3d2"
 dependencies = [
  "bytemuck",
  "fission-vello-encoding",
@@ -3364,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "fission-vello-encoding"
-version = "0.6.0-fission.2"
+version = "0.6.0-fission.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d034be7f5cacfd10a882743d629fb8ae5b58c62e0f285fa3eedb1e9081e4151"
+checksum = "99e8ef39b1c2aa335cd6c047c01cecf6263c2b3ce4233d4891ec9c19145d3063"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -3377,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "fission-vello-shaders"
-version = "0.6.0-fission.2"
+version = "0.6.0-fission.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364cc381f5ff3e1b195ecd43cf1f5700e015a809bed16746e00dd15b1cbf0cf8"
+checksum = "f82a394588d3cf6217cefee3a690ae980f040d3df0c4f9190e5ec0019a0e80e7"
 dependencies = [
  "bytemuck",
  "fission-vello-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,8 @@ dependencies = [
 [[package]]
 name = "android-activity"
 version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
  "bitflags 2.13.0",
@@ -3344,6 +3346,8 @@ dependencies = [
 [[package]]
 name = "fission-vello"
 version = "0.6.0-fission.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8840ee7e1d9bb6db8d1441d151b368ed1fe7438e9ad4c612991cc2b3cad8f6"
 dependencies = [
  "bytemuck",
  "fission-vello-encoding",
@@ -3361,6 +3365,8 @@ dependencies = [
 [[package]]
 name = "fission-vello-encoding"
 version = "0.6.0-fission.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d034be7f5cacfd10a882743d629fb8ae5b58c62e0f285fa3eedb1e9081e4151"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -3372,6 +3378,8 @@ dependencies = [
 [[package]]
 name = "fission-vello-shaders"
 version = "0.6.0-fission.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364cc381f5ff3e1b195ecd43cf1f5700e015a809bed16746e00dd15b1cbf0cf8"
 dependencies = [
  "bytemuck",
  "fission-vello-encoding",
@@ -3405,8 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "fission-winit"
-version = "0.30.13-fission.2"
-source = "git+https://github.com/worka-ai/winit.git?rev=86c4670cb364e109775079a9f63caef0fda919b5#86c4670cb364e109775079a9f63caef0fda919b5"
+version = "0.30.13-fission.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8a28d630be05dfb16c51b24e5134f0a07142c5f6be07a529ffcb852e1b6b17"
 dependencies = [
  "ahash",
  "android-activity",
@@ -5827,7 +5836,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,3 @@ lto = true
 opt-level = "z"
 codegen-units = 1
 panic = "abort"
-
-[patch.crates-io]
-android-activity = { path = "third_party/android-activity/android-activity" }
-fission-winit = { git = "https://github.com/worka-ai/winit.git", rev = "86c4670cb364e109775079a9f63caef0fda919b5" }

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -19,7 +19,7 @@ fission-render = { path = "../fission-render", version = "0.14.0" }
 fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
 fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
 anyhow = "1.0"
-vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2", features = ["wgpu"] }
+vello = { package = "fission-vello", version = "0.6.0-fission.2", features = ["wgpu"] }
 parley = "0.7.0"
 fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0" }
 image = "0.24"

--- a/crates/rendering/fission-render-vello/Cargo.toml
+++ b/crates/rendering/fission-render-vello/Cargo.toml
@@ -19,7 +19,7 @@ fission-render = { path = "../fission-render", version = "0.14.0" }
 fission-layout = { path = "../../core/fission-layout", version = "0.14.0" }
 fission-ir = { path = "../../core/fission-ir", version = "0.14.0" }
 anyhow = "1.0"
-vello = { package = "fission-vello", version = "0.6.0-fission.2", features = ["wgpu"] }
+vello = { package = "fission-vello", version = "0.6.0-fission.3", features = ["wgpu"] }
 parley = "0.7.0"
 fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0" }
 image = "0.24"

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -46,7 +46,7 @@ fission-theme = { path = "../../core/fission-theme", version = "0.14.0" }
 fission-3d = { path = "../../core/fission-3d", optional = true, version = "0.14.0" }
 fission-store = { path = "../../core/fission-store", optional = true, version = "0.14.0" }
 fission-store-sqlite = { path = "../../core/fission-store-sqlite", optional = true, version = "0.14.0", default-features = false }
-winit = { package = "fission-winit", version = "0.30.13-fission.2" }
+winit = { package = "fission-winit", version = "0.30.13-fission.3" }
 fission-diagnostics = { path = "../../tools/fission-diagnostics", version = "0.14.0" }
 fission-test-driver = { path = "../../tools/fission-test-driver", version = "0.14.0" }
 image = "0.25"
@@ -56,7 +56,7 @@ anyhow = "1.0"
 raw-window-handle = "0.6"
 bytemuck = "1.16"
 serde_json = "1"
-vello = { package = "fission-vello", path = "../../../third_party/vello/vello", version = "0.6.0-fission.2" }
+vello = { package = "fission-vello", version = "0.6.0-fission.2" }
 pollster = "0.3"
 fontique = "0.7"
 read-fonts = "0.35"
@@ -83,7 +83,7 @@ accesskit = "0.24.1"
 accesskit_winit = { package = "fission-accesskit-winit", version = "0.33.1-fission.1", default-features = false, features = ["accesskit_android", "rwh_06"] }
 jni = "0.21"
 ndk-context = "0.1"
-winit = { package = "fission-winit", version = "0.30.13-fission.2", features = ["android-game-activity"] }
+winit = { package = "fission-winit", version = "0.30.13-fission.3", features = ["android-game-activity"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [

--- a/crates/shell/fission-shell-winit/Cargo.toml
+++ b/crates/shell/fission-shell-winit/Cargo.toml
@@ -56,7 +56,7 @@ anyhow = "1.0"
 raw-window-handle = "0.6"
 bytemuck = "1.16"
 serde_json = "1"
-vello = { package = "fission-vello", version = "0.6.0-fission.2" }
+vello = { package = "fission-vello", version = "0.6.0-fission.3" }
 pollster = "0.3"
 fontique = "0.7"
 read-fonts = "0.35"

--- a/scripts/check_published_dependency_boundaries.sh
+++ b/scripts/check_published_dependency_boundaries.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+manifest_paths=(Cargo.toml)
+while IFS= read -r manifest; do
+  manifest_paths+=("$manifest")
+done < <(find crates -name Cargo.toml -type f | sort)
+
+if rg -n '^\s*\[(patch|replace)(\.|\])' "${manifest_paths[@]}"; then
+  echo >&2 "error: publishable Fission manifests must not override registry dependencies with [patch] or [replace]"
+  exit 1
+fi
+
+if rg -n '\bgit\s*=|\bpath\s*=\s*"[^"]*third_party/' "${manifest_paths[@]}"; then
+  echo >&2 "error: publishable Fission manifests must resolve external dependencies from the registry"
+  exit 1
+fi
+
+echo "published dependency boundaries are registry-resolvable"


### PR DESCRIPTION
Fission CI and published consumers now resolve the same external dependency graph. This removes the workspace-wide Winit and Android Activity patches, removes vendored Vello path resolution from publishable crates, and requires the newly published `fission-winit 0.30.13-fission.3` containing the mobile and Web IME APIs used by Fission 0.14.0.\n\nA new CI boundary check rejects future `[patch]`/`[replace]` sections and external Git or `third_party` path dependencies in publishable manifests. The lockfile confirms Android Activity, the Fission Vello fork, and the Fission Winit fork all resolve from crates.io. This makes the existing Web, Android, iOS, and CLI jobs exercise the same external artifacts downstream users receive.