### PR TITLE
Fix invisible styled text input on Web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9543,6 +9543,7 @@ dependencies = [
  "console_error_panic_hook",
  "fission",
  "fission-test-driver",
+ "image 0.25.8",
  "serde_json",
  "wasm-bindgen",
 ]

--- a/crates/rendering/fission-render-vello/src/text.rs
+++ b/crates/rendering/fission-render-vello/src/text.rs
@@ -169,6 +169,38 @@ impl VelloTextMeasurer {
         width.map(|w| ((w * 4.0).round() / 4.0).to_bits())
     }
 
+    /// Builds an authored font stack which always terminates in Fission's
+    /// registered default face.
+    ///
+    /// Font selection must never turn missing application font data into
+    /// missing text. The software renderer already falls back to its default
+    /// face; keeping the same invariant here also makes a temporarily missing
+    /// Web font a typography degradation instead of an invisible control.
+    fn font_stack_with_default<'a>(
+        &self,
+        primary: Option<&'a str>,
+        authored_fallbacks: impl IntoIterator<Item = &'a str>,
+    ) -> String {
+        let mut families = Vec::new();
+        if let Some(primary) = primary.filter(|family| !family.trim().is_empty()) {
+            families.push(primary.trim().to_string());
+        }
+        families.extend(
+            authored_fallbacks
+                .into_iter()
+                .map(str::trim)
+                .filter(|family| !family.is_empty())
+                .map(ToOwned::to_owned),
+        );
+        if !families
+            .iter()
+            .any(|family| family.eq_ignore_ascii_case(&self.default_family))
+        {
+            families.push(self.default_family.clone());
+        }
+        families.join(", ")
+    }
+
     fn inline_box_key(inline_box: &RichInlineBox) -> InlineBoxKey {
         InlineBoxKey {
             id: inline_box.id,
@@ -567,25 +599,13 @@ impl VelloTextMeasurer {
             let brush = ParleyBrush([style.color.r, style.color.g, style.color.b, style.color.a]);
             builder.push(StyleProperty::Brush(brush), range.clone());
             builder.push(StyleProperty::FontSize(style.font_size), range.clone());
-            if let Some(font_family) = &style.font_family {
-                let stack = if style.typography.font_fallback.is_empty() {
-                    font_family.clone()
-                } else {
-                    format!(
-                        "{}, {}",
-                        font_family,
-                        style.typography.font_fallback.join(", ")
-                    )
-                };
+            if style.font_family.is_some() || !style.typography.font_fallback.is_empty() {
+                let stack = self.font_stack_with_default(
+                    style.font_family.as_deref(),
+                    style.typography.font_fallback.iter().map(String::as_str),
+                );
                 builder.push(
                     StyleProperty::FontStack(FontStack::Source(Cow::Owned(stack))),
-                    range.clone(),
-                );
-            } else if !style.typography.font_fallback.is_empty() {
-                builder.push(
-                    StyleProperty::FontStack(FontStack::Source(Cow::Owned(
-                        style.typography.font_fallback.join(", "),
-                    ))),
                     range.clone(),
                 );
             }
@@ -1299,6 +1319,37 @@ mod tests {
 
         assert!((bounded - intrinsic).abs() < 0.5);
         assert!(bounded < 80.0);
+    }
+
+    #[test]
+    fn authored_font_stack_always_ends_with_the_registered_default() {
+        let measurer = VelloTextMeasurer::new_with_default_family(
+            Arc::new(Mutex::new(FontContext::new())),
+            "Fission Default",
+        );
+
+        assert_eq!(
+            measurer.font_stack_with_default(Some("Inter"), ["Arial", "sans-serif"]),
+            "Inter, Arial, sans-serif, Fission Default"
+        );
+        assert_eq!(
+            measurer.font_stack_with_default(Some("Fission Default"), std::iter::empty()),
+            "Fission Default"
+        );
+    }
+
+    #[test]
+    fn missing_authored_family_falls_back_instead_of_producing_blank_text() {
+        let measurer = measurer();
+        let mut run = text_run("123456", 42.0, 52.0);
+        run.style.font_family = Some("Definitely Missing Verification Font".into());
+        run.style.letter_spacing = 22.0;
+
+        let resolved = measurer.resolve_rich_text(&[run], Some(360.0));
+
+        assert!(!resolved.glyphs.is_empty());
+        assert!(resolved.size.width > 0.0);
+        assert!(resolved.size.height > 0.0);
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/ime.rs
+++ b/crates/shell/fission-shell-winit/src/ime.rs
@@ -326,7 +326,7 @@ fn report_unsupported(name: &'static str, configured: bool) {
             .expect("text input diagnostic lock poisoned")
             .insert((std::env::consts::OS, name))
     {
-        eprintln!(
+        log::warn!(
             "Fission text input configuration `{name}` is not implemented by the {} shell adapter; the host default remains active",
             std::env::consts::OS
         );
@@ -374,8 +374,22 @@ fn diagnose_web_unsupported(config: &TextInputConfig) {
         "enable_suggestions=false with autocorrect enabled",
         !config.enable_suggestions && config.autocorrect,
     );
-    report_unsupported("smart_dashes=false", !config.smart_dashes);
-    report_unsupported("smart_quotes=false", !config.smart_quotes);
+    // Disabling browser autocorrection also disables its smart substitution
+    // path. Only diagnose the two finer hints when autocorrection remains on
+    // and the browser cannot honor them independently.
+    report_unsupported(
+        "smart_dashes=false",
+        web_smart_hint_needs_advisory(config.autocorrect, config.smart_dashes),
+    );
+    report_unsupported(
+        "smart_quotes=false",
+        web_smart_hint_needs_advisory(config.autocorrect, config.smart_quotes),
+    );
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn web_smart_hint_needs_advisory(autocorrect: bool, hint_enabled: bool) -> bool {
+    autocorrect && !hint_enabled
 }
 
 fn mobile_ime_configuration(config: &TextInputConfig) -> winit::window::ImeConfiguration {
@@ -694,7 +708,8 @@ mod macos {
 mod tests {
     use super::{
         active_platform_config, effective_ime_allowed, mobile_ime_configuration,
-        text_edit_command_from_ime_state, web_autocomplete, TextInputConfig,
+        text_edit_command_from_ime_state, web_autocomplete, web_smart_hint_needs_advisory,
+        TextInputConfig,
     };
     use fission_core::{TextEditCommand, TextEditSource};
     use fission_ir::semantics::{TextInputAction, TextInputType};
@@ -754,6 +769,14 @@ mod tests {
 
         assert_eq!(config.name.as_deref(), Some("email"));
         assert_eq!(web_autocomplete(&config), "section-billing-address email");
+    }
+
+    #[test]
+    fn disabled_web_autocorrection_also_satisfies_disabled_smart_hints() {
+        assert!(!web_smart_hint_needs_advisory(false, false));
+        assert!(!web_smart_hint_needs_advisory(false, true));
+        assert!(!web_smart_hint_needs_advisory(true, true));
+        assert!(web_smart_hint_needs_advisory(true, false));
     }
 
     #[test]

--- a/crates/shell/fission-shell-winit/src/web_console.rs
+++ b/crates/shell/fission-shell-winit/src/web_console.rs
@@ -20,6 +20,7 @@ impl Log for BrowserConsoleLogger {
         let message = format!("[{} {}] {}", record.level(), record.target(), record.args());
         match record.level() {
             Level::Error => error(&message),
+            Level::Warn => warn(&message),
             _ => info(&message),
         }
     }
@@ -50,6 +51,10 @@ pub(crate) fn info(message: &str) {
 
 pub(crate) fn error(message: &str) {
     web_sys::console::error_1(&JsValue::from_str(message));
+}
+
+pub(crate) fn warn(message: &str) {
+    web_sys::console::warn_1(&JsValue::from_str(message));
 }
 
 #[cfg(test)]

--- a/examples/web-smoke/Cargo.toml
+++ b/examples/web-smoke/Cargo.toml
@@ -20,4 +20,5 @@ wasm-bindgen = "0.2"
 
 [dev-dependencies]
 fission-test-driver = { path = "../../crates/tools/fission-test-driver" }
+image = { version = "0.25", default-features = false, features = ["png"] }
 serde_json = "1"

--- a/examples/web-smoke/src/app.rs
+++ b/examples/web-smoke/src/app.rs
@@ -9,6 +9,7 @@ pub struct CounterState {
     pub primary_text: String,
     pub secondary_text: String,
     pub password: String,
+    pub verification_code: String,
     pub primary_edits: usize,
     pub secondary_edits: usize,
 }
@@ -43,6 +44,13 @@ fn edit_password(state: &mut CounterState, ctx: &mut ReducerContext<CounterState
     }
 }
 
+#[fission_reducer(EditVerificationCode)]
+fn edit_verification_code(state: &mut CounterState, ctx: &mut ReducerContext<CounterState>) {
+    if let Some(change) = ctx.input.text_change() {
+        state.verification_code = change.new_text.clone();
+    }
+}
+
 #[derive(Clone)]
 pub struct CounterApp;
 
@@ -54,6 +62,8 @@ impl From<CounterApp> for Widget {
         let edit_primary = with_reducer!(ctx, EditPrimary, edit_primary);
         let edit_secondary = with_reducer!(ctx, EditSecondary, edit_secondary);
         let edit_password = with_reducer!(ctx, EditPassword, edit_password);
+        let edit_verification_code =
+            with_reducer!(ctx, EditVerificationCode, edit_verification_code);
 
         let content = Container::new(Column {
             gap: Some(tokens.spacing.m),
@@ -124,6 +134,47 @@ impl From<CounterApp> for Widget {
                     autofill_hints: vec!["current-password".into()],
                     ..Default::default()
                 }
+                .into(),
+                ZStack {
+                    children: widgets![
+                        Container::new(Spacer::default())
+                            .width(360.0)
+                            .height(66.0)
+                            .bg(Color::WHITE),
+                        TextInput {
+                            id: Some(WidgetId::explicit("web-smoke.text.verification")),
+                            semantics_identifier: Some("web-smoke.text.verification".into()),
+                            value: view.state().verification_code.clone(),
+                            on_input: Some(edit_verification_code),
+                            width: Some(360.0),
+                            height: Some(66.0),
+                            padding: Some([9.0, 0.0, 2.0, 0.0]),
+                            borderless: true,
+                            font_family: Some("Unavailable Verification Font".into()),
+                            font_size: Some(42.0),
+                            line_height: Some(52.0),
+                            letter_spacing: Some(22.0),
+                            text_color: Some(Color::BLACK),
+                            show_cursor: false,
+                            keyboard_type: TextInputType::Number,
+                            input_formatters: vec![
+                                InputFormatter::DigitsOnly,
+                                InputFormatter::SingleLine,
+                            ],
+                            autocorrect: false,
+                            enable_suggestions: false,
+                            spell_check: false,
+                            autofill_hints: vec!["one-time-code".into()],
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }
+                .into(),
+                Text::new(format!(
+                    "Verification value: {}",
+                    view.state().verification_code
+                ))
                 .into(),
             ],
             ..Default::default()

--- a/examples/web-smoke/src/app.rs
+++ b/examples/web-smoke/src/app.rs
@@ -164,6 +164,8 @@ impl From<CounterApp> for Widget {
                             autocorrect: false,
                             enable_suggestions: false,
                             spell_check: false,
+                            smart_dashes: false,
+                            smart_quotes: false,
                             autofill_hints: vec!["one-time-code".into()],
                             ..Default::default()
                         },

--- a/examples/web-smoke/tests/text_input_browser.rs
+++ b/examples/web-smoke/tests/text_input_browser.rs
@@ -2,6 +2,35 @@ use anyhow::{Context, Result};
 use fission_test_driver::{BrowserTestOptions, LiveTestClient, SelectorQuery};
 use serde_json::Value;
 
+fn changed_pixels_in_bounds(
+    before: &[u8],
+    after: &[u8],
+    bounds: fission_test_driver::Bounds,
+) -> usize {
+    let before = image::load_from_memory(before)
+        .expect("decode baseline PNG")
+        .to_rgba8();
+    let after = image::load_from_memory(after)
+        .expect("decode edited PNG")
+        .to_rgba8();
+    assert_eq!(before.dimensions(), after.dimensions());
+    let left = bounds.x.max(0.0).floor() as u32;
+    let top = bounds.y.max(0.0).floor() as u32;
+    let right = (bounds.x + bounds.width)
+        .ceil()
+        .max(0.0)
+        .min(before.width() as f32) as u32;
+    let bottom = (bounds.y + bounds.height)
+        .ceil()
+        .max(0.0)
+        .min(before.height() as f32) as u32;
+
+    (top..bottom)
+        .flat_map(|y| (left..right).map(move |x| (x, y)))
+        .filter(|&(x, y)| before.get_pixel(x, y) != after.get_pixel(x, y))
+        .count()
+}
+
 fn browser_url() -> Option<String> {
     std::env::var("FISSION_WEB_SMOKE_URL").ok()
 }
@@ -249,5 +278,26 @@ fn canvas_text_adapter_reconciles_complete_browser_edits() -> Result<()> {
     assert!(semantic.masked);
     assert!(semantic.value_present);
     assert_eq!(semantic.value, None, "semantic tree leaked obscured text");
+
+    let verification = SelectorQuery::semantic_identifier("web-smoke.text.verification");
+    client.focus_selector(verification.clone())?;
+    let baseline = client.capture_screenshot_png()?;
+    apply_browser_edit(
+        &client,
+        "123456",
+        6,
+        6,
+        "insertText",
+        Some("123456"),
+        true,
+        false,
+    )?;
+    client.wait_for_text("Verification value: 123456", 5_000)?;
+    let edited = client.capture_screenshot_png()?;
+    let bounds = client.resolve_selector(verification)?.logical_bounds;
+    assert!(
+        changed_pixels_in_bounds(&baseline, &edited, bounds) > 100,
+        "the styled TextInput accepted its value but did not paint visible glyphs"
+    );
     Ok(())
 }


### PR DESCRIPTION
WebGPU text input could accept edits and update retained state while rendering no glyphs when an application requested a font family that was not packaged into the Web build. The software renderer already fell back to Fission default typography, but the Vello rich-text path did not. This change makes authored font stacks consistently terminate in the registered Fission default face, so a missing custom font degrades typography instead of making entered text invisible.

The Web smoke app now includes a Worka-shaped, borderless verification-code input inside a ZStack with large type, line height, letter spacing, numeric formatting, and one-time-code metadata. Its browser test performs a real edit and compares pixels inside the input bounds, proving that visible glyphs were painted rather than merely checking retained state or semantics.

Web text-hint diagnostics now preserve their actual warning severity in the browser console. Disabling autocorrection also satisfies disabled smart-dash and smart-quote behavior, so that supported combination no longer emits a diagnostic. Unsupported finer-grained combinations remain visible as console warnings without being misreported as application errors.

Fixes #189
Fixes #190