### PR TITLE
Stop publishing the incomplete example showcase

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -10,7 +10,6 @@ on:
       - 'documentation/**'
       - 'crates/**'
       - 'examples/chart-gallery/**'
-      - 'examples/showcase/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/publish-website.yml'
@@ -38,14 +37,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
 
       - name: Cache Rust build output
         uses: Swatinem/rust-cache@v2
-
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --version 0.13.1 --locked
 
       - name: Install Linux native build dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev pkg-config
@@ -77,18 +71,6 @@ jobs:
       - name: Check static site routes
         run: cargo run -p cargo-fission --bin fission -- site check --project-dir documentation --release
 
-      - name: Build Example Showcase for Web
-        run: cargo run -p cargo-fission --bin fission -- build --target web --project-dir examples/showcase --release
-
-      - name: Stage Example Showcase as a site asset
-        run: |
-          showcase_out="documentation/static/example-showcase"
-          mkdir -p "$showcase_out"
-          cp examples/showcase/platforms/web/index.html "$showcase_out/index.html"
-          cp examples/showcase/platforms/web/bootstrap.mjs "$showcase_out/bootstrap.mjs"
-          cp examples/showcase/platforms/web/app-icon.png "$showcase_out/app-icon.png"
-          cp -R examples/showcase/platforms/web/pkg "$showcase_out/pkg"
-
       - name: Package static site
         run: cargo run -p cargo-fission --bin fission -- package --project-dir documentation --target site --format static --release
 
@@ -103,10 +85,6 @@ jobs:
           test -f documentation/target/fission/release/static-site/static/search/docs.json
           test -f documentation/target/fission/release/static-site/static/img/fission-mark.svg
           test -f documentation/target/fission/release/static-site/static/img/charts/line-gradient-area.png
-          test -f documentation/target/fission/release/static-site/static/example-showcase/index.html
-          test -f documentation/target/fission/release/static-site/static/example-showcase/bootstrap.mjs
-          test -f documentation/target/fission/release/static-site/static/example-showcase/pkg/example_showcase.js
-          test -f documentation/target/fission/release/static-site/static/example-showcase/pkg/example_showcase_bg.wasm
           test -f documentation/target/fission/release/static-site/static/artifact-manifest.json
           test -f documentation/target/fission/release/static-site/static/crates/index.html
 

--- a/documentation/content/docs/guides/input-events-text-and-env.mdx
+++ b/documentation/content/docs/guides/input-events-text-and-env.mdx
@@ -217,7 +217,7 @@ Nothing about that flow requires the widgets to reach into native browser or mob
 
 ## Where to go next
 
-If you want the full explanation of locale, translation bundles, and theme loading, continue to [Theming and internationalization](/docs/guides/theming-and-i18n). If you need to decide whether a value belongs in `GlobalState`, local widget state, `Env`, or a provider, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want the deeper explanation of resources, jobs, services, and reducer-side effects, read [Resources and async](/docs/guides/resources-and-async/). For a live proof of text-heavy interaction, open `text-lab` from the public [Examples](/example-showcase/) page.
+If you want the full explanation of locale, translation bundles, and theme loading, continue to [Theming and internationalization](/docs/guides/theming-and-i18n). If you need to decide whether a value belongs in `GlobalState`, local widget state, `Env`, or a provider, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want the deeper explanation of resources, jobs, services, and reducer-side effects, read [Resources and async](/docs/guides/resources-and-async/).
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/layout-and-widgets.mdx
+++ b/documentation/content/docs/guides/layout-and-widgets.mdx
@@ -311,7 +311,7 @@ This workflow matches the architecture of Fission itself. The app model stays sh
 
 ## Where to go next
 
-If you want to understand how input, viewport data, locale, and theme reach widgets, read [Input, text, and environment](/docs/guides/input-events-text-and-env). If you want the beginner explanation of `ViewHandle`, `BuildCtxHandle`, and selectors first, go back to [Runtime model](/docs/learn/runtime-model). For a live tour of built-in widgets, open the public [Examples](/example-showcase/) page and start with Widget Gallery.
+If you want to understand how input, viewport data, locale, and theme reach widgets, read [Input, text, and environment](/docs/guides/input-events-text-and-env). If you want the beginner explanation of `ViewHandle`, `BuildCtxHandle`, and selectors first, go back to [Runtime model](/docs/learn/runtime-model).
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/media-animation-portals-and-3d.mdx
+++ b/documentation/content/docs/guides/media-animation-portals-and-3d.mdx
@@ -109,7 +109,7 @@ For 3D, watch scope. Treat the scene as a bounded part of the interface, not as 
 
 ## Where to go next
 
-If you want the underlying explanation of layout, viewport reasoning, and screen composition first, read [Layout and widgets](/docs/guides/layout-and-widgets). If you want the async and runtime side of jobs, timers, and long-lived work, continue to [Resources and async](/docs/guides/resources-and-async). For checked-in proofs, open `animation-gallery`, `chart-gallery`, `inbox`, or `fission-editor` from the public [Examples](/example-showcase/) page.
+If you want the underlying explanation of layout, viewport reasoning, and screen composition first, read [Layout and widgets](/docs/guides/layout-and-widgets). If you want the async and runtime side of jobs, timers, and long-lived work, continue to [Resources and async](/docs/guides/resources-and-async).
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/resources-and-async.mdx
+++ b/documentation/content/docs/guides/resources-and-async.mdx
@@ -370,7 +370,7 @@ The fifth mistake is choosing unstable resource keys or dependency payloads. Rec
 
 ## Where to go next
 
-If you want the app-model foundation behind reducers and pure `component conversion` methods, revisit [Runtime model](/docs/learn/runtime-model/). If you need the detailed rules for app state, local widget state, build handles, and provider scopes, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want a concrete streamed file-picker flow, read [How do I do file uploads in Fission?](/docs/guides/file-uploads/). If you want to see responsive user interface and state-driven composition before adding async work, read [Layout and widgets](/docs/guides/layout-and-widgets/). For a checked-in product example that uses job resources and timers heavily, inspect Fission Editor from the public [Examples](/example-showcase/) page after reading this guide.
+If you want the app-model foundation behind reducers and pure `component conversion` methods, revisit [Runtime model](/docs/learn/runtime-model/). If you need the detailed rules for app state, local widget state, build handles, and provider scopes, read [State, handles, and providers](/docs/guides/state-handles-and-providers/). If you want a concrete streamed file-picker flow, read [How do I do file uploads in Fission?](/docs/guides/file-uploads/). If you want to see responsive user interface and state-driven composition before adding async work, read [Layout and widgets](/docs/guides/layout-and-widgets/).
 
 ## What you should have working
 

--- a/documentation/content/docs/guides/testing-and-diagnostics.mdx
+++ b/documentation/content/docs/guides/testing-and-diagnostics.mdx
@@ -184,7 +184,7 @@ Finally, avoid diagnostics spam without a question. Enable the categories that m
 
 ## Where to go next
 
-If you want the shell-side picture for target generation, host launchers, and public shell builders, read [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing). If you want the async model behind many live app behaviors, continue to [Resources and async](/docs/guides/resources-and-async). For live examples backed by checked-in tests, browse the public [Examples](/example-showcase/) page and inspect the `live_e2e.rs` tests linked there.
+If you want the shell-side picture for target generation, host launchers, and public shell builders, read [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing). If you want the async model behind many live app behaviors, continue to [Resources and async](/docs/guides/resources-and-async).
 
 ## What you should have working
 

--- a/documentation/content/docs/learn/examples-and-targets.mdx
+++ b/documentation/content/docs/learn/examples-and-targets.mdx
@@ -91,7 +91,7 @@ If you keep that structure in mind, the site becomes much easier to navigate. Op
 
 ## Where to go next
 
-If you want the guided first-run flow, go to [Quickstart](/docs/learn/quickstart). If you want the fuller explanation of shell wrappers, generated hosts, and platform validation, continue to [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing). If you want help choosing an example by learning goal, visit the public [Examples](/example-showcase/) page.
+If you want the guided first-run flow, go to [Quickstart](/docs/learn/quickstart). If you want the fuller explanation of shell wrappers, generated hosts, and platform validation, continue to [Platform shells, command-line interface, and testing](/docs/guides/platform-shells-cli-and-testing).
 
 ## What you should be able to do next
 

--- a/documentation/fission.toml
+++ b/documentation/fission.toml
@@ -66,10 +66,6 @@ title = "Crates"
 href = "/crates/"
 
 [[site.nav.children]]
-title = "Example showcase"
-href = "/example-showcase/"
-
-[[site.nav.children]]
 title = "Blog"
 href = "/blog/"
 
@@ -136,10 +132,6 @@ href = "/docs/cookbook/add-platform-targets/"
 [[site.nav.children]]
 title = "API reference"
 href = "/reference/overview/overview/"
-
-[[site.nav.children]]
-title = "Example showcase"
-href = "/example-showcase/"
 
 [[site.nav]]
 title = "Crates"

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -33,7 +33,6 @@ impl From<DocsFooter> for Widget {
                                 ("Documentation", "/docs/learn/overview/"),
                                 ("Guides", "/docs/guides/layout-and-widgets/"),
                                 ("Cookbook", "/docs/cookbook/add-platform-targets/"),
-                                ("Examples", "/example-showcase/"),
                             ],
                         )
                         .into(),

--- a/documentation/src/components/home_nav.rs
+++ b/documentation/src/components/home_nav.rs
@@ -85,11 +85,6 @@ const DOCS_CHILDREN: &[NavItem] = &[
         href: "/reference/overview/overview/",
         children: &[],
     },
-    NavItem {
-        label: "Example showcase",
-        href: "/example-showcase/",
-        children: &[],
-    },
 ];
 
 const NAV_ITEMS: &[NavItem] = &[
@@ -139,11 +134,6 @@ const MOBILE_MENU_CHILDREN: &[NavItem] = &[
     NavItem {
         label: "Crates",
         href: "/crates/",
-        children: &[],
-    },
-    NavItem {
-        label: "Example Showcase",
-        href: "/example-showcase/",
         children: &[],
     },
     NavItem {

--- a/documentation/src/components/mod.rs
+++ b/documentation/src/components/mod.rs
@@ -1,6 +1,5 @@
 mod brand_logo;
 mod crates;
-mod example_showcase;
 mod footer;
 mod home;
 mod home_nav;
@@ -11,7 +10,6 @@ mod marketing;
 mod state;
 
 pub(crate) use crates::{CrateDetailPage, CrateDirectoryPage};
-pub(crate) use example_showcase::ExampleShowcasePage;
 pub(crate) use footer::DocsFooter;
 pub(crate) use home::RoutedHomePage;
 pub(crate) use localized::LocalizedLandingPage;

--- a/documentation/src/main.rs
+++ b/documentation/src/main.rs
@@ -4,8 +4,8 @@ mod registry;
 
 use anyhow::Result;
 use components::{
-    CrateDetailPage, CrateDirectoryPage, DocsFooter, DocsState, ExampleShowcasePage,
-    LocalizedLandingPage, MarketingPageKind, ProductMarketingPage, RoutedHomePage,
+    CrateDetailPage, CrateDirectoryPage, DocsFooter, DocsState, LocalizedLandingPage,
+    MarketingPageKind, ProductMarketingPage, RoutedHomePage,
 };
 use fission::prelude::*;
 use fission::site::{build_from_cli, FissionSite};
@@ -47,15 +47,6 @@ fn site_app() -> FissionSite {
             "Fission",
             Some("Crea aplicaciones Rust para todas las plataformas.".to_string()),
             LocalizedLandingPage,
-        )
-        .route_widget::<DocsState, _>(
-            "/example-showcase/",
-            "Fission example showcase",
-            Some(
-                "Working Fission applications, galleries, and platform examples with direct run commands."
-                    .to_string(),
-            ),
-            ExampleShowcasePage::new(),
         )
         .route_widget::<DocsState, _>(
             "/product/overview/",


### PR DESCRIPTION
The example showcase is still incomplete and is not part of the public site contract yet. This removes its Web build and staging steps from the website workflow, along with the corresponding artifact assertions.

The public route and navigation links are also removed so the documentation does not advertise an unfinished destination. The showcase source remains untouched and can be restored to the site when it is ready.