### PR TITLE
Align shell builder APIs and complete public authoring docs

### DIFF
--- a/crates/authoring/fission-widgets/src/accordion.rs
+++ b/crates/authoring/fission-widgets/src/accordion.rs
@@ -172,9 +172,13 @@ impl AccordionMotionPlan {
 /// The header displays a chevron indicator (triangledown/triangleright) and the title text.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccordionItem {
+    /// Header label for this section.
     pub title: String,
+    /// Panel content built while the section is expanded or retained by motion.
     pub content: Widget,
+    /// Controlled expanded state.
     pub is_expanded: bool,
+    /// Action dispatched when the header requests a state change.
     pub on_toggle: Option<ActionEnvelope>,
 }
 
@@ -184,6 +188,7 @@ pub struct AccordionItem {
 /// Items are stacked with zero gap, creating a continuous bordered surface.
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Accordion {
+    /// Collapsible sections in display order.
     pub items: Vec<AccordionItem>,
     /// Optional explicit accordion motion. `None` emits no accordion-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/alert.rs
+++ b/crates/authoring/fission-widgets/src/alert.rs
@@ -5,18 +5,27 @@ use fission_core::ui::{Container, Row, Text, Widget};
 use fission_icons::material;
 use serde::{Deserialize, Serialize};
 
+/// Semantic tone controlling an [`Alert`]'s icon and color treatment.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum AlertKind {
+    /// Neutral information.
     Info,
+    /// Potential problem requiring attention.
     Warning,
+    /// Failed or invalid state.
     Error,
+    /// Successful or confirmed state.
     Success,
 }
 
+/// Persistent inline message with semantic tone, title, and optional detail.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Alert {
+    /// Tone used to resolve icon and design-system colors.
     pub kind: AlertKind,
+    /// Concise primary message.
     pub title: String,
+    /// Optional supporting explanation.
     pub description: Option<String>,
 }
 

--- a/crates/authoring/fission-widgets/src/aspect_ratio.rs
+++ b/crates/authoring/fission-widgets/src/aspect_ratio.rs
@@ -3,9 +3,15 @@ use fission_core::ui::Widget;
 use fission_ir::{LayoutOp, Op, WidgetId};
 use serde::{Deserialize, Serialize};
 
+/// Constrains one child to a width-to-height ratio.
+///
+/// The ratio must be positive; `16.0 / 9.0`, for example, produces a widescreen
+/// box while allowing the surrounding layout to choose its final size.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AspectRatio {
+    /// Desired width divided by height.
     pub ratio: f32,
+    /// Content laid out inside the ratio-constrained box.
     pub child: Widget,
 }
 

--- a/crates/authoring/fission-widgets/src/avatar.rs
+++ b/crates/authoring/fission-widgets/src/avatar.rs
@@ -14,8 +14,11 @@ use serde::{Deserialize, Serialize};
 /// * `size` - Diameter in logical pixels (default 40).
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Avatar {
+    /// Display name used to derive up to two initials when no image is supplied.
     pub name: Option<String>,
+    /// Network URL or application asset path for the avatar image.
     pub src: Option<String>,
+    /// Diameter in logical pixels; defaults to 40 when omitted.
     pub size: Option<f32>,
 }
 

--- a/crates/authoring/fission-widgets/src/badge.rs
+++ b/crates/authoring/fission-widgets/src/badge.rs
@@ -18,10 +18,15 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Badge {
+    /// Short label or count displayed inside the badge.
     pub text: String,
+    /// Optional background override; otherwise the active badge theme applies.
     pub color: Option<Color>,
+    /// Optional foreground override; otherwise the active badge theme applies.
     pub text_color: Option<Color>,
+    /// Semantic color treatment resolved through the design system.
     pub tone: BadgeTone,
+    /// Design-system size used to resolve padding and typography.
     pub size: ComponentSize,
 }
 

--- a/crates/authoring/fission-widgets/src/breadcrumb.rs
+++ b/crates/authoring/fission-widgets/src/breadcrumb.rs
@@ -4,14 +4,19 @@ use fission_core::ActionEnvelope;
 use fission_icons::material;
 use serde::{Deserialize, Serialize};
 
+/// One segment of a [`Breadcrumb`] navigation trail.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BreadcrumbItem {
+    /// Segment label.
     pub label: String,
+    /// Optional navigation action; the final segment is rendered as current location.
     pub on_click: Option<ActionEnvelope>,
 }
 
+/// Ordered navigation trail from a broad parent to the current location.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Breadcrumb {
+    /// Segments in ancestor-to-current order.
     pub items: Vec<BreadcrumbItem>,
 }
 

--- a/crates/authoring/fission-widgets/src/calendar.rs
+++ b/crates/authoring/fission-widgets/src/calendar.rs
@@ -4,13 +4,21 @@ use fission_core::ui::{Button, ButtonVariant, Container, Text, Widget};
 use fission_core::ActionEnvelope;
 use std::sync::Arc;
 
+/// Controlled month calendar with navigation and day-selection actions.
 pub struct Calendar {
+    /// Four-digit year currently displayed.
     pub year: i32,
+    /// One-based month currently displayed (`1..=12`).
     pub month: u32,
+    /// Optional selected date highlighted in the grid.
     pub selected_date: Option<NaiveDate>,
+    /// Factory producing an action for a selected day.
     pub on_select: Option<Arc<dyn Fn(NaiveDate) -> ActionEnvelope + Send + Sync>>,
+    /// Factory producing an action for a requested `(year, month)` view change.
     pub on_navigate: Option<Arc<dyn Fn(i32, u32) -> ActionEnvelope + Send + Sync>>,
+    /// Optional logical square size for each day cell.
     pub cell_size: Option<f32>,
+    /// Optional logical padding around the calendar surface.
     pub padding: Option<f32>,
 }
 

--- a/crates/authoring/fission-widgets/src/card.rs
+++ b/crates/authoring/fission-widgets/src/card.rs
@@ -9,8 +9,14 @@ use serde::{Deserialize, Serialize};
 /// shadow. Content is padded with the `spacing.m` (16px) token.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Card {
+    /// Content grouped by the card surface.
     pub child: Widget,
+    /// Visual treatment, such as raised, outlined, or filled.
     pub pattern: CardPattern,
+    /// Whether to resolve the design system's interactive card treatment.
+    ///
+    /// This changes presentation only; wrap or compose the card with an input
+    /// widget when it should dispatch an action.
     pub interactive: bool,
 }
 

--- a/crates/authoring/fission-widgets/src/center.rs
+++ b/crates/authoring/fission-widgets/src/center.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 /// A convenience wrapper around [`Align`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Center {
+    /// Content positioned at the center of the available horizontal and
+    /// vertical space.
     pub child: Widget,
 }
 

--- a/crates/authoring/fission-widgets/src/code.rs
+++ b/crates/authoring/fission-widgets/src/code.rs
@@ -2,8 +2,12 @@ use fission_core::op::Color;
 use fission_core::ui::{Container, Text, Widget};
 use serde::{Deserialize, Serialize};
 
+/// Inline presentation for source code or another monospace fragment.
+///
+/// This widget displays text only; it does not perform syntax highlighting.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Code {
+    /// Literal code text to display.
     pub text: String,
 }
 
@@ -30,8 +34,10 @@ impl From<Code> for Widget {
     }
 }
 
+/// Keyboard-key label with a compact keycap border and background.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Kbd {
+    /// Key name or shortcut displayed on the keycap.
     pub text: String,
 }
 

--- a/crates/authoring/fission-widgets/src/combobox.rs
+++ b/crates/authoring/fission-widgets/src/combobox.rs
@@ -20,15 +20,24 @@ use std::sync::Arc;
 /// * `on_select` - Closure that produces an action when an item is picked.
 /// * `on_toggle` - Action dispatched to open/close the dropdown.
 pub struct Combobox {
+    /// Stable identity used for the editable field and popup anchor.
     pub id: WidgetId,
+    /// Current controlled filter or selected text.
     pub value: String,
+    /// Candidate labels presented in the popup.
     pub items: Vec<String>,
+    /// Whether the controlled popup is open.
     pub is_open: bool,
+    /// Optional logical width shared by field and popup.
     pub width: Option<f32>,
+    /// Optional maximum popup height before scrolling.
     pub max_popup_height: Option<f32>,
-    pub on_input: Option<ActionEnvelope>, // Text details arrive through ActionInput.
-    pub on_select: Option<Arc<dyn Fn(String) -> ActionEnvelope + Send + Sync>>, // Item picked
-    pub on_toggle: Option<ActionEnvelope>, // Focus/Blur handling usually
+    /// Action dispatched for edits; text details arrive through `ActionInput`.
+    pub on_input: Option<ActionEnvelope>,
+    /// Factory producing an action when an item is selected.
+    pub on_select: Option<Arc<dyn Fn(String) -> ActionEnvelope + Send + Sync>>,
+    /// Action requesting a popup open-state change.
+    pub on_toggle: Option<ActionEnvelope>,
 }
 
 impl std::fmt::Debug for Combobox {

--- a/crates/authoring/fission-widgets/src/data_table.rs
+++ b/crates/authoring/fission-widgets/src/data_table.rs
@@ -7,26 +7,40 @@ use fission_icons::material;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+/// Declarative description of one data-table column.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TableColumn {
+    /// Stable application identifier for sorting and column-specific behavior.
     pub id: String,
+    /// Header label.
     pub title: String,
+    /// Logical width allocated to each cell in the column.
     pub width: f32,
+    /// Whether the header should expose sorting affordance.
     pub sortable: bool,
 }
 
+/// One table row containing cells in the same order as the column declarations.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TableRow {
+    /// Stable application identifier used for controlled selection.
     pub id: String,
+    /// Preformatted cell text corresponding positionally to table columns.
     pub cells: Vec<String>,
 }
 
+/// Scrollable controlled data table with row selection.
 #[derive(Clone)]
 pub struct DataTable {
+    /// Stable widget identity used by retained interaction state.
     pub id: WidgetId,
+    /// Column definitions in display order.
     pub columns: Vec<TableColumn>,
+    /// Row values in display order.
     pub rows: Vec<TableRow>,
+    /// Application-owned set of selected row IDs.
     pub selected_ids: Vec<String>,
+    /// Factory that produces an action when a row selection is toggled.
     pub on_selection_change: Option<Arc<dyn Fn(String) -> ActionEnvelope + Send + Sync>>,
 }
 

--- a/crates/authoring/fission-widgets/src/date_picker.rs
+++ b/crates/authoring/fission-widgets/src/date_picker.rs
@@ -5,16 +5,27 @@ use fission_core::ui::{TextInput, Widget};
 use fission_core::{ActionEnvelope, WidgetId};
 use std::sync::Arc;
 
+/// Controlled date field with an anchored calendar popup.
 pub struct DatePicker {
+    /// Stable identity used for the field and popup anchor.
     pub id: WidgetId,
+    /// Current selected date, or `None` for an empty field.
     pub value: Option<NaiveDate>,
+    /// Whether the controlled calendar popup is open.
     pub is_open: bool,
+    /// Optional preferred logical field and popup width.
     pub width: Option<f32>,
+    /// Optional year displayed by the popup, independent of the selected date.
     pub view_year: Option<i32>,
+    /// Optional one-based month displayed by the popup.
     pub view_month: Option<u32>,
+    /// Factory producing an action for calendar month navigation.
     pub on_navigate: Option<Arc<dyn Fn(i32, u32) -> ActionEnvelope + Send + Sync>>,
+    /// Factory producing an action for a newly selected date.
     pub on_change: Option<Arc<dyn Fn(NaiveDate) -> ActionEnvelope + Send + Sync>>,
+    /// Action dispatched when the field requests an open-state toggle.
     pub on_toggle: Option<ActionEnvelope>,
+    /// Action dispatched when popup behavior requests dismissal.
     pub on_close: Option<ActionEnvelope>,
 }
 

--- a/crates/authoring/fission-widgets/src/date_range_picker.rs
+++ b/crates/authoring/fission-widgets/src/date_range_picker.rs
@@ -5,18 +5,30 @@ use fission_core::ui::{Text, Widget};
 use fission_core::{ActionEnvelope, WidgetId};
 use std::sync::Arc;
 
+/// Controlled inclusive start/end date range composed from two date pickers.
 pub struct DateRangePicker {
+    /// Stable identity of the start-date field and popup.
     pub id_start: WidgetId,
+    /// Stable identity of the end-date field and popup.
     pub id_end: WidgetId,
+    /// Optional inclusive start date.
     pub start: Option<NaiveDate>,
+    /// Optional inclusive end date.
     pub end: Option<NaiveDate>,
+    /// Whether the controlled start-date popup is open.
     pub is_start_open: bool,
+    /// Whether the controlled end-date popup is open.
     pub is_end_open: bool,
+    /// Factory producing an action for the proposed complete range.
     pub on_change:
         Option<Arc<dyn Fn(Option<NaiveDate>, Option<NaiveDate>) -> ActionEnvelope + Send + Sync>>,
+    /// Action requesting a start-popup state toggle.
     pub on_toggle_start: Option<ActionEnvelope>,
+    /// Action requesting an end-popup state toggle.
     pub on_toggle_end: Option<ActionEnvelope>,
+    /// Action dispatched when the start popup requests dismissal.
     pub on_close_start: Option<ActionEnvelope>,
+    /// Action dispatched when the end popup requests dismissal.
     pub on_close_end: Option<ActionEnvelope>,
 }
 

--- a/crates/authoring/fission-widgets/src/divider.rs
+++ b/crates/authoring/fission-widgets/src/divider.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 /// The direction of a [`Divider`] line.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Orientation {
+    /// A line that expands across the available width.
     Horizontal,
+    /// A line that expands across the available height.
     Vertical,
 }
 
@@ -21,6 +23,7 @@ impl Default for Orientation {
 /// (horizontal) or height (vertical).
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Divider {
+    /// Axis along which the separator is drawn.
     pub orientation: Orientation,
 }
 

--- a/crates/authoring/fission-widgets/src/draggable.rs
+++ b/crates/authoring/fission-widgets/src/draggable.rs
@@ -49,6 +49,8 @@ pub struct Draggable {
 }
 
 impl Draggable {
+    /// Sets the stable semantic/test identifier used to retain and locate this
+    /// source when an explicit widget ID is not supplied.
     pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
         self.semantics_identifier = Some(identifier.into());
         self
@@ -118,6 +120,10 @@ fn maybe_register_drag_preview(source: &Draggable, preview: Widget) {
     );
 }
 
+/// Drop target for internal Fission drags and shell-provided external drops.
+///
+/// The runtime supplies the dropped payload through contextual `ActionInput`;
+/// `hover_child` can provide a distinct visual while this target is active.
 #[derive(Clone, Debug)]
 pub struct DragTarget {
     /// Stable identity for the drop target.
@@ -133,6 +139,7 @@ pub struct DragTarget {
 }
 
 impl DragTarget {
+    /// Sets the stable semantic/test identifier used to retain and locate this target.
     pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
         self.semantics_identifier = Some(identifier.into());
         self

--- a/crates/authoring/fission-widgets/src/drawer.rs
+++ b/crates/authoring/fission-widgets/src/drawer.rs
@@ -12,7 +12,9 @@ use std::ops::Add;
 /// The edge from which a [`Drawer`] slides out.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DrawerSide {
+    /// Anchor the panel to the left viewport edge.
     Left,
+    /// Anchor the panel to the right viewport edge.
     Right,
 }
 
@@ -203,11 +205,17 @@ impl DrawerMotionPlan {
 /// * `on_dismiss` - Action dispatched when the backdrop is tapped.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Drawer {
+    /// Stable identity used for portal registration and motion slots.
     pub id: WidgetId,
+    /// Viewport edge from which the panel appears.
     pub side: DrawerSide,
+    /// Controlled visibility state.
     pub is_open: bool,
+    /// Action dispatched when the backdrop requests dismissal.
     pub on_dismiss: Option<ActionEnvelope>,
+    /// Panel contents.
     pub content: Widget,
+    /// Preferred logical panel width, clamped to the viewport.
     pub width: Option<f32>,
     /// Optional explicit drawer motion. `None` emits no drawer-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/dropdown.rs
+++ b/crates/authoring/fission-widgets/src/dropdown.rs
@@ -13,9 +13,15 @@ use fission_icons::material;
 /// with a popup menu.
 #[derive(Default, Clone)]
 pub struct DropDown {
+    /// Action dispatched when the trigger is pressed.
     pub on_toggle: Option<ActionEnvelope>,
+    /// Candidate labels retained for compatibility with existing dropdown
+    /// models; this trigger-only widget does not render them.
     pub options: Vec<String>,
+    /// Selection action retained for compatibility; use [`crate::Select`] when
+    /// the widget itself should present and dispatch option selection.
     pub on_select: Option<ActionEnvelope>,
+    /// Label displayed in the trigger, or the default placeholder when absent.
     pub selected: Option<String>,
 }
 

--- a/crates/authoring/fission-widgets/src/dropzone.rs
+++ b/crates/authoring/fission-widgets/src/dropzone.rs
@@ -32,6 +32,8 @@ pub struct Dropzone {
 }
 
 impl Dropzone {
+    /// Assigns the stable accessibility and LiveTest identifier used to locate
+    /// this drop target when no explicit widget ID is available.
     pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
         self.semantics_identifier = Some(identifier.into());
         self

--- a/crates/authoring/fission-widgets/src/editable.rs
+++ b/crates/authoring/fission-widgets/src/editable.rs
@@ -2,18 +2,30 @@ use fission_core::ui::{Button, ButtonVariant, Text, TextInput, Widget};
 use fission_core::{ActionEnvelope, WidgetId};
 use serde::{Deserialize, Serialize};
 
+/// Inline value that switches between read and edit presentations.
+///
+/// The application owns `is_editing` and `value`; actions let reducers enter
+/// editing and accept or cancel changes. This keeps the editable value in the
+/// normal retained Fission state flow rather than hidden inside the widget.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Editable {
+    /// Optional stable identity used to derive the inner text field identity.
     pub id: Option<WidgetId>,
+    /// Current controlled text value.
     pub value: String,
+    /// Text shown when `value` is empty and as the editor placeholder.
     pub placeholder: String,
+    /// Whether to render the text editor instead of the read-only button.
     pub is_editing: bool,
     /// Action dispatched when the editor text changes. The new text and
     /// selection are available through `ReducerContext::input.text_change()`.
     pub on_input: Option<ActionEnvelope>,
-    pub on_submit: Option<ActionEnvelope>, // Enter key
-    pub on_edit: Option<ActionEnvelope>,   // Click to edit
-    pub on_cancel: Option<ActionEnvelope>, // Esc or blur
+    /// Action intended to accept the current edit.
+    pub on_submit: Option<ActionEnvelope>,
+    /// Action dispatched from the read presentation to enter editing.
+    pub on_edit: Option<ActionEnvelope>,
+    /// Action intended to abandon editing and restore application state.
+    pub on_cancel: Option<ActionEnvelope>,
 }
 
 impl From<Editable> for Widget {

--- a/crates/authoring/fission-widgets/src/empty_state.rs
+++ b/crates/authoring/fission-widgets/src/empty_state.rs
@@ -10,9 +10,13 @@ use serde::{Deserialize, Serialize};
 /// parent using [`Center`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EmptyState {
+    /// Optional illustration or icon shown above the title.
     pub icon: Option<Widget>,
+    /// Primary explanation of the empty state.
     pub title: String,
+    /// Optional supporting guidance.
     pub description: Option<String>,
+    /// Optional action widget, commonly a button that creates the first item.
     pub action: Option<Widget>,
 }
 

--- a/crates/authoring/fission-widgets/src/file_upload.rs
+++ b/crates/authoring/fission-widgets/src/file_upload.rs
@@ -5,10 +5,18 @@ use fission_core::ActionEnvelope;
 use fission_icons::material;
 use serde::{Deserialize, Serialize};
 
+/// File-selection row containing a browse action and the selected file label.
+///
+/// The widget does not open a platform picker itself. Bind `on_browse` to a
+/// reducer that requests Fission's file-picker capability and pass the returned
+/// display name back through `selected_file`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FileUpload {
+    /// Text shown on the browse button.
     pub label: String,
+    /// Optional selected file name shown beside the button.
     pub selected_file: Option<String>,
+    /// Action dispatched when the browse button is pressed.
     pub on_browse: Option<ActionEnvelope>,
 }
 

--- a/crates/authoring/fission-widgets/src/form_control.rs
+++ b/crates/authoring/fission-widgets/src/form_control.rs
@@ -25,11 +25,17 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FormControl {
+    /// Optional stable identity for the complete labelled field group.
     pub id: Option<WidgetId>,
+    /// Optional user-facing field label.
     pub label: Option<String>,
+    /// Input or other form field associated with the label and messages.
     pub child: Widget,
+    /// Validation message; when present it takes precedence over helper text.
     pub error: Option<String>,
+    /// Optional guidance shown while no validation error is present.
     pub helper: Option<String>,
+    /// Whether to mark the label as required.
     pub required: bool,
 }
 

--- a/crates/authoring/fission-widgets/src/future_builder.rs
+++ b/crates/authoring/fission-widgets/src/future_builder.rs
@@ -5,6 +5,7 @@ use fission_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+/// Lifecycle state of the asynchronous resource represented by [`AsyncSnapshot`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AsyncConnectionState {
     /// No async work is currently connected to the builder.
@@ -23,6 +24,10 @@ impl Default for AsyncConnectionState {
     }
 }
 
+/// Immutable value/error snapshot used to render one asynchronous operation.
+///
+/// Application state owns this snapshot; completion reducers replace it after
+/// the corresponding job action arrives.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AsyncSnapshot<T, E> {
     /// Current async connection state.
@@ -34,10 +39,12 @@ pub struct AsyncSnapshot<T, E> {
 }
 
 impl<T, E> AsyncSnapshot<T, E> {
+    /// Compatibility alias for [`AsyncSnapshot::nothing`].
     pub fn none() -> Self {
         Self::nothing()
     }
 
+    /// Creates a disconnected snapshot with neither data nor error.
     pub fn nothing() -> Self {
         Self {
             connection_state: AsyncConnectionState::None,
@@ -46,6 +53,7 @@ impl<T, E> AsyncSnapshot<T, E> {
         }
     }
 
+    /// Creates a waiting snapshot before a result is available.
     pub fn waiting() -> Self {
         Self {
             connection_state: AsyncConnectionState::Waiting,
@@ -54,6 +62,7 @@ impl<T, E> AsyncSnapshot<T, E> {
         }
     }
 
+    /// Creates a snapshot containing successful data in the supplied lifecycle state.
     pub fn with_data(connection_state: AsyncConnectionState, data: T) -> Self {
         Self {
             connection_state,
@@ -62,6 +71,7 @@ impl<T, E> AsyncSnapshot<T, E> {
         }
     }
 
+    /// Creates a snapshot containing an error in the supplied lifecycle state.
     pub fn with_error(connection_state: AsyncConnectionState, error: E) -> Self {
         Self {
             connection_state,
@@ -70,27 +80,36 @@ impl<T, E> AsyncSnapshot<T, E> {
         }
     }
 
+    /// Returns this snapshot with a different lifecycle state while preserving its value.
     pub fn in_state(mut self, connection_state: AsyncConnectionState) -> Self {
         self.connection_state = connection_state;
         self
     }
 
+    /// Returns whether successful data is present.
     pub fn has_data(&self) -> bool {
         self.data.is_some()
     }
 
+    /// Returns whether an error is present.
     pub fn has_error(&self) -> bool {
         self.error.is_some()
     }
 
+    /// Borrows the successful value when present.
     pub fn data(&self) -> Option<&T> {
         self.data.as_ref()
     }
 
+    /// Borrows the error value when present.
     pub fn error(&self) -> Option<&E> {
         self.error.as_ref()
     }
 
+    /// Borrows successful data or panics when this snapshot has none.
+    ///
+    /// Prefer [`AsyncSnapshot::data`] for branches that can legitimately render
+    /// before completion.
     pub fn require_data(&self) -> &T {
         self.data
             .as_ref()
@@ -98,6 +117,7 @@ impl<T, E> AsyncSnapshot<T, E> {
     }
 }
 
+/// Shared builder that converts the current async snapshot into a widget tree.
 pub type AsyncWidgetBuilder<S, T, E> = Arc<
     dyn Fn(BuildCtxHandle<S>, ViewHandle<S>, &AsyncSnapshot<T, E>) -> Widget
         + Send
@@ -115,14 +135,23 @@ where
     S: GlobalState,
     J: JobSpec,
 {
+    /// Stable key used to retain and reconcile this declared job resource.
     pub key: ResourceKey,
+    /// Registered typed job to execute.
     pub job: JobRef<J>,
+    /// Request value sent to the job.
     pub request: J::Request,
+    /// Application-owned snapshot rendered during this build.
     pub snapshot: AsyncSnapshot<J::Ok, J::Err>,
+    /// Optional action receiving a successful contextual job result.
     pub on_ok: Option<ActionEnvelope>,
+    /// Optional action receiving a failed contextual job result.
     pub on_err: Option<ActionEnvelope>,
+    /// Optional serialized dependency identity used to detect input changes.
     pub deps: Option<Vec<u8>>,
+    /// Whether changing dependencies restarts or preserves the existing resource.
     pub policy: ResourcePolicy,
+    /// Renderer for the current snapshot.
     pub builder: AsyncWidgetBuilder<S, J::Ok, J::Err>,
 }
 
@@ -131,6 +160,7 @@ where
     S: GlobalState,
     J: JobSpec,
 {
+    /// Creates a job-backed builder using restart-on-change resource policy.
     pub fn new<F>(
         key: ResourceKey,
         job: JobRef<J>,
@@ -157,27 +187,34 @@ where
         }
     }
 
+    /// Dispatches `action` when the job completes successfully.
     pub fn on_ok(mut self, action: ActionEnvelope) -> Self {
         self.on_ok = Some(action);
         self
     }
 
+    /// Dispatches `action` when the job fails.
     pub fn on_err(mut self, action: ActionEnvelope) -> Self {
         self.on_err = Some(action);
         self
     }
 
+    /// Sets serializable dependency data used to recognize request changes.
+    ///
+    /// Serialization failure is a programming error and therefore panics.
     pub fn deps<T: Serialize>(mut self, deps: T) -> Self {
         self.deps =
             Some(serde_json::to_vec(&deps).expect("FutureBuilder deps serialization must succeed"));
         self
     }
 
+    /// Keeps the existing resource alive when dependency bytes change.
     pub fn preserve_on_change(mut self) -> Self {
         self.policy = ResourcePolicy::PreserveOnChange;
         self
     }
 
+    /// Restarts the job resource when dependency bytes change.
     pub fn restart_on_change(mut self) -> Self {
         self.policy = ResourcePolicy::RestartOnChange;
         self

--- a/crates/authoring/fission-widgets/src/hero.rs
+++ b/crates/authoring/fission-widgets/src/hero.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 /// * `child` - The widget to animate.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Hero {
+    /// Stable shared-element name that identifies the same visual across routes.
     pub tag: String,
+    /// Element whose bounds and appearance participate in the transition.
     pub child: Widget,
 }
 

--- a/crates/authoring/fission-widgets/src/lib.rs
+++ b/crates/authoring/fission-widgets/src/lib.rs
@@ -52,106 +52,140 @@ pub use fission_core::ui::{
 
 mod motion_support;
 
+/// Compact dropdown trigger; use `select` for the complete popup selection control.
 pub mod dropdown;
 pub use dropdown::DropDown;
 
+/// Horizontal and vertical convenience stacks built on Fission flex layout.
 pub mod stack;
 pub use stack::{HStack, VStack};
 
+/// Themed status, category, and count badges.
 pub mod badge;
 pub use badge::Badge;
 
+/// Compact removable labels represented as tags.
 pub mod tag;
 pub use tag::Tag;
 
+/// Circular image and initials-based identity avatars.
 pub mod avatar;
 pub use avatar::Avatar;
 
+/// Horizontal and vertical visual separators.
 pub mod divider;
 pub use divider::Divider;
 
+/// Design-system card surfaces for grouping related content.
 pub mod card;
 pub use card::Card;
 
+/// Determinate linear progress presentation.
 pub mod progress;
 pub use progress::ProgressBar;
 
+/// Indeterminate loading spinner and its motion policy.
 pub mod spinner;
 pub use spinner::{Spinner, SpinnerMotion};
 
+/// Controlled tab navigation and animated selection presentation.
 pub mod tabs;
 pub use tabs::{TabItem, Tabs, TabsMotion};
 
+/// Controlled popup selection field and option model.
 pub mod select;
 pub use select::{Select, SelectItem};
 
+/// Expandable sections with controlled open state.
 pub mod accordion;
 pub use accordion::{Accordion, AccordionItem, AccordionMotion};
 
+/// Anchored explanatory overlay with configurable motion.
 pub mod tooltip;
 pub use tooltip::{Tooltip, TooltipMotion};
+/// Action menus, menu items, and trigger composition.
 pub mod menu;
 pub use menu::{Menu, MenuButton, MenuItem};
 
+/// Transient status notifications and their semantic tone.
 pub mod toast;
 pub use toast::{Toast, ToastKind, ToastMotion};
 
+/// Modal dialog surface, actions, and entrance/exit motion.
 pub mod modal;
 pub use modal::{Modal, ModalAction, ModalMotion};
 
+/// Declarative tabular data columns, rows, and presentation.
 pub mod data_table;
 pub use data_table::{DataTable, TableColumn, TableRow};
 
+/// Two-pane horizontal or vertical split layout.
 pub mod split_view;
 pub use split_view::{SplitDirection, SplitView};
 
+/// Edge-mounted overlay drawer with controlled visibility.
 pub mod drawer;
 pub use drawer::{Drawer, DrawerMotion, DrawerSide};
 
+/// Label, help, validation, and field composition for form controls.
 pub mod form_control;
 pub use form_control::FormControl;
 
+/// Controlled numeric stepper with increment and decrement actions.
 pub mod number_input;
 pub use number_input::NumberInput;
 
+/// Persistent inline status and warning messages.
 pub mod alert;
 pub use alert::{Alert, AlertKind};
 
+/// Placeholder loading surfaces and shimmer motion.
 pub mod skeleton;
 pub use skeleton::{Skeleton, SkeletonMotion};
 
+/// Ordered navigation trail and actionable breadcrumb items.
 pub mod breadcrumb;
 pub use breadcrumb::{Breadcrumb, BreadcrumbItem};
 
+/// Controlled month calendar and day selection.
 pub mod calendar;
 pub use calendar::Calendar;
 
+/// Controlled date selection field composed with a calendar.
 pub mod date_picker;
 pub use date_picker::DatePicker;
 
+/// Controlled 24-hour hour-and-minute selector.
 pub mod time_picker;
 pub use time_picker::TimePicker;
 
+/// Controlled inclusive start/end date selection.
 pub mod date_range_picker;
 pub use date_range_picker::DateRangePicker;
 
+/// Colour selection controls and HSVA colour representation.
 pub mod colour_picker;
 pub use colour_picker::{
     ColorPicker, ColorPickerVariant, ColourHsva, ColourPicker, ColourPickerVariant,
 };
 
+/// Filterable text-and-option selection control.
 pub mod combobox;
 pub use combobox::Combobox;
 
+/// Mutually exclusive selection presented as adjacent segments.
 pub mod segmented_control;
 pub use segmented_control::SegmentedControl;
 
+/// Ordered event presentation with markers and supporting content.
 pub mod timeline;
 pub use timeline::{Timeline, TimelineItem};
 
+/// Shared-element identity annotation for route transitions.
 pub mod hero;
 pub use hero::Hero;
 
+/// Platform web-document embedding for graphical targets.
 pub mod web_view;
 pub use web_view::WebView;
 
@@ -159,6 +193,7 @@ pub use web_view::WebView;
     feature = "terminal",
     not(any(target_os = "ios", target_os = "android", target_arch = "wasm32"))
 ))]
+/// Native pseudo-terminal session and retained terminal-view widgets.
 pub mod terminal;
 #[cfg(all(
     feature = "terminal",
@@ -166,79 +201,104 @@ pub mod terminal;
 ))]
 pub use terminal::{TerminalLaunchConfig, TerminalSession, TerminalView};
 
+/// Internal drag sources, previews, payloads, and target declarations.
 pub mod draggable;
 pub use draggable::{DragPreviewOptions, DragTarget, Draggable};
 
+/// Empty-collection messaging with optional illustration and action.
 pub mod empty_state;
 pub use empty_state::EmptyState;
 
+/// File-picker trigger and selected-file presentation.
 pub mod file_upload;
 pub use file_upload::FileUpload;
 
+/// Internal and external file-drop target presentation.
 pub mod dropzone;
 pub use dropzone::Dropzone;
 
+/// Hierarchical controlled tree items and expansion.
 pub mod tree_view;
 pub use tree_view::{TreeItem, TreeView};
 
+/// Responsive minimum-width wrapping grid.
 pub mod simple_grid;
 pub use simple_grid::SimpleGrid;
 
+/// Row- or column-oriented wrapping flow layout.
 pub mod wrap;
 pub use wrap::Wrap;
 
+/// Convenience centering layout.
 pub mod center;
 pub use center::Center;
 
+/// Width-to-height constraint wrapper.
 pub mod aspect_ratio;
 pub use aspect_ratio::AspectRatio;
 
+/// Controlled two-thumb numeric range selection.
 pub mod range_slider;
 pub use range_slider::RangeSlider;
 
+/// Inline read/edit presentation for a controlled string.
 pub mod editable;
 pub use editable::Editable;
 
+/// Inline code and keyboard-key text presentation.
 pub mod code;
 pub use code::{Code, Kbd};
 
+/// Compact dashboard metric presentation.
 pub mod stat;
 pub use stat::Stat;
 
+/// Determinate or indeterminate circular progress indicator.
 pub mod circular_progress;
 pub use circular_progress::{CircularProgress, CircularProgressMotion};
 
+/// Declarative rendering of asynchronous job snapshots.
 pub mod future_builder;
 pub use future_builder::{AsyncConnectionState, AsyncSnapshot, AsyncWidgetBuilder, FutureBuilder};
 
+/// Pull-to-refresh state, appearance, and action dispatch.
 pub mod refresh_indicator;
 pub use refresh_indicator::{RefreshIndicator, RefreshIndicatorStatus};
 
+/// Ordered multi-step progress presentation.
 pub mod stepper;
 pub use stepper::Stepper;
 
+/// Navigational link with host-lowered hyperlink metadata.
 pub mod link;
 pub use link::Link;
 
+/// Markdown text rendering and scrollable document presentation.
 pub mod markdown;
 pub use markdown::{MarkdownContent, MarkdownViewer};
 
+/// Controlled page-number navigation.
 pub mod pagination;
 pub use pagination::Pagination;
 
+/// Anchored popup content and visibility motion.
 pub mod popover;
 pub use popover::{Popover, PopoverMotion};
 
+/// Ordered declarative path routing and route-parameter capture.
 pub mod router;
 pub use router::{Route, RouteParams, Router};
 
+/// Lazy access boundary for allowed, pending, denied, and redirect branches.
 pub mod protected_route;
 pub use protected_route::{DefaultRouteDenied, DefaultRoutePending, ProtectedRoute};
 
+/// Geometry for revealing an anchored element through an inverse overlay.
 pub mod spotlight;
 pub use spotlight::Spotlight;
 
 #[cfg(feature = "interactive-canvas")]
+/// Pan/zoom canvas authoring, nodes, edges, selection, and interaction models.
 pub mod infinite_canvas;
 #[cfg(feature = "interactive-canvas")]
 pub use infinite_canvas::{
@@ -260,8 +320,12 @@ use std::sync::Arc;
 /// Wraps a painter closure that produces child node IDs within a `Group` node,
 /// placed inside a fixed-size `Box` layout node.
 pub struct CanvasLowerer {
+    /// Optional logical width of the canvas layout box.
     pub width: Option<f32>,
+    /// Optional logical height of the canvas layout box.
     pub height: Option<f32>,
+    /// Painter invoked during lowering to append renderer-independent child
+    /// nodes and return their stable IDs.
     pub painter: Arc<dyn Fn(&mut InternalLoweringCx) -> Vec<WidgetId> + Send + Sync>,
 }
 
@@ -414,6 +478,7 @@ pub fn flyout(anchor: WidgetId, content: Widget) -> Widget {
 /// [`Popover`], and [`Tooltip`] to render above the main content.
 #[derive(Debug, Clone)]
 pub struct Portal {
+    /// Content registered in the window-level overlay instead of normal layout.
     pub child: Widget,
 }
 

--- a/crates/authoring/fission-widgets/src/link.rs
+++ b/crates/authoring/fission-widgets/src/link.rs
@@ -3,9 +3,16 @@ use fission_core::ActionEnvelope;
 use fission_core::{Action, Hyperlink, NavigationCommand, NavigationRequested};
 use serde::{Deserialize, Serialize};
 
+/// Text link backed by either a normal action or Fission navigation metadata.
+///
+/// Use [`Link::to`] or [`Link::hyperlink`] for navigation so Web, Static site,
+/// and SSR can lower a real `href`; use `on_click` directly for a non-navigation
+/// action that merely uses link styling.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Link {
+    /// Visible link label.
     pub text: String,
+    /// Action dispatched when activated; navigation actions also carry hyperlink metadata.
     pub on_click: Option<ActionEnvelope>,
 }
 

--- a/crates/authoring/fission-widgets/src/markdown.rs
+++ b/crates/authoring/fission-widgets/src/markdown.rs
@@ -22,7 +22,9 @@ use serde::{Deserialize, Serialize};
 /// Container nodes so it stays in the Fission rendering pipeline.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MarkdownViewer {
+    /// Source Markdown parsed into native Fission nodes.
     pub markdown: String,
+    /// Whether the widget-owned vertical viewport displays a scrollbar.
     pub show_scrollbar: bool,
 }
 
@@ -34,10 +36,12 @@ pub struct MarkdownViewer {
 /// document to participate in the parent's intrinsic layout.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct MarkdownContent {
+    /// Source Markdown parsed into native Fission nodes without a viewport.
     pub markdown: String,
 }
 
 impl MarkdownContent {
+    /// Creates non-scrolling native Markdown content from `markdown`.
     pub fn new(markdown: impl Into<String>) -> Self {
         Self {
             markdown: markdown.into(),
@@ -68,6 +72,7 @@ impl Default for MarkdownViewer {
 }
 
 impl MarkdownViewer {
+    /// Creates a scrollable native Markdown document with its scrollbar visible.
     pub fn new(markdown: impl Into<String>) -> Self {
         Self {
             markdown: markdown.into(),

--- a/crates/authoring/fission-widgets/src/menu.rs
+++ b/crates/authoring/fission-widgets/src/menu.rs
@@ -11,8 +11,11 @@ use serde::{Deserialize, Serialize};
 /// A single entry in a [`Menu`]: label text, optional SVG icon, and selection action.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MenuItem {
+    /// Text displayed for the menu entry.
     pub label: String,
+    /// Optional SVG markup displayed before the label.
     pub icon: Option<String>,
+    /// Action dispatched when the entry is selected.
     pub on_select: Option<ActionEnvelope>,
 }
 
@@ -26,8 +29,11 @@ pub struct MenuItem {
 /// [`crate::Select`], and other selection widgets.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Menu {
+    /// Menu entries in display order.
     pub items: Vec<MenuItem>,
+    /// Optional logical width; defaults to the widget's standard menu width.
     pub width: Option<f32>,
+    /// Optional maximum logical height before vertical scrolling is enabled.
     pub max_height: Option<f32>,
 }
 
@@ -138,10 +144,15 @@ impl From<Menu> for Widget {
 /// to the button.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MenuButton {
+    /// Stable identity used to anchor and retain the flyout.
     pub id: WidgetId,
+    /// Trigger-button label.
     pub label: String,
+    /// Entries shown in the controlled menu.
     pub items: Vec<MenuItem>,
+    /// Whether the controlled menu is currently open.
     pub is_open: bool,
+    /// Action dispatched when the trigger requests an open-state change.
     pub on_toggle: Option<ActionEnvelope>,
 }
 

--- a/crates/authoring/fission-widgets/src/modal.rs
+++ b/crates/authoring/fission-widgets/src/modal.rs
@@ -227,12 +227,19 @@ impl ModalMotionPlan {
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Modal {
+    /// Stable identity used for focus, portal registration, and motion slots.
     pub id: WidgetId,
+    /// Dialog heading exposed visually and through semantics.
     pub title: String,
+    /// Main dialog body.
     pub content: Widget,
+    /// Controlled visibility state.
     pub is_open: bool,
+    /// Action dispatched when the backdrop or another dismissal affordance is used.
     pub on_dismiss: Option<ActionEnvelope>,
+    /// Footer actions in display order.
     pub actions: Vec<ModalAction>,
+    /// Preferred logical width, clamped to the available viewport.
     pub width: Option<f32>,
     /// Optional explicit modal motion. `None` emits no modal-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -245,8 +252,11 @@ pub struct Modal {
 /// the primary color. Otherwise it uses `ButtonVariant::Outline`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModalAction {
+    /// Button label displayed in the modal footer.
     pub label: String,
+    /// Action dispatched when the button is pressed.
     pub on_press: Option<ActionEnvelope>,
+    /// Whether this action receives the primary filled-button treatment.
     pub is_primary: bool,
 }
 

--- a/crates/authoring/fission-widgets/src/number_input.rs
+++ b/crates/authoring/fission-widgets/src/number_input.rs
@@ -4,18 +4,33 @@ use fission_core::{ActionEnvelope, WidgetId};
 use fission_icons::material;
 use serde::{Deserialize, Serialize};
 
+/// Controlled numeric field with increment and decrement buttons.
+///
+/// Button presses dispatch the supplied actions; typed text is delivered
+/// through the normal contextual text-input contract for application parsing.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NumberInput {
+    /// Optional stable identity, also used to derive the inner text-field ID.
     pub id: Option<WidgetId>,
+    /// Current numeric value owned by application state.
     pub value: f32,
+    /// Optional preformatted text; otherwise `value` is formatted directly.
     pub display_text: Option<String>,
+    /// Optional inclusive lower bound communicated to button behavior.
     pub min: Option<f32>,
+    /// Optional inclusive upper bound communicated to button behavior.
     pub max: Option<f32>,
+    /// Amount represented by each increment or decrement action.
     pub step: f32,
+    /// Optional logical width of the editable field.
     pub field_width: Option<f32>,
+    /// Optional logical square size of each step button.
     pub button_size: Option<f32>,
+    /// Optional logical gap between buttons and field.
     pub gap: Option<f32>,
+    /// Action dispatched when increment is available and requested.
     pub on_increment: Option<ActionEnvelope>,
+    /// Action dispatched when decrement is available and requested.
     pub on_decrement: Option<ActionEnvelope>,
     /// Action dispatched for typed edits. Parse `ctx.input.text_change().new_text`
     /// in the reducer so validation remains an application decision.

--- a/crates/authoring/fission-widgets/src/pagination.rs
+++ b/crates/authoring/fission-widgets/src/pagination.rs
@@ -3,10 +3,13 @@ use fission_core::ui::{Button, ButtonVariant, Text, Widget};
 use fission_core::ActionEnvelope;
 use std::sync::Arc;
 
+/// Controlled page-number navigation with previous and next controls.
 pub struct Pagination {
+    /// Current one-based page number.
     pub current_page: usize,
+    /// Total number of available pages.
     pub total_pages: usize,
-    // Callback factory
+    /// Factory producing an action for a requested one-based page number.
     pub on_change: Option<Arc<dyn Fn(usize) -> ActionEnvelope + Send + Sync>>,
 }
 

--- a/crates/authoring/fission-widgets/src/popover.rs
+++ b/crates/authoring/fission-widgets/src/popover.rs
@@ -142,12 +142,18 @@ impl PopoverMotionPlan {
 /// * `content` - The popup content rendered in the flyout layer.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Popover {
+    /// Stable identity used to derive the anchor and portal motion slots.
     pub id: WidgetId,
+    /// Controlled popup visibility.
     pub is_open: bool,
+    /// Optional action requesting an open-state toggle.
     pub on_toggle: Option<ActionEnvelope>,
+    /// Optional action dispatched by backdrop dismissal.
     pub on_close: Option<ActionEnvelope>,
 
+    /// Inline anchor content.
     pub trigger: Widget,
+    /// Content rendered in the flyout layer while open or retained by motion.
     pub content: Widget,
     /// Optional explicit popover motion. `None` emits no popover-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/progress.rs
+++ b/crates/authoring/fission-widgets/src/progress.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 /// * `value` - Progress fraction from 0.0 (empty) to 1.0 (full).
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct ProgressBar {
-    pub value: f32, // 0.0 to 1.0
+    /// Completion fraction; values outside `0.0..=1.0` are clamped for paint.
+    pub value: f32,
 }
 
 impl From<ProgressBar> for Widget {

--- a/crates/authoring/fission-widgets/src/protected_route.rs
+++ b/crates/authoring/fission-widgets/src/protected_route.rs
@@ -9,13 +9,28 @@ use fission_core::{RouteBuildOutcome, RouteDecision, WidgetId};
 /// cannot register resources or reducers from its protected component.
 #[derive(Clone, Debug)]
 pub struct ProtectedRoute<A, P = DefaultRoutePending, D = DefaultRouteDenied> {
+    /// The already-resolved access result for this route.
+    ///
+    /// Resolve authentication, authorization, feature availability, or other
+    /// prerequisites in application state and reducers. `ProtectedRoute` does
+    /// not execute those checks itself; it only selects the corresponding
+    /// branch without constructing inactive components.
     pub decision: RouteDecision,
+    /// Component constructed when `decision` is [`RouteDecision::Allow`].
     pub allowed: A,
+    /// Component shown while access is pending or a redirect is being applied.
     pub pending: P,
+    /// Component shown when access is explicitly denied.
     pub denied: D,
 }
 
 impl<A> ProtectedRoute<A> {
+    /// Creates an access boundary around `allowed` using Fission's default
+    /// progress and access-denied branches.
+    ///
+    /// `decision` is normally copied from application state or produced by a
+    /// pure selector. Async work belongs in reducers; leave the decision as
+    /// [`RouteDecision::Pending`] until that work completes.
     pub fn new(decision: RouteDecision, allowed: A) -> Self {
         Self {
             decision,
@@ -27,6 +42,8 @@ impl<A> ProtectedRoute<A> {
 }
 
 impl<A, P, D> ProtectedRoute<A, P, D> {
+    /// Replaces the branch shown for [`RouteDecision::Pending`] and while a
+    /// [`RouteDecision::Redirect`] is being handed to the host shell.
     pub fn pending<P2>(self, pending: P2) -> ProtectedRoute<A, P2, D> {
         ProtectedRoute {
             decision: self.decision,
@@ -36,6 +53,10 @@ impl<A, P, D> ProtectedRoute<A, P, D> {
         }
     }
 
+    /// Replaces the branch shown for [`RouteDecision::Deny`].
+    ///
+    /// On SSR this branch is accompanied by a forbidden route outcome so the
+    /// server can return HTTP 403 without rendering the protected component.
     pub fn denied<D2>(self, denied: D2) -> ProtectedRoute<A, P, D2> {
         ProtectedRoute {
             decision: self.decision,
@@ -70,6 +91,7 @@ where
 }
 
 #[derive(Clone, Copy, Debug, Default)]
+/// Default centered progress indicator used while route access is unresolved.
 pub struct DefaultRoutePending;
 
 impl From<DefaultRoutePending> for Widget {
@@ -87,6 +109,7 @@ impl From<DefaultRoutePending> for Widget {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
+/// Default centered "Access denied" branch used for denied routes.
 pub struct DefaultRouteDenied;
 
 impl From<DefaultRouteDenied> for Widget {

--- a/crates/authoring/fission-widgets/src/range_slider.rs
+++ b/crates/authoring/fission-widgets/src/range_slider.rs
@@ -5,13 +5,20 @@ use fission_core::ActionEnvelope;
 use fission_ir::{LayoutOp, Op, PaintOp, WidgetId};
 use serde::{Deserialize, Serialize};
 
+/// Controlled two-thumb slider selecting an inclusive numeric interval.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RangeSlider {
+    /// Optional stable identity for retained hit and interaction state.
     pub id: Option<WidgetId>,
+    /// Current controlled lower value.
     pub start: f32,
+    /// Current controlled upper value.
     pub end: f32,
+    /// Minimum value represented by the track.
     pub min: f32,
+    /// Maximum value represented by the track.
     pub max: f32,
+    /// Action dispatched when interaction proposes a changed range.
     pub on_change: Option<ActionEnvelope>,
 }
 

--- a/crates/authoring/fission-widgets/src/refresh_indicator.rs
+++ b/crates/authoring/fission-widgets/src/refresh_indicator.rs
@@ -10,10 +10,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RefreshIndicatorStatus {
     #[default]
+    /// No pull or refresh is active and the indicator is hidden.
     Inactive,
+    /// The user is pulling but has not crossed the trigger distance.
     Drag,
+    /// The pull crossed the trigger distance and will refresh if released.
     Armed,
+    /// Refresh work is running and progress is indeterminate.
     Refreshing,
+    /// Refresh work completed and the indicator may settle away.
     Done,
 }
 
@@ -24,21 +29,37 @@ pub enum RefreshIndicatorStatus {
 /// provide an `on_refresh` action that starts the refresh work.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RefreshIndicator {
+    /// Stable identity for gesture handling and the derived progress indicator.
     pub id: WidgetId,
+    /// Scrollable content displaced by the pull interaction.
     pub child: Widget,
+    /// Current controlled interaction lifecycle.
     pub status: RefreshIndicatorStatus,
+    /// Current controlled pull distance in logical pixels.
     pub pulled_extent: f32,
+    /// Pull distance required to enter [`RefreshIndicatorStatus::Armed`].
     pub trigger_distance: f32,
+    /// Resting content displacement while refresh work is active.
     pub displacement: f32,
+    /// Additional distance between the viewport edge and indicator.
     pub edge_offset: f32,
+    /// Optional progress foreground color.
     pub color: Option<Color>,
+    /// Optional indicator surface color.
     pub background_color: Option<Color>,
+    /// Optional circular progress track color.
     pub track_color: Option<Color>,
+    /// Circular progress stroke width in logical pixels.
     pub stroke_width: f32,
+    /// Logical square size of the progress indicator.
     pub indicator_size: f32,
+    /// Action dispatched when a pull gesture begins.
     pub on_pull_start: Option<ActionEnvelope>,
+    /// Action dispatched with contextual drag input while pulling.
     pub on_pull_update: Option<ActionEnvelope>,
+    /// Action dispatched when a pull is cancelled before refresh.
     pub on_pull_cancel: Option<ActionEnvelope>,
+    /// Action dispatched when an armed pull is released.
     pub on_refresh: Option<ActionEnvelope>,
 }
 
@@ -66,6 +87,7 @@ impl Default for RefreshIndicator {
 }
 
 impl RefreshIndicator {
+    /// Wraps `child` with default pull-to-refresh geometry and colors.
     pub fn new(child: impl Into<Widget>) -> Self {
         Self {
             child: child.into(),
@@ -73,71 +95,85 @@ impl RefreshIndicator {
         }
     }
 
+    /// Sets the application-owned interaction status.
     pub fn status(mut self, status: RefreshIndicatorStatus) -> Self {
         self.status = status;
         self
     }
 
+    /// Sets the non-negative current pull distance in logical pixels.
     pub fn pulled_extent(mut self, pulled_extent: f32) -> Self {
         self.pulled_extent = pulled_extent.max(0.0);
         self
     }
 
+    /// Sets the positive distance at which a pull becomes armed.
     pub fn trigger_distance(mut self, trigger_distance: f32) -> Self {
         self.trigger_distance = trigger_distance.max(1.0);
         self
     }
 
+    /// Sets the non-negative content displacement maintained during refresh.
     pub fn displacement(mut self, displacement: f32) -> Self {
         self.displacement = displacement.max(0.0);
         self
     }
 
+    /// Sets the non-negative offset between viewport edge and indicator.
     pub fn edge_offset(mut self, edge_offset: f32) -> Self {
         self.edge_offset = edge_offset.max(0.0);
         self
     }
 
+    /// Overrides the progress foreground color.
     pub fn color(mut self, color: Color) -> Self {
         self.color = Some(color);
         self
     }
 
+    /// Overrides the indicator surface color.
     pub fn background_color(mut self, color: Color) -> Self {
         self.background_color = Some(color);
         self
     }
 
+    /// Overrides the circular progress track color.
     pub fn track_color(mut self, color: Color) -> Self {
         self.track_color = Some(color);
         self
     }
 
+    /// Sets progress stroke width, clamped to at least one logical pixel.
     pub fn stroke_width(mut self, stroke_width: f32) -> Self {
         self.stroke_width = stroke_width.max(1.0);
         self
     }
 
+    /// Sets indicator size, clamped to at least one logical pixel.
     pub fn indicator_size(mut self, indicator_size: f32) -> Self {
         self.indicator_size = indicator_size.max(1.0);
         self
     }
 
+    /// Sets the action dispatched when pulling begins.
     pub fn on_pull_start(mut self, action: ActionEnvelope) -> Self {
         self.on_pull_start = Some(action);
         self
     }
 
+    /// Sets the action receiving contextual pull updates.
     pub fn on_pull_update(mut self, action: ActionEnvelope) -> Self {
         self.on_pull_update = Some(action);
         self
     }
 
+    /// Sets the action dispatched when pulling is cancelled.
     pub fn on_pull_cancel(mut self, action: ActionEnvelope) -> Self {
         self.on_pull_cancel = Some(action);
         self
     }
 
+    /// Sets the action dispatched when an armed pull requests refresh.
     pub fn on_refresh(mut self, action: ActionEnvelope) -> Self {
         self.on_refresh = Some(action);
         self

--- a/crates/authoring/fission-widgets/src/router.rs
+++ b/crates/authoring/fission-widgets/src/router.rs
@@ -5,18 +5,45 @@ use fission_ir::WidgetId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Named path parameters captured while matching a route pattern.
+///
+/// A pattern such as `/projects/:project_id` inserts the matching path segment
+/// under `project_id`. Query-string and fragment values are not included.
 pub type RouteParams = HashMap<String, String>;
+
+/// Type-erased builder invoked for the first matching route.
+///
+/// Builders receive the current build and view handles plus captured path
+/// parameters. Prefer [`Router::route_component`] for ordinary retained
+/// components; use this lower-level form when construction genuinely needs
+/// route parameters or direct build context.
 pub type PageBuilder<S> =
     Arc<dyn Fn(BuildCtxHandle<S>, ViewHandle<S>, &RouteParams) -> Widget + Send + Sync>;
 
+/// One ordered route-table entry.
 pub struct Route<S: GlobalState> {
+    /// Exact-segment path pattern, optionally containing `:named` segments.
     pub path: String,
+    /// Lazy component builder invoked only when `path` matches.
     pub builder: PageBuilder<S>,
 }
 
+/// Declarative, ordered router for a Fission application state type.
+///
+/// The router compares [`Router::current_path`] with each registered pattern
+/// and constructs only the first matching route. This laziness is important:
+/// inactive pages cannot register reducers, resources, jobs, or local state.
 pub struct Router<S: GlobalState> {
+    /// Current origin-free path used for matching.
+    ///
+    /// Applications normally mirror the shell route into `GlobalState` with a
+    /// route handler and pass that value through [`Router::with_path`].
     pub current_path: String,
+    /// Route entries in matching order; the first match wins.
     pub routes: Vec<Route<S>>,
+    /// Optional fallback builder for paths not matched by `routes`.
+    ///
+    /// Without a custom fallback, the router renders a small `404` text node.
     pub not_found: Option<PageBuilder<S>>,
 }
 
@@ -27,10 +54,12 @@ impl<S: GlobalState> From<Router<S>> for Widget {
 
         for route in &this.routes {
             if let Some(params) = match_route(&route.path, &this.current_path) {
-                return route_scoped_widget(
-                    &format!("{}=>{}", route.path, this.current_path),
-                    (route.builder)(ctx, view, &params),
-                );
+                return build::provide(params.clone(), || {
+                    route_scoped_widget(
+                        &format!("{}=>{}", route.path, this.current_path),
+                        (route.builder)(ctx, view, &params),
+                    )
+                });
             }
         }
 
@@ -46,6 +75,7 @@ impl<S: GlobalState> From<Router<S>> for Widget {
 }
 
 impl<S: GlobalState> Router<S> {
+    /// Creates an empty router initially matching `/`.
     pub fn new() -> Self {
         Self {
             current_path: "/".to_string(),
@@ -54,11 +84,19 @@ impl<S: GlobalState> Router<S> {
         }
     }
 
+    /// Sets the origin-free path to match during this build.
+    ///
+    /// The value may contain the shell-provided query and fragment, but route
+    /// pattern matching currently operates on path segments only.
     pub fn with_path(mut self, path: impl Into<String>) -> Self {
         self.current_path = path.into();
         self
     }
 
+    /// Registers a lazy zero-argument route builder.
+    ///
+    /// Use this for simple pages that need neither route parameters nor direct
+    /// build handles. Routes are tested in registration order.
     pub fn route<W, F>(mut self, path: impl Into<String>, builder: F) -> Self
     where
         W: Into<Widget>,
@@ -71,7 +109,13 @@ impl<S: GlobalState> Router<S> {
         self
     }
 
-    /// Registers a concrete component and converts it only when its route matches.
+    /// Registers a retained component and converts it only when its route matches.
+    ///
+    /// This is the preferred API for component values such as
+    /// `ProtectedRoute::new(decision, AccountPage)`. The component is cloned as
+    /// a value for the route table, but inactive branches are not converted to
+    /// [`Widget`] values. A matching component can read captured parameters
+    /// with `fission::build::read::<RouteParams>()`.
     pub fn route_component<W>(mut self, path: impl Into<String>, component: W) -> Self
     where
         W: Clone + Into<Widget> + Send + Sync + 'static,
@@ -83,6 +127,10 @@ impl<S: GlobalState> Router<S> {
         self
     }
 
+    /// Registers a fully typed [`PageBuilder`].
+    ///
+    /// Use this when the page needs captured [`RouteParams`] or direct access
+    /// to its build/view handles.
     pub fn route_builder(mut self, path: impl Into<String>, builder: PageBuilder<S>) -> Self {
         self.routes.push(Route {
             path: path.into(),
@@ -91,6 +139,7 @@ impl<S: GlobalState> Router<S> {
         self
     }
 
+    /// Installs a lazy fallback for paths that do not match any route.
     pub fn not_found<W, F>(mut self, builder: F) -> Self
     where
         W: Into<Widget>,
@@ -139,6 +188,7 @@ mod tests {
     use fission_core::internal::BuildCtx;
     use fission_core::{Env, RuntimeState, Text, View};
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     #[derive(Debug, Default)]
     struct State;
@@ -151,6 +201,18 @@ mod tests {
         fn from(page: CountedPage) -> Self {
             page.0.fetch_add(1, Ordering::SeqCst);
             Text::new("matched").into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct ParameterPage(Arc<Mutex<Option<String>>>);
+
+    impl From<ParameterPage> for Widget {
+        fn from(page: ParameterPage) -> Self {
+            let params = build::read::<RouteParams>();
+            let project_id = params.get("project_id").cloned().unwrap_or_default();
+            *page.0.lock().unwrap() = Some(project_id.clone());
+            Text::new(project_id).into()
         }
     }
 
@@ -172,5 +234,22 @@ mod tests {
 
         assert_eq!(unmatched.load(Ordering::SeqCst), 0);
         assert_eq!(matched.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn route_component_provides_captured_parameters_during_conversion() {
+        let observed = Arc::new(Mutex::new(None));
+        let router = Router::<State>::new()
+            .with_path("/projects/42")
+            .route_component("/projects/:project_id", ParameterPage(observed.clone()));
+        let state = State;
+        let runtime = RuntimeState::default();
+        let env = Env::default();
+        let view = View::new(&state, &runtime, &env, None);
+        let mut ctx = BuildCtx::<State>::new();
+
+        let _ = fission_core::build::enter(&mut ctx, &view, || -> Widget { router.into() });
+
+        assert_eq!(observed.lock().unwrap().as_deref(), Some("42"));
     }
 }

--- a/crates/authoring/fission-widgets/src/segmented_control.rs
+++ b/crates/authoring/fission-widgets/src/segmented_control.rs
@@ -15,8 +15,11 @@ use std::sync::Arc;
 /// * `selected_index` - Index of the currently active segment.
 /// * `on_change` - Closure that produces an action for the newly selected index.
 pub struct SegmentedControl {
+    /// Segment labels in display order.
     pub options: Vec<String>,
+    /// Zero-based controlled selected segment.
     pub selected_index: usize,
+    /// Factory producing an action for a requested selection index.
     pub on_change: Option<Arc<dyn Fn(usize) -> ActionEnvelope + Send + Sync>>,
 }
 

--- a/crates/authoring/fission-widgets/src/select.rs
+++ b/crates/authoring/fission-widgets/src/select.rs
@@ -8,8 +8,11 @@ use serde::{Deserialize, Serialize};
 /// A single option in a [`Select`] dropdown.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SelectItem {
+    /// Text displayed for the option.
     pub label: String,
+    /// Optional SVG markup displayed before the label.
     pub icon: Option<String>,
+    /// Action dispatched when the option is selected.
     pub on_select: ActionEnvelope,
 }
 
@@ -37,12 +40,19 @@ pub struct SelectItem {
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Select {
+    /// Stable identity used to anchor and retain the popup surface.
     pub id: WidgetId,
+    /// Current controlled selection label, or `None` to show `placeholder`.
     pub selected_label: Option<String>,
+    /// Options presented in the popup menu.
     pub items: Vec<SelectItem>,
+    /// Whether the controlled popup is currently open.
     pub is_open: bool,
+    /// Action dispatched when the trigger requests an open-state change.
     pub on_toggle: Option<ActionEnvelope>,
+    /// Text shown when no selection is present.
     pub placeholder: String,
+    /// Optional logical width shared by the trigger and popup.
     pub width: Option<f32>,
 }
 

--- a/crates/authoring/fission-widgets/src/simple_grid.rs
+++ b/crates/authoring/fission-widgets/src/simple_grid.rs
@@ -4,10 +4,18 @@ use fission_core::ui::{Container, Widget};
 use fission_ir::op::FlexWrap;
 use serde::{Deserialize, Serialize};
 
+/// Responsive wrapping grid whose children share a minimum width.
+///
+/// Children expand evenly across each row and wrap when another
+/// `min_child_width` item no longer fits. Use [`fission_core::ui::Grid`] when
+/// the application needs explicit rows, columns, or named placements.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimpleGrid {
+    /// Smallest logical width assigned to an item before wrapping occurs.
     pub min_child_width: f32,
+    /// Optional horizontal and vertical gap between items.
     pub gap: Option<f32>,
+    /// Items laid out in declaration order.
     pub children: Vec<Widget>,
 }
 

--- a/crates/authoring/fission-widgets/src/skeleton.rs
+++ b/crates/authoring/fission-widgets/src/skeleton.rs
@@ -24,9 +24,13 @@ const LOW_PRIORITY_REPEAT_FRAME_MS: u64 = 166;
 /// * `circle` - If `true`, uses `border_radius: 9999` for a circular shape.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Skeleton {
+    /// Stable identity required for independent pulse motion.
     pub id: WidgetId,
+    /// Optional logical width; defaults to 100.
     pub width: Option<f32>,
+    /// Optional logical height; defaults to 20.
     pub height: Option<f32>,
+    /// Whether to use a fully rounded shape instead of the normal radius.
     pub circle: bool,
     /// Optional explicit skeleton motion. `None` emits no skeleton-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/spinner.rs
+++ b/crates/authoring/fission-widgets/src/spinner.rs
@@ -22,7 +22,9 @@ const LOW_PRIORITY_REPEAT_FRAME_MS: u64 = 166;
 /// * `color` - Override dot color (defaults to `tokens.colors.primary`).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Spinner {
+    /// Stable identity used to retain independent motion state for each dot.
     pub id: WidgetId,
+    /// Optional dot color; the design-system primary color is used when absent.
     pub color: Option<fission_core::op::Color>,
     /// Optional explicit spinner motion. `None` emits no spinner-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/split_view.rs
+++ b/crates/authoring/fission-widgets/src/split_view.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 /// The axis along which a [`SplitView`] divides its two panes.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SplitDirection {
+    /// Places the panes left and right with a vertical divider.
     Horizontal,
+    /// Places the panes top and bottom with a horizontal divider.
     Vertical,
 }
 
@@ -25,12 +27,18 @@ pub enum SplitDirection {
 /// * `on_resize` - Action dispatched when the handle is dragged (user must update `split_ratio`).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SplitView {
+    /// Stable identity for the split region and its drag handle.
     pub id: WidgetId,
+    /// Axis along which available space is divided.
     pub direction: SplitDirection,
+    /// Leading or top pane.
     pub first: Widget,
+    /// Trailing or bottom pane.
     pub second: Widget,
-    pub split_ratio: f32,                  // 0.0 to 1.0
-    pub on_resize: Option<ActionEnvelope>, // Action(f32)
+    /// Controlled fraction allocated to `first`, clamped to `0.1..=0.9`.
+    pub split_ratio: f32,
+    /// Action dispatched by drag interaction so the application can update the ratio.
+    pub on_resize: Option<ActionEnvelope>,
 }
 
 // Since we can't easily capture local drag state without a reducer in the user app,

--- a/crates/authoring/fission-widgets/src/spotlight.rs
+++ b/crates/authoring/fission-widgets/src/spotlight.rs
@@ -13,8 +13,11 @@ use std::sync::Arc;
 /// accessibility semantics.
 #[derive(Debug)]
 pub struct Spotlight {
+    /// Stable ID of the already-laid-out widget to reveal.
     pub anchor: WidgetId,
+    /// Logical-pixel clearance between the anchor bounds and focus ring.
     pub padding: f32,
+    /// Top, bottom, left, right, and focus-ring children in that order.
     pub children: [Widget; 5],
 }
 

--- a/crates/authoring/fission-widgets/src/stack.rs
+++ b/crates/authoring/fission-widgets/src/stack.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct HStack {
+    /// Children arranged from start to end along the horizontal axis.
     pub children: Vec<Widget>,
+    /// Optional logical-pixel gap between adjacent children.
     pub spacing: Option<f32>,
 }
 
@@ -34,7 +36,9 @@ pub struct HStack {
 /// ```
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct VStack {
+    /// Children arranged from start to end along the vertical axis.
     pub children: Vec<Widget>,
+    /// Optional logical-pixel gap between adjacent children.
     pub spacing: Option<f32>,
 }
 

--- a/crates/authoring/fission-widgets/src/stat.rs
+++ b/crates/authoring/fission-widgets/src/stat.rs
@@ -2,10 +2,17 @@ use crate::stack::VStack;
 use fission_core::ui::{Container, Text, Widget};
 use serde::{Deserialize, Serialize};
 
+/// Compact themed presentation of one labelled metric.
+///
+/// `Stat` is intended for dashboard summaries: it renders a subdued label, a
+/// prominent value, and optional explanatory text inside a bordered surface.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Stat {
+    /// Short description of the metric, such as `Active users`.
     pub label: String,
+    /// Preformatted value displayed prominently.
     pub value: String,
+    /// Optional secondary explanation or comparison.
     pub help_text: Option<String>,
 }
 

--- a/crates/authoring/fission-widgets/src/stepper.rs
+++ b/crates/authoring/fission-widgets/src/stepper.rs
@@ -2,9 +2,12 @@ use crate::stack::{HStack, VStack};
 use fission_core::ui::{Align, Container, Text, Widget};
 use serde::{Deserialize, Serialize};
 
+/// Ordered progress indicator for a finite multi-step workflow.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Stepper {
+    /// Step labels in workflow order.
     pub steps: Vec<String>,
+    /// Zero-based current step; earlier steps receive completed treatment.
     pub active_index: usize,
 }
 

--- a/crates/authoring/fission-widgets/src/tabs.rs
+++ b/crates/authoring/fission-widgets/src/tabs.rs
@@ -158,8 +158,11 @@ impl TabsMotionPlan {
 /// A single tab definition containing a title, content node, and selection action.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TabItem {
+    /// Label displayed in the tab bar.
     pub title: String,
+    /// Content shown when this item is selected.
     pub content: Widget,
+    /// Action dispatched when this tab's trigger is pressed.
     pub on_press: Option<ActionEnvelope>,
 }
 
@@ -182,8 +185,11 @@ pub struct TabItem {
 /// ```
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Tabs {
+    /// Zero-based selected item index; an out-of-range value shows no content.
     pub active_index: usize,
+    /// Tab definitions in display order.
     pub items: Vec<TabItem>,
+    /// Design-system size used for tab typography, spacing, and indicator style.
     pub size: ComponentSize,
     /// Optional explicit tabs motion. `None` emits no tabs-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/tag.rs
+++ b/crates/authoring/fission-widgets/src/tag.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 /// The close button (an "x" character) appears when `on_close` is provided.
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Tag {
+    /// Text displayed inside the tag.
     pub label: String,
+    /// Optional removal action; supplying it also displays the close affordance.
     pub on_close: Option<ActionEnvelope>,
 }
 

--- a/crates/authoring/fission-widgets/src/time_picker.rs
+++ b/crates/authoring/fission-widgets/src/time_picker.rs
@@ -4,9 +4,16 @@ use fission_core::ui::{Text, Widget};
 use fission_core::ActionEnvelope;
 use std::sync::Arc;
 
+/// Controlled 24-hour time picker with increment and decrement controls.
+///
+/// The application owns the selected time. `on_change` receives the proposed
+/// hour and minute and should dispatch an action that updates application state.
 pub struct TimePicker {
-    pub hour: u32,   // 0-23
-    pub minute: u32, // 0-59
+    /// Hour in the inclusive range `0..=23`.
+    pub hour: u32,
+    /// Minute in the inclusive range `0..=59`.
+    pub minute: u32,
+    /// Factory used to create an action for a proposed `(hour, minute)` value.
     pub on_change: Option<Arc<dyn Fn(u32, u32) -> ActionEnvelope + Send + Sync>>,
 }
 

--- a/crates/authoring/fission-widgets/src/timeline.rs
+++ b/crates/authoring/fission-widgets/src/timeline.rs
@@ -2,15 +2,21 @@ use crate::stack::VStack;
 use fission_core::ui::{Container, Text, Widget};
 use serde::{Deserialize, Serialize};
 
+/// One event displayed in a [`Timeline`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TimelineItem {
+    /// Primary event label.
     pub title: String,
+    /// Optional supporting detail.
     pub description: Option<String>,
+    /// Optional preformatted time or date label.
     pub timestamp: Option<String>,
 }
 
+/// Ordered vertical presentation of related events.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Timeline {
+    /// Events displayed from first to last.
     pub items: Vec<TimelineItem>,
 }
 

--- a/crates/authoring/fission-widgets/src/toast.rs
+++ b/crates/authoring/fission-widgets/src/toast.rs
@@ -136,9 +136,13 @@ impl ToastMotionPlan {
 /// The severity level of a [`Toast`] notification, which determines the icon and color.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ToastKind {
+    /// Neutral informational update.
     Info,
+    /// Successful completion or positive result.
     Success,
+    /// Condition requiring attention but not an immediate failure.
     Warning,
+    /// Failed operation or invalid state.
     Error,
 }
 
@@ -153,9 +157,13 @@ pub enum ToastKind {
 /// when `on_close` fires or after a timeout.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Toast {
+    /// Stable identity used for retained motion and independent instances.
     pub id: WidgetId,
+    /// Semantic tone controlling the icon and color treatment.
     pub kind: ToastKind,
+    /// User-facing notification text.
     pub message: String,
+    /// Optional action dispatched from the close button.
     pub on_close: Option<ActionEnvelope>,
     /// Optional explicit toast motion. `None` emits no toast-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/tooltip.rs
+++ b/crates/authoring/fission-widgets/src/tooltip.rs
@@ -138,9 +138,13 @@ impl TooltipMotionPlan {
 /// * `is_visible` - Force the tooltip visible regardless of hover state.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Tooltip {
+    /// Stable identity used for hover state and overlay anchoring.
     pub id: WidgetId,
+    /// Trigger content over which the tooltip is anchored.
     pub child: Widget,
+    /// Explanatory text displayed in the overlay.
     pub text: String,
+    /// Controlled visibility override in addition to framework hover state.
     pub is_visible: bool,
     /// Optional explicit tooltip motion. `None` emits no tooltip-owned motion declarations.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/authoring/fission-widgets/src/tree_view.rs
+++ b/crates/authoring/fission-widgets/src/tree_view.rs
@@ -8,20 +8,31 @@ use fission_core::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+/// One recursively nested entry in a [`TreeView`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TreeItem {
+    /// Stable application identity used by expansion and selection state.
     pub id: String,
+    /// Optional SVG markup displayed before the label.
     pub icon: Option<String>,
+    /// User-facing item label.
     pub label: String,
+    /// Child entries displayed when this item is expanded.
     pub children: Vec<TreeItem>,
+    /// Action dispatched when the disclosure control is pressed.
     pub on_toggle: Option<ActionEnvelope>,
+    /// Action dispatched when the item row is selected.
     pub on_select: Option<ActionEnvelope>,
 }
 
+/// Controlled hierarchical navigation or data browser.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TreeView {
+    /// Root items in display order.
     pub items: Vec<TreeItem>,
+    /// IDs of items whose children should currently be visible.
     pub expanded_ids: HashSet<String>,
+    /// Optional ID receiving selected-row treatment.
     pub selected_id: Option<String>,
 }
 

--- a/crates/authoring/fission-widgets/src/web_view.rs
+++ b/crates/authoring/fission-widgets/src/web_view.rs
@@ -5,12 +5,22 @@ use fission_core::{Widget, WidgetId};
 use fission_ir::{EmbedKind, LayoutOp, Op};
 use serde::{Deserialize, Serialize};
 
+/// Embeds a web document inside a graphical Fission application.
+///
+/// Native shells register a platform web view, while Web lowers the same
+/// contract to an iframe. Static site, SSR, and Terminal builds do not provide
+/// an interactive embedded browser surface.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WebView {
+    /// Stable identity used to retain and update the platform-owned surface.
     pub id: WidgetId,
+    /// Absolute or application-supported URL loaded by the embedded browser.
     pub url: String,
+    /// Optional user-agent override where the platform web-view API supports it.
     pub user_agent: Option<String>,
+    /// Optional logical width; surrounding constraints apply when absent.
     pub width: Option<f32>,
+    /// Optional logical height; surrounding constraints apply when absent.
     pub height: Option<f32>,
 }
 

--- a/crates/authoring/fission-widgets/src/wrap.rs
+++ b/crates/authoring/fission-widgets/src/wrap.rs
@@ -14,8 +14,11 @@ use serde::{Deserialize, Serialize};
 /// * `children` - The child nodes to lay out.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Wrap {
+    /// Main axis along which children are placed before wrapping.
     pub direction: FlexDirection,
+    /// Optional logical-pixel gap between adjacent children and lines.
     pub spacing: Option<f32>,
+    /// Children placed in declaration order.
     pub children: Vec<Widget>,
 }
 

--- a/crates/authoring/fission/src/lib.rs
+++ b/crates/authoring/fission/src/lib.rs
@@ -203,6 +203,11 @@ pub mod test_driver {
     pub use fission_test_driver::*;
 }
 
+/// Declarative motion specifications, transitions, curves, and animated values.
+///
+/// These types describe framework-owned motion without embedding imperative
+/// animation loops in application widgets. Most application code can import
+/// them directly from [`prelude`].
 pub mod motion {
     pub use fission_core::motion::*;
 }
@@ -352,6 +357,11 @@ pub use fission_core::{
 // Build-scope access for authoring code. The facade intentionally exposes the
 // scoped authoring functions, not the framework-only build entry point used by
 // shells and test harnesses.
+/// Build-scope access used while converting components into widget trees.
+///
+/// Handles returned here borrow the current build and must not be stored in
+/// application state, services, async tasks, or statics. Use them to read state,
+/// register reducers, or access a provider only during component conversion.
 pub mod build {
     pub use fission_core::build::{current, provide, read, try_read, BuildCtxHandle, ViewHandle};
 }
@@ -438,7 +448,11 @@ pub use fission_shell_mobile::{
     UnsupportedPasskeyHost, UnsupportedVolumeHost, UnsupportedWifiHost, VolumeHost, WifiHost,
 };
 #[cfg(feature = "terminal-shell")]
-pub use fission_shell_terminal::TerminalApp;
+pub use fission_shell_terminal::{
+    write_frame_png, ScreenshotOptions, TerminalApp, TerminalCell, TerminalColor, TerminalFrame,
+    TerminalLiveTest, TerminalRenderer, TerminalRunOptions, TerminalStyle, TerminalSupportError,
+    TerminalTextMeasurer,
+};
 #[cfg(all(
     any(feature = "web", feature = "platform-shells"),
     target_arch = "wasm32"
@@ -465,8 +479,52 @@ pub use fission_macros::{
 
 // ── Prelude ──────────────────────────────────────────────────────────────
 
-/// Prelude for UI authoring — import this for the most common types.
+/// Complete application-authoring prelude.
+///
+/// `use fission::prelude::*` exposes every built-in type that Fission presents
+/// through its public facade, together with all authoring widgets. Target- and
+/// capability-specific APIs remain controlled by their Cargo features, so for
+/// example `DesktopApp` appears only in a desktop build and Store types appear
+/// only when storage is enabled.
+///
+/// The glob from the facade is intentional: the crate root is the authority for
+/// conflict-resolved public names, and the prelude must not drift into a second
+/// manually maintained list. Namespaces such as [`crate::render`] and
+/// [`crate::text_engine`] remain available when two subsystems use an equally
+/// appropriate short type name.
 pub mod prelude {
+    // Keep the facade root as the authority for public names. Explicit imports
+    // below provide whole widget/theme families that the root intentionally
+    // exposes primarily through namespaces.
+    pub use crate::*;
+    pub use fission_core::public::*;
+    pub use fission_diagnostics::{
+        begin_frame, emit, end_frame, init, init_from_env, DiagCategory, DiagEvent, DiagEventKind,
+        DiagLevel, DiagSink, DiagnosticsConfig, FrameStats, SnapshotBlob, SnapshotKind,
+        SnapshotProvider,
+    };
+    pub use fission_i18n::*;
+    pub use fission_layout::*;
+    pub use fission_render::{
+        embed_surface_id, surface_placeholder_color, DisplayList, DisplayOp, LayerClip, LayerStyle,
+        RenderLayer, RenderNode, RenderScene, Renderer,
+    };
+    pub use fission_render::{
+        BoxShadow as RenderBoxShadow, Color as RenderColor, Fill as RenderFill,
+        ImageFit as RenderImageFit, LineCap as RenderLineCap, LineJoin as RenderLineJoin,
+        Stroke as RenderStroke, TextRun as RenderTextRun, TextStyle as RenderTextStyle,
+    };
+    pub use fission_text_engine::*;
+
+    #[cfg(feature = "three-d")]
+    pub use fission_3d::*;
+    #[cfg(feature = "charts")]
+    pub use fission_charts::*;
+    #[cfg(feature = "store")]
+    pub use fission_store::*;
+    #[cfg(any(feature = "store-sqlite-native", feature = "store-sqlite-web"))]
+    pub use fission_store_sqlite::*;
+
     // Widgets
     pub use fission_core::ui::{
         ActionScope, Align, BadgeTone, Builder, Button, ButtonContentAlign, ButtonHierarchy,
@@ -706,7 +764,11 @@ pub mod prelude {
     #[cfg(feature = "site")]
     pub use fission_shell_site::*;
     #[cfg(feature = "terminal-shell")]
-    pub use fission_shell_terminal::TerminalApp;
+    pub use fission_shell_terminal::{
+        write_frame_png, ScreenshotOptions, TerminalApp, TerminalCell, TerminalColor,
+        TerminalFrame, TerminalLiveTest, TerminalRenderer, TerminalRunOptions, TerminalStyle,
+        TerminalSupportError, TerminalTextMeasurer,
+    };
     #[cfg(all(
         any(feature = "web", feature = "platform-shells"),
         target_arch = "wasm32"
@@ -720,8 +782,8 @@ pub mod prelude {
         NotificationHost, PasskeyHost, UnsupportedBarcodeScannerHost, UnsupportedBiometricHost,
         UnsupportedBluetoothHost, UnsupportedCameraHost, UnsupportedGeolocationHost,
         UnsupportedHapticHost, UnsupportedMicrophoneHost, UnsupportedNfcHost,
-        UnsupportedNotificationHost, UnsupportedPasskeyHost, UnsupportedWifiHost, WebApp,
-        WebNavigationConfig, WebRouteStrategy, WifiHost,
+        UnsupportedNotificationHost, UnsupportedPasskeyHost, UnsupportedVolumeHost,
+        UnsupportedWifiHost, VolumeHost, WebApp, WebNavigationConfig, WebRouteStrategy, WifiHost,
     };
 
     // Serde (commonly needed for actions)

--- a/crates/shell/fission-shell-desktop/src/lib.rs
+++ b/crates/shell/fission-shell-desktop/src/lib.rs
@@ -1,5 +1,11 @@
 #![allow(unexpected_cfgs)]
 
+//! Native macOS, Windows, and Linux application shell.
+//!
+//! [`DesktopApp`] owns the window/event loop and desktop host integrations
+//! while preserving Fission's shared state, reducer, environment, and widget
+//! contracts.
+
 use anyhow::Result;
 use fission_core::{Action, ActionId, Env, GlobalState, Widget, WidgetId};
 use fission_shell::{async_host::AsyncRegistry, NativeSurfaceHandler};
@@ -24,6 +30,7 @@ pub use fission_shell_winit::{
     WindowMinimizeBehavior,
 };
 
+/// Stateful Fission application hosted in a native desktop window.
 pub struct DesktopApp<S: GlobalState, W>
 where
     W: Clone + Into<Widget>,
@@ -36,28 +43,34 @@ where
     S: GlobalState + Default,
     W: Clone + Into<Widget> + 'static,
 {
+    /// Creates a desktop app using `S::default()` as global state.
     pub fn new(root_widget: W) -> Self {
         Self {
             inner: WinitApp::new(root_widget),
         }
     }
 
+    /// Creates a desktop app with explicitly prepared global state.
     pub fn new_with_global_state(root_widget: W, global_state: S) -> Self {
         Self {
             inner: WinitApp::new_with_global_state(root_widget, global_state),
         }
     }
 
+    /// Replaces global state before the app starts.
     pub fn with_global_state(mut self, global_state: S) -> Self {
         self.inner = self.inner.with_global_state(global_state);
         self
     }
 
+    /// Sets the stable identity from which implicit descendant IDs derive.
     pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
         self.inner = self.inner.with_root_id(root_id);
         self
     }
 
+    /// Registers an app-wide key handler before widget routing; return `true`
+    /// to consume the key.
     pub fn with_key_handler<F>(mut self, handler: F) -> Self
     where
         F: Fn(&mut S, &fission_core::KeyCode, u8) -> bool + Send + Sync + 'static,
@@ -66,6 +79,7 @@ where
         self
     }
 
+    /// Sets the native window and application title.
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.inner = self.inner.with_title(title);
         self
@@ -80,16 +94,19 @@ where
         self
     }
 
+    /// Opens the native live-test control listener on `port` in test builds.
     pub fn with_test_control_port(mut self, port: u16) -> Self {
         self.inner = self.inner.with_test_control_port(port);
         self
     }
 
+    /// Requires `token` from clients connecting to the live-test port.
     pub fn with_test_control_token(mut self, token: impl Into<String>) -> Self {
         self.inner = self.inner.with_test_control_token(token);
         self
     }
 
+    /// Mutates initial global state synchronously before the first frame.
     pub fn with_state_init<F>(mut self, init: F) -> Self
     where
         F: FnOnce(&mut S),
@@ -98,11 +115,13 @@ where
         self
     }
 
+    /// Replaces the base environment used to build every frame.
     pub fn with_env(mut self, env: Env) -> Self {
         self.inner = self.inner.with_env(env);
         self
     }
 
+    /// Installs a generated design system's theme and packaged fonts.
     pub fn with_design_system<D: fission_theme::DesignSystem>(
         mut self,
         mode: fission_theme::DesignMode,
@@ -117,6 +136,7 @@ where
         self
     }
 
+    /// Mirrors global-state presentation values into `Env` before each build.
     pub fn with_sync_env<F>(mut self, f: F) -> Self
     where
         F: Fn(&S, &mut Env) + Send + Sync + 'static,
@@ -125,6 +145,7 @@ where
         self
     }
 
+    /// Runs a lightweight host hook between frames; return `true` to redraw.
     pub fn with_frame_hook<F>(mut self, f: F) -> Self
     where
         F: Fn(&mut S) -> bool + Send + Sync + 'static,
@@ -143,6 +164,8 @@ where
         self
     }
 
+    /// Registers app jobs, services, and operation capability handlers with
+    /// the desktop shell's asynchronous host.
     pub fn with_async<F>(mut self, configure: F) -> Self
     where
         F: FnOnce(&mut AsyncRegistry),
@@ -152,6 +175,7 @@ where
     }
 
     #[cfg(feature = "store")]
+    /// Replaces the key/value store provider used by Store effects.
     pub fn with_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::StoreProvider + Send + Sync,
@@ -161,6 +185,7 @@ where
     }
 
     #[cfg(feature = "store-sql")]
+    /// Replaces the SQL-capable provider used by Store and SQL effects.
     pub fn with_sql_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::SqlStoreProvider + Send + Sync,
@@ -169,6 +194,7 @@ where
         self
     }
 
+    /// Installs the implementation used by notification effects.
     pub fn with_notification_host<H>(mut self, host: H) -> Self
     where
         H: NotificationHost,
@@ -188,6 +214,7 @@ where
         self
     }
 
+    /// Installs the implementation used by NFC effects.
     pub fn with_nfc_host<H>(mut self, host: H) -> Self
     where
         H: NfcHost,
@@ -196,6 +223,7 @@ where
         self
     }
 
+    /// Installs the implementation used by biometric authentication effects.
     pub fn with_biometric_host<H>(mut self, host: H) -> Self
     where
         H: BiometricHost,
@@ -204,6 +232,7 @@ where
         self
     }
 
+    /// Installs the implementation used by passkey registration and sign-in.
     pub fn with_passkey_host<H>(mut self, host: H) -> Self
     where
         H: PasskeyHost,
@@ -212,6 +241,7 @@ where
         self
     }
 
+    /// Installs the implementation used by Bluetooth effects.
     pub fn with_bluetooth_host<H>(mut self, host: H) -> Self
     where
         H: BluetoothHost,
@@ -220,6 +250,7 @@ where
         self
     }
 
+    /// Installs the implementation used by barcode scanning effects.
     pub fn with_barcode_scanner_host<H>(mut self, host: H) -> Self
     where
         H: BarcodeScannerHost,
@@ -228,6 +259,7 @@ where
         self
     }
 
+    /// Installs the implementation used by camera effects.
     pub fn with_camera_host<H>(mut self, host: H) -> Self
     where
         H: CameraHost,
@@ -236,6 +268,7 @@ where
         self
     }
 
+    /// Installs the implementation used by clipboard effects.
     pub fn with_clipboard_host<H>(mut self, host: H) -> Self
     where
         H: ClipboardHost,
@@ -244,6 +277,7 @@ where
         self
     }
 
+    /// Installs the implementation used by geolocation effects.
     pub fn with_geolocation_host<H>(mut self, host: H) -> Self
     where
         H: GeolocationHost,
@@ -252,6 +286,7 @@ where
         self
     }
 
+    /// Installs the implementation used by haptic feedback effects.
     pub fn with_haptic_host<H>(mut self, host: H) -> Self
     where
         H: HapticHost,
@@ -260,6 +295,7 @@ where
         self
     }
 
+    /// Installs the implementation used by microphone capture effects.
     pub fn with_microphone_host<H>(mut self, host: H) -> Self
     where
         H: MicrophoneHost,
@@ -268,6 +304,7 @@ where
         self
     }
 
+    /// Installs the implementation used by Wi-Fi effects.
     pub fn with_wifi_host<H>(mut self, host: H) -> Self
     where
         H: WifiHost,
@@ -276,6 +313,7 @@ where
         self
     }
 
+    /// Installs the implementation used by system/media volume effects.
     pub fn with_volume_host<H>(mut self, host: H) -> Self
     where
         H: VolumeHost,
@@ -284,37 +322,44 @@ where
         self
     }
 
+    /// Dispatches one typed action after the first widget registry is built.
     pub fn with_startup_action<A: Action>(mut self, action: A) -> Self {
         self.inner = self.inner.with_startup_action(action);
         self
     }
 
     #[cfg(feature = "tray")]
+    /// Installs the desktop tray menu and window-lifecycle policy.
     pub fn with_tray(mut self, config: TrayConfig<S>) -> Self {
         self.inner = self.inner.with_tray(config);
         self
     }
 
+    /// Sets the accepted schemes, domains, and path prefixes for inbound links.
     pub fn with_deep_link_config(mut self, config: fission_core::DeepLinkConfig) -> Self {
         self.inner = self.inner.with_deep_link_config(config);
         self
     }
 
+    /// Adds an accepted custom URI scheme to the deep-link policy.
     pub fn with_deep_link_scheme(mut self, scheme: impl Into<String>) -> Self {
         self.inner = self.inner.with_deep_link_scheme(scheme);
         self
     }
 
+    /// Adds an accepted HTTP(S) host to the deep-link policy.
     pub fn with_deep_link_domain(mut self, domain: impl Into<String>) -> Self {
         self.inner = self.inner.with_deep_link_domain(domain);
         self
     }
 
+    /// Queues an already-resolved inbound link for startup dispatch.
     pub fn with_startup_deep_link(mut self, link: fission_core::DeepLink) -> Self {
         self.inner = self.inner.with_startup_deep_link(link);
         self
     }
 
+    /// Queues a notification interaction received before app startup.
     pub fn with_startup_notification_response(
         mut self,
         response: fission_core::NotificationResponse,
@@ -323,6 +368,7 @@ where
         self
     }
 
+    /// Registers a persistent typed reducer for accepted inbound deep links.
     pub fn on_deep_link<H>(mut self, handler: H) -> Self
     where
         H: fission_core::registry::IntoHandler<S, fission_core::DeepLinkReceived>
@@ -334,6 +380,7 @@ where
         self
     }
 
+    /// Registers a persistent typed reducer for notification interactions.
     pub fn on_notification_response<H>(mut self, handler: H) -> Self
     where
         H: fission_core::registry::IntoHandler<S, fission_core::NotificationResponseReceived>
@@ -345,6 +392,8 @@ where
         self
     }
 
+    /// Registers the persistent reducer that mirrors host route changes into
+    /// application state.
     pub fn with_route_handler(
         mut self,
         handler: fission_core::registry::Handler<S, fission_core::ShellRouteChanged>,
@@ -353,6 +402,7 @@ where
         self
     }
 
+    /// Registers one host-owned reducer in the persistent action registry.
     pub fn register_reducer(
         &mut self,
         action_id: ActionId,
@@ -361,15 +411,19 @@ where
         self.inner.register_reducer(action_id, reducer)
     }
 
+    /// Merges host-owned reducers into the persistent registry.
     pub fn absorb_registry(&mut self, registry: fission_core::ActionRegistry<S>) {
         self.inner.absorb_registry(registry);
     }
 
+    /// Creates the native window and runs its event/render loop until exit.
     pub fn run(self) -> Result<()> {
         self.inner.run()
     }
 
     #[cfg(target_os = "android")]
+    /// Internal compatibility entrypoint for builds that reuse this wrapper
+    /// with an Android activity. Mobile apps should prefer `MobileApp`.
     pub fn run_with_android_app(
         self,
         android_app: winit::platform::android::activity::AndroidApp,

--- a/crates/shell/fission-shell-mobile/src/lib.rs
+++ b/crates/shell/fission-shell-mobile/src/lib.rs
@@ -1,3 +1,9 @@
+//! Android and iOS application shell built on Fission's shared winit runtime.
+//!
+//! [`MobileApp`] owns mobile lifecycle and native host integration while using
+//! the same state, reducer, environment, and widget contracts as other
+//! continuously running Fission targets.
+
 use anyhow::Result;
 use fission_core::{Action, ActionRegistry, Env, GlobalState, Widget, WidgetId};
 use fission_shell::{async_host::AsyncRegistry, NativeSurfaceHandler};
@@ -18,6 +24,11 @@ pub use fission_shell_winit::{
 #[cfg(target_os = "android")]
 pub use winit::platform::android::activity::AndroidApp;
 
+/// Stateful Fission application hosted by Android or iOS.
+///
+/// `S` is the app's global state and `W` its retained root widget. Platform
+/// lifecycle attachment occurs when [`Self::run`] (or Android's explicit host
+/// entrypoint) is called.
 pub struct MobileApp<S: GlobalState, W>
 where
     W: Clone + Into<Widget>,
@@ -25,33 +36,59 @@ where
     inner: WinitApp<S, W>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct TestState;
+    impl GlobalState for TestState {}
+
+    #[test]
+    fn common_stateful_builder_contract_is_available() {
+        let _app = MobileApp::<TestState, _>::new(fission_core::ui::Text::new("mobile"))
+            .with_env(Env::default())
+            .with_state_init(|_state| {})
+            .with_key_handler(|_state, _key, _modifiers| false)
+            .with_test_control_port(0)
+            .with_test_control_token("test-token")
+            .with_sync_env(|_state, _env| {});
+    }
+}
+
 impl<S, W> MobileApp<S, W>
 where
     S: GlobalState + Default,
     W: Clone + Into<Widget> + 'static,
 {
+    /// Creates a mobile app using `S::default()` as its global state.
     pub fn new(root_widget: W) -> Self {
         Self {
             inner: WinitApp::new(root_widget),
         }
     }
 
+    /// Creates a mobile app with an explicitly prepared global state.
     pub fn new_with_global_state(root_widget: W, global_state: S) -> Self {
         Self {
             inner: WinitApp::new_with_global_state(root_widget, global_state),
         }
     }
 
+    /// Replaces the registered global state before the app starts.
     pub fn with_global_state(mut self, global_state: S) -> Self {
         self.inner = self.inner.with_global_state(global_state);
         self
     }
 
+    /// Sets the stable identity from which implicit descendant IDs are derived.
     pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
         self.inner = self.inner.with_root_id(root_id);
         self
     }
 
+    /// Registers an app-wide hardware-key handler before widget routing.
+    /// Return `true` to consume the key.
     pub fn with_key_handler<F>(mut self, handler: F) -> Self
     where
         F: Fn(&mut S, &fission_core::KeyCode, u8) -> bool + Send + Sync + 'static,
@@ -60,16 +97,29 @@ where
         self
     }
 
+    /// Sets the application/window title exposed by the mobile host.
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.inner = self.inner.with_title(title);
         self
     }
 
+    /// Opens the native live-test control listener on `port` in test builds.
     pub fn with_test_control_port(mut self, port: u16) -> Self {
         self.inner = self.inner.with_test_control_port(port);
         self
     }
 
+    /// Requires this token when a native live-test client connects.
+    ///
+    /// Pair it with [`Self::with_test_control_port`]. The token is a test-host
+    /// access control and should be supplied through development configuration,
+    /// not embedded as a production credential.
+    pub fn with_test_control_token(mut self, token: impl Into<String>) -> Self {
+        self.inner = self.inner.with_test_control_token(token);
+        self
+    }
+
+    /// Mutates initial global state synchronously before the first frame.
     pub fn with_state_init<F>(mut self, init: F) -> Self
     where
         F: FnOnce(&mut S),
@@ -78,11 +128,25 @@ where
         self
     }
 
+    /// Replaces the environment used to build the first and subsequent frames.
+    ///
+    /// Use this to install app-wide inputs that are not product state, such as
+    /// translation bundles, an initial locale, or host presentation values.
+    /// Values which change with [`GlobalState`] should be mirrored afterward
+    /// with [`Self::with_sync_env`].
+    pub fn with_env(mut self, env: Env) -> Self {
+        self.inner = self.inner.with_env(env);
+        self
+    }
+
+    /// Dispatches one typed action after the first widget registry is built.
     pub fn with_startup_action<A: Action>(mut self, action: A) -> Self {
         self.inner = self.inner.with_startup_action(action);
         self
     }
 
+    /// Registers the persistent reducer that mirrors host route/deep-link
+    /// changes into application state.
     pub fn with_route_handler(
         mut self,
         handler: fission_core::registry::Handler<S, fission_core::ShellRouteChanged>,
@@ -91,6 +155,7 @@ where
         self
     }
 
+    /// Installs a generated design system's theme and packaged fonts.
     pub fn with_design_system<D: fission_theme::DesignSystem>(
         mut self,
         mode: fission_theme::DesignMode,
@@ -105,6 +170,7 @@ where
         self
     }
 
+    /// Mirrors global-state presentation values into `Env` before each build.
     pub fn with_sync_env<F>(mut self, sync: F) -> Self
     where
         F: Fn(&S, &mut Env) + Send + Sync + 'static,
@@ -113,6 +179,8 @@ where
         self
     }
 
+    /// Runs a lightweight host hook between frames; return `true` to request a
+    /// redraw.
     pub fn with_frame_hook<F>(mut self, hook: F) -> Self
     where
         F: Fn(&mut S) -> bool + Send + Sync + 'static,
@@ -131,6 +199,8 @@ where
         self
     }
 
+    /// Registers app jobs, services, and operation capability handlers with
+    /// the mobile shell's asynchronous host.
     pub fn with_async<F>(mut self, configure: F) -> Self
     where
         F: FnOnce(&mut AsyncRegistry),
@@ -140,6 +210,7 @@ where
     }
 
     #[cfg(feature = "store")]
+    /// Replaces the key/value store provider used by Store effects.
     pub fn with_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::StoreProvider + Send + Sync,
@@ -149,6 +220,7 @@ where
     }
 
     #[cfg(feature = "store-sql")]
+    /// Replaces the SQL-capable store provider used by Store and SQL effects.
     pub fn with_sql_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::SqlStoreProvider + Send + Sync,
@@ -157,6 +229,7 @@ where
         self
     }
 
+    /// Installs the implementation used by notification effects.
     pub fn with_notification_host<H>(mut self, host: H) -> Self
     where
         H: NotificationHost,
@@ -165,6 +238,7 @@ where
         self
     }
 
+    /// Installs the implementation used by NFC effects.
     pub fn with_nfc_host<H>(mut self, host: H) -> Self
     where
         H: NfcHost,
@@ -173,6 +247,7 @@ where
         self
     }
 
+    /// Installs the implementation used by biometric authentication effects.
     pub fn with_biometric_host<H>(mut self, host: H) -> Self
     where
         H: BiometricHost,
@@ -181,6 +256,7 @@ where
         self
     }
 
+    /// Installs the implementation used by passkey registration and sign-in.
     pub fn with_passkey_host<H>(mut self, host: H) -> Self
     where
         H: PasskeyHost,
@@ -189,6 +265,7 @@ where
         self
     }
 
+    /// Installs the implementation used by Bluetooth effects.
     pub fn with_bluetooth_host<H>(mut self, host: H) -> Self
     where
         H: BluetoothHost,
@@ -197,6 +274,7 @@ where
         self
     }
 
+    /// Installs the implementation used by barcode scanning effects.
     pub fn with_barcode_scanner_host<H>(mut self, host: H) -> Self
     where
         H: BarcodeScannerHost,
@@ -205,6 +283,7 @@ where
         self
     }
 
+    /// Installs the implementation used by camera effects.
     pub fn with_camera_host<H>(mut self, host: H) -> Self
     where
         H: CameraHost,
@@ -213,6 +292,7 @@ where
         self
     }
 
+    /// Installs the implementation used by clipboard effects.
     pub fn with_clipboard_host<H>(mut self, host: H) -> Self
     where
         H: ClipboardHost,
@@ -221,6 +301,7 @@ where
         self
     }
 
+    /// Installs the implementation used by geolocation effects.
     pub fn with_geolocation_host<H>(mut self, host: H) -> Self
     where
         H: GeolocationHost,
@@ -229,6 +310,7 @@ where
         self
     }
 
+    /// Installs the implementation used by haptic feedback effects.
     pub fn with_haptic_host<H>(mut self, host: H) -> Self
     where
         H: HapticHost,
@@ -237,6 +319,7 @@ where
         self
     }
 
+    /// Installs the implementation used by microphone capture effects.
     pub fn with_microphone_host<H>(mut self, host: H) -> Self
     where
         H: MicrophoneHost,
@@ -245,6 +328,7 @@ where
         self
     }
 
+    /// Installs the implementation used by Wi-Fi effects.
     pub fn with_wifi_host<H>(mut self, host: H) -> Self
     where
         H: WifiHost,
@@ -253,6 +337,7 @@ where
         self
     }
 
+    /// Installs the implementation used by system/media volume effects.
     pub fn with_volume_host<H>(mut self, host: H) -> Self
     where
         H: VolumeHost,
@@ -261,26 +346,31 @@ where
         self
     }
 
+    /// Sets the accepted schemes, domains, and path prefixes for inbound links.
     pub fn with_deep_link_config(mut self, config: fission_core::DeepLinkConfig) -> Self {
         self.inner = self.inner.with_deep_link_config(config);
         self
     }
 
+    /// Adds an accepted custom URI scheme to the deep-link policy.
     pub fn with_deep_link_scheme(mut self, scheme: impl Into<String>) -> Self {
         self.inner = self.inner.with_deep_link_scheme(scheme);
         self
     }
 
+    /// Adds an accepted HTTP(S) host to the deep-link policy.
     pub fn with_deep_link_domain(mut self, domain: impl Into<String>) -> Self {
         self.inner = self.inner.with_deep_link_domain(domain);
         self
     }
 
+    /// Queues an already-resolved inbound link for startup dispatch.
     pub fn with_startup_deep_link(mut self, link: fission_core::DeepLink) -> Self {
         self.inner = self.inner.with_startup_deep_link(link);
         self
     }
 
+    /// Queues a notification interaction received before app startup.
     pub fn with_startup_notification_response(
         mut self,
         response: fission_core::NotificationResponse,
@@ -289,6 +379,7 @@ where
         self
     }
 
+    /// Registers a persistent typed reducer for accepted inbound deep links.
     pub fn on_deep_link<H>(mut self, handler: H) -> Self
     where
         H: fission_core::registry::IntoHandler<S, fission_core::DeepLinkReceived>
@@ -300,6 +391,7 @@ where
         self
     }
 
+    /// Registers a persistent typed reducer for notification interactions.
     pub fn on_notification_response<H>(mut self, handler: H) -> Self
     where
         H: fission_core::registry::IntoHandler<S, fission_core::NotificationResponseReceived>
@@ -311,15 +403,31 @@ where
         self
     }
 
+    /// Merges a set of host-owned reducers into the persistent registry.
     pub fn absorb_registry(&mut self, registry: ActionRegistry<S>) {
         self.inner.absorb_registry(registry);
     }
 
+    /// Registers one reducer in the shell's persistent action registry.
+    ///
+    /// Components normally register reducers declaratively while building.
+    /// This lower-level hook is for host-owned actions that must remain
+    /// available independently of the current widget tree.
+    pub fn register_reducer(
+        &mut self,
+        action_id: fission_core::ActionId,
+        reducer: fission_core::action::Reducer<S>,
+    ) -> Result<()> {
+        self.inner.register_reducer(action_id, reducer)
+    }
+
+    /// Attaches to the current mobile host and runs its lifecycle/event loop.
     pub fn run(self) -> Result<()> {
         self.inner.run()
     }
 
     #[cfg(target_os = "android")]
+    /// Runs using an Android activity supplied by the generated host project.
     pub fn run_with_android_app(self, app: AndroidApp) -> Result<()> {
         self.inner.run_with_android_app(app)
     }

--- a/crates/shell/fission-shell-server/src/action_token.rs
+++ b/crates/shell/fission-shell-server/src/action_token.rs
@@ -7,23 +7,38 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// A serialized application action authenticated for one SSR route and node.
 pub struct SignedServerAction {
+    /// Route against which the action was issued.
     pub route_path: String,
+    /// Stable widget node that should receive the action.
     pub target_node: u128,
+    /// Typed action identifier and encoded payload to dispatch.
     pub action: ActionEnvelope,
+    /// Expiry time as Unix seconds.
     pub expires_unix: u64,
+    /// Per-token replay identifier covered by the signature.
     pub nonce: String,
+    /// Keyed BLAKE3 signature encoded as hexadecimal.
     pub signature: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Trusted action data returned after token verification.
 pub struct VerifiedServerAction {
+    /// Verified route path.
     pub route_path: String,
+    /// Verified target widget node.
     pub target_node: u128,
+    /// Verified action envelope.
     pub action: ActionEnvelope,
 }
 
 #[derive(Clone)]
+/// Signs and verifies expiring server-action tokens.
+///
+/// A signer also tracks consumed nonces for `verify_once`, preventing a valid
+/// mutation token from being replayed within this process.
 pub struct ServerActionSigner {
     key: [u8; 32],
     used_tokens: Arc<Mutex<BTreeMap<String, u64>>>,
@@ -32,6 +47,7 @@ pub struct ServerActionSigner {
 const MAX_REPLAY_CACHE_TOKENS: usize = 100_000;
 
 impl ServerActionSigner {
+    /// Creates a signer by deriving a fixed-size key from `secret`.
     pub fn new(secret: impl AsRef<[u8]>) -> Self {
         let hash = blake3::hash(secret.as_ref());
         Self {
@@ -40,10 +56,14 @@ impl ServerActionSigner {
         }
     }
 
+    /// Creates a predictable development signer.
+    ///
+    /// This key is public and must not be used for a deployed application.
     pub fn development() -> Self {
         Self::new(b"fission-development-server-action-key")
     }
 
+    /// Signs a typed action for a route and target node for the supplied TTL.
     pub fn sign<A: Action>(
         &self,
         route_path: impl Into<String>,
@@ -54,6 +74,7 @@ impl ServerActionSigner {
         self.sign_envelope(route_path, target_node, action.into(), ttl)
     }
 
+    /// Signs an existing action envelope without decoding its payload.
     pub fn sign_envelope(
         &self,
         route_path: impl Into<String>,
@@ -75,6 +96,7 @@ impl ServerActionSigner {
         }
     }
 
+    /// Verifies signature and expiry without consuming the token.
     pub fn verify(&self, token: &SignedServerAction) -> Result<VerifiedServerAction> {
         if token.expires_unix < unix_now() {
             bail!("server action token expired");
@@ -96,6 +118,7 @@ impl ServerActionSigner {
         })
     }
 
+    /// Verifies and consumes a token, rejecting subsequent replay attempts.
     pub fn verify_once(&self, token: &SignedServerAction) -> Result<VerifiedServerAction> {
         let verified = self.verify(token)?;
         let replay_key = replay_key(token);
@@ -115,11 +138,13 @@ impl ServerActionSigner {
         Ok(verified)
     }
 
+    /// Encodes a token as URL-safe, unpadded base64 JSON.
     pub fn encode(&self, token: &SignedServerAction) -> Result<String> {
         let bytes = serde_json::to_vec(token).context("failed to encode server action token")?;
         Ok(BASE64_URL_SAFE_NO_PAD.encode(bytes))
     }
 
+    /// Decodes a token; call `verify` or `verify_once` before trusting it.
     pub fn decode(&self, encoded: &str) -> Result<SignedServerAction> {
         let bytes = BASE64_URL_SAFE_NO_PAD
             .decode(encoded)

--- a/crates/shell/fission-shell-server/src/adapters.rs
+++ b/crates/shell/fission-shell-server/src/adapters.rs
@@ -1,11 +1,13 @@
 use crate::{ServerRenderer, ServerRequest, ServerResponse};
 use std::sync::Arc;
 
+/// Adapter for Hyper request and response types.
 pub mod hyper_adapter {
     use super::*;
     use hyper::{Body, Request, Response, StatusCode};
     use std::convert::Infallible;
 
+    /// Converts a Hyper request, renders it, and converts the result back to Hyper.
     pub async fn handle(
         renderer: Arc<ServerRenderer>,
         request: Request<Body>,
@@ -61,6 +63,7 @@ pub mod axum_adapter {
         http::{Response, StatusCode},
     };
 
+    /// Axum handler that delegates a request to the shared Fission renderer.
     pub async fn handle(
         State(renderer): State<Arc<ServerRenderer>>,
         request: axum::http::Request<axum::body::Body>,
@@ -108,6 +111,7 @@ pub mod actix_adapter {
     use super::*;
     use actix_web::{web, HttpRequest, HttpResponse};
 
+    /// Actix handler that delegates a request to the shared Fission renderer.
     pub async fn handle(
         renderer: web::Data<Arc<ServerRenderer>>,
         request: HttpRequest,

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Arc;
 
+/// Named values captured from dynamic route segments such as `:project_id`.
 pub type ServerRouteParams = BTreeMap<String, String>;
 
 pub(crate) type RouteRenderer =
@@ -51,32 +52,56 @@ pub(crate) struct ServerRenderedNode {
 }
 
 #[derive(Clone)]
+/// Request information available while selecting locale and constructing `Env`.
 pub struct ServerEnvContext<'a> {
+    /// Root directory of the server application.
     pub project_dir: &'a Path,
+    /// Concrete normalized request path.
     pub route_path: &'a str,
+    /// Base document theme before request-specific synchronization.
     pub theme: &'a Theme,
+    /// Logical viewport used for server layout.
     pub viewport_size: LayoutSize,
+    /// Registry of jobs executable during server rendering.
     pub jobs: &'a ServerJobRegistry,
+    /// Current normalized HTTP request.
     pub request: &'a ServerRequest,
+    /// Session resolved for the request.
     pub session: &'a ServerSession,
+    /// Verified action being handled, when this is an action submission.
     pub action: Option<&'a VerifiedServerAction>,
+    /// Maximum reducer/resource rebuild passes allowed for this request.
     pub render_pass_limit: usize,
+    /// Configured fallback locale identifier.
     pub default_locale: &'a str,
+    /// Values captured from dynamic route segments.
     pub route_params: ServerRouteParams,
 }
 
 #[derive(Clone)]
+/// Complete request context supplied to route state factories and renderers.
 pub struct ServerRenderContext<'a> {
+    /// Root directory of the server application.
     pub project_dir: &'a Path,
+    /// Concrete normalized request path.
     pub route_path: &'a str,
+    /// Theme selected for this request.
     pub theme: &'a Theme,
+    /// Logical viewport used for server layout.
     pub viewport_size: LayoutSize,
+    /// Registry of server-executable jobs.
     pub jobs: &'a ServerJobRegistry,
+    /// Current normalized HTTP request.
     pub request: &'a ServerRequest,
+    /// Session resolved for the request.
     pub session: &'a ServerSession,
+    /// Verified action being handled, when present.
     pub action: Option<&'a VerifiedServerAction>,
+    /// Maximum reducer/resource rebuild passes allowed for this request.
     pub render_pass_limit: usize,
+    /// Configured fallback locale identifier.
     pub default_locale: &'a str,
+    /// Values captured from dynamic route segments.
     pub route_params: ServerRouteParams,
     #[cfg(feature = "store")]
     pub(crate) store: Option<&'a (dyn fission_store::StoreProvider + Send + Sync)>,
@@ -87,19 +112,28 @@ pub struct ServerRenderContext<'a> {
 }
 
 impl<'a> ServerRenderContext<'a> {
+    /// Returns the request-specific environment used to build widgets.
     pub fn env(&self) -> &'a Env {
         self.env
     }
 
+    /// Selects the HTTP status returned with the rendered route.
+    ///
+    /// This can be used by a route to render a Fission error page while still
+    /// returning an appropriate status such as 404 or 403.
     pub fn set_response_status(&self, status: u16) {
         self.response_status.store(status, Ordering::Relaxed);
     }
 }
 
 #[derive(Clone)]
+/// Minimal request context supplied to custom HTTP and form handlers.
 pub struct ServerHttpContext<'a> {
+    /// Root directory of the server application.
     pub project_dir: &'a Path,
+    /// Current normalized HTTP request.
     pub request: &'a ServerRequest,
+    /// Session resolved for the request.
     pub session: &'a ServerSession,
 }
 
@@ -167,14 +201,20 @@ pub(crate) struct CacheInvalidationEndpoint {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Directory mounted below a public URL prefix.
 pub struct StaticMount {
+    /// Normalized public path prefix.
     pub url_prefix: String,
+    /// Filesystem directory from which files are served.
     pub directory: PathBuf,
+    /// Optional index filename for application-style mounts.
     pub index_file: Option<String>,
+    /// Whether unresolved paths fall back to the index file for SPA routing.
     pub fallback_to_index: bool,
 }
 
 #[derive(Clone)]
+/// Builder describing an SSR application, its document environment, and routes.
 pub struct FissionServerApp {
     pub(crate) project_name: String,
     pub(crate) project_dir: std::path::PathBuf,
@@ -198,6 +238,10 @@ pub struct FissionServerApp {
 }
 
 impl FissionServerApp {
+    /// Creates an SSR app with default environment, jobs, and route inventory.
+    ///
+    /// When native SQLite storage is enabled, the default provider is prepared
+    /// here and any initialization failure is retained for explicit reporting.
     pub fn new(project_name: impl Into<String>) -> Self {
         let project_name = project_name.into();
         #[cfg(feature = "store-sqlite-native")]
@@ -245,6 +289,7 @@ impl FissionServerApp {
     }
 
     #[cfg(feature = "store")]
+    /// Replaces the request-visible key/value storage provider.
     pub fn with_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::StoreProvider + Send + Sync,
@@ -255,6 +300,7 @@ impl FissionServerApp {
     }
 
     #[cfg(feature = "store-sql")]
+    /// Replaces both key/value and SQL storage with one SQL-capable provider.
     pub fn with_sql_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::SqlStoreProvider + Send + Sync,
@@ -266,11 +312,13 @@ impl FissionServerApp {
         self
     }
 
+    /// Sets the project root used for configuration, content, and static files.
     pub fn project_dir(mut self, project_dir: impl Into<std::path::PathBuf>) -> Self {
         self.project_dir = project_dir.into();
         self
     }
 
+    /// Sets the base theme used for every request.
     pub fn theme(mut self, theme: Theme) -> Self {
         self.document = self.document.with_theme(theme);
         self
@@ -288,6 +336,10 @@ impl FissionServerApp {
         self
     }
 
+    /// Replaces the complete base environment cloned for each request.
+    ///
+    /// This is the SSR equivalent of `WebApp::with_env` and is the normal way to
+    /// install translation bundles or other immutable environment services.
     pub fn with_env(mut self, env: Env) -> Self {
         self.document = self.document.with_env(env);
         self
@@ -310,16 +362,19 @@ impl FissionServerApp {
         self
     }
 
+    /// Replaces the internationalization registry in the base environment.
     pub fn i18n(mut self, i18n: I18nRegistry) -> Self {
         self.document = self.document.with_i18n(i18n);
         self
     }
 
+    /// Adds or replaces one locale's translation bundle.
     pub fn translation_bundle(mut self, bundle: TranslationBundle) -> Self {
         self.document = self.document.with_translation_bundle(bundle);
         self
     }
 
+    /// Selects the fallback locale used when a request resolver does not override it.
     pub fn default_locale(mut self, locale: impl Into<Locale>) -> Self {
         let locale = locale.into();
         let mut env = self.document.env().clone();
@@ -329,6 +384,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Selects a locale from request, session, route, or other server context.
     pub fn locale_resolver<F>(mut self, resolver: F) -> Self
     where
         F: for<'a> Fn(&ServerEnvContext<'a>) -> Result<Locale> + Send + Sync + 'static,
@@ -353,6 +409,10 @@ impl FissionServerApp {
         self
     }
 
+    /// Mutates a fresh request environment after locale selection.
+    ///
+    /// Use this for request-scoped presentation values. It runs once per request
+    /// rather than once per client frame, which is the intentional SSR lifetime.
     pub fn with_request_env<F>(mut self, sync: F) -> Self
     where
         F: for<'a> Fn(&ServerEnvContext<'a>, &mut Env) -> Result<()> + Send + Sync + 'static,
@@ -361,11 +421,13 @@ impl FissionServerApp {
         self
     }
 
+    /// Replaces the registry of jobs available during server rendering.
     pub fn jobs(mut self, jobs: ServerJobRegistry) -> Self {
         self.jobs = jobs;
         self
     }
 
+    /// Appends trusted application CSS to every rendered document.
     pub fn user_css(mut self, css: impl Into<String>) -> Self {
         self.document = self.document.with_user_css(css);
         self
@@ -416,6 +478,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Registers a synchronous custom HTTP handler for a method and exact path.
     pub fn http_handler<F>(
         mut self,
         method: impl Into<String>,
@@ -433,6 +496,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Registers a convenience POST handler for an HTML form endpoint.
     pub fn form_post<F>(self, path: impl Into<String>, handler: F) -> Self
     where
         F: for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static,
@@ -440,6 +504,7 @@ impl FissionServerApp {
         self.http_handler("POST", path, handler)
     }
 
+    /// Adds a bearer-protected endpoint that invalidates configured cache entries.
     pub fn cache_invalidation_endpoint(
         mut self,
         path: impl Into<String>,
@@ -453,6 +518,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Mounts a directory of files below a URL prefix without index fallback.
     pub fn static_dir(
         mut self,
         url_prefix: impl Into<String>,
@@ -467,6 +533,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Mounts a browser SPA and falls back to its index file for deep links.
     pub fn static_app(
         mut self,
         url_prefix: impl Into<String>,
@@ -482,6 +549,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Registers an exact or parameterized widget route with default state.
     pub fn route_widget<S, W>(
         self,
         path: impl Into<String>,
@@ -497,6 +565,9 @@ impl FissionServerApp {
         self.route_widget_with_state(path, title, description, mode, widget, |_| Ok(S::default()))
     }
 
+    /// Registers a widget route whose initial state is loaded per request.
+    ///
+    /// Dynamic `:segments` are exposed through `ServerRenderContext::route_params`.
     pub fn route_widget_with_state<S, W, F>(
         mut self,
         path: impl Into<String>,
@@ -533,6 +604,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Registers a prefix route whose initial state is loaded per request.
     pub fn route_prefix_widget_with_state<S, W, F>(
         mut self,
         path_prefix: impl Into<String>,
@@ -569,6 +641,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Attaches a progressive browser worker to an existing route.
     pub fn worker(mut self, path: &str, worker: ProgressiveWorker) -> Self {
         let path = normalize_server_path(path);
         if let Some(route) = self
@@ -581,6 +654,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Attaches a WebAssembly island to an existing route.
     pub fn island(mut self, path: &str, island: WasmIsland) -> Self {
         let path = normalize_server_path(path);
         if let Some(route) = self
@@ -593,6 +667,7 @@ impl FissionServerApp {
         self
     }
 
+    /// Registers a conventional uncached server-rendered widget route.
     pub fn server_route_widget<S, W>(
         self,
         path: impl Into<String>,
@@ -613,6 +688,7 @@ impl FissionServerApp {
         )
     }
 
+    /// Returns a cloned inventory of registered public route metadata.
     pub fn routes(&self) -> Vec<WebRoute> {
         self.routes
             .iter()
@@ -620,6 +696,7 @@ impl FissionServerApp {
             .collect()
     }
 
+    /// Attaches serialized JSON-LD documents to an existing route.
     pub fn with_route_structured_data<I, S>(mut self, path: impl Into<String>, data: I) -> Self
     where
         I: IntoIterator<Item = S>,

--- a/crates/shell/fission-shell-server/src/artifacts.rs
+++ b/crates/shell/fission-shell-server/src/artifacts.rs
@@ -7,37 +7,57 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Kind of independently compiled browser artifact.
 pub enum BrowserArtifactKind {
+    /// Progressive Web Worker attached to a route.
     Worker,
+    /// Hydrated WebAssembly island mounted into the document.
     Island,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Validated build plan for one generated browser artifact shim.
 pub struct BrowserArtifactPlan {
+    /// Stable worker or island identifier.
     pub id: String,
+    /// Artifact execution kind.
     pub kind: BrowserArtifactKind,
+    /// Rust entry path exported by the application package.
     pub entry: String,
+    /// Public artifact path expected by the rendered document.
     pub artifact: String,
+    /// Directory into which the generated shim crate is written.
     pub shim_dir: PathBuf,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Inputs controlling browser artifact generation and compilation.
 pub struct BrowserArtifactBuildOptions {
+    /// Application project root.
     pub project_dir: PathBuf,
+    /// Root directory for generated shims and compiled assets.
     pub output_dir: PathBuf,
+    /// Cargo package that exports worker and island entry functions.
     pub package_name: String,
+    /// Whether that package's default features remain enabled.
     pub package_default_features: bool,
+    /// Additional package features enabled for artifact builds.
     pub package_features: Vec<String>,
+    /// Whether to compile with Cargo's release profile.
     pub release: bool,
+    /// Whether `write_shims` also invokes compilation.
     pub compile: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Collection of browser artifacts discovered from an SSR application.
 pub struct BrowserArtifactBuild {
+    /// Validated worker and island plans in route declaration order.
     pub plans: Vec<BrowserArtifactPlan>,
 }
 
 impl BrowserArtifactBuild {
+    /// Discovers and validates every worker and island registered by `app`.
     pub fn from_app(app: &FissionServerApp, options: &BrowserArtifactBuildOptions) -> Result<Self> {
         let mut plans = Vec::new();
         for route in app.routes() {
@@ -51,6 +71,7 @@ impl BrowserArtifactBuild {
         Ok(Self { plans })
     }
 
+    /// Writes generated shim crates and optionally compiles their Wasm artifacts.
     pub fn write_shims(&self, options: &BrowserArtifactBuildOptions) -> Result<()> {
         for plan in &self.plans {
             write_shim(plan, options)?;

--- a/crates/shell/fission-shell-server/src/cache.rs
+++ b/crates/shell/fission-shell-server/src/cache.rs
@@ -5,11 +5,13 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Error returned by a configured SSR cache backend.
 pub struct CacheError {
     message: String,
 }
 
 impl CacheError {
+    /// Creates an error with a provider-facing diagnostic message.
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
@@ -26,26 +28,32 @@ impl fmt::Display for CacheError {
 impl std::error::Error for CacheError {}
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+/// Stable, provider-independent cache entry key.
 pub struct CacheKey(String);
 
 impl CacheKey {
+    /// Creates a cache key from its complete namespaced value.
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
 
+    /// Returns the underlying key string used by providers.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+/// Logical label used to invalidate related entries together.
 pub struct CacheTag(String);
 
 impl CacheTag {
+    /// Creates an invalidation tag.
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
 
+    /// Returns the underlying tag value.
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -64,28 +72,40 @@ impl From<String> for CacheTag {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Isolation boundary controlling where cached data may be reused.
 pub enum CacheScope {
+    /// Shareable across all requests and users.
     Public,
+    /// Reusable only within one session.
     PrivateSession,
+    /// Reusable only for one authenticated user.
     PrivateUser,
+    /// Reusable only within one tenant.
     PrivateTenant,
+    /// Must not be stored.
     NoStore,
 }
 
 impl CacheScope {
+    /// Returns whether an entry may be served to unrelated requests.
     pub fn is_publicly_shareable(&self) -> bool {
         matches!(self, Self::Public)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Descriptive metadata stored beside a cache value.
 pub struct CacheMetadata {
+    /// Route that produced the value.
     pub route_path: String,
+    /// MIME content type of the value.
     pub content_type: String,
+    /// Component or service that produced the value.
     pub source: String,
 }
 
 impl CacheMetadata {
+    /// Creates metadata for a complete HTML page rendered by Fission.
     pub fn full_page(route_path: impl Into<String>) -> Self {
         Self {
             route_path: route_path.into(),
@@ -96,41 +116,65 @@ impl CacheMetadata {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Rendered document material stored as one cache value.
 pub struct RenderedPage {
+    /// HTML document or fragment.
     pub html: String,
+    /// CSS required by the rendered nodes.
     pub css: String,
+    /// HTTP status associated with the response.
     pub status: u16,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Serialized result of a server job.
 pub struct StoredJobResult {
+    /// Registered job name.
     pub job_name: String,
+    /// Job-specific encoded result payload.
     pub payload: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Values supported by the shared cache abstraction.
 pub enum CacheValue {
+    /// Complete page output.
     FullPage(RenderedPage),
+    /// Reusable rendered fragment.
     Fragment(String),
+    /// Encoded server-job result.
     JobResult(StoredJobResult),
+    /// Metadata associated with a generated asset.
     AssetMetadata(BTreeMap<String, String>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Cache value plus its freshness, isolation, invalidation, and provenance data.
 pub struct CacheEntry {
+    /// Provider-independent cache key.
     pub key: CacheKey,
+    /// Stored page, fragment, job, or asset value.
     pub value: CacheValue,
+    /// Isolation boundary for reuse.
     pub scope: CacheScope,
+    /// Creation time.
     pub created_at: SystemTime,
+    /// Time through which the value is fresh.
     pub fresh_until: SystemTime,
+    /// Optional time through which stale serving remains allowed.
     pub stale_until: Option<SystemTime>,
+    /// Logical invalidation tags.
     pub tags: Vec<CacheTag>,
+    /// Request field names included in the cache variance contract.
     pub vary: Vec<String>,
+    /// Stable content fingerprint used for change detection.
     pub content_hash: u64,
+    /// Origin and content metadata.
     pub metadata: CacheMetadata,
 }
 
 impl CacheEntry {
+    /// Creates a complete-page entry and computes its freshness boundaries.
     pub fn full_page(
         key: CacheKey,
         page: RenderedPage,
@@ -158,6 +202,7 @@ impl CacheEntry {
         }
     }
 
+    /// Classifies this entry at the supplied time.
     pub fn freshness(&self, now: SystemTime) -> Freshness {
         if now <= self.fresh_until {
             Freshness::Fresh
@@ -171,6 +216,7 @@ impl CacheEntry {
         }
     }
 
+    /// Returns the page value when this entry stores a complete page.
     pub fn rendered_page(&self) -> Option<&RenderedPage> {
         match &self.value {
             CacheValue::FullPage(page) => Some(page),
@@ -180,25 +226,39 @@ impl CacheEntry {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Current freshness state of a cache entry.
 pub enum Freshness {
+    /// The value is within its primary TTL.
     Fresh,
+    /// The primary TTL elapsed but stale serving is still allowed.
     Stale,
+    /// The value must no longer be served.
     Expired,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Counts produced by one cache invalidation operation.
 pub struct InvalidationReport {
+    /// Number of unique keys removed.
     pub removed_keys: usize,
+    /// Number of requested tags successfully processed.
     pub removed_tags: usize,
+    /// Number of cache layers from which entries were removed.
     pub layers_affected: usize,
 }
 
+/// Synchronous cache-provider contract used by the SSR renderer.
 pub trait Cache: Send + Sync + 'static {
+    /// Loads an entry by exact key.
     fn get(&self, key: &CacheKey) -> Result<Option<CacheEntry>, CacheError>;
+    /// Stores or replaces an entry, respecting its `NoStore` scope.
     fn put(&self, entry: CacheEntry) -> Result<(), CacheError>;
+    /// Removes an entry by exact key.
     fn remove(&self, key: &CacheKey) -> Result<(), CacheError>;
+    /// Removes entries associated with one tag.
     fn invalidate_tag(&self, tag: &CacheTag) -> Result<InvalidationReport, CacheError>;
 
+    /// Invalidates multiple tags and combines their reports.
     fn invalidate_tags(&self, tags: &[CacheTag]) -> Result<InvalidationReport, CacheError> {
         let mut out = InvalidationReport::default();
         for tag in tags {
@@ -210,6 +270,7 @@ pub trait Cache: Send + Sync + 'static {
         Ok(out)
     }
 
+    /// Returns whether the provider currently contains a fresh entry.
     fn contains_fresh(&self, key: &CacheKey, now: SystemTime) -> Result<bool, CacheError> {
         Ok(self
             .get(key)?
@@ -218,7 +279,9 @@ pub trait Cache: Send + Sync + 'static {
 }
 
 #[derive(Clone, Debug)]
+/// Capacity settings for the in-process Moka cache.
 pub struct MokaCacheOptions {
+    /// Maximum weighted entry capacity retained by Moka.
     pub max_capacity: u64,
 }
 
@@ -230,12 +293,14 @@ impl Default for MokaCacheOptions {
     }
 }
 
+/// Bounded in-process implementation of [`Cache`].
 pub struct MokaCache {
     inner: moka::sync::Cache<String, CacheEntry>,
     tag_index: Mutex<BTreeMap<String, BTreeSet<String>>>,
 }
 
 impl MokaCache {
+    /// Creates an in-process cache with the supplied capacity.
     pub fn new(options: MokaCacheOptions) -> Self {
         Self {
             inner: moka::sync::Cache::builder()
@@ -309,17 +374,23 @@ impl Cache for MokaCache {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Read/write policy for one cache-pipeline layer.
 pub enum CacheLayerPolicy {
+    /// Read from and write through this layer.
     WriteThrough,
+    /// Read existing values but never populate the layer.
     ReadOnly,
+    /// Use as a hot near-cache populated from lower layers.
     HotOnly,
 }
 
+/// Ordered cache that reads through and promotes values across multiple layers.
 pub struct CachePipeline {
     layers: Vec<(Arc<dyn Cache>, CacheLayerPolicy)>,
 }
 
 #[cfg(feature = "redis")]
+/// Redis-backed cache suitable for sharing entries across server processes.
 pub struct RedisCache {
     client: redis::Client,
     prefix: String,
@@ -327,6 +398,7 @@ pub struct RedisCache {
 
 #[cfg(feature = "redis")]
 impl RedisCache {
+    /// Connects to Redis and namespaces all keys with `prefix`.
     pub fn new(url: &str, prefix: impl Into<String>) -> Result<Self, CacheError> {
         let client = redis::Client::open(url)
             .map_err(|error| CacheError::new(format!("failed to create redis client: {error}")))?;
@@ -430,6 +502,7 @@ impl Cache for RedisCache {
 }
 
 impl CachePipeline {
+    /// Creates a write-through pipeline from nearest to farthest layers.
     pub fn new(layers: Vec<Arc<dyn Cache>>) -> Self {
         Self {
             layers: layers
@@ -439,14 +512,17 @@ impl CachePipeline {
         }
     }
 
+    /// Creates a pipeline with an explicit policy for every ordered layer.
     pub fn with_policies(layers: Vec<(Arc<dyn Cache>, CacheLayerPolicy)>) -> Self {
         Self { layers }
     }
 
+    /// Returns the number of configured cache layers.
     pub fn len(&self) -> usize {
         self.layers.len()
     }
 
+    /// Returns whether this pipeline contains no cache layers.
     pub fn is_empty(&self) -> bool {
         self.layers.is_empty()
     }

--- a/crates/shell/fission-shell-server/src/config.rs
+++ b/crates/shell/fission-shell-server/src/config.rs
@@ -9,14 +9,23 @@ use std::path::Path;
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
+/// Effective SSR configuration loaded from the project's `fission.toml`.
 pub struct ServerRuntimeConfig {
+    /// Locale used when a route or request does not select one.
     pub default_locale: String,
+    /// Optional default mode applied to routes without an explicit policy.
     pub default_route_mode: Option<WebRouteMode>,
+    /// Optional cap on reducer/resource render passes per request.
     pub render_pass_limit: Option<usize>,
+    /// Page and resource cache configuration.
     pub cache: ServerCacheConfig,
+    /// HTTP origin and proxy-trust configuration.
     pub http: ServerHttpConfig,
+    /// Session cookie configuration.
     pub sessions: ServerSessionConfig,
+    /// Progressive worker artifact configuration.
     pub workers: ServerBrowserArtifactConfig,
+    /// WebAssembly island artifact configuration.
     pub islands: ServerIslandConfig,
 }
 
@@ -36,14 +45,23 @@ impl Default for ServerRuntimeConfig {
 }
 
 #[derive(Clone, Debug)]
+/// Cache provider, lifetime, and optional layered-cache configuration.
 pub struct ServerCacheConfig {
+    /// Provider used when no explicit layers are configured.
     pub provider: ServerCacheProvider,
+    /// In-process Moka settings.
     pub moka: MokaCacheOptions,
+    /// Optional default fresh lifetime.
     pub ttl: Option<Duration>,
+    /// Optional default stale-serving lifetime.
     pub stale_while_revalidate: Option<Duration>,
+    /// Explicit Redis connection URL, when configured.
     pub redis_url: Option<String>,
+    /// Environment variable from which to load the Redis URL.
     pub redis_url_env: Option<String>,
+    /// Namespace prepended to Redis keys.
     pub redis_prefix: Option<String>,
+    /// Ordered cache layers, from nearest/fastest to farthest.
     pub layers: Vec<ServerCacheLayerConfig>,
 }
 
@@ -63,38 +81,61 @@ impl Default for ServerCacheConfig {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Cache backend selected by server configuration.
 pub enum ServerCacheProvider {
+    /// Bounded in-process cache.
     #[default]
     Moka,
+    /// Shared Redis cache, available with the `redis` feature.
     Redis,
+    /// Explicit ordered collection of cache layers.
     Pipeline,
 }
 
 #[derive(Clone, Debug)]
+/// Configuration for one layer in a cache pipeline.
 pub struct ServerCacheLayerConfig {
+    /// Diagnostic name of the layer.
     pub name: String,
+    /// Backend used by the layer.
     pub provider: ServerCacheProvider,
+    /// Read/write behavior for the layer.
     pub policy: CacheLayerPolicy,
+    /// In-process cache settings when `provider` is Moka.
     pub moka: MokaCacheOptions,
+    /// Explicit Redis URL for this layer.
     pub redis_url: Option<String>,
+    /// Environment variable containing this layer's Redis URL.
     pub redis_url_env: Option<String>,
+    /// Namespace prepended to this layer's Redis keys.
     pub redis_prefix: Option<String>,
+    /// Optional layer-specific fresh lifetime.
     pub ttl: Option<Duration>,
+    /// Optional layer-specific stale-serving lifetime.
     pub stale_while_revalidate: Option<Duration>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// HTTP-origin behavior used when constructing absolute URLs.
 pub struct ServerHttpConfig {
+    /// Canonical externally visible base URL.
     pub base_url: Option<String>,
+    /// Whether trusted deployment proxy headers may override request origin.
     pub trust_proxy_headers: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Server-side session cookie configuration.
 pub struct ServerSessionConfig {
+    /// Session implementation selected for requests.
     pub provider: ServerSessionProvider,
+    /// Name of the signed session cookie.
     pub cookie_name: String,
+    /// Environment variable containing the signing key.
     pub signing_key_env: Option<String>,
+    /// Whether the cookie is restricted to HTTPS.
     pub secure: bool,
+    /// Browser cross-site cookie policy.
     pub same_site: ServerSameSite,
 }
 
@@ -111,22 +152,31 @@ impl Default for ServerSessionConfig {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Session persistence backend.
 pub enum ServerSessionProvider {
+    /// Signed browser cookie session identifier.
     #[default]
     Cookie,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// `SameSite` policy emitted for the session cookie.
 pub enum ServerSameSite {
+    /// Never send the cookie with cross-site requests.
     Strict,
+    /// Send for safe top-level cross-site navigation.
     #[default]
     Lax,
+    /// Allow cross-site use; normally requires a secure cookie.
     None,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Build configuration for progressive browser workers.
 pub struct ServerBrowserArtifactConfig {
+    /// Whether every worker is compiled as its own browser artifact.
     pub separate_artifacts: bool,
+    /// Main-thread bridge implementation emitted for workers.
     pub bridge: ServerWorkerBridge,
 }
 
@@ -140,8 +190,11 @@ impl Default for ServerBrowserArtifactConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Build and preload configuration for WebAssembly islands.
 pub struct ServerIslandConfig {
+    /// Whether every island is compiled as its own browser artifact.
     pub separate_artifacts: bool,
+    /// When island artifacts are preloaded.
     pub preload: ServerIslandPreload,
 }
 
@@ -155,14 +208,19 @@ impl Default for ServerIslandConfig {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Main-thread bridge source for progressive workers.
 pub enum ServerWorkerBridge {
+    /// Generate Fission's version-matched bridge during the build.
     #[default]
     Generated,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Preload strategy for browser island artifacts.
 pub enum ServerIslandPreload {
+    /// Load only when normal browser execution reaches the island.
     None,
+    /// Emit preloads for islands attached to the current route.
     #[default]
     Route,
 }
@@ -242,6 +300,10 @@ struct ServerIslandsToml {
 }
 
 impl ServerRuntimeConfig {
+    /// Loads `[server]` configuration from `project_dir/fission.toml`.
+    ///
+    /// A missing file or section yields defaults; malformed or unsupported
+    /// values return an error rather than silently changing runtime behavior.
     pub fn load(project_dir: &Path) -> Result<Self> {
         let path = project_dir.join("fission.toml");
         if !path.exists() {

--- a/crates/shell/fission-shell-server/src/jobs.rs
+++ b/crates/shell/fission-shell-server/src/jobs.rs
@@ -11,8 +11,11 @@ use std::sync::Arc;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 #[derive(Clone, Debug)]
+/// Request-local information and data-stream access supplied to a server job.
 pub struct ServerJobCtx {
+    /// Unique resource request identifier for this render pass.
     pub req_id: u64,
+    /// Stable resource key that requested the job.
     pub resource_key: String,
     data_streams: DataStreamRegistry,
 }
@@ -66,12 +69,16 @@ impl ServerJobCtx {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Encoded typed error or diagnostic returned by a server job.
 pub struct ServerJobError {
+    /// Serialized application error payload, when available.
     pub payload: Option<Vec<u8>>,
+    /// Human-readable infrastructure or decoding error.
     pub message: Option<String>,
 }
 
 impl ServerJobError {
+    /// Creates a diagnostic-only job error.
     pub fn message(message: impl Into<String>) -> Self {
         Self {
             payload: None,
@@ -79,6 +86,7 @@ impl ServerJobError {
         }
     }
 
+    /// Serializes a typed application error for the requesting resource.
     pub fn typed<E: Serialize>(error: &E) -> Self {
         Self {
             payload: serde_json::to_vec(error).ok(),
@@ -91,24 +99,29 @@ type JobHandler =
     dyn Fn(Vec<u8>, ServerJobCtx) -> std::result::Result<Vec<u8>, ServerJobError> + Send + Sync;
 
 #[derive(Clone, Default)]
+/// Typed server-job handlers and request data streams available during SSR.
 pub struct ServerJobRegistry {
     handlers: BTreeMap<String, Arc<JobHandler>>,
     data_streams: DataStreamRegistry,
 }
 
 impl ServerJobRegistry {
+    /// Creates an empty job and stream registry.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Returns the shared data-stream registry used by job contexts.
     pub fn data_streams(&self) -> DataStreamRegistry {
         self.data_streams.clone()
     }
 
+    /// Registers a one-shot data stream and returns its opaque identifier.
     pub fn register_data_stream(&self, stream: BoxFissionDataStream) -> DataStreamId {
         self.data_streams.register(stream)
     }
 
+    /// Opens and consumes a registered stream handle.
     pub fn open_data_stream(
         &self,
         id: DataStreamId,
@@ -116,10 +129,15 @@ impl ServerJobRegistry {
         self.data_streams.open(id)
     }
 
+    /// Releases a stream without opening it.
     pub fn release_data_stream(&self, id: DataStreamId) -> bool {
         self.data_streams.release(id)
     }
 
+    /// Registers a typed synchronous handler for a declared Fission job.
+    ///
+    /// Requests and successful or error results use the job specification's
+    /// serde contract; malformed payloads become diagnostic job errors.
     pub fn register_job<J, F>(mut self, job: JobRef<J>, handler: F) -> Self
     where
         J: JobSpec,
@@ -144,10 +162,12 @@ impl ServerJobRegistry {
         self
     }
 
+    /// Returns whether a handler is registered for `name`.
     pub fn has_job(&self, name: &str) -> bool {
         self.handlers.contains_key(name)
     }
 
+    /// Runs a job using its encoded request and request-local context.
     pub fn run(
         &self,
         name: &str,
@@ -162,6 +182,7 @@ impl ServerJobRegistry {
         handler(payload, ctx)
     }
 
+    /// Validates that a required job handler was registered.
     pub fn require_job(&self, name: &str) -> AnyResult<()> {
         if self.has_job(name) {
             Ok(())

--- a/crates/shell/fission-shell-server/src/lib.rs
+++ b/crates/shell/fission-shell-server/src/lib.rs
@@ -63,6 +63,10 @@ pub use route::{
 };
 pub use serve::{serve, ServeOptions};
 
+/// Executes the SSR command-line interface for a configured application.
+///
+/// The default command is `serve`; `check`, `routes`, and `artifacts` validate
+/// routes, list route metadata, and prepare browser worker/island artifacts.
 pub fn run_from_cli(app: FissionServerApp) -> anyhow::Result<()> {
     let args = CliArgs::parse(std::env::args().skip(1))?;
     match args.command.as_str() {

--- a/crates/shell/fission-shell-server/src/protocol.rs
+++ b/crates/shell/fission-shell-server/src/protocol.rs
@@ -5,88 +5,148 @@ use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+/// Messages sent by the browser main thread to a progressive worker.
 pub enum MainToWorker {
+    /// Initializes a newly created worker instance.
     Boot(WorkerBoot),
+    /// Delivers a sanitized DOM event.
     Event(WorkerDomEvent),
+    /// Reports the worker-owned viewport size.
     Resize(WorkerResize),
-    VisibilityChanged { visible: bool },
-    ThemeChanged { theme_id: String },
-    LocaleChanged { locale: String },
+    /// Reports page visibility.
+    VisibilityChanged {
+        /// Whether the document is currently visible.
+        visible: bool,
+    },
+    /// Reports a theme selection change.
+    ThemeChanged {
+        /// Stable theme identifier selected by the page.
+        theme_id: String,
+    },
+    /// Reports a locale selection change.
+    LocaleChanged {
+        /// BCP-47-like locale identifier selected by the page.
+        locale: String,
+    },
+    /// Completes an earlier host request.
     Response(WorkerResponse),
+    /// Requests orderly worker shutdown.
     Shutdown,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Initialization data supplied to one progressive worker instance.
 pub struct WorkerBoot {
+    /// Version of this serialized protocol.
     pub protocol_version: u16,
+    /// Unique identifier for this concrete worker instance.
     pub worker_instance_id: String,
+    /// Route declaration that created the worker.
     pub route_id: String,
+    /// Public base URL used to resolve application requests.
     pub base_url: String,
+    /// DOM root the worker is authorized to manage.
     pub root_node_id: String,
+    /// Active locale identifier.
     pub locale: String,
+    /// Active theme identifier.
     pub theme_id: String,
+    /// Host capabilities enabled for this worker.
     pub feature_flags: Vec<String>,
     #[serde(default)]
+    /// Application-defined initialization properties.
     pub props: BTreeMap<String, Value>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Sanitized browser event delivered to a progressive worker.
 pub struct WorkerDomEvent {
+    /// Monotonic event sequence within this worker instance.
     pub sequence: u64,
+    /// Numeric DOM target authorized by the worker policy.
     pub target_node_id: u64,
+    /// Browser event name, such as `click` or `input`.
     pub event_kind: String,
     #[serde(default)]
+    /// Current control value for value-bearing events.
     pub value: Option<String>,
     #[serde(default)]
+    /// Active keyboard modifier names.
     pub modifiers: Vec<String>,
     #[serde(default)]
+    /// Pointer coordinates and button for pointer events.
     pub pointer: Option<WorkerPointer>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Pointer details attached to a worker DOM event.
 pub struct WorkerPointer {
+    /// Horizontal coordinate relative to the worker root.
     pub x: f64,
+    /// Vertical coordinate relative to the worker root.
     pub y: f64,
+    /// Browser button number, when applicable.
     pub button: Option<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Current browser viewport information sent to a worker.
 pub struct WorkerResize {
+    /// CSS-pixel width.
     pub width: f64,
+    /// CSS-pixel height.
     pub height: f64,
+    /// Device pixels per CSS pixel.
     pub scale_factor: f64,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Host response to a worker's capability request.
 pub struct WorkerResponse {
+    /// Identifier copied from the corresponding request.
     pub request_id: u64,
+    /// Whether the request completed successfully.
     pub ok: bool,
     #[serde(default)]
+    /// Capability-specific success value.
     pub payload: Option<Value>,
     #[serde(default)]
+    /// Failure diagnostic when `ok` is false.
     pub error: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+/// Messages emitted by a progressive worker for the browser main thread.
 pub enum WorkerToMain {
+    /// Signals that boot completed and events may be delivered.
     Ready,
+    /// Requests a validated batch of DOM mutations.
     DomBatch(DomBatch),
+    /// Requests a host/browser capability.
     Request(WorkerRequest),
+    /// Requests browser navigation.
     Navigate(NavigateRequest),
+    /// Emits a developer diagnostic.
     Log(WorkerLog),
+    /// Reports an unhandled worker failure.
     Error(WorkerError),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Ordered DOM operations committed as one worker update.
 pub struct DomBatch {
+    /// Monotonic batch sequence within this worker instance.
     pub sequence: u64,
     #[serde(default)]
+    /// Optional application transaction identifier for diagnostics.
     pub transaction_id: Option<String>,
+    /// Operations applied in declaration order after validation.
     pub ops: Vec<DomOp>,
 }
 
 impl DomBatch {
+    /// Validates every operation against the worker's authority policy.
     pub fn validate(&self, policy: &WorkerDomPolicy) -> Result<(), WorkerProtocolError> {
         for op in &self.ops {
             op.validate(policy)?;
@@ -96,6 +156,7 @@ impl DomBatch {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Explicit authority granted to a progressive worker over page DOM and navigation.
 pub struct WorkerDomPolicy {
     allowed_nodes: BTreeSet<u64>,
     allowed_semantics: BTreeSet<String>,
@@ -104,15 +165,18 @@ pub struct WorkerDomPolicy {
 }
 
 impl WorkerDomPolicy {
+    /// Creates a deny-by-default policy.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Authorizes mutation of one numeric DOM node.
     pub fn allow_node(mut self, node: u64) -> Self {
         self.allowed_nodes.insert(node);
         self
     }
 
+    /// Authorizes mutation of multiple numeric DOM nodes.
     pub fn allow_nodes<I>(mut self, nodes: I) -> Self
     where
         I: IntoIterator<Item = u64>,
@@ -121,11 +185,13 @@ impl WorkerDomPolicy {
         self
     }
 
+    /// Authorizes one stable semantic target.
     pub fn allow_semantics(mut self, semantics: impl Into<String>) -> Self {
         self.allowed_semantics.insert(semantics.into());
         self
     }
 
+    /// Authorizes multiple stable semantic targets.
     pub fn allow_semantics_many<I, S>(mut self, semantics: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -136,6 +202,7 @@ impl WorkerDomPolicy {
         self
     }
 
+    /// Authorizes navigation only to URLs beginning with `prefix`.
     pub fn allow_navigation_to_prefix(mut self, prefix: impl Into<String>) -> Self {
         self.allow_navigation = true;
         self.allowed_url_prefixes.push(prefix.into());
@@ -161,6 +228,8 @@ impl WorkerDomPolicy {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Rejection returned when a worker message exceeds its declared authority or
+/// contains unsafe browser content.
 pub struct WorkerProtocolError {
     message: String,
 }
@@ -183,130 +252,230 @@ impl std::error::Error for WorkerProtocolError {}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
+/// Validated browser DOM operation requested by a progressive worker.
+///
+/// Numeric-node variants target a host-assigned node ID. `BySemantics`
+/// variants target a stable semantic name. Both forms require explicit
+/// authorization in [`WorkerDomPolicy`]; URL, attribute, CSS, and replacement
+/// HTML values receive additional safety validation before execution.
 pub enum DomOp {
+    /// Replaces a node's text content.
     SetText {
+        /// Authorized numeric target.
         node: u64,
+        /// Literal text content.
         text: String,
     },
+    /// Replaces text at a semantic target.
     SetTextBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Literal text content.
         text: String,
     },
+    /// Replaces a semantic target's children with sanitized renderer HTML.
     ReplaceChildrenHtmlBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Non-executable HTML fragment.
         html: String,
     },
+    /// Creates or replaces a worker-owned stylesheet.
     SetStylesheet {
+        /// Safe stylesheet element identifier.
         id: String,
+        /// Complete CSS text.
         css: String,
     },
+    /// Sets a validated attribute on a numeric target.
     SetAttr {
+        /// Authorized numeric target.
         node: u64,
+        /// Attribute name; inline event handlers are rejected.
         name: String,
+        /// Attribute value; URL-bearing attributes require safe URLs.
         value: String,
     },
+    /// Sets a validated attribute on a semantic target.
     SetAttrBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Attribute name; inline event handlers are rejected.
         name: String,
+        /// Attribute value; URL-bearing attributes require safe URLs.
         value: String,
     },
+    /// Removes an attribute from a numeric target.
     RemoveAttr {
+        /// Authorized numeric target.
         node: u64,
+        /// Attribute name to remove.
         name: String,
     },
+    /// Removes an attribute from a semantic target.
     RemoveAttrBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Attribute name to remove.
         name: String,
     },
+    /// Adds a CSS class to a numeric target.
     AddClass {
+        /// Authorized numeric target.
         node: u64,
+        /// Class token to add.
         class: String,
     },
+    /// Adds a CSS class to a semantic target.
     AddClassBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Class token to add.
         class: String,
     },
+    /// Removes a CSS class from a numeric target.
     RemoveClass {
+        /// Authorized numeric target.
         node: u64,
+        /// Class token to remove.
         class: String,
     },
+    /// Removes a CSS class from a semantic target.
     RemoveClassBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Class token to remove.
         class: String,
     },
+    /// Sets whether a numeric target contains a CSS class.
     ToggleClass {
+        /// Authorized numeric target.
         node: u64,
+        /// Class token to update.
         class: String,
+        /// `true` adds the class and `false` removes it.
         enabled: bool,
     },
+    /// Sets whether a semantic target contains a CSS class.
     ToggleClassBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Class token to update.
         class: String,
+        /// `true` adds the class and `false` removes it.
         enabled: bool,
     },
+    /// Sets a CSS custom property on a numeric target.
     SetStyleVar {
+        /// Authorized numeric target.
         node: u64,
+        /// Custom property name beginning with `--`.
         name: String,
+        /// Property value without control characters.
         value: String,
     },
+    /// Sets a CSS custom property on a semantic target.
     SetStyleVarBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Custom property name beginning with `--`.
         name: String,
+        /// Property value without control characters.
         value: String,
     },
+    /// Updates the hidden state of a numeric target.
     SetHidden {
+        /// Authorized numeric target.
         node: u64,
+        /// Whether the element is hidden.
         hidden: bool,
     },
+    /// Updates the hidden state of a semantic target.
     SetHiddenBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// Whether the element is hidden.
         hidden: bool,
     },
+    /// Replaces the form value of a numeric target.
     SetValue {
+        /// Authorized numeric target.
         node: u64,
+        /// New form-control value.
         value: String,
     },
+    /// Replaces the form value of a semantic target.
     SetValueBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// New form-control value.
         value: String,
     },
+    /// Updates the checked state of a numeric target.
     SetChecked {
+        /// Authorized numeric target.
         node: u64,
+        /// New checked state.
         checked: bool,
     },
+    /// Updates the checked state of a semantic target.
     SetCheckedBySemantics {
+        /// Authorized semantic target.
         semantics: String,
+        /// New checked state.
         checked: bool,
     },
+    /// Moves browser focus to a numeric target.
     Focus {
+        /// Authorized numeric target.
         node: u64,
     },
+    /// Moves browser focus to a semantic target.
     FocusBySemantics {
+        /// Authorized semantic target.
         semantics: String,
     },
+    /// Removes browser focus from a numeric target.
     Blur {
+        /// Authorized numeric target.
         node: u64,
     },
+    /// Removes browser focus from a semantic target.
     BlurBySemantics {
+        /// Authorized semantic target.
         semantics: String,
     },
+    /// Scrolls a numeric target into its nearest scroll container.
     ScrollIntoView {
+        /// Authorized numeric target.
         node: u64,
+        /// Alignment within the visible scroll area.
         block: ScrollBlock,
     },
+    /// Sets absolute scroll offsets on a numeric target.
     SetScroll {
+        /// Authorized numeric target.
         node: u64,
+        /// Horizontal CSS-pixel offset.
         x: f64,
+        /// Vertical CSS-pixel offset.
         y: f64,
     },
+    /// Pushes a validated URL into browser history.
     PushHistory {
+        /// URL allowed by the worker navigation policy.
         url: String,
     },
+    /// Replaces the current browser history entry with a validated URL.
     ReplaceHistory {
+        /// URL allowed by the worker navigation policy.
         url: String,
     },
+    /// Announces text through an ARIA live region.
     Announce {
+        /// Interruption priority for assistive technology.
         politeness: AriaPoliteness,
+        /// Human-readable announcement.
         text: String,
     },
 }
@@ -542,89 +711,136 @@ fn safe_navigation_url(url: &str) -> bool {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Vertical alignment used by a worker scroll-into-view request.
 pub enum ScrollBlock {
+    /// Align the element with the start of the scroll viewport.
     Start,
+    /// Center the element in the scroll viewport.
     Center,
+    /// Align the element with the end of the scroll viewport.
     End,
+    /// Perform the smallest scroll needed to reveal the element.
     Nearest,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Priority for text announced through an ARIA live region.
 pub enum AriaPoliteness {
+    /// Wait for the current assistive-technology announcement to finish.
     Polite,
+    /// Interrupt with time-sensitive information.
     Assertive,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Capability request sent by a progressive worker to the main thread.
 pub struct WorkerRequest {
+    /// Identifier copied into the eventual response.
     pub request_id: u64,
+    /// Browser or server capability being requested.
     pub kind: WorkerRequestKind,
     #[serde(default)]
+    /// Capability-specific request value.
     pub payload: Option<Value>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Capabilities a worker may request from the browser main thread.
 pub enum WorkerRequestKind {
+    /// Submit a signed Fission action to the SSR endpoint.
     FetchServerAction,
+    /// Read a browser local-storage key.
     ReadLocalStorage,
+    /// Write a browser local-storage key.
     WriteLocalStorage,
+    /// Remove a browser local-storage key.
     RemoveLocalStorage,
+    /// Read a browser session-storage key.
     ReadSessionStorage,
+    /// Write a browser session-storage key.
     WriteSessionStorage,
+    /// Write plain text to the system clipboard.
     ClipboardWriteText,
+    /// Read plain text from the system clipboard.
     ClipboardReadText,
+    /// Read the current browser location.
     CurrentLocation,
+    /// Read the current document visibility state.
     DocumentVisibility,
+    /// Evaluate a browser media query.
     MatchMedia,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Browser navigation requested by a progressive worker.
 pub struct NavigateRequest {
+    /// Destination URL.
     pub url: String,
+    /// History/document transition to perform.
     pub mode: NavigateMode,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Browser navigation behavior requested by a worker.
 pub enum NavigateMode {
+    /// Push a new same-document history entry.
     Push,
+    /// Replace the current same-document history entry.
     Replace,
+    /// Navigate the complete browser document.
     FullDocument,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Structured developer log emitted by a progressive worker.
 pub struct WorkerLog {
+    /// Severity used by browser logging and diagnostics.
     pub level: WorkerLogLevel,
+    /// Human-readable message.
     pub message: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Severity of a progressive worker log record.
 pub enum WorkerLogLevel {
+    /// Fine-grained execution trace.
     Trace,
+    /// Developer debugging detail.
     Debug,
+    /// Normal lifecycle information.
     Info,
+    /// Recoverable or suspicious condition.
     Warn,
+    /// Failed worker operation.
     Error,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Unhandled failure reported by a progressive worker.
 pub struct WorkerError {
+    /// Human-readable failure message.
     pub message: String,
+    /// Optional JavaScript stack trace.
     pub stack: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+/// Complete messages and event bindings produced by a browser worker bridge.
 pub struct BrowserBridgeOutput {
     #[serde(default)]
+    /// Worker messages to process in declaration order.
     pub messages: Vec<WorkerToMain>,
     #[serde(default)]
+    /// DOM events the browser should route back to the worker.
     pub bindings: Vec<BrowserEventBinding>,
 }
 
 impl BrowserBridgeOutput {
+    /// Validates DOM operations, semantic targets, and event bindings.
     pub fn validate(&self, policy: &WorkerDomPolicy) -> Result<(), WorkerProtocolError> {
         for message in &self.messages {
             if let WorkerToMain::DomBatch(batch) = message {
@@ -640,14 +856,19 @@ impl BrowserBridgeOutput {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Declarative DOM event subscription installed for a worker.
 pub struct BrowserEventBinding {
+    /// Authorized semantic target on which to listen.
     pub semantics: String,
+    /// Browser event forwarded to the worker.
     pub event: BrowserEventKind,
     #[serde(default)]
+    /// Application-defined message included with each forwarded event.
     pub message: Value,
 }
 
 impl BrowserEventBinding {
+    /// Validates that the semantic target has a safe identifier shape.
     pub fn validate(&self) -> Result<(), WorkerProtocolError> {
         if safe_semantics_identifier(&self.semantics) {
             Ok(())
@@ -662,10 +883,15 @@ impl BrowserEventBinding {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Browser events supported by declarative worker bindings.
 pub enum BrowserEventKind {
+    /// Pointer or keyboard activation.
     Click,
+    /// Incremental form-control value change.
     Input,
+    /// Committed form-control value change.
     Change,
+    /// Form submission.
     Submit,
 }
 

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -31,21 +31,30 @@ use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
 
+/// Maximum encoded action submission accepted by the built-in SSR endpoint.
 pub const MAX_SERVER_ACTION_BODY_BYTES: usize = 1024 * 1024;
+/// Default name used for Fission's signed session cookie.
 pub const DEFAULT_SESSION_COOKIE_NAME: &str = "fission_session";
 const SERVER_BROWSER_RUNTIME_JS: &str = include_str!("../assets/server-runtime.js");
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Framework-neutral HTTP request consumed by [`ServerRenderer`].
 pub struct ServerRequest {
+    /// Uppercase HTTP method.
     pub method: String,
+    /// Request path without query text.
     pub path: String,
+    /// Decoded query parameters.
     pub query: BTreeMap<String, String>,
+    /// Lowercase header names and their decoded values.
     pub headers: BTreeMap<String, String>,
+    /// Complete request body bytes.
     pub body: Vec<u8>,
 }
 
 impl ServerRequest {
+    /// Creates an empty GET request for `path`.
     pub fn get(path: impl Into<String>) -> Self {
         Self {
             method: "GET".to_string(),
@@ -56,6 +65,7 @@ impl ServerRequest {
         }
     }
 
+    /// Creates a POST request with body bytes and no headers or query values.
     pub fn post(path: impl Into<String>, body: impl Into<Vec<u8>>) -> Self {
         Self {
             method: "POST".to_string(),
@@ -68,14 +78,20 @@ impl ServerRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Framework-neutral HTTP response produced by [`ServerRenderer`].
 pub struct ServerResponse {
+    /// HTTP status code.
     pub status: u16,
+    /// Response header name/value pairs.
     pub headers: Vec<(String, String)>,
+    /// Complete response body bytes.
     pub body: Vec<u8>,
+    /// Cache freshness when the response came from cache.
     pub cache_status: Option<Freshness>,
 }
 
 impl ServerResponse {
+    /// Creates a response with a content type and arbitrary bytes.
     pub fn text(status: u16, content_type: &str, body: impl Into<Vec<u8>>) -> Self {
         Self {
             status,
@@ -85,6 +101,7 @@ impl ServerResponse {
         }
     }
 
+    /// Creates a non-cacheable `303 See Other` redirect.
     pub fn see_other(location: impl Into<String>) -> Self {
         Self {
             status: 303,
@@ -97,6 +114,7 @@ impl ServerResponse {
         }
     }
 
+    /// Creates a non-cacheable `302 Found` redirect.
     pub fn found(location: impl Into<String>) -> Self {
         Self {
             status: 302,
@@ -109,22 +127,26 @@ impl ServerResponse {
         }
     }
 
+    /// Decodes the body lossily as UTF-8 for diagnostics and tests.
     pub fn body_string(&self) -> String {
         String::from_utf8_lossy(&self.body).into_owned()
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Signed-session identity resolved for one request.
 pub struct ServerSession {
     id: String,
     is_new: bool,
 }
 
 impl ServerSession {
+    /// Returns the stable opaque session identifier.
     pub fn id(&self) -> &str {
         &self.id
     }
 
+    /// Returns whether this request created the session.
     pub fn is_new(&self) -> bool {
         self.is_new
     }
@@ -139,16 +161,25 @@ struct CacheInvalidationPayload {
 }
 
 #[derive(Clone, Debug)]
+/// Route metadata and render products before conversion to an HTTP response.
 pub struct RenderedServerRoute {
+    /// Registered route that matched the request.
     pub route: WebRoute,
+    /// Rendered HTML document.
     pub html: String,
+    /// CSS generated for the rendered Fission nodes.
     pub css: String,
+    /// Runtime resource declarations encountered during rendering.
     pub resources: Vec<RuntimeResourceDeclaration>,
+    /// Number of signed server actions emitted into the document.
     pub server_action_count: usize,
+    /// HTTP status selected by the route.
     pub status: u16,
+    /// Navigation requested while reducers settled the route.
     pub navigation: Option<NavigationCommand>,
 }
 
+/// Request renderer and HTTP dispatcher for a configured Fission SSR app.
 pub struct ServerRenderer {
     app: FissionServerApp,
     cache: Arc<dyn Cache>,
@@ -167,6 +198,9 @@ pub struct ServerRenderer {
 }
 
 impl ServerRenderer {
+    /// Creates a renderer from programmatic app configuration and safe defaults.
+    ///
+    /// Use `configured` when the project should also load `fission.toml`.
     pub fn new(app: FissionServerApp) -> Self {
         let jobs = app.jobs.clone();
         let default_locale = app.default_locale.0.clone();
@@ -188,11 +222,13 @@ impl ServerRenderer {
         }
     }
 
+    /// Loads project runtime configuration and creates a renderer.
     pub fn configured(app: FissionServerApp) -> Result<Self> {
         let config = ServerRuntimeConfig::load(&app.project_dir)?;
         Self::with_config(app, config)
     }
 
+    /// Creates a renderer from an already loaded runtime configuration.
     pub fn with_config(mut app: FissionServerApp, config: ServerRuntimeConfig) -> Result<Self> {
         if let Some(mode) = config.default_route_mode {
             app.apply_default_route_mode(mode);
@@ -212,20 +248,24 @@ impl ServerRenderer {
         Ok(renderer)
     }
 
+    /// Replaces the page and resource cache backend.
     pub fn with_cache(mut self, cache: Arc<dyn Cache>) -> Self {
         self.cache = cache;
         self
     }
 
+    /// Returns the active cache provider.
     pub fn cache(&self) -> Arc<dyn Cache> {
         self.cache.clone()
     }
 
+    /// Removes one exact cache key.
     pub fn remove_cache_entry(&self, key: &CacheKey) -> Result<()> {
         self.cache.remove(key)?;
         Ok(())
     }
 
+    /// Removes multiple exact cache keys and reports affected entries.
     pub fn remove_cache_entries<I, K>(&self, keys: I) -> Result<InvalidationReport>
     where
         I: IntoIterator<Item = K>,
@@ -243,10 +283,12 @@ impl ServerRenderer {
         Ok(report)
     }
 
+    /// Invalidates every entry associated with one logical tag.
     pub fn invalidate_cache_tag(&self, tag: impl Into<CacheTag>) -> Result<InvalidationReport> {
         Ok(self.cache.invalidate_tag(&tag.into())?)
     }
 
+    /// Invalidates entries associated with any supplied tag.
     pub fn invalidate_cache_tags<I, T>(&self, tags: I) -> Result<InvalidationReport>
     where
         I: IntoIterator<Item = T>,
@@ -256,26 +298,31 @@ impl ServerRenderer {
         Ok(self.cache.invalidate_tags(&tags)?)
     }
 
+    /// Sets the logical viewport used by server layout.
     pub fn with_viewport_size(mut self, size: LayoutSize) -> Self {
         self.viewport_size = size;
         self
     }
 
+    /// Replaces the server-job registry used while settling resources.
     pub fn with_jobs(mut self, jobs: ServerJobRegistry) -> Self {
         self.jobs = jobs;
         self
     }
 
+    /// Replaces the signer used for interactive server actions.
     pub fn with_action_signer(mut self, signer: ServerActionSigner) -> Self {
         self.action_signer = signer;
         self
     }
 
+    /// Allows one browser origin to submit signed actions.
     pub fn with_allowed_action_origin(mut self, origin: impl Into<String>) -> Self {
         self.allowed_action_origins.insert(origin.into());
         self
     }
 
+    /// Replaces the set of browser origins allowed to submit signed actions.
     pub fn with_allowed_action_origins<I, O>(mut self, origins: I) -> Self
     where
         I: IntoIterator<Item = O>,
@@ -286,11 +333,13 @@ impl ServerRenderer {
         self
     }
 
+    /// Caps reducer/resource rebuild passes for one request.
     pub fn with_render_pass_limit(mut self, limit: usize) -> Self {
         self.render_pass_limit = limit;
         self
     }
 
+    /// Signs an application action for one route and widget node.
     pub fn sign_action<A: fission_core::Action>(
         &self,
         route_path: impl Into<String>,
@@ -302,10 +351,12 @@ impl ServerRenderer {
             .sign(route_path, target_node, action, ttl)
     }
 
+    /// Returns the configured route inventory.
     pub fn routes(&self) -> Vec<WebRoute> {
         self.app.routes()
     }
 
+    /// Renders a registered route without adapting it to an HTTP response.
     pub fn render_route(&self, path: &str) -> Result<RenderedServerRoute> {
         let path = normalize_server_path(path);
         let route = self
@@ -317,6 +368,8 @@ impl ServerRenderer {
         self.render_uncached(route, None, &request, &session)
     }
 
+    /// Dispatches a framework-neutral request to actions, handlers, static files,
+    /// or the matching SSR route and returns the resulting response.
     pub fn handle(&self, request: ServerRequest) -> Result<ServerResponse> {
         if request.method == "POST" && normalize_server_path(&request.path) == "/__fission/action/"
         {

--- a/crates/shell/fission-shell-server/src/route.rs
+++ b/crates/shell/fission-shell-server/src/route.rs
@@ -3,15 +3,22 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Rendering and caching strategy for an SSR route.
 pub enum WebRouteMode {
+    /// Render immutable output suitable for indefinite public caching.
     Static,
+    /// Serve cached output and regenerate it according to a policy.
     Revalidated(RevalidationPolicy),
+    /// Render each request, optionally using the configured public cache scope.
     Server(ServerRenderPolicy),
+    /// Render request-specific output that must not enter a shared public cache.
     ServerPrivate(ServerPrivatePolicy),
+    /// Serve a browser-owned client application at this route.
     ClientApp(ClientAppPolicy),
 }
 
 impl WebRouteMode {
+    /// Returns the effective cache isolation required by this mode.
     pub fn cache_scope(&self) -> CacheScope {
         match self {
             Self::Static | Self::Revalidated(_) | Self::Server(_) | Self::ClientApp(_) => {
@@ -21,6 +28,7 @@ impl WebRouteMode {
         }
     }
 
+    /// Returns the revalidation policy when this is a revalidated route.
     pub fn revalidation(&self) -> Option<&RevalidationPolicy> {
         match self {
             Self::Revalidated(policy) => Some(policy),
@@ -30,14 +38,20 @@ impl WebRouteMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Lifetime, stale-serving, tagging, and variation rules for cached output.
 pub struct RevalidationPolicy {
+    /// Time for which newly generated output is fresh.
     pub ttl: Duration,
+    /// Optional additional interval during which stale output may be served.
     pub stale_while_revalidate: Option<Duration>,
+    /// Tags through which related cache entries can be invalidated together.
     pub tags: Vec<CacheTag>,
+    /// Request field names incorporated into the cache key.
     pub vary: Vec<String>,
 }
 
 impl RevalidationPolicy {
+    /// Creates a policy with a fresh TTL and no stale window, tags, or variance.
     pub fn new(ttl: Duration) -> Self {
         Self {
             ttl,
@@ -47,16 +61,19 @@ impl RevalidationPolicy {
         }
     }
 
+    /// Allows stale content to be served for `duration` while it is refreshed.
     pub fn stale_while_revalidate(mut self, duration: Duration) -> Self {
         self.stale_while_revalidate = Some(duration);
         self
     }
 
+    /// Adds one invalidation tag.
     pub fn tag(mut self, tag: impl Into<CacheTag>) -> Self {
         self.tags.push(tag.into());
         self
     }
 
+    /// Adds multiple invalidation tags.
     pub fn tags<I, T>(mut self, tags: I) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -66,6 +83,7 @@ impl RevalidationPolicy {
         self
     }
 
+    /// Adds one request field to the cache-key variance set.
     pub fn vary(mut self, field: impl Into<String>) -> Self {
         self.vary.push(field.into());
         self
@@ -73,12 +91,16 @@ impl RevalidationPolicy {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Per-request rendering policy for publicly shareable routes.
 pub struct ServerRenderPolicy {
+    /// Optional explicit cache scope; `None` defers to server configuration.
     pub cache_scope: Option<CacheScope>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Cache isolation policy for request-specific routes.
 pub struct ServerPrivatePolicy {
+    /// Private scope, normally per session or per authenticated user.
     pub scope: CacheScope,
 }
 
@@ -91,28 +113,42 @@ impl Default for ServerPrivatePolicy {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Browser application boot policy for a client-owned route.
 pub struct ClientAppPolicy {
+    /// Whether the browser artifact should be preloaded by the document.
     pub preload: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Determines where and when a route resource is executed.
 pub enum ServerResourcePolicy {
+    /// Complete the resource before producing the server response.
     Blocking,
+    /// Produce initial output while the resource completes later.
     Deferred,
+    /// Execute only inside a browser island.
     IslandOnly,
+    /// Never execute this resource during SSR.
     NoServerExecution,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Browser worker attached to a progressively enhanced route.
 pub struct ProgressiveWorker {
+    /// Stable worker identifier within the route.
     pub id: String,
+    /// URL or generated artifact path loaded by the browser.
     pub artifact: String,
+    /// Optional exported entry function.
     pub entry: Option<String>,
+    /// Optional DOM node whose subtree the worker owns.
     pub root_node_id: Option<String>,
+    /// Human-readable purpose shown by tooling.
     pub description: Option<String>,
 }
 
 impl ProgressiveWorker {
+    /// Creates a worker declaration with an identifier and artifact path.
     pub fn new(id: impl Into<String>, artifact: impl Into<String>) -> Self {
         Self {
             id: id.into(),
@@ -123,16 +159,19 @@ impl ProgressiveWorker {
         }
     }
 
+    /// Selects the artifact's exported entry function.
     pub fn entry(mut self, entry: impl Into<String>) -> Self {
         self.entry = Some(entry.into());
         self
     }
 
+    /// Limits the worker to a specific rendered DOM root.
     pub fn root_node_id(mut self, id: impl Into<String>) -> Self {
         self.root_node_id = Some(id.into());
         self
     }
 
+    /// Adds a tooling-facing description.
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
@@ -140,15 +179,22 @@ impl ProgressiveWorker {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Independently hydrated browser component embedded in an SSR document.
 pub struct WasmIsland {
+    /// Stable island identifier within the route.
     pub id: String,
+    /// URL or generated artifact path loaded by the browser.
     pub artifact: String,
+    /// Optional exported entry function.
     pub entry: Option<String>,
+    /// DOM element ID where the island mounts.
     pub mount_id: String,
+    /// Human-readable purpose shown by tooling.
     pub description: Option<String>,
 }
 
 impl WasmIsland {
+    /// Creates an island declaration and its mount-point identifier.
     pub fn new(
         id: impl Into<String>,
         artifact: impl Into<String>,
@@ -163,11 +209,13 @@ impl WasmIsland {
         }
     }
 
+    /// Selects the artifact's exported entry function.
     pub fn entry(mut self, entry: impl Into<String>) -> Self {
         self.entry = Some(entry.into());
         self
     }
 
+    /// Adds a tooling-facing description.
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
@@ -175,12 +223,20 @@ impl WasmIsland {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Public metadata and execution policy for one registered SSR route.
 pub struct WebRoute {
+    /// Normalized route pattern or path.
     pub path: String,
+    /// Default browser-document title.
     pub title: String,
+    /// Optional default document description.
     pub description: Option<String>,
+    /// Rendering and caching mode.
     pub mode: WebRouteMode,
+    /// Progressive workers attached to the route.
     pub workers: Vec<ProgressiveWorker>,
+    /// Hydrated WebAssembly islands attached to the route.
     pub islands: Vec<WasmIsland>,
+    /// Serialized JSON-LD documents emitted into the page.
     pub structured_data: Vec<String>,
 }

--- a/crates/shell/fission-shell-server/src/serve.rs
+++ b/crates/shell/fission-shell-server/src/serve.rs
@@ -7,8 +7,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Network address used by the built-in SSR development server.
 pub struct ServeOptions {
+    /// Host name or IP address on which to listen.
     pub host: String,
+    /// TCP port on which to listen.
     pub port: u16,
 }
 
@@ -21,6 +24,10 @@ impl Default for ServeOptions {
     }
 }
 
+/// Runs the built-in Hyper server until it stops or encounters an error.
+///
+/// Production deployments may instead use one of the framework adapters and
+/// integrate [`ServerRenderer`] into an existing HTTP server.
 pub fn serve(renderer: ServerRenderer, options: ServeOptions) -> Result<()> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_io()

--- a/crates/shell/fission-shell-site/src/browser_island.rs
+++ b/crates/shell/fission-shell-site/src/browser_island.rs
@@ -10,7 +10,7 @@ use fission_core::{
     WidgetId,
 };
 use fission_ir::{semantics::ActionTrigger, CoreIR, Op, Role, Semantics};
-use fission_theme::Theme;
+use fission_theme::{DesignMode, DesignSystem, Theme};
 use serde_json::{json, Value};
 use std::any::Any;
 use std::cell::RefCell;
@@ -36,7 +36,8 @@ where
     mount_id: String,
     runtime: Runtime,
     widget: W,
-    theme: Theme,
+    env: Env,
+    sync_env: Option<Box<dyn Fn(&S, &mut Env)>>,
     _state: std::marker::PhantomData<fn() -> S>,
 }
 
@@ -58,7 +59,8 @@ where
             mount_id: mount_id.into(),
             runtime,
             widget,
-            theme: Theme::default(),
+            env: Env::default(),
+            sync_env: None,
             _state: std::marker::PhantomData,
         }
     }
@@ -69,7 +71,37 @@ where
     /// visually blend into the server-rendered page. If omitted, the default
     /// Fission theme is used.
     pub fn theme(mut self, theme: Theme) -> Self {
-        self.theme = theme;
+        self.env.theme = theme;
+        self
+    }
+
+    /// Replaces the environment used to build and lower this browser island.
+    ///
+    /// Use the same prepared `Env` as the surrounding route when the island
+    /// needs matching translations, locale, theme, or other presentation
+    /// context. The island owns its copy and never mutates the server's request
+    /// environment.
+    pub fn with_env(mut self, env: Env) -> Self {
+        self.env = env;
+        self
+    }
+
+    /// Installs a generated design system's theme for the requested mode.
+    pub fn with_design_system<D: DesignSystem>(mut self, mode: DesignMode) -> Self {
+        self.env.theme = D::theme(mode);
+        self
+    }
+
+    /// Mirrors island state into its environment before every build.
+    ///
+    /// This is the browser-island equivalent of the stateful shell builders'
+    /// `with_sync_env`: use it for app-selected locale or theme values, not for
+    /// side effects or durable product data.
+    pub fn with_sync_env<F>(mut self, sync: F) -> Self
+    where
+        F: Fn(&S, &mut Env) + 'static,
+    {
+        self.sync_env = Some(Box::new(sync));
         self
     }
 
@@ -165,7 +197,7 @@ where
         let ir = lower_browser_island_widget(
             output.node,
             output.portals,
-            &self.theme,
+            &output.env,
             &self.runtime.runtime_state,
         );
         let semantics = ir
@@ -200,7 +232,7 @@ where
         let ir = lower_browser_island_widget(
             output.node,
             output.portals,
-            &self.theme,
+            &output.env,
             &self.runtime.runtime_state,
         );
 
@@ -210,7 +242,7 @@ where
             &HtmlRenderOptions {
                 document_title: self.id.clone(),
                 root_class: "fission-browser-island-root".to_string(),
-                css_variables: CssVariableMap::from_theme(&self.theme),
+                css_variables: CssVariableMap::from_theme(&output.env.theme),
                 browser_action_bindings: true,
                 motion_declarations: output.motion_declarations,
                 video_registrations: output
@@ -259,12 +291,14 @@ where
     }
 
     fn build_widget(&self) -> BrowserIslandBuildOutput<S> {
-        let mut env = Env::default();
-        env.theme = self.theme.clone();
+        let mut env = self.env.clone();
         let state = self
             .runtime
             .get_global_state::<S>()
             .expect("browser island state is registered at construction");
+        if let Some(sync_env) = &self.sync_env {
+            sync_env(state, &mut env);
+        }
         let view = View::new(state, &self.runtime.runtime_state, &env, None);
         let mut ctx = BuildCtx::<S>::new();
         let node = fission_core::build::enter(&mut ctx, &view, || self.widget.clone().into());
@@ -280,6 +314,7 @@ where
             video_registrations,
             web_registrations,
             portals,
+            env,
         }
     }
 
@@ -325,13 +360,11 @@ fn validate_browser_text_target(target: WidgetId, semantics: &Semantics) -> Resu
 fn lower_browser_island_widget(
     node: Widget,
     portals: Vec<(Option<WidgetId>, Widget)>,
-    theme: &Theme,
+    env: &Env,
     runtime: &RuntimeState,
 ) -> CoreIR {
     let node = compose_browser_island_portals(node, portals);
-    let mut env = Env::default();
-    env.theme = theme.clone();
-    let mut lowering = InternalLoweringCx::new(&env, runtime, None, None);
+    let mut lowering = InternalLoweringCx::new(env, runtime, None, None);
     let root = fission_core::internal::lower_widget(&node, &mut lowering);
     lowering.ir.set_root(root);
     lowering.ir
@@ -357,6 +390,7 @@ struct BrowserIslandBuildOutput<S: GlobalState> {
     video_registrations: Vec<VideoRegistration>,
     web_registrations: Vec<WebRegistration>,
     portals: Vec<(Option<WidgetId>, Widget)>,
+    env: Env,
 }
 
 fn compose_browser_island_portals(
@@ -535,6 +569,16 @@ mod tests {
                 ..Default::default()
             }
             .into()
+        }
+    }
+
+    #[derive(Clone)]
+    struct LocaleIsland;
+
+    impl From<LocaleIsland> for Widget {
+        fn from(_component: LocaleIsland) -> Widget {
+            let (_, view) = fission_core::build::current::<CounterState>();
+            Text::new(format!("locale:{}", view.env().locale.0)).into()
         }
     }
 
@@ -788,6 +832,24 @@ mod tests {
             BrowserIslandApp::new(&id, "counter-mount", CounterState::default(), CounterIsland)
         });
         assert!(update.contains("1 clicks"));
+    }
+
+    #[test]
+    fn browser_island_uses_seed_and_state_synchronized_environment() {
+        let id = format!("locale-{}", std::process::id());
+        let mut env = Env::default();
+        env.locale = "es".into();
+        let boot = run_browser_island(&id, r#"{"type":"boot"}"#, || {
+            BrowserIslandApp::new(&id, "locale-mount", CounterState::default(), LocaleIsland)
+                .with_env(env)
+                .with_sync_env(|state, env| {
+                    if state.count == 0 {
+                        env.locale = "es-MX".into();
+                    }
+                })
+        });
+
+        assert!(boot.contains("locale:es-MX"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -29,45 +29,74 @@ const SITE_CSS: &str = include_str!("../assets/site.css");
 const SITE_ENHANCEMENT_JS: &str = include_str!("../assets/site-enhancement.js");
 const SEARCH_JS: &str = include_str!("../assets/search.js");
 
+/// Returns the framework CSS embedded into generated Static and SSR sites.
 pub fn site_base_css() -> &'static str {
     SITE_CSS
 }
 
+/// Returns the optional browser enhancement script used by generated pages.
 pub fn site_enhancement_js() -> &'static str {
     SITE_ENHANCEMENT_JS
 }
 
 #[derive(Clone, Debug)]
+/// Complete filesystem and document configuration for one static-site build.
 pub struct SiteBuildOptions {
+    /// Project root used to resolve relative source and asset paths.
     pub project_dir: PathBuf,
+    /// Directory receiving generated HTML, CSS, scripts, and copied assets.
     pub output_dir: PathBuf,
+    /// Site-wide brand title used by default document templates.
     pub site_title: String,
+    /// Optional default meta description.
     pub site_description: Option<String>,
+    /// Optional logo URL/path rendered by the default documentation shell.
     pub site_logo: Option<String>,
+    /// Optional favicon URL/path.
     pub site_favicon: Option<String>,
+    /// Public canonical origin used for sitemap and canonical URLs.
     pub base_url: Option<String>,
+    /// Locale used when a route does not declare or resolve another locale.
     pub default_locale: String,
+    /// Top-level navigation entries for the default page chrome.
     pub site_nav: Vec<SiteNavLink>,
+    /// App CSS blocks appended after Fission's base stylesheet.
     pub user_css: Vec<String>,
+    /// Trusted document-level elements inserted into matching pages.
     pub page_elements: Vec<SitePageElement>,
+    /// Filesystem content mounts converted into site routes.
     pub content_routes: Vec<SiteContentRouteConfig>,
+    /// Directories copied verbatim into the output root.
     pub asset_dirs: Vec<PathBuf>,
+    /// Whether to generate `sitemap.xml`.
     pub generate_sitemap: bool,
+    /// Whether to generate `robots.txt`.
     pub generate_robots: bool,
+    /// Syntax-highlighting assets emitted for code-bearing pages.
     pub code_highlighting: CodeHighlightingOptions,
+    /// Static search-index generation settings.
     pub search: SiteSearchOptions,
+    /// Whether the existing output directory is removed before generation.
     pub clean: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// One filesystem content tree mounted below a public route prefix.
 pub struct SiteContentRouteConfig {
+    /// Public route prefix, such as `/docs`.
     pub path: String,
+    /// Source directory containing Markdown/MDX documents.
     pub source: PathBuf,
+    /// Optional named page template selected for this content mount.
     pub template: Option<String>,
+    /// Optional sidebar definition path for the mount.
     pub sidebar: Option<PathBuf>,
 }
 
 impl SiteBuildOptions {
+    /// Creates conventional defaults for `project_dir` without reading a
+    /// manifest. Content defaults to `content/` and output to
+    /// `target/fission/site/`.
     pub fn for_project(project_dir: impl Into<PathBuf>, site_title: impl Into<String>) -> Self {
         let project_dir = project_dir.into();
         Self {
@@ -97,6 +126,8 @@ impl SiteBuildOptions {
         }
     }
 
+    /// Loads `[site]` configuration from `project_dir/fission.toml`, resolving
+    /// all relative paths against the project root.
     pub fn from_project_dir(
         project_dir: impl Into<PathBuf>,
         fallback_title: impl Into<String>,
@@ -197,31 +228,44 @@ impl SiteBuildOptions {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// One discovered/generated route returned by build and inspection APIs.
 pub struct SiteRouteReport {
+    /// Public normalized route path.
     pub path: String,
+    /// Resolved document title.
     pub title: String,
+    /// Source document path, or a synthetic path for custom routes.
     pub source: PathBuf,
+    /// HTML file path below the build output.
     pub output: PathBuf,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Result of a complete static-site build or validation pass.
 pub struct SiteBuildReport {
+    /// Root output directory associated with the operation.
     pub output_dir: PathBuf,
+    /// Routes in deterministic public-path order.
     pub routes: Vec<SiteRouteReport>,
 }
 
+/// Builds a manifest/content-driven site with no programmatic custom routes.
 pub fn build_content_site(options: &SiteBuildOptions) -> Result<SiteBuildReport> {
     build_site(options, &FissionSite::new())
 }
 
+/// Validates content routes and rendering without writing the output site.
 pub fn check_content_site(options: &SiteBuildOptions) -> Result<SiteBuildReport> {
     check_site(options, &FissionSite::new())
 }
 
+/// Discovers content routes without rendering or writing them.
 pub fn list_content_routes(options: &SiteBuildOptions) -> Result<Vec<SiteRouteReport>> {
     list_site_routes(options, &FissionSite::new())
 }
 
+/// Generates content and programmatic [`FissionSite`] routes into the output
+/// directory described by `options`.
 pub fn build_site(options: &SiteBuildOptions, site: &FissionSite) -> Result<SiteBuildReport> {
     eprintln!("Loading static site routes...");
     let mut routes = load_content_routes(options, site.content_transform.as_deref())?;
@@ -291,6 +335,7 @@ fn report_route_progress(stage: &str, index: usize, total: usize, path: &str) {
     }
 }
 
+/// Fully validates content and programmatic routes without writing output.
 pub fn check_site(options: &SiteBuildOptions, site: &FissionSite) -> Result<SiteBuildReport> {
     let mut routes = load_content_routes(options, site.content_transform.as_deref())?;
     let mut styles = StyleRegistry::default();
@@ -314,6 +359,8 @@ pub fn check_site(options: &SiteBuildOptions, site: &FissionSite) -> Result<Site
     })
 }
 
+/// Returns the combined content and programmatic route inventory without
+/// writing output files.
 pub fn list_site_routes(
     options: &SiteBuildOptions,
     site: &FissionSite,

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -25,13 +25,18 @@ pub(crate) struct ContentRoute {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// One navigation link, optionally containing a nested dropdown/tree.
 pub struct SiteNavLink {
+    /// User-visible label.
     pub title: String,
+    /// Route-relative or absolute destination.
     pub href: String,
+    /// Nested navigation entries rendered beneath this entry.
     pub children: Vec<SiteNavLink>,
 }
 
 impl SiteNavLink {
+    /// Creates a leaf navigation link.
     pub fn new(title: impl Into<String>, href: impl Into<String>) -> Self {
         Self {
             title: title.into(),
@@ -40,6 +45,7 @@ impl SiteNavLink {
         }
     }
 
+    /// Replaces this entry's nested links in iteration order.
     pub fn with_children(mut self, children: impl IntoIterator<Item = SiteNavLink>) -> Self {
         self.children = children.into_iter().collect();
         self

--- a/crates/shell/fission-shell-site/src/document_config.rs
+++ b/crates/shell/fission-shell-site/src/document_config.rs
@@ -6,11 +6,14 @@ use fission_theme::{DesignMode, DesignSystem, PackagedFont, Theme};
 /// Browser and social metadata for one rendered document.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DocumentMetadata {
+    /// Browser/tab and social-card title.
     pub title: String,
+    /// Optional search/social meta description.
     pub description: Option<String>,
 }
 
 impl DocumentMetadata {
+    /// Creates document metadata with a required title and optional description.
     pub fn new(title: impl Into<String>, description: impl Into<Option<String>>) -> Self {
         Self {
             title: title.into(),
@@ -59,16 +62,20 @@ impl Default for DocumentShellConfig {
 }
 
 impl DocumentShellConfig {
+    /// Creates document configuration using Fission's default environment and
+    /// theme.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Replaces the active theme used for build-time/request-time rendering.
     pub fn with_theme(mut self, theme: Theme) -> Self {
         self.env.theme = theme.clone();
         self.theme = theme;
         self
     }
 
+    /// Installs a generated design system theme and its packaged font faces.
     pub fn with_design_system<D: DesignSystem>(mut self, mode: DesignMode) -> Self {
         self.theme = D::theme(mode);
         self.env.theme = self.theme.clone();
@@ -76,27 +83,34 @@ impl DocumentShellConfig {
         self
     }
 
+    /// Replaces the packaged font faces embedded in generated CSS.
     pub fn with_fonts(mut self, fonts: &'static [PackagedFont]) -> Self {
         self.font_faces = fonts;
         self
     }
 
+    /// Replaces the base environment while retaining the separately selected
+    /// document theme as the single theme authority.
     pub fn with_env(mut self, mut env: Env) -> Self {
         env.theme = self.theme.clone();
         self.env = env;
         self
     }
 
+    /// Replaces the complete translation registry in the base environment.
     pub fn with_i18n(mut self, i18n: I18nRegistry) -> Self {
         self.env.i18n = i18n;
         self
     }
 
+    /// Adds or replaces one locale's translation bundle.
     pub fn with_translation_bundle(mut self, bundle: TranslationBundle) -> Self {
         self.env.i18n.add_bundle(bundle);
         self
     }
 
+    /// Enables browser theme switching using complete light and dark themes
+    /// and chooses which one is rendered initially.
     pub fn with_light_dark_themes(
         mut self,
         light: Theme,
@@ -115,66 +129,81 @@ impl DocumentShellConfig {
         self
     }
 
+    /// Appends a trusted CSS block after the framework stylesheet.
     pub fn with_user_css(mut self, css: impl Into<String>) -> Self {
         self.user_css.push(css.into());
         self
     }
 
+    /// Adds trusted host markup to matching document positions/routes.
     pub fn with_page_element(mut self, element: SitePageElement) -> Self {
         self.page_elements.push(element);
         self
     }
 
+    /// Sets the favicon URL emitted into document heads.
     pub fn with_favicon(mut self, href: impl Into<String>) -> Self {
         self.favicon_href = Some(href.into());
         self
     }
 
+    /// Configures conditional code-highlighting assets.
     pub fn with_code_highlighting(mut self, options: CodeHighlightingOptions) -> Self {
         self.code_highlighting = Some(options);
         self
     }
 
+    /// Returns the active render theme.
     pub fn theme(&self) -> &Theme {
         &self.theme
     }
 
+    /// Returns the base environment cloned for route rendering.
     pub fn env(&self) -> &Env {
         &self.env
     }
 
+    /// Returns the browser-switchable light theme when configured.
     pub fn light_theme(&self) -> Option<&Theme> {
         self.light_theme.as_ref()
     }
 
+    /// Returns the browser-switchable dark theme when configured.
     pub fn dark_theme(&self) -> Option<&Theme> {
         self.dark_theme.as_ref()
     }
 
+    /// Returns the initially selected mode when theme switching is configured.
     pub fn default_theme_mode(&self) -> Option<DesignMode> {
         self.default_theme_mode
     }
 
+    /// Reports whether both light and dark theme variable sets are emitted.
     pub fn theme_switching(&self) -> bool {
         self.theme_switching
     }
 
+    /// Returns app CSS blocks in cascade order.
     pub fn user_css(&self) -> &[String] {
         &self.user_css
     }
 
+    /// Returns trusted document insertions in registration order.
     pub fn page_elements(&self) -> &[SitePageElement] {
         &self.page_elements
     }
 
+    /// Returns font faces embedded into generated site CSS.
     pub fn font_faces(&self) -> &'static [PackagedFont] {
         self.font_faces
     }
 
+    /// Returns the configured favicon URL.
     pub fn favicon_href(&self) -> Option<&str> {
         self.favicon_href.as_deref()
     }
 
+    /// Returns explicit syntax-highlighting configuration when supplied.
     pub fn code_highlighting(&self) -> Option<&CodeHighlightingOptions> {
         self.code_highlighting.as_ref()
     }

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -16,31 +16,57 @@ use fission_theme::{DesignMode, PackagedFont, PackagedFontStyle, Theme};
 use std::collections::{BTreeMap, HashSet};
 
 #[derive(Clone, Debug)]
+/// Document, enhancement, and renderer inputs for semantic HTML lowering.
 pub struct HtmlRenderOptions {
+    /// BCP 47 language emitted on the root HTML element.
     pub lang: String,
+    /// Browser document title.
     pub document_title: String,
+    /// Optional meta description.
     pub description: Option<String>,
+    /// Optional absolute canonical URL.
     pub canonical_url: Option<String>,
+    /// Optional Open Graph site name.
     pub site_name: Option<String>,
+    /// Optional favicon URL.
     pub favicon_href: Option<String>,
+    /// URL of the generated/shared site stylesheet.
     pub stylesheet_href: String,
+    /// CSS class placed on the rendered app root.
     pub root_class: String,
+    /// Current public path used to resolve links and current-page state.
     pub current_route_path: String,
+    /// CSS custom properties resolved from the active theme.
     pub css_variables: CssVariableMap,
+    /// Initially selected light/dark mode when switching is enabled.
     pub default_theme_mode: Option<DesignMode>,
+    /// Whether browser theme controls and persistence are enabled.
     pub theme_switching: bool,
+    /// Conditional syntax-highlighting asset configuration.
     pub code_highlighting: CodeHighlightingOptions,
+    /// Optional browser search-controller script URL.
     pub search_script_href: Option<String>,
+    /// SSR endpoint receiving signed server-action form posts.
     pub server_action_post_path: Option<String>,
+    /// Signed token indexed by semantic target and action ID.
     pub server_action_tokens: BTreeMap<(WidgetId, u128), String>,
+    /// Whether browser-island action attributes are emitted.
     pub browser_action_bindings: bool,
+    /// Trusted JSON-LD documents inserted into the page head.
     pub structured_data: Vec<String>,
+    /// Trusted markup inserted immediately after opening `<head>`.
     pub head_start_html: Vec<String>,
+    /// Trusted markup inserted immediately before closing `</head>`.
     pub head_end_html: Vec<String>,
+    /// Trusted markup inserted immediately after opening `<body>`.
     pub body_start_html: Vec<String>,
+    /// Trusted markup inserted immediately before closing `</body>`.
     pub body_end_html: Vec<String>,
+    /// Build-time motion declarations lowered to CSS.
     pub motion_declarations: Vec<MotionDeclaration>,
+    /// Video registrations keyed by lowered semantic node.
     pub video_registrations: BTreeMap<WidgetId, VideoRegistration>,
+    /// WebView/iframe registrations keyed by lowered semantic node.
     pub web_registrations: BTreeMap<WidgetId, WebRegistration>,
     /// Font faces embedded by the selected design system.
     pub font_faces: &'static [PackagedFont],
@@ -80,9 +106,13 @@ impl Default for HtmlRenderOptions {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// External assets used to highlight code blocks in generated pages.
 pub struct CodeHighlightingOptions {
+    /// Whether highlighting assets and initialization are emitted.
     pub enabled: bool,
+    /// Highlighting theme stylesheet URL.
     pub stylesheet_href: String,
+    /// Highlighting JavaScript URL.
     pub script_src: String,
 }
 
@@ -101,9 +131,13 @@ impl Default for CodeHighlightingOptions {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// HTML and CSS products of lowering one Core IR document.
 pub struct RenderedHtml {
+    /// Complete standalone HTML document.
     pub html: String,
+    /// Rendered app-root fragment without surrounding document chrome.
     pub body_html: String,
+    /// Deduplicated CSS generated while rendering.
     pub css: String,
 }
 
@@ -160,11 +194,13 @@ fn default_form_field_kind() -> StaticFormFieldKind {
     StaticFormFieldKind::Text
 }
 
+/// Validates and lowers Core IR using a fresh style registry.
 pub fn render_ir_to_html(ir: &CoreIR, options: &HtmlRenderOptions) -> Result<RenderedHtml> {
     let mut registry = StyleRegistry::default();
     render_ir_to_html_with_styles(ir, options, &mut registry)
 }
 
+/// Lowers Core IR while reusing `styles` to deduplicate CSS across routes.
 pub fn render_ir_to_html_with_styles(
     ir: &CoreIR,
     options: &HtmlRenderOptions,
@@ -463,12 +499,14 @@ fn site_enhancement_script_href(stylesheet_href: &str) -> String {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+/// Deterministic CSS custom-property lookup resolved from a Fission theme.
 pub struct CssVariableMap {
     color_vars: Vec<(Color, &'static str)>,
     font_vars: Vec<(String, &'static str)>,
 }
 
 impl CssVariableMap {
+    /// Builds color and font variable mappings from `theme`.
     pub fn from_theme(theme: &Theme) -> Self {
         Self {
             color_vars: theme_color_vars(theme)
@@ -496,6 +534,7 @@ impl CssVariableMap {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Deduplicates normalized declaration sets into stable generated classes.
 pub struct StyleRegistry {
     style_to_class: BTreeMap<String, String>,
     class_to_style: BTreeMap<String, String>,
@@ -503,6 +542,8 @@ pub struct StyleRegistry {
 }
 
 impl StyleRegistry {
+    /// Returns a stable class for `style`, creating it if needed. Empty
+    /// declaration sets return `None`.
     pub fn class_for(&mut self, style: Vec<String>) -> Option<String> {
         let style = normalize_style(style)?;
         if let Some(class_name) = self.style_to_class.get(&style) {
@@ -525,6 +566,7 @@ impl StyleRegistry {
         Some(class_name)
     }
 
+    /// Serializes generated classes and raw rules in deterministic order.
     pub fn to_css(&self) -> String {
         let mut out = String::new();
         for (class_name, style) in &self.class_to_style {
@@ -543,11 +585,13 @@ impl StyleRegistry {
         out
     }
 
+    /// Registers a complete trusted CSS rule under a deterministic dedup key.
     pub fn raw_rule(&mut self, key: impl Into<String>, rule: impl Into<String>) {
         self.raw_rules.insert(key.into(), rule.into());
     }
 }
 
+/// Serializes `theme` as CSS custom properties beneath `selector`.
 pub fn theme_variables_css(selector: &str, theme: &Theme) -> String {
     let mut out = String::new();
     out.push_str(selector);

--- a/crates/shell/fission-shell-site/src/site.rs
+++ b/crates/shell/fission-shell-site/src/site.rs
@@ -11,6 +11,10 @@ use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+/// A build-time transformation applied to a content file before it is rendered.
+///
+/// The callback receives the source text, its source path, and the site project
+/// directory. Returning an error aborts the build with that route's context.
 pub type ContentTransform = dyn Fn(&str, &Path, &Path) -> Result<String> + Send + Sync + 'static;
 
 type RouteRenderer =
@@ -186,19 +190,29 @@ impl SitePageElement {
 }
 
 #[derive(Clone)]
+/// A programmatically registered route in a static Fission site.
 pub struct CustomRoute {
+    /// Normalized public route path, such as `/account/`.
     pub path: String,
+    /// Human-readable document title used by the page shell.
     pub title: String,
+    /// Optional description emitted as page metadata.
     pub description: Option<String>,
+    /// Serialized JSON-LD documents emitted for this route.
     pub structured_data: Vec<String>,
     pub(crate) render: Arc<RouteRenderer>,
 }
 
 #[derive(Clone, Debug)]
+/// Build-time context supplied while constructing a programmatic route.
 pub struct SiteRenderContext<'a> {
+    /// Root directory of the site project being built.
     pub project_dir: &'a Path,
+    /// Normalized route currently being rendered.
     pub route_path: &'a str,
+    /// Theme selected for the current document.
     pub theme: &'a Theme,
+    /// Site-wide fallback locale identifier.
     pub default_locale: &'a str,
     pub(crate) env: &'a Env,
 }
@@ -206,20 +220,34 @@ pub struct SiteRenderContext<'a> {
 /// Build-time context used to select a locale for a static route.
 #[derive(Clone, Debug)]
 pub struct SiteLocaleContext<'a> {
+    /// Root directory of the site project being built.
     pub project_dir: &'a Path,
+    /// Normalized route whose locale is being resolved.
     pub route_path: &'a str,
+    /// Theme selected for the current document.
     pub theme: &'a Theme,
+    /// Site-wide fallback locale identifier.
     pub default_locale: &'a str,
+    /// Locale declared by route content, when one was provided.
     pub declared_locale: Option<&'a str>,
 }
 
 impl<'a> SiteRenderContext<'a> {
+    /// Returns the complete environment used to build this route.
+    ///
+    /// This includes the selected locale, translation bundles, theme, and any
+    /// application-defined environment values installed with `with_env`.
     pub fn env(&self) -> &'a Env {
         self.env
     }
 }
 
 #[derive(Clone)]
+/// Builder for a statically generated Fission site.
+///
+/// `FissionSite` combines content routes with programmatic widget routes and a
+/// shared document environment. Calling [`build_from_cli`] applies the selected
+/// command (`build`, `check`, `routes`, or `serve`) to the configured site.
 pub struct FissionSite {
     pub(crate) custom_routes: Vec<CustomRoute>,
     pub(crate) content_transform: Option<Arc<ContentTransform>>,
@@ -245,10 +273,12 @@ impl Default for FissionSite {
 }
 
 impl FissionSite {
+    /// Creates a site with the default document shell and no custom routes.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the theme used for every generated route.
     pub fn theme(mut self, theme: Theme) -> Self {
         self.document = self.document.with_theme(theme);
         self
@@ -266,21 +296,29 @@ impl FissionSite {
         self
     }
 
+    /// Replaces the complete environment used while building routes.
+    ///
+    /// Use this to install translations and other shared environment services.
+    /// Later theme or i18n builder calls update the corresponding part of this
+    /// environment.
     pub fn with_env(mut self, env: Env) -> Self {
         self.document = self.document.with_env(env);
         self
     }
 
+    /// Replaces the internationalization registry for generated routes.
     pub fn i18n(mut self, i18n: I18nRegistry) -> Self {
         self.document = self.document.with_i18n(i18n);
         self
     }
 
+    /// Adds or replaces one locale's translations in the site environment.
     pub fn translation_bundle(mut self, bundle: TranslationBundle) -> Self {
         self.document = self.document.with_translation_bundle(bundle);
         self
     }
 
+    /// Sets the locale used when neither content nor a resolver selects one.
     pub fn default_locale(mut self, locale: impl Into<Locale>) -> Self {
         self.default_locale = Some(locale.into());
         self
@@ -310,6 +348,10 @@ impl FissionSite {
         self
     }
 
+    /// Provides paired light and dark themes and selects the initial mode.
+    ///
+    /// Both theme variable sets are emitted so generated pages can switch modes
+    /// without rebuilding the site.
     pub fn light_dark_themes(
         mut self,
         light: Theme,
@@ -322,6 +364,7 @@ impl FissionSite {
         self
     }
 
+    /// Appends trusted application CSS to every generated document.
     pub fn user_css(mut self, css: impl Into<String>) -> Self {
         self.document = self.document.with_user_css(css);
         self
@@ -369,6 +412,10 @@ impl FissionSite {
         self.page_element(SitePageElement::body_end(html))
     }
 
+    /// Registers a widget-backed route using a default application state.
+    ///
+    /// The route is normalized, rendered through the normal Fission build and
+    /// lowering pipeline, and receives the same environment as content routes.
     pub fn route_widget<S, W>(
         self,
         path: impl Into<String>,
@@ -440,6 +487,10 @@ impl FissionSite {
         self
     }
 
+    /// Renders a widget below every route's main content.
+    ///
+    /// The footer is built independently for each route with the route's
+    /// selected environment and a fresh default state of `S`.
     pub fn footer_widget<S, W>(mut self, widget: W) -> Self
     where
         S: GlobalState + Default + 'static,
@@ -452,6 +503,10 @@ impl FissionSite {
         self
     }
 
+    /// Installs a build-time transformation for content-source text.
+    ///
+    /// The transform runs before parsing and may return modified source or an
+    /// error. It does not run for routes registered with `route_widget`.
     pub fn content_transform<F>(mut self, transform: F) -> Self
     where
         F: Fn(&str, &Path, &Path) -> Result<String> + Send + Sync + 'static,
@@ -481,6 +536,12 @@ where
     })
 }
 
+/// Runs the static-site CLI command against a configured site.
+///
+/// Arguments are read from the current process. `build` generates files,
+/// `check` validates all routes, `routes` lists discovered routes, and `serve`
+/// builds before starting the local development server. Only the final
+/// `Serving ...` message indicates that the listening socket is ready.
 pub fn build_from_cli(site: FissionSite) -> Result<()> {
     let args = SiteCliArgs::parse(std::env::args().skip(1))?;
     let options = SiteBuildOptions::from_project_dir(&args.project_dir, "Site")?;

--- a/crates/shell/fission-shell-terminal/src/app.rs
+++ b/crates/shell/fission-shell-terminal/src/app.rs
@@ -20,10 +20,10 @@ use fission_core::internal::BuildCtx;
 use fission_core::internal::InternalLoweringCx;
 use fission_core::ui::{Container, Overlay, Widget, ZStack};
 use fission_core::{
-    ActionRegistry, Effect, Env, GlobalState, InputEvent, KeyCode, KeyEvent, LayoutEngine,
-    LayoutPoint, LayoutSize, LayoutSnapshot, NavigationCommand, PointerButton, PointerEvent,
-    RouteLocation, Runtime, RuntimeEffect, RuntimeState, ShellRouteChanged, View, WidgetId,
-    WidgetIdExt, WindowTitle,
+    Action, ActionEnvelope, ActionId, ActionRegistry, Effect, Env, GlobalState, InputEvent,
+    KeyCode, KeyEvent, LayoutEngine, LayoutPoint, LayoutSize, LayoutSnapshot, NavigationCommand,
+    PointerButton, PointerEvent, RouteLocation, Runtime, RuntimeEffect, RuntimeState,
+    ShellRouteChanged, View, WidgetId, WidgetIdExt, WindowTitle,
 };
 use fission_ir::CoreIR;
 use fission_layout::TextMeasurer;
@@ -35,11 +35,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
+/// Runtime and capture options for [`TerminalApp::run_with_options`].
 pub struct TerminalRunOptions {
+    /// Fixed terminal width, or `None` to use the current TTY width.
     pub width: Option<u16>,
+    /// Fixed terminal height, or `None` to use the current TTY height.
     pub height: Option<u16>,
+    /// Optional PNG path written after each rendered frame.
     pub screenshot: Option<PathBuf>,
+    /// Render once and return instead of entering the interactive input loop.
     pub exit_after_render: bool,
+    /// Maximum interval between terminal input/state polling iterations.
     pub poll_interval: Duration,
 }
 
@@ -55,6 +61,12 @@ impl Default for TerminalRunOptions {
     }
 }
 
+/// Stateful Fission application hosted in a terminal cell grid.
+///
+/// `S` is the app's [`GlobalState`] and `W` is its retained root widget. The
+/// shell uses the normal build, lower, layout, action, and reducer pipeline,
+/// then verifies that the resulting Core IR can be represented honestly in a
+/// terminal before drawing it.
 pub struct TerminalApp<S, W>
 where
     S: GlobalState + 'static,
@@ -83,6 +95,7 @@ where
     route_initialized: bool,
     navigation_entries: Vec<RouteLocation>,
     navigation_index: usize,
+    startup_action: Option<ActionEnvelope>,
     _state: std::marker::PhantomData<S>,
 }
 
@@ -91,6 +104,7 @@ where
     S: GlobalState + Default + 'static,
     W: Clone + Into<Widget>,
 {
+    /// Creates a terminal app with `S::default()` as its global state.
     pub fn new(root: W) -> Self {
         Self::new_with_global_state(root, S::default())
     }
@@ -101,6 +115,7 @@ where
     S: GlobalState + 'static,
     W: Clone + Into<Widget>,
 {
+    /// Creates a terminal app with an explicitly prepared global state.
     pub fn new_with_global_state(root: W, state: S) -> Self {
         let measurer: Arc<dyn TextMeasurer> = Arc::new(TerminalTextMeasurer);
         let mut runtime = Runtime::default().with_measurer(measurer.clone());
@@ -135,6 +150,7 @@ where
             route_initialized: false,
             navigation_entries: vec![RouteLocation::default()],
             navigation_index: 0,
+            startup_action: None,
             _state: std::marker::PhantomData,
         }
     }
@@ -144,6 +160,7 @@ where
         Self::new_with_global_state(root, state)
     }
 
+    /// Replaces the registered global state before the first frame.
     pub fn with_global_state(mut self, global_state: S) -> Self {
         *self.runtime.get_global_state_mut::<S>().expect(
             "Fission global state must be registered before TerminalApp::with_global_state is called",
@@ -151,11 +168,14 @@ where
         self
     }
 
+    /// Sets the stable identity from which implicit descendant widget IDs are
+    /// derived. Use a durable app-specific value when several roots coexist.
     pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
         self.root_id = root_id;
         self
     }
 
+    /// Sets the terminal title and the app name used by default host services.
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         let title = title.into();
         self.env.window.title = WindowTitle::plain(title.clone());
@@ -164,6 +184,7 @@ where
     }
 
     #[cfg(feature = "store")]
+    /// Replaces the key/value provider used by terminal Store effects.
     pub fn with_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::StoreProvider + Send + Sync,
@@ -176,6 +197,7 @@ where
     }
 
     #[cfg(feature = "store-sql")]
+    /// Replaces the SQL-capable provider used by terminal Store and SQL effects.
     pub fn with_sql_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::SqlStoreProvider + Send + Sync,
@@ -187,11 +209,62 @@ where
         self
     }
 
-    pub fn with_env(mut self, configure: impl FnOnce(&mut Env)) -> Self {
+    /// Replaces the environment used to build terminal frames.
+    ///
+    /// This has the same contract as the graphical app builders: pass a
+    /// complete base environment containing translation bundles, an initial
+    /// locale, theme, and other app-wide presentation inputs. The terminal
+    /// shell restores its own text measurer and viewport before every frame.
+    pub fn with_env(mut self, env: Env) -> Self {
+        self.env = env;
+        self
+    }
+
+    /// Mutates the terminal shell's initial environment in place.
+    ///
+    /// This preserves the older terminal convenience API without giving
+    /// `with_env` a different meaning from every other shell.
+    pub fn configure_env(mut self, configure: impl FnOnce(&mut Env)) -> Self {
         configure(&mut self.env);
         self
     }
 
+    /// Installs a generated design system's theme for the requested mode.
+    ///
+    /// Packaged font faces are intentionally not registered: a terminal
+    /// emulator, rather than Fission, owns the font used to draw terminal
+    /// cells. All non-font design tokens remain available to widgets.
+    pub fn with_design_system<D: fission_theme::DesignSystem>(
+        mut self,
+        mode: fission_theme::DesignMode,
+    ) -> Self {
+        self.env.theme = D::theme(mode);
+        self
+    }
+
+    /// Mutates the initial global state before the first terminal frame.
+    pub fn with_state_init<F>(mut self, init: F) -> Self
+    where
+        F: FnOnce(&mut S),
+    {
+        if let Some(state) = self.runtime.get_global_state_mut::<S>() {
+            init(state);
+        }
+        self
+    }
+
+    /// Queues one typed action for dispatch when the terminal runtime starts.
+    ///
+    /// Dispatch is deferred until the first frame so persistent handlers may
+    /// be registered later in the builder chain without making method order
+    /// observable.
+    pub fn with_startup_action<A: Action>(mut self, action: A) -> Self {
+        self.startup_action = Some(action.into());
+        self
+    }
+
+    /// Mirrors global-state presentation choices into the environment before
+    /// each build. The closure must not perform I/O or mutate app state.
     pub fn with_sync_env<F>(mut self, sync: F) -> Self
     where
         F: Fn(&S, &mut Env) + 'static,
@@ -200,6 +273,10 @@ where
         self
     }
 
+    /// Installs a terminal polling hook with access to app state, retained
+    /// runtime state, and the current environment.
+    ///
+    /// Return `true` when a state change requires another frame.
     pub fn with_state_update<F>(mut self, update: F) -> Self
     where
         F: FnMut(&mut S, &mut RuntimeState, &Env) -> bool + 'static,
@@ -208,6 +285,21 @@ where
         self
     }
 
+    /// Runs a lightweight state hook between terminal input polls.
+    ///
+    /// Return `true` to request another frame. Use [`Self::with_state_update`]
+    /// when the hook also needs terminal runtime state or environment access.
+    pub fn with_frame_hook<F>(self, hook: F) -> Self
+    where
+        F: Fn(&mut S) -> bool + 'static,
+    {
+        self.with_state_update(move |state, _runtime, _env| hook(state))
+    }
+
+    /// Handles a user-requested exit, such as `Esc` or `Ctrl+C`.
+    ///
+    /// Return `true` to leave the interactive loop. The hook may update state
+    /// to present confirmation UI and return `false` instead.
     pub fn with_exit_request<F>(mut self, request: F) -> Self
     where
         F: FnMut(&mut S, &mut RuntimeState, &Env) -> bool + 'static,
@@ -216,6 +308,8 @@ where
         self
     }
 
+    /// Adds a state predicate checked after updates to end the interactive
+    /// terminal loop without requiring a key event.
     pub fn with_should_exit<F>(mut self, should_exit: F) -> Self
     where
         F: Fn(&S, &RuntimeState, &Env) -> bool + 'static,
@@ -224,6 +318,8 @@ where
         self
     }
 
+    /// Registers an app-wide key handler before normal widget input routing.
+    /// Return `true` to consume the key.
     pub fn with_key_handler<F>(mut self, handler: F) -> Self
     where
         F: FnMut(&mut S, &KeyCode, u8) -> bool + 'static,
@@ -243,6 +339,22 @@ where
         self
     }
 
+    /// Registers one reducer in the shell's persistent action registry.
+    pub fn register_reducer(
+        &mut self,
+        action_id: ActionId,
+        reducer: fission_core::action::Reducer<S>,
+    ) -> Result<()> {
+        self.runtime.register_reducer::<S>(action_id, reducer)
+    }
+
+    /// Merges an action registry into the shell's persistent registry.
+    pub fn absorb_registry(&mut self, registry: ActionRegistry<S>) {
+        self.runtime.absorb_persistent_registry(registry);
+    }
+
+    /// Builds, lays out, verifies, and renders one frame at the given cell
+    /// dimensions. Runtime state and reducers remain alive for later frames.
     pub fn render_frame(&mut self, width: u16, height: u16) -> Result<TerminalFrame> {
         if !self.route_initialized {
             self.route_initialized = true;
@@ -273,6 +385,11 @@ where
 
         let route_before_build = self.env.current_route.clone();
         let mut node_tree = self.build_widget_tree(viewport)?;
+        if let Some(action) = self.startup_action.take() {
+            self.runtime.dispatch(action, WidgetId::from_u128(0))?;
+            self.process_navigation()?;
+            node_tree = self.build_widget_tree(viewport)?;
+        }
         self.process_navigation()?;
         if self.env.current_route != route_before_build {
             node_tree = self.build_widget_tree(viewport)?;
@@ -317,6 +434,11 @@ where
         Ok(frame)
     }
 
+    /// Sends one normalized Fission input event through the most recently
+    /// rendered IR and layout snapshot.
+    ///
+    /// Events sent before the first frame are ignored because no hit-test or
+    /// focus geometry exists yet.
     pub fn send_event(&mut self, event: InputEvent) -> Result<()> {
         let (Some(ir), Some(snapshot)) = (&self.last_ir, &self.last_snapshot) else {
             return Ok(());
@@ -408,10 +530,13 @@ where
         Ok(handler(state, key_code, *modifiers))
     }
 
+    /// Runs an interactive terminal app using detected TTY dimensions and the
+    /// default polling interval.
     pub fn run(self) -> Result<()> {
         self.run_with_options(TerminalRunOptions::default())
     }
 
+    /// Runs the terminal app with explicit sizing, capture, and loop options.
     pub fn run_with_options(mut self, options: TerminalRunOptions) -> Result<()> {
         #[cfg(feature = "store-sqlite-native")]
         fission_shell::store_host::register_default_native_store(
@@ -956,7 +1081,7 @@ mod navigation_tests {
     #[test]
     fn terminal_dispatches_initial_and_programmatic_route_changes() {
         let mut app = TerminalApp::<RouteState, _>::new(fission_core::ui::Text::new("route"))
-            .with_env(|env| env.current_route = RouteLocation::new("/initial"))
+            .configure_env(|env| env.current_route = RouteLocation::new("/initial"))
             .with_route_handler(route_changed);
 
         app.render_frame(40, 10).expect("initial frame");
@@ -975,5 +1100,24 @@ mod navigation_tests {
         let state = app.runtime.get_global_state::<RouteState>().unwrap();
         assert_eq!(state.path, "/next");
         assert_eq!(state.changes, 2);
+    }
+
+    #[test]
+    fn terminal_accepts_the_common_environment_and_startup_contract() {
+        let mut env = Env::default();
+        env.current_route = RouteLocation::new("/initial");
+        let mut app = TerminalApp::<RouteState, _>::new(fission_core::ui::Text::new("route"))
+            .with_env(env)
+            .with_state_init(|state| state.path = "/prepared".into())
+            .with_route_handler(route_changed)
+            .with_startup_action(ShellRouteChanged {
+                location: RouteLocation::new("/startup"),
+            });
+
+        app.render_frame(40, 10).expect("initial frame");
+        let state = app.runtime.get_global_state::<RouteState>().unwrap();
+        assert_eq!(state.path, "/startup");
+        assert_eq!(state.changes, 2);
+        assert_eq!(app.env.current_route.pathname, "/initial");
     }
 }

--- a/crates/shell/fission-shell-terminal/src/frame.rs
+++ b/crates/shell/fission-shell-terminal/src/frame.rs
@@ -1,20 +1,28 @@
 use fission_ir::op::Color;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Opaque 24-bit RGB color used by terminal frame cells.
 pub struct TerminalColor {
+    /// Red channel in the inclusive range `0..=255`.
     pub r: u8,
+    /// Green channel in the inclusive range `0..=255`.
     pub g: u8,
+    /// Blue channel in the inclusive range `0..=255`.
     pub b: u8,
 }
 
 impl TerminalColor {
+    /// Black (`#000000`).
     pub const BLACK: Self = Self { r: 0, g: 0, b: 0 };
+    /// White (`#ffffff`).
     pub const WHITE: Self = Self {
         r: 255,
         g: 255,
         b: 255,
     };
 
+    /// Drops the alpha channel from an IR color after surrounding rendering
+    /// has resolved compositing.
     pub fn from_ir(color: Color) -> Self {
         Self {
             r: color.r,
@@ -23,6 +31,8 @@ impl TerminalColor {
         }
     }
 
+    /// Alpha-composites this foreground over `background` using an 8-bit
+    /// opacity where `0` is transparent and `255` is opaque.
     pub fn blend_over(self, background: Self, alpha: u8) -> Self {
         if alpha == 255 {
             return self;
@@ -47,14 +57,20 @@ impl From<Color> for TerminalColor {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Visual attributes attached to one terminal cell.
 pub struct TerminalStyle {
+    /// Foreground glyph color.
     pub fg: TerminalColor,
+    /// Cell background color.
     pub bg: TerminalColor,
+    /// Whether the terminal should request bold/intense text.
     pub bold: bool,
+    /// Whether the terminal should request an underline.
     pub underline: bool,
 }
 
 impl TerminalStyle {
+    /// Creates a normal-weight, non-underlined style with the given colors.
     pub fn new(fg: TerminalColor, bg: TerminalColor) -> Self {
         Self {
             fg,
@@ -66,25 +82,34 @@ impl TerminalStyle {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// One character cell in a rendered terminal frame.
 pub struct TerminalCell {
+    /// Unicode scalar displayed in this cell.
     pub ch: char,
+    /// Foreground, background, and emphasis applied to the cell.
     pub style: TerminalStyle,
 }
 
 impl TerminalCell {
+    /// Creates a space cell carrying `style`.
     pub fn blank(style: TerminalStyle) -> Self {
         Self { ch: ' ', style }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Complete row-major terminal output for one Fission frame.
 pub struct TerminalFrame {
+    /// Number of character columns.
     pub width: u16,
+    /// Number of character rows.
     pub height: u16,
+    /// Row-major cells; the expected length is `width * height`.
     pub cells: Vec<TerminalCell>,
 }
 
 impl TerminalFrame {
+    /// Allocates a frame filled with blank cells using `style`.
     pub fn new(width: u16, height: u16, style: TerminalStyle) -> Self {
         let len = usize::from(width).saturating_mul(usize::from(height));
         Self {
@@ -94,16 +119,20 @@ impl TerminalFrame {
         }
     }
 
+    /// Replaces every cell with a styled blank.
     pub fn clear(&mut self, style: TerminalStyle) {
         for cell in &mut self.cells {
             *cell = TerminalCell::blank(style);
         }
     }
 
+    /// Returns the cell at zero-based column `x` and row `y`, or `None` when
+    /// the coordinate is outside the frame.
     pub fn get(&self, x: u16, y: u16) -> Option<&TerminalCell> {
         self.index(x, y).and_then(|idx| self.cells.get(idx))
     }
 
+    /// Writes a character and style, clipping coordinates outside the frame.
     pub fn set(&mut self, x: i32, y: i32, ch: char, style: TerminalStyle) {
         if x < 0 || y < 0 {
             return;
@@ -118,6 +147,7 @@ impl TerminalFrame {
         }
     }
 
+    /// Fills the clipped rectangle with styled blank cells.
     pub fn fill_rect(&mut self, x: i32, y: i32, width: i32, height: i32, style: TerminalStyle) {
         if width <= 0 || height <= 0 {
             return;
@@ -133,6 +163,7 @@ impl TerminalFrame {
         }
     }
 
+    /// Draws a clipped horizontal run of `ch` beginning at `(x, y)`.
     pub fn draw_hline(&mut self, x: i32, y: i32, width: i32, ch: char, style: TerminalStyle) {
         if width <= 0 {
             return;
@@ -142,6 +173,7 @@ impl TerminalFrame {
         }
     }
 
+    /// Draws a clipped vertical run of `ch` beginning at `(x, y)`.
     pub fn draw_vline(&mut self, x: i32, y: i32, height: i32, ch: char, style: TerminalStyle) {
         if height <= 0 {
             return;
@@ -151,6 +183,8 @@ impl TerminalFrame {
         }
     }
 
+    /// Returns the character grid as newline-separated rows without ANSI
+    /// styling. Trailing spaces are retained for deterministic snapshots.
     pub fn as_plain_text(&self) -> String {
         let mut out = String::new();
         for y in 0..self.height {

--- a/crates/shell/fission-shell-terminal/src/render.rs
+++ b/crates/shell/fission-shell-terminal/src/render.rs
@@ -11,14 +11,20 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 #[derive(Clone, Debug)]
+/// Converts verified Fission Core IR and layout geometry into terminal cells.
 pub struct TerminalRenderer {
+    /// Default canvas background used for otherwise unpainted cells.
     pub background: TerminalColor,
+    /// Default text color.
     pub foreground: TerminalColor,
+    /// Default color for borders and separators.
     pub border: TerminalColor,
+    /// Theme accent used by interactive controls and focus indicators.
     pub accent: TerminalColor,
 }
 
 impl TerminalRenderer {
+    /// Resolves terminal colors from the active Fission theme.
     pub fn from_theme(theme: &Theme) -> Self {
         Self {
             background: TerminalColor::from(theme.tokens.colors.background),
@@ -28,6 +34,11 @@ impl TerminalRenderer {
         }
     }
 
+    /// Renders `ir` using `snapshot` geometry and current scroll offsets into
+    /// a frame of `width` columns by `height` rows.
+    ///
+    /// Call [`crate::verify_terminal_ir`] first when rendering IR that did not
+    /// come through [`crate::TerminalApp`].
     pub fn render(
         &self,
         ir: &CoreIR,

--- a/crates/shell/fission-shell-terminal/src/screenshot.rs
+++ b/crates/shell/fission-shell-terminal/src/screenshot.rs
@@ -6,8 +6,11 @@ use std::fs;
 use std::path::Path;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Pixel dimensions used to rasterize each terminal cell into a PNG.
 pub struct ScreenshotOptions {
+    /// Width of one output cell in pixels.
     pub cell_width: u32,
+    /// Height of one output cell in pixels.
     pub cell_height: u32,
 }
 
@@ -20,6 +23,11 @@ impl Default for ScreenshotOptions {
     }
 }
 
+/// Rasterizes `frame` with Fission's bundled font and writes a PNG to `path`.
+///
+/// Parent directories are created automatically. The result is intended for
+/// deterministic tests and documentation; a live terminal may use a different
+/// font and cell aspect ratio.
 pub fn write_frame_png(
     frame: &TerminalFrame,
     path: impl AsRef<Path>,

--- a/crates/shell/fission-shell-terminal/src/test_control.rs
+++ b/crates/shell/fission-shell-terminal/src/test_control.rs
@@ -33,6 +33,8 @@ where
     S: GlobalState + 'static,
     W: Clone + Into<fission_core::ui::Widget>,
 {
+    /// Creates a headless terminal session and renders its initial frame using
+    /// the supplied cell dimensions.
     pub fn new(mut app: TerminalApp<S, W>, width: u16, height: u16) -> Result<Self> {
         let frame = app.render_frame(width, height)?;
         Ok(Self {
@@ -44,14 +46,19 @@ where
         })
     }
 
+    /// Returns the most recently rendered terminal frame.
     pub fn frame(&self) -> &TerminalFrame {
         &self.frame
     }
 
+    /// Reports whether a dispatched test command requested that the session
+    /// terminate.
     pub fn is_quit_requested(&self) -> bool {
         self.quit_requested
     }
 
+    /// Executes one cross-shell test command and returns a protocol response.
+    /// Errors are converted to [`TestResponse::Error`] instead of panicking.
     pub fn dispatch(&mut self, command: TestCommand) -> TestResponse {
         match self.try_dispatch(command) {
             Ok(response) => response,

--- a/crates/shell/fission-shell-terminal/src/text.rs
+++ b/crates/shell/fission-shell-terminal/src/text.rs
@@ -4,6 +4,10 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 #[derive(Clone, Debug, Default)]
+/// Cell-based text measurer used by the terminal layout backend.
+///
+/// Horizontal values are terminal column widths and vertical values are line
+/// counts; font pixel size is intentionally irrelevant.
 pub struct TerminalTextMeasurer;
 
 impl TerminalTextMeasurer {
@@ -47,6 +51,8 @@ impl TerminalTextMeasurer {
         (width, height)
     }
 
+    /// Returns the number of terminal columns occupied by `ch`, with
+    /// zero-width/unknown scalars conservatively treated as one column.
     pub fn char_width(ch: char) -> usize {
         UnicodeWidthChar::width(ch).unwrap_or(1).max(1)
     }

--- a/crates/shell/fission-shell-terminal/src/verify.rs
+++ b/crates/shell/fission-shell-terminal/src/verify.rs
@@ -3,8 +3,12 @@ use fission_ir::{CoreIR, Op, WidgetId};
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// Explanation of a Core IR operation that cannot be represented by terminal
+/// cells without silently changing its meaning.
 pub struct TerminalSupportError {
+    /// Node containing the unsupported layout or paint operation.
     pub node_id: WidgetId,
+    /// Human-readable description of the unsupported capability.
     pub reason: String,
 }
 
@@ -20,6 +24,11 @@ impl fmt::Display for TerminalSupportError {
 
 impl std::error::Error for TerminalSupportError {}
 
+/// Verifies that every layout and paint operation in `ir` has an honest
+/// terminal representation.
+///
+/// The first unsupported node is returned. Call this before rendering custom
+/// or generated IR so graphical-only effects do not disappear silently.
 pub fn verify_terminal_ir(ir: &CoreIR) -> Result<(), TerminalSupportError> {
     for (node_id, node) in &ir.nodes {
         match &node.op {

--- a/crates/shell/fission-shell-web/src/lib.rs
+++ b/crates/shell/fission-shell-web/src/lib.rs
@@ -1,3 +1,10 @@
+//! Browser/WebAssembly application shell built on Fission's shared winit
+//! runtime and canvas renderer.
+//!
+//! [`WebApp`] owns browser mounting, history integration, input defaults, and
+//! browser capability hosts while preserving the same state/reducer/widget
+//! model as native graphical targets.
+
 use anyhow::Result;
 use fission_core::{Action, ActionRegistry, Env, GlobalState, Widget, WidgetId};
 use fission_shell::async_host::AsyncRegistry;
@@ -16,6 +23,10 @@ pub use fission_shell_winit::{
     WebNavigationConfig, WebRouteStrategy, WifiHost,
 };
 
+/// Stateful Fission application mounted into a browser document.
+///
+/// `S` is the app's global state and `W` its retained root widget. Constructing
+/// this value has no DOM side effects; [`Self::run`] performs the mount.
 pub struct WebApp<S: GlobalState, W>
 where
     W: Clone + Into<Widget>,
@@ -23,38 +34,76 @@ where
     inner: WinitApp<S, W>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct TestState;
+    impl GlobalState for TestState {}
+
+    #[test]
+    fn common_stateful_builder_contract_is_available() {
+        let _app = WebApp::<TestState, _>::new(fission_core::ui::Text::new("web"))
+            .with_env(Env::default())
+            .with_state_init(|_state| {})
+            .with_key_handler(|_state, _key, _modifiers| false)
+            .with_sync_env(|_state, _env| {});
+    }
+}
+
 impl<S, W> WebApp<S, W>
 where
     S: GlobalState + Default,
     W: Clone + Into<Widget> + 'static,
 {
+    /// Creates a Web app using `S::default()` as its global state.
     pub fn new(root_widget: W) -> Self {
         Self {
             inner: WinitApp::new(root_widget),
         }
     }
 
+    /// Creates a Web app with an explicitly prepared global state.
     pub fn new_with_global_state(root_widget: W, global_state: S) -> Self {
         Self {
             inner: WinitApp::new_with_global_state(root_widget, global_state),
         }
     }
 
+    /// Replaces the registered global state before the app starts.
     pub fn with_global_state(mut self, global_state: S) -> Self {
         self.inner = self.inner.with_global_state(global_state);
         self
     }
 
+    /// Sets the stable identity from which implicit descendant IDs are derived.
     pub fn with_root_id(mut self, root_id: WidgetId) -> Self {
         self.inner = self.inner.with_root_id(root_id);
         self
     }
 
+    /// Registers a host-level keyboard handler before normal widget routing.
+    ///
+    /// Return `true` when the handler consumes the key. Text entry, focus, and
+    /// ordinary shortcuts should normally remain in widgets; this hook is for
+    /// application-wide commands such as a command palette shortcut.
+    pub fn with_key_handler<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&mut S, &fission_core::KeyCode, u8) -> bool + Send + Sync + 'static,
+    {
+        self.inner = self.inner.with_key_handler(handler);
+        self
+    }
+
+    /// Sets the browser document title used by the running app.
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.inner = self.inner.with_title(title);
         self
     }
 
+    /// Selects the existing DOM element that will contain Fission's canvas.
+    /// The selector must resolve to exactly the intended app mount.
     pub fn with_mount_selector(mut self, selector: impl Into<String>) -> Self {
         self.inner = self.inner.with_mount_selector(selector);
         self
@@ -67,10 +116,12 @@ where
         self
     }
 
+    /// Concise alias for [`Self::with_mount_selector`].
     pub fn mount(self, selector: impl Into<String>) -> Self {
         self.with_mount_selector(selector)
     }
 
+    /// Mutates initial global state synchronously before the first frame.
     pub fn with_state_init<F>(mut self, init: F) -> Self
     where
         F: FnOnce(&mut S),
@@ -79,6 +130,18 @@ where
         self
     }
 
+    /// Replaces the environment used to build the first and subsequent frames.
+    ///
+    /// Use this to install app-wide inputs that are not product state, such as
+    /// translation bundles, an initial locale, or host presentation values.
+    /// Values which change with [`GlobalState`] should be mirrored afterward
+    /// with [`Self::with_sync_env`].
+    pub fn with_env(mut self, env: Env) -> Self {
+        self.inner = self.inner.with_env(env);
+        self
+    }
+
+    /// Dispatches one typed action after the first widget registry is built.
     pub fn with_startup_action<A: Action>(mut self, action: A) -> Self {
         self.inner = self.inner.with_startup_action(action);
         self
@@ -90,6 +153,8 @@ where
         self
     }
 
+    /// Registers the persistent reducer that mirrors browser route changes
+    /// into application state.
     pub fn with_route_handler(
         mut self,
         handler: fission_core::registry::Handler<S, fission_core::ShellRouteChanged>,
@@ -98,6 +163,7 @@ where
         self
     }
 
+    /// Installs a generated design system's theme and packaged fonts.
     pub fn with_design_system<D: fission_theme::DesignSystem>(
         mut self,
         mode: fission_theme::DesignMode,
@@ -112,6 +178,7 @@ where
         self
     }
 
+    /// Mirrors global-state presentation values into `Env` before each build.
     pub fn with_sync_env<F>(mut self, sync: F) -> Self
     where
         F: Fn(&S, &mut Env) + Send + Sync + 'static,
@@ -120,6 +187,8 @@ where
         self
     }
 
+    /// Runs a lightweight host hook between browser frames; return `true` to
+    /// request a redraw.
     pub fn with_frame_hook<F>(mut self, hook: F) -> Self
     where
         F: Fn(&mut S) -> bool + Send + Sync + 'static,
@@ -128,6 +197,8 @@ where
         self
     }
 
+    /// Registers app jobs, services, and operation capability handlers with
+    /// the browser-owned asynchronous host.
     pub fn with_async<F>(mut self, configure: F) -> Self
     where
         F: FnOnce(&mut AsyncRegistry),
@@ -137,6 +208,7 @@ where
     }
 
     #[cfg(feature = "store")]
+    /// Replaces the key/value store provider used by Store effects.
     pub fn with_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::StoreProvider + Send + Sync,
@@ -146,6 +218,7 @@ where
     }
 
     #[cfg(feature = "store-sql")]
+    /// Replaces the SQL-capable store provider used by Store and SQL effects.
     pub fn with_sql_store_provider<P>(mut self, provider: P) -> Self
     where
         P: fission_store::SqlStoreProvider + Send + Sync,
@@ -154,6 +227,7 @@ where
         self
     }
 
+    /// Installs the implementation used by notification effects.
     pub fn with_notification_host<H>(mut self, host: H) -> Self
     where
         H: NotificationHost,
@@ -162,6 +236,7 @@ where
         self
     }
 
+    /// Installs the implementation used by NFC effects.
     pub fn with_nfc_host<H>(mut self, host: H) -> Self
     where
         H: NfcHost,
@@ -170,6 +245,7 @@ where
         self
     }
 
+    /// Installs the implementation used by biometric authentication effects.
     pub fn with_biometric_host<H>(mut self, host: H) -> Self
     where
         H: BiometricHost,
@@ -178,6 +254,7 @@ where
         self
     }
 
+    /// Installs the implementation used by passkey registration and sign-in.
     pub fn with_passkey_host<H>(mut self, host: H) -> Self
     where
         H: PasskeyHost,
@@ -186,6 +263,7 @@ where
         self
     }
 
+    /// Installs the implementation used by Bluetooth effects.
     pub fn with_bluetooth_host<H>(mut self, host: H) -> Self
     where
         H: BluetoothHost,
@@ -194,6 +272,7 @@ where
         self
     }
 
+    /// Installs the implementation used by barcode scanning effects.
     pub fn with_barcode_scanner_host<H>(mut self, host: H) -> Self
     where
         H: BarcodeScannerHost,
@@ -202,6 +281,7 @@ where
         self
     }
 
+    /// Installs the implementation used by camera effects.
     pub fn with_camera_host<H>(mut self, host: H) -> Self
     where
         H: CameraHost,
@@ -210,6 +290,7 @@ where
         self
     }
 
+    /// Installs the implementation used by clipboard effects.
     pub fn with_clipboard_host<H>(mut self, host: H) -> Self
     where
         H: ClipboardHost,
@@ -218,6 +299,7 @@ where
         self
     }
 
+    /// Installs the implementation used by geolocation effects.
     pub fn with_geolocation_host<H>(mut self, host: H) -> Self
     where
         H: GeolocationHost,
@@ -226,6 +308,7 @@ where
         self
     }
 
+    /// Installs the implementation used by haptic feedback effects.
     pub fn with_haptic_host<H>(mut self, host: H) -> Self
     where
         H: HapticHost,
@@ -234,6 +317,7 @@ where
         self
     }
 
+    /// Installs the implementation used by microphone capture effects.
     pub fn with_microphone_host<H>(mut self, host: H) -> Self
     where
         H: MicrophoneHost,
@@ -242,6 +326,7 @@ where
         self
     }
 
+    /// Installs the implementation used by Wi-Fi effects.
     pub fn with_wifi_host<H>(mut self, host: H) -> Self
     where
         H: WifiHost,
@@ -250,6 +335,7 @@ where
         self
     }
 
+    /// Installs the implementation used by system/media volume effects.
     pub fn with_volume_host<H>(mut self, host: H) -> Self
     where
         H: VolumeHost,
@@ -258,26 +344,31 @@ where
         self
     }
 
+    /// Sets the accepted schemes, domains, and path prefixes for inbound links.
     pub fn with_deep_link_config(mut self, config: fission_core::DeepLinkConfig) -> Self {
         self.inner = self.inner.with_deep_link_config(config);
         self
     }
 
+    /// Adds an accepted custom URI scheme to the deep-link policy.
     pub fn with_deep_link_scheme(mut self, scheme: impl Into<String>) -> Self {
         self.inner = self.inner.with_deep_link_scheme(scheme);
         self
     }
 
+    /// Adds an accepted HTTP(S) host to the deep-link policy.
     pub fn with_deep_link_domain(mut self, domain: impl Into<String>) -> Self {
         self.inner = self.inner.with_deep_link_domain(domain);
         self
     }
 
+    /// Queues an already-resolved inbound link for startup dispatch.
     pub fn with_startup_deep_link(mut self, link: fission_core::DeepLink) -> Self {
         self.inner = self.inner.with_startup_deep_link(link);
         self
     }
 
+    /// Queues a notification interaction received before app startup.
     pub fn with_startup_notification_response(
         mut self,
         response: fission_core::NotificationResponse,
@@ -286,6 +377,7 @@ where
         self
     }
 
+    /// Registers a persistent typed reducer for accepted inbound deep links.
     pub fn on_deep_link<H>(mut self, handler: H) -> Self
     where
         H: fission_core::registry::IntoHandler<S, fission_core::DeepLinkReceived>
@@ -297,6 +389,7 @@ where
         self
     }
 
+    /// Registers a persistent typed reducer for notification interactions.
     pub fn on_notification_response<H>(mut self, handler: H) -> Self
     where
         H: fission_core::registry::IntoHandler<S, fission_core::NotificationResponseReceived>
@@ -308,10 +401,26 @@ where
         self
     }
 
+    /// Merges a set of host-owned reducers into the persistent registry.
     pub fn absorb_registry(&mut self, registry: ActionRegistry<S>) {
         self.inner.absorb_registry(registry);
     }
 
+    /// Registers one reducer in the shell's persistent action registry.
+    ///
+    /// Components normally register reducers declaratively while building.
+    /// This lower-level hook is for host-owned actions that must remain
+    /// available independently of the current widget tree.
+    pub fn register_reducer(
+        &mut self,
+        action_id: fission_core::ActionId,
+        reducer: fission_core::action::Reducer<S>,
+    ) -> Result<()> {
+        self.inner.register_reducer(action_id, reducer)
+    }
+
+    /// Mounts the app, starts the browser event loop, and renders until the
+    /// page tears down the WebAssembly instance.
     pub fn run(self) -> Result<()> {
         self.inner.run()
     }

--- a/crates/tools/fission-command-ui/src/publish/mod.rs
+++ b/crates/tools/fission-command-ui/src/publish/mod.rs
@@ -60,7 +60,7 @@ pub fn run_publish_tui(options: PublishUiOptions) -> Result<()> {
     let state = PublishUiState::load(options);
     fission::terminal::TerminalApp::with_state(PublishApp, state)
         .with_title("Fission publish")
-        .with_env(|env| env.theme = fission::theme::Theme::dark())
+        .configure_env(|env| env.theme = fission::theme::Theme::dark())
         .with_sync_env(|state, env| env.theme = theme_for_mode(state.theme_mode))
         .with_key_handler(publish_key_handler)
         .with_state_update(|state, _runtime, _env| state.poll_background_tasks())

--- a/crates/tools/fission-command-ui/src/release_config.rs
+++ b/crates/tools/fission-command-ui/src/release_config.rs
@@ -624,7 +624,7 @@ pub fn run_release_config_tui(options: ReleaseConfigEditorOptions) -> Result<()>
     let state = ReleaseConfigEditorState::load(options);
     fission::terminal::TerminalApp::with_state(ReleaseConfigEditorApp, state)
         .with_title("Fission release config")
-        .with_env(|env| env.theme = fission::theme::Theme::dark())
+        .configure_env(|env| env.theme = fission::theme::Theme::dark())
         .with_sync_env(|state, env| {
             env.theme = match state.theme_mode {
                 EditorThemeMode::Dark => fission::theme::Theme::dark(),

--- a/documentation/content/docs/guides/input-events-text-and-env.mdx
+++ b/documentation/content/docs/guides/input-events-text-and-env.mdx
@@ -156,7 +156,10 @@ A user may toggle dark mode. They may choose a locale from a settings screen. Yo
 
 That is what `.with_sync_env(...)` is for.
 
-The public `DesktopApp`, `MobileApp`, and `WebApp` builders all expose `.with_sync_env(...)`. The hook receives the current app state and a mutable `Env`, and it runs as part of the shell-managed app setup so the environment can reflect the latest state before widgets build.
+The public `DesktopApp`, `MobileApp`, `WebApp`, and `TerminalApp` builders all
+expose `.with_env(...)` and `.with_sync_env(...)`. Browser islands do as well.
+The sync hook receives the current app state and a mutable `Env`, and runs
+before widgets build so the environment reflects the latest state.
 
 A typical example looks like this:
 

--- a/documentation/content/docs/guides/platform-shells-cli-and-testing.mdx
+++ b/documentation/content/docs/guides/platform-shells-cli-and-testing.mdx
@@ -86,13 +86,25 @@ These runtime wrappers revolve around the same product questions. What is the in
 
 That shared shape is the important part. It means the same mental model travels with you across platforms.
 
-The public wrappers are not completely symmetrical, so it helps to understand the differences by purpose rather than memorizing a method inventory.
+The stateful wrappers deliberately share the same core setup vocabulary.
+`DesktopApp`, `MobileApp`, `WebApp`, and `TerminalApp` all accept a prepared
+environment with `with_env(...)`, synchronize it with `with_sync_env(...)`,
+prepare state, dispatch a startup action, install a host key handler and frame
+hook, and register persistent host-owned reducers. The setup used to install
+translations therefore does not change merely because an app moves from a
+desktop entrypoint to Web.
 
-`DesktopApp` currently exposes the broadest public setup API. It can replace the initial environment with `with_env(...)`, it exposes reducer-registration helpers directly, and it can open the live test-control port with `with_test_control_port(...)`. That makes it a very convenient host for local iteration and automated live testing.
+`DesktopApp` and `MobileApp` can open the native live test-control port with
+`with_test_control_port(...)` and protect it with
+`with_test_control_token(...)`. Web testing uses the browser control bridge
+instead of opening a TCP listener inside WebAssembly. `MobileApp` also includes
+the Android-specific `run_with_android_app(...)` entrypoint used when the host
+activity hands control to Fission.
 
-`MobileApp` exposes the same core runtime ideas: state setup, startup action flow, environment synchronization, async registration, and live test-control support. It also includes the Android-specific `run_with_android_app(...)` host entrypoint used when the Android shell hands control to Fission.
-
-`WebApp` keeps the browser wrapper intentionally small. It supports the same shared startup and async-registration story, but it does not currently expose a public live test-control port or a public key-handler hook. That should be read as a shell-tooling difference in the current browser wrapper, not as a statement that the browser target is less real. A web app still runs the same shared runtime and can still be a production app.
+`WebApp` adds browser-owned configuration such as its mount selector, selective
+browser defaults, and pathname/hash navigation strategy. Those methods do not
+appear on native wrappers because there is no DOM or browser history to
+configure there.
 
 `TerminalApp` runs the same build, lower, layout, verify, and render pipeline inside a terminal. It is useful for command tools, dashboards, setup flows, and developer workflows where the user already lives in a terminal. It verifies terminal compatibility from Core IR and semantics rather than from hard-coded widget names. Continue to [Terminal user interfaces](/docs/guides/terminal-user-interfaces/) for a full guide.
 
@@ -106,7 +118,13 @@ A good rule is to use the wrapper for host startup concerns and keep product beh
 
 `with_state_init(...)` is for synchronous state preparation before the first frame. `with_startup_action(...)` is for entering the normal reducer flow as soon as the runtime is ready. `with_sync_env(...)` is for values that belong in `Env`, such as theme, locale, translation bundles, or other read-only context widgets should consume during component conversion.
 
-`with_async(...)` is where you register jobs, services, and capabilities that the host may need to run outside pure reducers. `with_frame_hook(...)` exists for narrow polling or wakeup cases, but it should stay a host-level helper instead of becoming your primary application architecture.
+`with_async(...)` is where graphical shells register jobs, services, and
+capabilities that the host may need to run outside pure reducers. Terminal
+currently hosts storage operations but does not yet expose the general async
+job/service builder; use its frame hook for terminal-specific polling rather
+than assuming a background service registration exists. `with_frame_hook(...)`
+should remain a narrow host-level helper instead of becoming your primary
+application architecture.
 
 The practical lesson is simple: the shell should prepare the platform around your app, not become the place where your app logic drifts.
 

--- a/documentation/content/reference/core/environment-input-and-ime.mdx
+++ b/documentation/content/reference/core/environment-input-and-ime.mdx
@@ -36,13 +36,24 @@ A widget should read environment through `ViewHandle`, for example with `view.vi
 
 ## How `Env` reaches the app
 
-Desktop currently exposes public `with_env(...)` and `with_sync_env(...)` builders. Mobile and web expose public `with_sync_env(...)`. SSR apps expose `with_env(...)` and `with_request_env(...)`; Static site targets expose `with_env(...)`.
+Desktop, Mobile, Web, and Terminal app builders expose the same `with_env(...)`
+and `with_sync_env(...)` contract. Browser islands also expose both methods so
+an interactive island can receive the same translations and theme as its
+server-rendered route. SSR apps expose `with_env(...)` plus
+`with_request_env(...)`; Static site targets expose `with_env(...)` plus
+build-time locale resolution.
 
 Use `with_env(...)` when you want to seed a prepared environment, such as an environment that already contains translation bundles.
 
 Use `with_sync_env(...)` when values in `GlobalState` should be mirrored into `Env`, such as a user-selected locale or theme mode.
 
 Use `with_request_env(...)` on server-rendered apps when request data should select presentation context before rendering, such as a locale stored in a route prefix, header, cookie, or session.
+
+Static and SSR do not expose `with_sync_env(...)` because they do not own a
+long-lived app state that is rebuilt every frame. Static routes are rendered at
+build time. SSR routes receive a new request environment, so
+`with_request_env(...)` is the equivalent request-lifecycle hook rather than a
+per-frame state hook.
 
 The important contract is that environment remains explicit and shell-managed, not hidden behind global process state.
 

--- a/documentation/content/reference/core/platform-runtime.mdx
+++ b/documentation/content/reference/core/platform-runtime.mdx
@@ -51,14 +51,15 @@ That does not mean the shell is unimportant. It means the shell should do real h
 
 ## The public shell wrappers
 
-The current public shell wrappers are:
+The current public app and document builders are:
 
 - `DesktopApp<S, W>`
 - `MobileApp<S, W>`
 - `WebApp<S, W>`
 - `TerminalApp<S, W>`
 - `FissionSite`
-- `FissionServerApp<S, W>`
+- `FissionServerApp`
+- `BrowserIslandApp<S, W>`
 
 They host the same shared runtime model. Where a wrapper has type parameters, they mean:
 
@@ -102,47 +103,36 @@ Even though the wrappers do not expose identical method sets, several concepts r
 
 Those concepts matter more than memorizing every wrapper method immediately, because they tell you how the shell participates in the runtime boundary.
 
-## Wrapper differences
+## Builder parity and intentional differences
 
-The wrappers are intentionally similar, but not identical.
+The continuously running Desktop, Mobile, Web, and Terminal shells share the
+same environment and startup vocabulary. They all accept a complete base
+`Env`, can synchronize it from `GlobalState`, can prepare initial state, can
+dispatch a startup action, can install an app-wide key handler and frame hook,
+and can register host-owned reducers. This means i18n and design-system setup do
+not need a target-specific workaround.
 
-`DesktopApp` currently has the richest public setup API. In addition to the common startup and environment hooks, it exposes:
+| Capability | Desktop | Mobile | Web | Terminal | Static site | SSR |
+| --- | --- | --- | --- | --- | --- | --- |
+| Seed a complete environment with `with_env` | Yes | Yes | Yes | Yes | Yes | Yes |
+| Install a design system | Yes | Yes | Yes | Yes | Yes | Yes |
+| Synchronize environment from live app state | `with_sync_env` | `with_sync_env` | `with_sync_env` | `with_sync_env` | Not applicable | `with_request_env` uses request context |
+| Prepare live app state | Yes | Yes | Yes | Yes | Per-route state factory | Per-route state factory |
+| Dispatch a startup action | Yes | Yes | Yes | Yes | Not applicable | Not applicable |
+| Register packaged fonts | Yes | Yes | Yes | No; terminal emulator owns fonts | Yes | Yes |
+| Configure browser history/path strategy | Not applicable | Host deep links | `with_navigation` | In-memory navigation | Route output paths | Request routes |
+| Native live-test TCP port | Yes | Yes | No; browser control bridge | No | Not applicable | Not applicable |
 
-- `with_key_handler(...)`
-- `with_test_control_port(...)`
-- `with_env(...)`
-- `register_reducer(...)`
-- `absorb_registry(...)`
+Static site and SSR builders intentionally do not pretend to have a persistent
+frame loop. A static route is built once, while an SSR route is built for an
+HTTP request. Their locale resolvers and SSR's `with_request_env` therefore
+express real build/request inputs instead of imitating `with_sync_env` with the
+wrong lifetime.
 
-`with_env(...)` replaces the default `Env` up front on shells that expose a base environment, including desktop, SSR apps, and Static site targets. `register_reducer(...)` and `absorb_registry(...)` are direct reducer-registration helpers on the desktop wrapper. `with_test_control_port(...)` is the desktop live-shell testing entrypoint.
-
-`MobileApp` keeps the same overall model but exposes a smaller public setup API. It currently supports:
-
-- `with_key_handler(...)`
-- `with_test_control_port(...)`
-- `with_state_init(...)`
-- `with_startup_action(...)`
-- `with_sync_env(...)`
-- `with_frame_hook(...)`
-- `with_async(...)`
-- `run()`
-- `run_with_android_app(...)` on Android
-
-It does not currently expose public `with_env(...)`, `register_reducer(...)`, or `absorb_registry(...)` methods of its own.
-
-`WebApp` is smaller still. It currently supports:
-
-- `with_title(...)`
-- `with_state_init(...)`
-- `with_startup_action(...)`
-- `with_sync_env(...)`
-- `with_frame_hook(...)`
-- `with_async(...)`
-- `run()`
-
-It does not currently expose public `with_key_handler(...)` or `with_test_control_port(...)`.
-
-These differences matter for reference work, but they should be read as wrapper API differences, not as different application architectures. The same shared runtime is still underneath.
+Browser-only methods such as `with_mount_selector`, `with_browser_defaults`,
+and `with_navigation` stay on `WebApp`. Desktop window, tray, and AppUserModelID
+configuration stays on `DesktopApp`. Android host injection stays on Mobile.
+Those are host capabilities, not gaps in the shared app model.
 
 ## Practical boundary guidance
 

--- a/documentation/content/reference/core/theming-and-i18n.mdx
+++ b/documentation/content/reference/core/theming-and-i18n.mdx
@@ -55,7 +55,11 @@ Use a preset when it matches the platform or brand direction you want. Copy it i
 
 `Env` carries the active theme, internationalization registry, locale, and other app-wide presentation context. During component conversion, widgets can read those values through `view.env` or convenience helpers such as `view.theme()`.
 
-Desktop exposes both `with_env(...)` and `with_sync_env(...)`. Mobile and web expose `with_sync_env(...)`. Static site and SSR apps expose `with_env(...)`, `i18n(...)`, `translation_bundle(...)`, `default_locale(...)`, and `locale_resolver(...)`. SSR additionally exposes `with_request_env(...)` for request-owned environment values.
+Desktop, Mobile, Web, and Terminal expose both `with_env(...)` and
+`with_sync_env(...)`. Browser islands expose the same pair. Static site and SSR
+apps expose `with_env(...)`, `i18n(...)`, `translation_bundle(...)`,
+`default_locale(...)`, and `locale_resolver(...)`. SSR additionally exposes
+`with_request_env(...)` for request-owned environment values.
 
 Use `with_env(...)` to seed a base environment before the first frame, such as one that already contains translation bundles.
 
@@ -65,12 +69,29 @@ Use `translation_bundle(...)` or `i18n(...)` on `FissionServerApp` to register s
 
 ```rust
 DesktopApp::new(MyApp)
+    .with_env(create_env()?)
     .with_sync_env(|state: &MyState, env: &mut Env| {
         env.theme = AppDesignSystem::theme(state.theme_mode);
         env.locale = state.locale.clone();
     })
     .run()?;
 ```
+
+The setup is identical for a Web app:
+
+```rust
+WebApp::new(MyApp)
+    .with_env(create_env()?)
+    .with_sync_env(|state: &MyState, env: &mut Env| {
+        env.theme = AppDesignSystem::theme(state.theme_mode);
+        env.locale = state.locale.clone();
+    })
+    .run()?;
+```
+
+Terminal supports the same design-system and environment data. Packaged font
+registration is the deliberate exception: the terminal emulator owns the font
+used for its cell grid, so Fission cannot install an app font there.
 
 ## Internationalization types
 

--- a/documentation/content/reference/widgets/widget-pages/protected-route.mdx
+++ b/documentation/content/reference/widgets/widget-pages/protected-route.mdx
@@ -10,15 +10,27 @@ concrete component values and converts only the branch selected by its
 `RouteDecision`, preventing a protected component from registering resources or
 reducers before access is allowed.
 
+The decision is resolved once at the route boundary and may be reused by every
+route in the same protection group. Individual page widgets do not perform an
+authentication check.
+
+## Synchronous decisions
+
+When all required information is already in application state, derive the
+decision with a pure selector:
+
 ```rust
-let decision = match &view.state().session {
-    SessionState::Loading => RouteDecision::Pending,
-    SessionState::Authenticated(_) => RouteDecision::Allow,
-    SessionState::SignedOut => RouteRedirect::replace("/sign-in")
-        .return_to(&view.env().current_route)
-        .into(),
-    SessionState::Failed(_) => RouteDecision::Deny,
-};
+fn account_access(state: &AppState, current_route: &str) -> RouteDecision {
+    if state.session.is_some() {
+        RouteDecision::Allow
+    } else {
+        RouteRedirect::replace("/sign-in")
+            .return_to(current_route)
+            .into()
+    }
+}
+
+let decision = account_access(view.state(), &view.env().current_route);
 
 Router::<AppState>::new()
     .with_path(view.state().current_path.clone())
@@ -30,6 +42,111 @@ Router::<AppState>::new()
     )
     .route_component("/sign-in", SignInRoute)
 ```
+
+The selector is read-only. It does not dispatch, read storage, contact a server,
+or mutate state during component conversion. If several routes use the same
+policy, compute the decision once and clone it into each `ProtectedRoute`.
+
+## Asynchronous decisions from SQLite
+
+Do not start a Store read from `ProtectedRoute` or from every protected page.
+Dispatch one startup action, let reducers resolve SQLite into a
+`RouteDecision` stored in `GlobalState`, and have the route table consume that
+already-resolved value.
+
+```rust
+use fission::prelude::*;
+use fission::store::{StoreErrorKind, StoreKey};
+
+struct AppState {
+    current_path: String,
+    session: Option<Session>,
+    account_access: RouteDecision,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            current_path: "/".into(),
+            session: None,
+            account_access: RouteDecision::Pending,
+        }
+    }
+}
+
+impl GlobalState for AppState {}
+
+#[fission_reducer(LoadSession)]
+fn load_session(_state: &mut AppState, ctx: &mut ReducerContext<AppState>) {
+    ctx.effects
+        .store()
+        .get(StoreKey::<Session>::new("auth", "session"))
+        .on_ok(ActionEnvelope::from(SessionLoaded))
+        .on_err(ActionEnvelope::from(SessionLoadFailed));
+}
+
+#[fission_reducer(SessionLoaded)]
+fn session_loaded(state: &mut AppState, ctx: &mut ReducerContext<AppState>) {
+    match ctx.input.store_value::<Session>() {
+        Some(Ok(session)) => {
+            state.session = Some(session);
+            state.account_access = RouteDecision::Allow;
+        }
+        Some(Err(error)) if error.kind == StoreErrorKind::InvalidRequest => {
+            state.session = None;
+            state.account_access = RouteRedirect::replace("/sign-in")
+                .return_to("/account")
+                .into();
+        }
+        Some(Err(error)) => {
+            state.account_access = RouteDecision::Deny;
+            // Store `error.message` separately when the denied page should
+            // explain why session restoration failed.
+        }
+        None => state.account_access = RouteDecision::Deny,
+    }
+}
+
+#[fission_reducer(SessionLoadFailed)]
+fn session_load_failed(state: &mut AppState) {
+    state.account_access = RouteDecision::Deny;
+}
+```
+
+Register these reducers once in the application root. The route declaration has
+no persistence logic:
+
+```rust
+let decision = view.state().account_access.clone();
+
+Router::<AppState>::new()
+    .with_path(view.state().current_path.clone())
+    .route_component(
+        "/account",
+        ProtectedRoute::new(decision, AccountRoute)
+            .pending(SessionLoadingRoute)
+            .denied(SessionUnavailableRoute),
+    )
+    .route_component("/sign-in", SignInRoute)
+```
+
+Start the asynchronous read exactly once after the runtime is ready:
+
+```rust
+WebApp::<AppState, _>::new(App)
+    .with_startup_action(LoadSession)
+    .run()
+```
+
+The state transition is therefore `Pending -> Allow`, `Pending -> Redirect`, or
+`Pending -> Deny`. Login and logout reducers should update SQLite through Store
+effects and update the same decision from their completion actions. On Web,
+enable the storage capability with `fission add-capability storage`.
+
+Web SQLite uses browser-local OPFS and is unavailable during SSR. An SSR host
+must resolve its initial session from request data, normally a cookie backed by
+server-side storage, then provide the corresponding decision before rendering.
+The `ProtectedRoute` contract remains the same.
 
 ## Decisions
 
@@ -45,9 +162,9 @@ removes the rejected route from active history. `RouteRedirect::push` is
 available when retaining that entry is intentional. `return_to` adds the
 origin-free current path, query, and fragment as an encoded query parameter.
 
-The decision should be derived by a pure function or selector from
-`GlobalState`. Reducers remain responsible for changing that state, including
-handling asynchronous Store or authentication results.
+For synchronous policies, derive the decision with a pure function or selector
+from `GlobalState`. For asynchronous policies, reducers should store the
+resolved decision in `GlobalState`; route widgets only consume it.
 
 Client-side route protection is a presentation and resource-construction
 boundary, not authorization for a server API. SSR prevents protected markup

--- a/documentation/content/reference/widgets/widget-pages/route-params.mdx
+++ b/documentation/content/reference/widgets/widget-pages/route-params.mdx
@@ -28,6 +28,25 @@ let builder = |params: &RouteParams| {
 };
 ```
 
+`route_component` supplies the same captured map as a build-scoped provider so
+a named component does not have to fall back to an anonymous builder:
+
+```rust
+impl From<ProjectRoute> for Widget {
+    fn from(_: ProjectRoute) -> Widget {
+        let params = fission::build::read::<RouteParams>();
+        ProjectScreen {
+            id: params.get("id").cloned(),
+        }
+        .into()
+    }
+}
+```
+
+The map exists only during conversion of the matched route. Copy the values a
+component needs into ordinary widget fields or actions; do not retain a
+build-scope handle.
+
 ## Entry table
 
 | Part | Type | Meaning | Notes / default behavior |
@@ -54,4 +73,3 @@ If a screen starts repeating the same `RouteParams` setup, extract a named compo
 ## Related
 
 [`Route`](/reference/widgets/route), [`Router`](/reference/widgets/router), and [`State system`](/reference/core/state-system).
-

--- a/documentation/content/reference/widgets/widget-pages/router.mdx
+++ b/documentation/content/reference/widgets/widget-pages/router.mdx
@@ -28,6 +28,29 @@ let router: Widget = Router::<AppState>::new()
 path matches. The existing closure-based `route` and parameter-aware
 `route_builder` APIs remain available.
 
+Captured parameters are available to every registration form. A
+`route_builder` receives `&RouteParams` directly. A named component registered
+with `route_component` reads the same map from its matched build scope:
+
+```rust
+impl From<ProjectRoute> for Widget {
+    fn from(_: ProjectRoute) -> Widget {
+        let params = fission::build::read::<RouteParams>();
+        let project_id = params.get("project_id").cloned();
+
+        ProjectScreen { project_id }.into()
+    }
+}
+
+Router::<AppState>::new()
+    .with_path(view.state().current_path.clone())
+    .route_component("/projects/:project_id", ProjectRoute)
+```
+
+The provider exists only while the matched component is converted. Nested
+components therefore see the correct values, and unmatched routes cannot read
+stale parameters from another route.
+
 ## Protected routes
 
 Keep access checks at the route table rather than repeating them inside every
@@ -61,8 +84,9 @@ replace the default progress and access-denied branches.
 
 Authentication restoration remains an ordinary asynchronous Fission effect.
 For example, a startup reducer can read a session from the Store and update
-`SessionState` in its success or failure reducer. The route decision is a pure
-derivation from that state; it is not itself a reducer.
+the route decision in its success or failure reducer. See
+[`ProtectedRoute`](/reference/widgets/protected-route) for both the synchronous
+selector and asynchronous SQLite patterns.
 
 Redirects replace history by default, preventing browser Back from immediately
 retrying the rejected route. SSR returns an HTTP 302 without protected markup,

--- a/examples/showcase/src/lib.rs
+++ b/examples/showcase/src/lib.rs
@@ -70,14 +70,13 @@ pub fn run_desktop() -> Result<()> {
 
 #[cfg(target_arch = "wasm32")]
 fn web_app() -> WebApp<ShowcaseState, ShowcaseApp> {
-    let base_env = create_env().expect("showcase translations must parse");
     WebApp::<ShowcaseState, _>::new(ShowcaseApp)
         .mount("#fission-web-mount")
         .with_title("Fission Example Showcase")
+        .with_env(create_env().expect("showcase translations must parse"))
         .with_design_system::<ShowcaseDesignSystem>(DesignMode::Light)
         .with_async(|asyncs| register_example_jobs!(asyncs))
-        .with_sync_env(move |state: &ShowcaseState, env: &mut Env| {
-            env.i18n = base_env.i18n.clone();
+        .with_sync_env(|state: &ShowcaseState, env: &mut Env| {
             env.locale = state.locale.clone();
             env.theme = ShowcaseDesignSystem::theme(state.theme_mode);
         })


### PR DESCRIPTION
Fission applications can now seed the same prepared `Env` on Desktop, Mobile, Web, and Terminal. That makes translation and design-system setup portable instead of forcing Web apps to smuggle bundles through `with_sync_env`. Browser islands now retain the complete environment too, and can synchronize locale or theme from their own state before each build.\n\nA Web app can use the same setup as native:\n\n```rust\nWebApp::<AppState, _>::new(App)\n    .with_env(create_env()?)\n    .with_design_system::<AppDesignSystem>(DesignMode::Light)\n    .with_sync_env(|state, env| {\n        env.locale = state.locale.clone();\n        env.theme = AppDesignSystem::theme(state.theme_mode);\n    })\n    .run()?;\n```\n\nThe common stateful builders now also expose the shared host key-handler and persistent reducer hooks where they were accidentally omitted. Mobile gains the matching live-test token builder. Terminal gains state initialization, startup action, design-system, frame-hook, and registry APIs. Its old closure-shaped `with_env(|env| ...)` convenience is renamed `configure_env(...)`; `with_env(...)` now consistently takes a complete `Env`. Terminal font registration remains intentionally absent because the terminal emulator owns its font. Static and SSR retain build-time and request-time environment hooks because they do not have a persistent frame loop.\n\nThe routing reference now documents both synchronous and SQLite-backed asynchronous protected-route decisions at the router boundary. `route_component` publishes captured `RouteParams` during retained component conversion, so a matching component can read parameters without falling back to a function-built widget tree.\n\nFinally, the facade prelude is now rooted in the conflict-resolved public facade and includes the previously omitted built-in widget and terminal types. Public authoring widgets and the stateful shell APIs have substantive Rust documentation describing their behavior and parameters.