### PR TITLE
fix(cli): support Windows mapped-drive projects

### DIFF
--- a/crates/tools/fission-command-core/src/native_cargo.rs
+++ b/crates/tools/fission-command-core/src/native_cargo.rs
@@ -16,14 +16,16 @@ pub(crate) fn cargo_target_directory(
     module_name: &str,
     platform: &str,
 ) -> Result<PathBuf> {
-    let output = Command::new("cargo")
+    let mut command = Command::new("cargo");
+    command
         .arg("metadata")
         .arg("--format-version")
         .arg("1")
         .arg("--no-deps")
         .arg("--manifest-path")
-        .arg(manifest)
-        .current_dir(project_dir)
+        .arg(manifest);
+    set_cargo_working_directory(&mut command, project_dir);
+    let output = command
         .output()
         .with_context(|| {
             format!(
@@ -52,6 +54,14 @@ pub(crate) fn cargo_target_directory(
         );
     }
     Ok(metadata.target_directory)
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn set_cargo_working_directory(_command: &mut Command, _project_dir: &Path) {}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn set_cargo_working_directory(command: &mut Command, project_dir: &Path) {
+    command.current_dir(project_dir);
 }
 
 pub(crate) fn expand_cargo_target_directory(

--- a/crates/tools/fission-command-core/src/windows_native.rs
+++ b/crates/tools/fission-command-core/src/windows_native.rs
@@ -1,5 +1,7 @@
 use crate::{
-    native_cargo::{cargo_target_directory, expand_cargo_target_directory},
+    native_cargo::{
+        cargo_target_directory, expand_cargo_target_directory, set_cargo_working_directory,
+    },
     FissionProject, NativeVariant,
 };
 use anyhow::{bail, Context, Result};
@@ -367,8 +369,8 @@ fn run_cargo_module_command(
         .arg("--manifest-path")
         .arg(&manifest)
         .arg("--package")
-        .arg(package)
-        .current_dir(project_dir);
+        .arg(package);
+    set_cargo_working_directory(&mut command, project_dir);
     if release && cargo_command == "build" {
         command.arg("--release");
     }
@@ -563,6 +565,18 @@ fn resolve_project_path(project_dir: &Path, value: &str) -> PathBuf {
 }
 
 fn canonical_project_dir(project_dir: &Path) -> Result<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        return if project_dir.is_absolute() {
+            Ok(project_dir.to_path_buf())
+        } else {
+            Ok(env::current_dir()
+                .context("failed to resolve the current directory")?
+                .join(project_dir))
+        };
+    }
+
+    #[cfg(not(target_os = "windows"))]
     fs::canonicalize(project_dir).with_context(|| {
         format!(
             "failed to resolve project directory {}",
@@ -846,6 +860,14 @@ destination = "tools/demo-helper.exe"
         let path = r"D:\a\demo\packages".encode_utf16().collect::<Vec<_>>();
 
         assert!(normalize_windows_verbatim_units(&path).is_none());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn preserves_absolute_mapped_drive_project_path() {
+        let project_dir = Path::new(r"Z:\shared\example");
+
+        assert_eq!(canonical_project_dir(project_dir).unwrap(), project_dir);
     }
 
     fn unique_dir(label: &str) -> PathBuf {

--- a/crates/tools/fission-command-package/src/artifact.rs
+++ b/crates/tools/fission-command-package/src/artifact.rs
@@ -53,8 +53,16 @@ pub(super) fn prepare_icon_manifest(
     };
 
     let icon_root = project_dir.join("target/fission/icons");
-    fs::create_dir_all(&icon_root)
-        .with_context(|| format!("failed to create {}", icon_root.display()))?;
+    if let Err(error) = fs::create_dir_all(&icon_root) {
+        // Some remote Windows filesystems report ERROR_ALREADY_EXISTS for
+        // CreateDirectory even when the existing path is a directory.
+        // Preserve create_dir_all's idempotent contract after confirming the
+        // path really is a directory; a file or an inaccessible path must
+        // still fail closed.
+        if !icon_root.is_dir() {
+            return Err(error).with_context(|| format!("failed to create {}", icon_root.display()));
+        }
+    }
     let manifest_path = icon_root.join("icon-manifest.json");
     let (source_sha256, source_size_bytes) = hash_file(&icon.path)?;
     let outputs = collect_icon_package_outputs(package_root)?;

--- a/crates/tools/fission-command-package/src/package.rs
+++ b/crates/tools/fission-command-package/src/package.rs
@@ -1550,6 +1550,15 @@ fn build_desktop_binary_with_cargo_options(
     cargo_features: &[String],
     cargo_no_default_features: bool,
 ) -> Result<PathBuf> {
+    #[cfg(target_os = "windows")]
+    let project_dir = if project_dir.is_absolute() {
+        project_dir.to_path_buf()
+    } else {
+        env::current_dir()
+            .context("failed to resolve the current directory")?
+            .join(project_dir)
+    };
+    #[cfg(not(target_os = "windows"))]
     let project_dir = fs::canonicalize(project_dir).with_context(|| {
         format!(
             "failed to resolve project directory {}",
@@ -1603,8 +1612,8 @@ fn desktop_cargo_build_command(
         .arg("--manifest-path")
         .arg(&manifest_path)
         .arg("--package")
-        .arg(&name)
-        .current_dir(&project_dir);
+        .arg(&name);
+    set_desktop_cargo_working_directory(&mut command, project_dir);
     if release {
         command.arg("--release").arg("--locked");
     }
@@ -1636,14 +1645,16 @@ struct CargoTargetMetadata {
 }
 
 fn cargo_target_directory(project_dir: &Path, manifest_path: &Path) -> Result<PathBuf> {
-    let output = Command::new("cargo")
+    let mut command = Command::new("cargo");
+    command
         .arg("metadata")
         .arg("--format-version")
         .arg("1")
         .arg("--no-deps")
         .arg("--manifest-path")
-        .arg(manifest_path)
-        .current_dir(project_dir)
+        .arg(manifest_path);
+    set_desktop_cargo_working_directory(&mut command, project_dir);
+    let output = command
         .output()
         .context("failed to run cargo metadata for desktop package")?;
     if !output.status.success() {
@@ -1656,6 +1667,14 @@ fn cargo_target_directory(project_dir: &Path, manifest_path: &Path) -> Result<Pa
     let metadata: CargoTargetMetadata = serde_json::from_slice(&output.stdout)
         .context("failed to parse cargo metadata for desktop package")?;
     Ok(metadata.target_directory)
+}
+
+#[cfg(target_os = "windows")]
+fn set_desktop_cargo_working_directory(_command: &mut Command, _project_dir: &Path) {}
+
+#[cfg(not(target_os = "windows"))]
+fn set_desktop_cargo_working_directory(command: &mut Command, project_dir: &Path) {
+    command.current_dir(project_dir);
 }
 
 fn create_macos_app_bundle(

--- a/crates/tools/fission-command-package/src/package_tests.rs
+++ b/crates/tools/fission-command-package/src/package_tests.rs
@@ -79,6 +79,10 @@ fn release_desktop_builds_require_the_existing_lockfile() {
         .collect::<Vec<_>>();
     assert!(release_args.iter().any(|argument| argument == "--release"));
     assert!(release_args.iter().any(|argument| argument == "--locked"));
+    #[cfg(target_os = "windows")]
+    assert_eq!(release.get_current_dir(), None);
+    #[cfg(not(target_os = "windows"))]
+    assert_eq!(release.get_current_dir(), Some(project_dir));
 
     let debug =
         desktop_cargo_build_command(project_dir, &manifest_path, "example", false, &[], false);


### PR DESCRIPTION
## Summary

- preserve mapped-drive project paths instead of canonicalizing them to extended UNC paths that Cargo rejects as path URLs
- let Windows Cargo commands inherit a caller-selected local working directory while continuing to pass an explicit mapped-drive manifest path
- retain idempotent icon-manifest directory creation on remote Windows filesystems that return `ERROR_ALREADY_EXISTS` for an existing directory

## Validation

- focused Windows package command test passed
- end-to-end Windows ARM64 and x86_64 EXE packaging completed from a WebDAV mapped-drive source checkout with Cargo output on local NTFS
- both generated installers completed signing validation; the x86_64 artifact also passed clean install, launch, and uninstall qualification
- `git diff --check` passed

The changes and tests use generic mapped-drive/example paths only.