### PR TITLE
Fix documentation scrolling and clarify site startup

### DIFF
--- a/crates/shell/fission-shell-desktop/README.md
+++ b/crates/shell/fission-shell-desktop/README.md
@@ -118,6 +118,8 @@ The render pipeline (`Pipeline`) manages incremental updates:
 | `FISSION_SCROLL_TRACE` | `false` | Enable scroll event tracing to stderr. |
 | `FISSION_TEST_CONTROL_PORT` | (none) | Start an HTTP test control server on this port. |
 
+The [complete environment-variable reference](https://fission.rs/reference/config/environment-variables/) covers all shell, renderer, diagnostics, storage, build, testing, packaging, signing, and publishing variables.
+
 ## Test control
 
 When `FISSION_TEST_CONTROL_PORT` is set, the shell spawns a TCP server that accepts JSON commands from `fission-test-driver::LiveTestClient`. This enables automated UI testing by sending tap, scroll, type, screenshot, and semantic tree queries over HTTP. See the `fission-test-driver` crate for the client API.

--- a/crates/shell/fission-shell-site/assets/site.css
+++ b/crates/shell/fission-shell-site/assets/site.css
@@ -12,6 +12,10 @@ a:hover { text-decoration: underline; }
 img, svg { max-width: 100%; }
 .fission-site-root { min-height: 100vh; }
 .fission-site-node { min-width: 0; }
+.fission-site-footer {
+  position: static;
+  flex: 0 0 auto;
+}
 /* Browsers ignore `justify-content: stretch` on a row flexbox. Native Fission
    stretches a Container child only while its width and max-width are automatic,
    so the renderer emits this class solely for that same lowering shape. */
@@ -374,14 +378,10 @@ h6.fission-site-semantics {
 .fission-site-markdown-align-center { text-align: center; }
 .fission-site-markdown-align-right { text-align: right; }
 
-.fission-site-doc-layout {
-  height: calc(100vh - 4.75rem);
-  overflow: hidden;
-}
-
+.fission-site-doc-layout,
 .fission-site-blog-layout {
-  height: calc(100vh - 4.75rem);
-  overflow: hidden;
+  min-height: calc(100vh - 4.75rem);
+  overflow: visible;
 }
 
 .fission-site-doc-header {
@@ -392,27 +392,33 @@ h6.fission-site-semantics {
 
 .fission-site-doc-layout > .fission-site-row,
 .fission-site-blog-layout > .fission-site-row {
-  height: 100%;
-  align-items: stretch;
+  align-items: flex-start;
 }
 
-.fission-site-doc-sidebar,
-.fission-site-doc-main,
-.fission-site-doc-toc,
-.fission-site-blog-rail {
-  max-height: 100%;
-  overflow-y: auto;
-  overscroll-behavior: auto;
-  scrollbar-gutter: stable;
+.fission-site-doc-main {
+  max-height: none;
+  overflow: visible;
 }
 
 .fission-site-doc-sidebar,
 .fission-site-doc-toc,
 .fission-site-blog-rail {
-  position: sticky;
-  top: 0;
+  position: relative;
   align-self: stretch;
   min-height: 100%;
+  max-height: none;
+  overflow: visible;
+}
+
+.fission-site-doc-sidebar > .fission-site-column,
+.fission-site-doc-toc > .fission-site-column,
+.fission-site-blog-rail > .fission-site-column {
+  position: sticky;
+  top: 4.75rem;
+  max-height: calc(100vh - 4.75rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .fission-site-doc-main {
@@ -755,8 +761,11 @@ h6.fission-site-semantics {
 
   .fission-site-doc-sidebar > .fission-site-column,
   .fission-site-doc-sidebar > .fission-site-column > .fission-site-box {
+    position: static;
     width: 100% !important;
     min-height: 100vh !important;
+    max-height: none;
+    overflow: visible;
   }
 
   .fission-site-sidebar-open {

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -223,12 +223,14 @@ pub fn list_content_routes(options: &SiteBuildOptions) -> Result<Vec<SiteRouteRe
 }
 
 pub fn build_site(options: &SiteBuildOptions, site: &FissionSite) -> Result<SiteBuildReport> {
+    eprintln!("Loading static site routes...");
     let mut routes = load_content_routes(options, site.content_transform.as_deref())?;
     let mut styles = StyleRegistry::default();
     let custom_routes = render_custom_routes(options, site, &mut styles)?;
     routes.extend(custom_routes);
     routes.sort_by(|a, b| a.path.cmp(&b.path));
     detect_duplicate_routes(&routes)?;
+    eprintln!("Preparing output for {} static routes...", routes.len());
 
     if options.clean && options.output_dir.exists() {
         fs::remove_dir_all(&options.output_dir).with_context(|| {
@@ -242,15 +244,18 @@ pub fn build_site(options: &SiteBuildOptions, site: &FissionSite) -> Result<Site
     copy_asset_dirs(options)?;
 
     let mut rendered_routes = Vec::new();
-    for route in &routes {
+    for (index, route) in routes.iter().enumerate() {
+        report_route_progress("Rendering", index, routes.len(), &route.path);
         let html = render_route(route, &routes, options, site, &mut styles)?;
         rendered_routes.push((route, html));
     }
+    eprintln!("Writing generated styles and route output...");
     write_site_css(options, site, &styles)?;
     write_site_enhancement_js(options)?;
 
     let mut report_routes = Vec::new();
-    for (route, html) in rendered_routes {
+    for (index, (route, html)) in rendered_routes.into_iter().enumerate() {
+        report_route_progress("Writing", index, routes.len(), &route.path);
         let output = output_path_for_route(&options.output_dir, &route.path);
         if let Some(parent) = output.parent() {
             fs::create_dir_all(parent)?;
@@ -265,16 +270,25 @@ pub fn build_site(options: &SiteBuildOptions, site: &FissionSite) -> Result<Site
         });
     }
 
+    eprintln!("Generating search and discovery assets...");
     write_search_assets_if_needed(options, &routes)?;
     write_root_index_if_needed(options, &routes)?;
     write_sitemap_if_needed(options, &routes)?;
     write_robots_if_needed(options)?;
+    eprintln!("Validating generated internal links...");
     validate_generated_internal_links(&options.output_dir)?;
 
     Ok(SiteBuildReport {
         output_dir: options.output_dir.clone(),
         routes: report_routes,
     })
+}
+
+fn report_route_progress(stage: &str, index: usize, total: usize, path: &str) {
+    let completed = index + 1;
+    if completed == 1 || completed == total || completed % 100 == 0 {
+        eprintln!("{stage} route {completed}/{total}: {path}");
+    }
 }
 
 pub fn check_site(options: &SiteBuildOptions, site: &FissionSite) -> Result<SiteBuildReport> {
@@ -1888,6 +1902,14 @@ mod tests {
         assert!(css.contains(".fission-site-svg-colored svg *"));
         assert!(css.contains("fill: currentColor;"));
         assert!(css.contains(".fission-site-svg-colored svg [fill=\"none\"]"));
+        assert!(css.contains(".fission-site-footer {\n  position: static;"));
+        assert!(css.contains("flex: 0 0 auto;"));
+        assert!(css.contains(".fission-site-doc-main {\n  max-height: none;"));
+        assert!(css.contains("min-height: calc(100vh - 4.75rem);"));
+        assert!(css.contains(".fission-site-doc-sidebar > .fission-site-column,"));
+        assert!(css.contains("align-self: stretch;\n  min-height: 100%;"));
+        assert!(!css.contains(".fission-site-doc-layout {\n  height:"));
+        assert!(!css.contains(".fission-site-doc-main {\n  max-height: 100%;"));
         assert!(!css.contains(
             ".fission-site-route-link,\n.fission-site-heading-link { display: contents; }"
         ));
@@ -1964,6 +1986,10 @@ mod tests {
         assert!(css.contains(":root"));
         assert!(css.contains(".fs_"));
         assert!(css.contains(".fission-doc-tabs"));
+        assert!(
+            !css.contains("min-height:864px"),
+            "the documentation template must not bake its render viewport into browser flow"
+        );
         assert!(temp.join("target/fission/site/sitemap.xml").exists());
         assert!(temp.join("target/fission/site/robots.txt").exists());
         assert!(temp.join("target/fission/site/search/search.js").exists());

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -78,12 +78,15 @@ impl From<DocumentationPage<'_>> for Widget {
     fn from(page: DocumentationPage<'_>) -> Widget {
         let (_, view) = fission_core::build::current::<SitePageState>();
         let tokens = &view.env().theme.tokens;
+        // The site builder appends the footer after this widget. Keep the page
+        // content-sized so the footer remains in normal document flow; a fixed
+        // render-time minimum becomes stale as soon as the browser viewport or
+        // content height differs from the static renderer's default viewport.
         Container::new(Column {
             children: vec![page.header(tokens), page.document_grid(view)],
             flex_grow: 1.0,
             ..Default::default()
         })
-        .min_height(tokens.spacing.xxxxl * 9.0)
         .bg_fill(Fill::Solid(tokens.colors.background))
         .into()
     }
@@ -233,7 +236,6 @@ impl DocumentationPage<'_> {
             .bg_fill(Fill::Solid(tokens.colors.surface))
             .border(tokens.colors.border, 1.0)
             .width(tokens.spacing.xxxxl * 3.0)
-            .min_height(tokens.spacing.xxxxl * 9.0)
             .flex_shrink(0.0)
             .into()],
             semantics: Some(site_semantics("site-doc-sidebar")),

--- a/crates/shell/fission-shell-site/src/site.rs
+++ b/crates/shell/fission-shell-site/src/site.rs
@@ -502,7 +502,12 @@ pub fn build_from_cli(site: FissionSite) -> Result<()> {
         }
         "serve" => {
             let report = build_site(&options, &site)?;
-            print_report("Built", &report);
+            println!(
+                "Built {} static route(s) into {}",
+                report.routes.len(),
+                report.output_dir.display()
+            );
+            eprintln!("Static site build complete; starting local server...");
             serve_static(options.output_dir, args.host, args.port, !args.no_open)?;
         }
         other => bail!("unknown site command `{other}`; expected build, check, routes, or serve"),

--- a/crates/shell/fission-shell-winit/README.md
+++ b/crates/shell/fission-shell-winit/README.md
@@ -121,6 +121,9 @@ The render pipeline (`Pipeline`) manages incremental updates:
 | `FISSION_TEXT_TRACE` | `false` | Enable text input latency tracing to stderr. |
 | `FISSION_SCROLL_TRACE` | `false` | Enable scroll event tracing to stderr. |
 | `FISSION_TEST_CONTROL_PORT` | (none) | Start an HTTP test control server on this port. |
+| `FISSION_WEB_TEST_CONTROL` | (none) | Web only: include the test bridge when present at WASM compile time. Use `1`; setting it after compilation has no effect. |
+
+The [complete environment-variable reference](https://fission.rs/reference/config/environment-variables/) covers the additional renderer, diagnostics, storage, build, packaging, signing, and publishing variables and distinguishes compile-time switches from runtime settings.
 
 ## Test control
 

--- a/crates/tools/fission-command-site/src/lib.rs
+++ b/crates/tools/fission-command-site/src/lib.rs
@@ -70,6 +70,7 @@ pub fn routes(project_dir: &Path) -> Result<()> {
 }
 
 pub fn serve(project_dir: &Path, release: bool, host: String, port: u16, open: bool) -> Result<()> {
+    eprintln!("Building static site before starting local server...");
     if site_entry_configured(project_dir)? {
         let port = port.to_string();
         let open_flag = if open { "" } else { "--no-open" };
@@ -79,8 +80,14 @@ pub fn serve(project_dir: &Path, release: bool, host: String, port: u16, open: b
         }
         return run_site_builder(project_dir, release, "serve", &args);
     }
-    build(project_dir, release)?;
     let options = site_build_options(project_dir)?;
+    let report = fission_shell_site::build_content_site(&options)?;
+    println!(
+        "Built {} static route(s) into {}",
+        report.routes.len(),
+        report.output_dir.display()
+    );
+    eprintln!("Static site build complete; starting local server...");
     serve_static(options.output_dir, host, port, open)
 }
 

--- a/crates/tools/fission-test-driver/README.md
+++ b/crates/tools/fission-test-driver/README.md
@@ -17,7 +17,9 @@ Test process                         Application
                                           TestEvent / Runtime
 ```
 
-Native applications use `FISSION_TEST_CONTROL_PORT=<port>`. Web applications use a test-only bridge included by `fission test --target web` or a WASM build with `FISSION_WEB_TEST_CONTROL=1`.
+Native applications use `FISSION_TEST_CONTROL_PORT=<port>`. Web applications use a test-only bridge included by `fission test --target web` or a WASM build compiled with `FISSION_WEB_TEST_CONTROL=1`. The Web variable is read at compile time: it must be present on the WASM build command, and setting it only while serving an existing build or running the browser test has no effect.
+
+See the [complete environment-variable reference](https://fission.rs/reference/config/environment-variables/) for test, shell, renderer, diagnostics, storage, build, packaging, signing, and publishing variables.
 
 ## Protocol types
 

--- a/documentation/content/docs/test-and-debug/live-test-api.mdx
+++ b/documentation/content/docs/test-and-debug/live-test-api.mdx
@@ -29,7 +29,15 @@ curl -s http://127.0.0.1:9876/cmd   -H 'content-type: application/json'   -d '{"
 
 Prefer `LiveTestClient` in Rust tests and `curl` for quick manual QA or screenshot capture.
 
-For Web, build and serve the application with `fission test --target web`, or set `FISSION_WEB_TEST_CONTROL=1` while building WASM, then connect to the served URL:
+For Web, build and serve the application with `fission test --target web`, or set `FISSION_WEB_TEST_CONTROL=1` **on the command that compiles the WASM application**, then connect to the served URL. This is a compile-time switch: setting it only while serving the already-built files or while running the Rust browser test does not install the bridge. Rebuild the WASM output after changing it.
+
+```bash
+FISSION_WEB_TEST_CONTROL=1 ./platforms/web/build-wasm.sh
+```
+
+Ordinary production Web builds deliberately omit `globalThis.__FISSION_TEST__`.
+
+Then use the browser client:
 
 ```rust
 use fission_test_driver::{BrowserTestOptions, LiveTestClient};

--- a/documentation/content/reference/config/environment-variables.mdx
+++ b/documentation/content/reference/config/environment-variables.mdx
@@ -1,0 +1,164 @@
+---
+title: Environment variables
+description: Complete reference for environment variables read or supplied by Fission runtime shells, tests, diagnostics, builds, packaging, and publishing.
+---
+
+# Environment variables
+
+Fission prefers typed Rust APIs and `fission.toml` for durable configuration. Environment variables are reserved for process-local overrides, test instrumentation, tool discovery, generated build-script inputs, and secrets that must not be committed.
+
+The moment at which a variable is read is part of its contract:
+
+| Kind | When it must be set |
+| --- | --- |
+| Compile time | On the command that compiles the affected crate or WASM application. Setting it while serving or launching an existing artifact has no effect. |
+| Runtime | On the application process. A parent test process does not affect an already-running child unless it passes the variable through. |
+| Command | On the `fission`, `cargo fission`, or provider command invocation. |
+| Generated input | Fission sets it for a configured script. Application developers should read it, not set it manually. |
+
+Unless a row explicitly says otherwise, an invalid value is ignored and the documented default is used. Variables described as internal diagnostics are useful for investigation but are not stable application configuration APIs.
+
+## Live testing and browser testing
+
+| Variable | Kind | Values and default | Effect |
+| --- | --- | --- | --- |
+| `FISSION_WEB_TEST_CONTROL` | Compile time, Web only | Unset by default; use `1` | Includes the test-only `globalThis.__FISSION_TEST__` bridge in the compiled WASM application. `fission test --target web` sets this for its build. If you build WASM yourself, use `FISSION_WEB_TEST_CONTROL=1` on the build command and rebuild whenever its presence changes. Setting it only while serving files or running a browser test does nothing. Do not enable it in a production build. |
+| `FISSION_TEST_CONTROL_PORT` | Runtime, native and mobile | TCP port; unset by default | Starts the LiveTest HTTP control server. The builder API is preferred when the app owns the port. |
+| `FISSION_BACKGROUND_TEST` | Runtime | Presence enables it | Marks checked-in example applications as unattended test launches. It is an example convention rather than a general shell mode. |
+| `FISSION_CHROME` | Command/test | Path; automatic discovery by default | Selects the Chrome or Chromium executable used by browser tests and `fission doctor web`. `CHROME` and `CHROME_BIN` are fallback aliases for tool discovery. |
+| `FISSION_WEB_SMOKE_URL` | Test | URL; unset skips the checked-in browser conformance test | Points the `web-smoke` browser test at an already-served application. It does not build or serve the app. |
+| `FISSION_SCREENSHOT_DIR` | Test/examples | Directory; example-specific temporary default | Selects output for checked-in live screenshot tests. |
+| `FISSION_TEST_MEASURER` | Test | `mock` or unset | Selects the deterministic mock text measurer in `fission-test`. |
+| `FISSION_TEST_USE_MOCK_MEASURER` | Test | Boolean; false by default | Legacy boolean spelling for selecting the mock text measurer. Prefer `FISSION_TEST_MEASURER=mock`. |
+| `FISSION_TEST_TRACE` | Test | `1` or unset | Emits `fission-test` frame/input trace output. |
+| `FISSION_TEST_DEBUG` | Test | Presence enables it | Emits extra diagnostics from selected framework test cases. |
+| `FISSION_WEB_HOST` | Generated Web helper scripts | Host; `127.0.0.1` | Selects the local Web server bind address. |
+| `FISSION_WEB_PORT` | Generated Web helper scripts | Port; first available from `8123` | Selects an exact local Web server port. When unset, the helper probes the next available port. |
+| `FISSION_WEB_CDP_PORT` | Generated browser test | Port; first available from `9222` | Selects an exact Chrome DevTools Protocol port. When unset, the helper probes the next available port. |
+| `FISSION_WEB_PROFILE` | Generated Web build | `dev` (default) or `release` | Selects the wasm-pack build profile. Values other than `release` use the development profile. |
+| `FISSION_WEB_OPEN` | Generated Web run helper | `1` or unset | Opens the served URL with the platform browser launcher. |
+| `FISSION_WEB_MAX_AVG_FRAME_MS` | Generated browser test | Milliseconds; `80` | Sets the average-frame-time failure threshold in generated smoke tests. |
+| `FISSION_WEB_MAX_INPUT_LATENCY_MS` | Generated browser test | Milliseconds; `180` | Sets the average-input-latency failure threshold in generated smoke tests. |
+| `FISSION_ALLOW_WEBGPU_FALLBACK` | Generated browser test | `1` or unset | Allows a Canvas2D result on a WebGPU-capable browser without making the generated renderer smoke test fail. It does not change renderer fallback behavior. |
+
+For a manually built Web target, the complete order is:
+
+```bash
+FISSION_WEB_TEST_CONTROL=1 ./platforms/web/build-wasm.sh
+# Serve the generated directory, then point the test at that URL.
+FISSION_WEB_SMOKE_URL=http://127.0.0.1:8123/platforms/web/ \
+  cargo test -p web-smoke --test text_input_browser
+```
+
+## Rendering, layout, text, and input
+
+| Variable | Kind | Values and default | Effect |
+| --- | --- | --- | --- |
+| `FISSION_RENDERER` | Runtime, native | `auto` (default), `native-vello-gpu`, `native-vello-cpu`, or `native-software` | Selects the native renderer. Web renderer selection uses `?fission_renderer=` or `globalThis.FISSION_RENDERER`, because a browser cannot read process environment variables at runtime. |
+| `FISSION_VELLO_USE_CPU` | Runtime, native | Boolean; false | Compatibility alias that forces Vello CPU mode. Prefer `FISSION_RENDERER=native-vello-cpu`. |
+| `FISSION_IMAGE_CACHE_BYTES` | Runtime | Positive byte count; 50 MiB default | Sets the decoded image-cache budget used by Vello and the software renderer. |
+| `FISSION_COMPOSITOR_CACHE_MB` | Runtime | Non-negative MiB count; 256 default | Sets the texture-compositor cache budget. |
+| `FISSION_ENABLE_TEXTURE_COMPOSITOR` | Runtime, internal | `1` or unset | Enables the experimental texture compositor when the scene and device limits allow it. |
+| `FISSION_ENABLE_VELLO_SCENE_CACHE` | Runtime, internal | `1` or unset | Enables retained Vello scene-layer caching. |
+| `FISSION_MAX_FPS` | Runtime | Positive integer; `60` | Caps normal presentation rate. |
+| `FISSION_REPEAT_ANIMATION_FPS` | Runtime | Positive integer, capped by `FISSION_MAX_FPS`; `10` | Sets the redraw rate for repeating animations. |
+| `FISSION_RESIZE_FPS` | Runtime | Positive integer, capped by `FISSION_MAX_FPS`; `60` | Sets the live-resize redraw rate. |
+| `FISSION_RESIZE_SETTLE_MS` | Runtime | Positive milliseconds; `90` | Sets the quiet period before the settled resize frame. |
+| `FISSION_TEXTINPUT_BLINK` | Runtime | Boolean; true | Enables the TextInput caret blink. |
+| `FISSION_TEXTINPUT_BLINK_MS` | Runtime | Positive milliseconds; `530` | Sets the caret blink period. |
+| `FISSION_USE_SYSTEM_FONTS` | Runtime | Boolean; false | Adds operating-system fonts to the packaged font collection. |
+| `FISSION_TEXT_SCALE_FACTOR` | Runtime | Positive finite number; platform setting by default | Overrides the platform accessibility text scale. |
+| `FISSION_IOS_SCALE_FACTOR` | Runtime, iOS | Positive finite number; reported display scale or `3` fallback | Overrides the iOS display scale used by the shell. Intended for platform diagnosis and test hosts. |
+| `FISSION_SCROLL_TRACE` | Runtime, internal diagnostics | `1` or unset | Emits scroll routing, state, and layout diagnostics. |
+| `FISSION_TEXT_TRACE` | Runtime, internal diagnostics | Boolean; false | Emits TextInput latency diagnostics. |
+| `FISSION_FRAME_TRACE` | Runtime, internal diagnostics | Boolean; false | Emits frame scheduling and presentation diagnostics. |
+| `FISSION_RENDER_TRACE` | Runtime, internal diagnostics | Presence enables it | Emits render-pipeline diagnostics. |
+| `FISSION_DEBUG_ANDROID_EVENTS` | Runtime, Android diagnostics | Presence enables it | Emits Android lifecycle and input-event diagnostics. |
+| `FISSION_ANDROID_AUDIO_TRACE` | Runtime, Android diagnostics | Presence enables it | Emits Android audio capability diagnostics. |
+
+## Runtime services, storage, and server rendering
+
+| Variable | Kind | Values and default | Effect |
+| --- | --- | --- | --- |
+| `FISSION_STORE_PATH` | Runtime, native SQLite store | File path; platform application-data path by default | Overrides the database file used by the default native SQLite store. Web SQLite uses OPFS instead. |
+| `FISSION_DEEP_LINK_URL` | Runtime | One URL; unset by default | Adds one startup deep link to the native shell. |
+| `FISSION_DEEP_LINKS` | Runtime | Newline-separated URLs; unset by default | Adds multiple startup deep links. Command-line deep links and platform-delivered links remain supported. |
+| `FISSION_SERVER_ARTIFACTS` | Runtime/build, SSR | Directory; configured server artifact directory by default | Overrides where the server shell reads generated server artifacts. |
+| `FISSION_BUILD_ID` | Build or runtime, SSR | String; generated/fallback identity by default | Supplies the server build identity used for artifact and client compatibility. A compile-time value is used when no runtime value is present. |
+| `FISSION_STATIC_ROOT` | Runtime, packaged Static site/SSR server | Directory; `/srv/fission-site` | Selects the static asset root in generated container entrypoints. |
+| `HOST` | Runtime, packaged Static site/SSR server | Address; `0.0.0.0` | Selects the bind address in generated container entrypoints. |
+| `PORT` | Runtime, packaged Static site/SSR server | TCP port; generated default | Selects the bind port in generated container entrypoints. |
+| `FISSION_WINDOWS_APP_USER_MODEL_ID` | Runtime, Windows | AppUserModelID; package/process identity by default | Supplies the Windows notification AppUserModelID when the process has not already registered one. |
+
+## Diagnostics
+
+Call `fission_diagnostics::init_from_env()` before expecting these variables to configure the diagnostics registry.
+
+| Variable | Kind | Values and default | Effect |
+| --- | --- | --- | --- |
+| `FISSION_DIAG` | Runtime | Comma-separated categories or `*`; empty | Enables diagnostic categories. |
+| `FISSION_DIAG_LEVEL` | Runtime | `error`, `warn`, `info`, `debug`, `trace`; `warn` | Sets the minimum recorded level. |
+| `FISSION_DIAG_SINK` | Runtime | `stdout`, `disabled`, or `file:/path`; `stdout` | Selects the diagnostic sink. |
+| `FISSION_DIAG_SAMPLING` | Runtime | Number from `0.0` to `1.0`; `1.0` | Sets event sampling probability. |
+
+## Build and generated-script inputs
+
+| Variable | Kind | Values and default | Effect |
+| --- | --- | --- | --- |
+| `FISSION_MATERIAL_ICONS_DIR` | Compile time | Directory; vendored Material Symbols source | Overrides the icon source consumed by the `fission-icons` build script. |
+| `FISSION_APP_ICON` | Generated Android/iOS package script | Image path; generated target icon | Overrides the source image used to generate package icon assets. |
+| `FISSION_GRADLE` | Generated Android package script | Command plus arguments; project wrapper or `gradle` discovery by default | Overrides the Gradle command used by generated Android packaging scripts. |
+| `FISSION_VARIANT` | Generated input | Selected desktop variant or unset | Fission supplies the selected variant to configured build and packaging scripts. It removes an inherited value when no variant was selected. |
+| `FISSION_LINUX_PAYLOAD_DIR` | Generated input | Directory | Linux packaging supplies the staged payload directory. |
+| `FISSION_LINUX_NATIVE_PRODUCTS_MANIFEST` | Generated input | JSON file path | Linux packaging supplies the native-products manifest. |
+| `FISSION_WINDOWS_ASSETS_DIR` | Generated input | Directory | Windows packaging supplies generated package assets. |
+| `FISSION_WINDOWS_NATIVE_PRODUCTS_MANIFEST` | Generated input | JSON file path | Windows packaging supplies the native-products manifest. |
+| `FISSION_INSTALL_DIR` | Generated input | Directory | Packaging supplies the intended install root to scripts that declare this input. |
+| `FISSION_CAPTURE_TARGET`, `FISSION_CAPTURE_SCENARIO`, `FISSION_CAPTURE_SET`, `FISSION_CAPTURE_OUTPUT` | Generated input | Strings or paths | Store-screenshot workflows supply the target, scenario, capture set, and output location to configured capture commands. |
+
+`FISSION_WEB_URL` is an internal value passed from the generated browser-test shell script to its embedded DevTools Protocol client. The script owns it; callers should use `FISSION_WEB_HOST` and `FISSION_WEB_PORT` instead.
+
+Cargo also supplies standard build-script variables such as `OUT_DIR`, `CARGO_MANIFEST_DIR`, `CARGO_BUILD_TARGET`, and `CARGO_BIN_EXE_<name>`. Those are Cargo contracts, not Fission configuration.
+
+## Toolchain discovery
+
+These are established platform/tool variables that Fission reads rather than Fission-owned settings.
+
+| Variables | Purpose |
+| --- | --- |
+| `ANDROID_HOME`, `ANDROID_SDK_ROOT` | Android SDK discovery. |
+| `ANDROID_NDK`, `ANDROID_NDK_HOME`, `ANDROID_NDK_ROOT` | Android NDK discovery. |
+| `ANDROID_TOOLCHAIN` | Explicit Android LLVM toolchain directory. |
+| `ANDROID_MIN_API_LEVEL` | Minimum API level used by doctor/build tooling when no stronger project value exists. |
+| `BUNDLETOOL` | Explicit `bundletool` executable or JAR used for local Android App Bundle inspection. |
+| `CHROME`, `CHROME_BIN` | Browser executable fallbacks after `FISSION_CHROME`. |
+| `GH_TOKEN`, `GITHUB_TOKEN` | GitHub release and Pages provider authentication. |
+| `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` | Cloudflare Pages publishing. |
+| `NETLIFY_AUTH_TOKEN` | Netlify publishing. |
+| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`, `AWS_REGION`, `AWS_ENDPOINT_URL_S3`, `AWS_WEB_IDENTITY_TOKEN_FILE` | S3-compatible publishing through the standard AWS credential chain and endpoint override. |
+| `DROPBOX_ACCESS_TOKEN`, `GOOGLE_DRIVE_ACCESS_TOKEN`, `ONEDRIVE_ACCESS_TOKEN` | File-provider publishing. |
+| `DOCKER_CONFIG` | Docker credential and configuration discovery. |
+| `VISUAL`, `EDITOR` | Editor used for release metadata and notes. |
+
+Normal operating-system variables such as `HOME`, `USERPROFILE`, `LOCALAPPDATA`, `APPDATA`, `XDG_DATA_HOME`, and `PATH` are used only for conventional directory and tool discovery.
+
+## Signing and store credentials
+
+The names below are defaults. Relevant `fission.toml` fields can replace most credential variable names, which is useful when a CI secret store enforces project-specific naming. Never place the secret value itself in `fission.toml`.
+
+| Provider | Default variables |
+| --- | --- |
+| Android signing | `ANDROID_KEYSTORE`, `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_ALIAS`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_PASSWORD` |
+| Windows signing | `WINDOWS_CERTIFICATE`, `WINDOWS_CERTIFICATE_BASE64`, `WINDOWS_CERTIFICATE_THUMBPRINT`, `WINDOWS_CERTIFICATE_PASSWORD`; `WINDOWS_SKIP_SIGNING=1` is limited to deliberate local unsigned validation |
+| Apple signing and notarization | `APPLE_TEAM_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY`, `APP_STORE_CONNECT_API_KEY_BASE64`, `APP_STORE_CONNECT_API_KEY_PATH` |
+| Google Play | `PLAY_STORE_ACCESS_TOKEN`, `PLAY_STORE_SERVICE_ACCOUNT_JSON`, `PLAY_STORE_SERVICE_ACCOUNT_JSON_BASE64`, `GOOGLE_APPLICATION_CREDENTIALS` |
+| App Store Connect publishing | `APP_STORE_CONNECT_ACCESS_TOKEN`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_API_KEY`, `APP_STORE_CONNECT_API_KEY_BASE64`, `APP_STORE_CONNECT_API_KEY_PATH` |
+| Microsoft Store | `MICROSOFT_STORE_TOKEN`, `MICROSOFT_STORE_SELLER_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `MICROSOFT_STORE_CLIENT_SECRET`; `PARTNER_CENTER_SELLER_ID`, `PARTNER_CENTER_TENANT_ID`, `PARTNER_CENTER_CLIENT_ID`, and `PARTNER_CENTER_CLIENT_SECRET` remain accepted fallbacks |
+
+Credential precedence and configurable variable-name fields are documented beside the matching sections in [`fission.toml`](/reference/config/fission-toml/). Fission reports the variable name it used but must never print its value.
+
+Generated target and packaging scripts also receive orchestration inputs such as `ANDROID_AVD_NAME`, `ANDROID_EMULATOR_HEADLESS`, `ANDROID_PROFILE`, `IOS_SIM_DEVICE_ID`, `IOS_SIM_HEADLESS`, `IOS_SIM_PROFILE`, `LINUX_PROFILE`, and `WINDOWS_PROFILE`. These are owned by the `fission` command invocation; custom scripts may read them, but users should select the device, headless mode, target, and profile through the corresponding command options instead of setting these variables directly.
+
+## Repository-maintainer and example-only variables
+
+The source tree contains variables used only by Fission's own examples, capture jobs, performance qualification, and release tests. They are not framework configuration for downstream applications. Examples include `FISSION_UPDATE_CHART_DOCS`, `FISSION_CHART_DOC_SLUG`, `FISSION_FIELD_INSPECTOR_DEMO_HOSTS`, `FISSION_REPRO_*`, `FISSION_REDIS_URL` for the opt-in Redis integration test, and test-secret sentinels. Their authoritative usage lives beside the relevant checked-in script or test; they are intentionally not compatibility commitments.

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -8,7 +8,7 @@ description: Complete reference for every fission.toml section currently read by
 
 `fission.toml` is the project manifest read by the Fission command-line interface and the static-site shell. It is the place for stable project facts: the app identity, enabled targets, declared host capabilities, site build settings, package references, release entries, provider configuration, and release workflow commands.
 
-Keep this file human-reviewable. Short identifiers and non-secret paths belong here. Long release notes, localized store descriptions, review instructions, privacy declarations, screenshots, and videos can live in referenced files. Certificates, private keys, signing passwords, tokens, keystores, and service-account JSON must come from environment variables, provider tools, platform key stores, or CI secrets.
+Keep this file human-reviewable. Short identifiers and non-secret paths belong here. Long release notes, localized store descriptions, review instructions, privacy declarations, screenshots, and videos can live in referenced files. Certificates, private keys, signing passwords, tokens, keystores, and service-account JSON must come from environment variables, provider tools, platform key stores, or CI secrets. The centralized [environment-variable reference](/reference/config/environment-variables/) lists the framework, testing, toolchain, signing, and publishing names and explains when each is read.
 
 This reference lists accepted fields. For the release reasoning behind those
 fields, use the platform guides:

--- a/documentation/content/reference/overview/overview.mdx
+++ b/documentation/content/reference/overview/overview.mdx
@@ -60,7 +60,7 @@ The platform pages explain what happens after the shared runtime reaches a real 
 
 The command-line interface is part of the public workflow, from project setup through run, logs, readiness, package, release content, distribution, and release receipts.
 
-Open [command-line interface overview](/reference/cli/overview) when you want the exact scaffold and target-management commands, the meaning of their major flags, and the files they generate. Open the [`fission.toml` manifest](/reference/config/fission-toml) when you need the complete project manifest schema for targets, capabilities, site builds, packaging, signing, release metadata, publishing providers, beta testing, and workflows.
+Open [command-line interface overview](/reference/cli/overview) when you want the exact scaffold and target-management commands, the meaning of their major flags, and the files they generate. Open the [`fission.toml` manifest](/reference/config/fission-toml) when you need the complete project manifest schema for targets, capabilities, site builds, packaging, signing, release metadata, publishing providers, beta testing, and workflows. Use [Environment variables](/reference/config/environment-variables/) for process-local runtime overrides, Web and native test switches, generated script inputs, tool discovery, and the default names of signing and publishing secrets.
 
 Maintainers preparing a framework release should use [Fission release checklist](/reference/project/fission-release-checklist) for the exact version bump, changelog, blog post, crates.io, GitHub release, tag, and website verification sequence.
 

--- a/documentation/content/reference/platform/testing.mdx
+++ b/documentation/content/reference/platform/testing.mdx
@@ -56,7 +56,9 @@ client.tap_selector(SelectorQuery::test_id("settings.save"))?;
 client.assert_text_visible("Saved")?;
 ```
 
-The application must be served before `launch_browser` is called and must have been built by `fission test --target web`, or with `FISSION_WEB_TEST_CONTROL=1` set for the WASM build. Ordinary Web builds do not expose the bridge.
+The application must be served before `launch_browser` is called and must have been built by `fission test --target web`, or with `FISSION_WEB_TEST_CONTROL=1` set on the command that compiles the WASM application. The variable is read by `option_env!` at compile time. Setting it only on the server or browser-test process is too late; rebuild the WASM output. Ordinary Web builds do not expose the bridge.
+
+The complete process-variable reference, including test, renderer, diagnostics, storage, packaging, and provider variables, is at [Environment variables](/reference/config/environment-variables/).
 
 Browser tests cover:
 

--- a/documentation/site/overrides.css
+++ b/documentation/site/overrides.css
@@ -767,7 +767,7 @@ pre,
   max-width: 90rem !important;
   min-height: 70vh;
   margin-inline: auto !important;
-  padding: 3rem clamp(1.25rem, 3vw, 2.75rem) 7rem !important;
+  padding: 0 clamp(1.25rem, 3vw, 2.75rem) !important;
 }
 
 .fission-site-doc-layout > .fission-site-row {
@@ -780,10 +780,18 @@ pre,
 
 .fission-site-doc-sidebar,
 .fission-site-doc-toc {
+  position: relative;
+  align-self: stretch;
+  max-height: none;
+  overflow: visible;
+}
+
+.fission-site-doc-sidebar > .fission-site-column,
+.fission-site-doc-toc > .fission-site-column {
   position: sticky;
-  top: 6.4rem;
-  max-height: calc(100vh - 7.5rem);
-  overflow: auto;
+  top: 4.75rem;
+  max-height: calc(100vh - 4.75rem);
+  overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--atlas-line-strong) transparent;
 }
@@ -1086,6 +1094,7 @@ pre,
 
 /* Global footer. */
 [data-fission-semantics="site-footer"] {
+  position: static !important;
   width: 100%;
   padding: clamp(3.5rem, 7vw, 6rem) clamp(1.5rem, 4vw, 3.5rem) !important;
   border-top: 1px solid var(--atlas-line) !important;
@@ -1286,6 +1295,17 @@ pre,
     transition: transform 180ms ease;
   }
 
+  .fission-site-doc-sidebar > .fission-site-column {
+    position: static;
+    padding-top: 0;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .fission-site-doc-main {
+    padding-top: 0;
+  }
+
   .fission-site-sidebar-open {
     overflow: hidden;
   }
@@ -1426,7 +1446,7 @@ pre,
   }
 
   .fission-site-doc-layout {
-    padding: 2rem 1.15rem 5rem !important;
+    padding: 2rem 1.15rem 0 !important;
   }
 
   .fission-site-doc-main h1,
@@ -1523,7 +1543,15 @@ pre,
 
 .fission-site-doc-layout {
   width: min(100%, 90rem) !important;
-  padding: 2.8rem clamp(1.5rem, 3vw, 2.4rem) 7rem !important;
+  padding: 0 clamp(1.5rem, 3vw, 2.4rem) !important;
+}
+
+@media (min-width: 60.001rem) {
+  .fission-site-doc-main,
+  .fission-site-doc-sidebar > .fission-site-column,
+  .fission-site-doc-toc > .fission-site-column {
+    padding-top: 2.8rem;
+  }
 }
 
 .fission-site-doc-layout > .fission-site-row {
@@ -1965,16 +1993,21 @@ pre,
 }
 
 .fission-site-doc-adjacent-pages {
-  display: grid !important;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem !important;
+  display: block !important;
   width: 100% !important;
   margin-top: 4.5rem;
   padding-top: 1.5rem;
   border-top: 1px solid var(--atlas-line);
 }
 
-.fission-site-doc-adjacent-pages > .fission-site-box {
+.fission-site-doc-adjacent-pages > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem !important;
+  width: 100% !important;
+}
+
+.fission-site-doc-adjacent-pages > .fission-site-row > .fission-site-box {
   width: 100% !important;
   min-width: 0 !important;
   border: 0 !important;
@@ -1982,7 +2015,7 @@ pre,
   background: color-mix(in srgb, var(--atlas-surface-2) 64%, transparent) !important;
 }
 
-.fission-site-doc-adjacent-pages > .fission-site-box:only-child:last-child {
+.fission-site-doc-adjacent-pages > .fission-site-row > .fission-site-box:only-child:last-child {
   grid-column: 2;
 }
 
@@ -2087,11 +2120,11 @@ pre,
 }
 
 @media (max-width: 45rem) {
-  .fission-site-doc-adjacent-pages {
+  .fission-site-doc-adjacent-pages > .fission-site-row {
     grid-template-columns: 1fr;
   }
 
-  .fission-site-doc-adjacent-pages > .fission-site-box:only-child:last-child {
+  .fission-site-doc-adjacent-pages > .fission-site-row > .fission-site-box:only-child:last-child {
     grid-column: 1;
   }
 

--- a/documentation/site/reference-sidebar.toml
+++ b/documentation/site/reference-sidebar.toml
@@ -227,6 +227,11 @@ href = "/reference/config/fission-toml/"
 level = 1
 
 [[items]]
+title = "Environment variables"
+href = "/reference/config/environment-variables/"
+level = 1
+
+[[items]]
 title = "Fission release checklist"
 href = "/reference/project/fission-release-checklist/"
 level = 1

--- a/documentation/src/components/crates.rs
+++ b/documentation/src/components/crates.rs
@@ -65,7 +65,6 @@ impl From<CrateDirectoryPage> for Widget {
             semantics: Some(site_semantics("crate-directory-page")),
             ..Default::default()
         })
-        .min_height_length(Length::vh(100.0))
         .bg_fill(page_fill(tokens))
         .into()
     }
@@ -738,7 +737,6 @@ impl From<CrateDetailPage> for Widget {
             semantics: Some(site_semantics("crate-detail-page")),
             ..Default::default()
         })
-        .min_height_length(Length::vh(100.0))
         .bg_fill(page_fill(tokens))
         .into()
     }

--- a/documentation/src/components/example_showcase.rs
+++ b/documentation/src/components/example_showcase.rs
@@ -49,7 +49,6 @@ impl From<ExampleShowcasePage> for Widget {
             flex_grow: 1.0,
             ..Default::default()
         })
-        .min_height(tokens.spacing.xxxxl * 9.0)
         .bg_fill(page_fill(tokens))
         .into()
     }

--- a/documentation/src/components/home.rs
+++ b/documentation/src/components/home.rs
@@ -67,7 +67,6 @@ impl From<HomePage> for Widget {
             flex_grow: 1.0,
             ..Default::default()
         })
-        .min_height(tokens.spacing.xxxxl * 9.0)
         .bg_fill(page_fill(tokens))
         .into()
     }

--- a/documentation/src/components/localized.rs
+++ b/documentation/src/components/localized.rs
@@ -16,7 +16,6 @@ impl From<LocalizedLandingPage> for Widget {
             gap: Some(0.0),
             ..Default::default()
         })
-        .min_height_length(Length::vh(100.0))
         .bg_fill(page_fill(tokens))
         .into()
     }

--- a/documentation/src/components/marketing.rs
+++ b/documentation/src/components/marketing.rs
@@ -560,7 +560,6 @@ impl From<ProductMarketingPage> for Widget {
             flex_grow: 1.0,
             ..Default::default()
         })
-        .min_height(tokens.spacing.xxxxl * 9.0)
         .bg_fill(page_fill(tokens))
         .into()
     }


### PR DESCRIPTION
This change restores natural browser scrolling across Fission documentation sites. The generated documentation shell no longer traps the article inside a viewport-height scroll container or leaves the footer behaving like a second scroll stage. The browser document owns vertical scrolling, while the header remains sticky and the sidebar navigation remains independently usable when its contents exceed the viewport. The border-bearing sidebar columns stretch from the header to the footer, and the Fission website removes its old fixed page heights and excessive terminal whitespace. Previous and next documentation cards now target the actual inner navigation row, so long titles remain aligned on one row at desktop widths and collapse cleanly on mobile.

`fission site serve` now says that it is building before the local server starts, reports route rendering and writing progress throughout long static builds, and announces the transition to server startup. `Serving …` remains the readiness message emitted only after the listener has successfully bound its address. This makes Cargo’s earlier process-launch line much less likely to be mistaken for an accepting HTTP server.

The PR also adds a centralized environment-variable reference covering runtime shells, Web and native testing, renderer and diagnostic controls, storage, generated scripts, packaging, signing, and publishing. In particular, it documents that `FISSION_WEB_TEST_CONTROL=1` must be present when the WASM application is compiled; setting it only while serving or running a browser test cannot add the test bridge to an existing build. The live-test guides and relevant crate READMEs link back to that authority.