### PR TITLE
Fix server integration gaps reported by application QA

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# The Debian controller supplies its project-specific build settings here.
+# Other shared-checkout hosts skip the absent optional file and retain their
+# own Cargo target configuration.
+include = [
+    { path = "/home/zcourts/.config/fission/cargo-debian.toml", optional = true },
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
-# The Debian controller supplies its project-specific build settings here.
+# The Debian controller supplies its project-specific target directory here.
 # Other shared-checkout hosts skip the absent optional file and retain their
 # own Cargo target configuration.
 include = [
     { path = "/home/zcourts/.config/fission/cargo-debian.toml", optional = true },
 ]
+
+[build]
+jobs = 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,6 +2864,7 @@ name = "fission-command-server"
 version = "0.14.1"
 dependencies = [
  "anyhow",
+ "serde_json",
  "toml 0.8.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,12 +3184,14 @@ dependencies = [
  "fission-store-sqlite",
  "fission-theme",
  "fission-widgets",
+ "form_urlencoded",
  "futures-lite",
  "getrandom 0.2.17",
  "hyper 0.14.32",
  "moka",
  "redis",
  "serde",
+ "serde_html_form",
  "serde_json",
  "tokio",
  "toml 0.8.2",
@@ -7805,6 +7807,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0346d7a342ab90f405cfc08f25d15075f944f42fcabbc5eac923829fa6d228"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,11 +1286,10 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -1303,8 +1302,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "sync_wrapper",
  "tower",
  "tower-layer",
@@ -1313,19 +1311,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -5403,9 +5399,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "nix 0.27.1",
+ "winapi",
+]
+
+[[package]]
 name = "comrak"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2319,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -2825,6 +2848,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fission-command-process"
+version = "0.14.1"
+dependencies = [
+ "anyhow",
+ "command-group",
+ "ctrlc",
+ "signal-hook",
+]
+
+[[package]]
 name = "fission-command-release"
 version = "0.14.1"
 dependencies = [
@@ -2851,6 +2884,7 @@ version = "0.14.1"
 dependencies = [
  "anyhow",
  "fission-command-core",
+ "fission-command-process",
  "fission-command-server",
  "fission-command-site",
  "fission-test-driver",
@@ -2864,6 +2898,7 @@ name = "fission-command-server"
 version = "0.14.1"
 dependencies = [
  "anyhow",
+ "fission-command-process",
  "serde_json",
  "toml 0.8.2",
 ]
@@ -2873,6 +2908,7 @@ name = "fission-command-site"
 version = "0.14.1"
 dependencies = [
  "anyhow",
+ "fission-command-process",
  "fission-shell-site",
  "serde_json",
  "toml 0.8.2",
@@ -5692,6 +5728,17 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
@@ -5713,6 +5760,18 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/tools/cargo-fission",
     "crates/tools/fission-command-package",
     "crates/tools/fission-command-release",
+    "crates/tools/fission-command-process",
     "crates/tools/fission-command-run",
     "crates/tools/fission-command-core",
     "crates/tools/fission-command-site",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,11 @@ resolver = "2"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(cargo_clippy)', 'cfg(feature, values("cargo-clippy"))'] }
 
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.dev.package."*"]
+debug = false
 opt-level = 1
 
 [profile.release]

--- a/crates/core/fission-core/src/ui/widgets/button.rs
+++ b/crates/core/fission-core/src/ui/widgets/button.rs
@@ -296,6 +296,16 @@ impl Button {
         self
     }
 
+    /// Associates this submit action with named controls in one logical form.
+    ///
+    /// Server-rendered HTML uses this id to bind the signed action to its typed
+    /// form schema. Text inputs submitted by the action use the same `form_id`.
+    pub fn form_id(mut self, form_id: impl Into<String>) -> Self {
+        let semantics = self.semantics.get_or_insert_with(default_button_semantics);
+        semantics.text_form_id = Some(form_id.into());
+        self
+    }
+
     pub fn background_fill(mut self, fill: Fill) -> Self {
         self.background_fill = Some(fill);
         self

--- a/crates/core/fission-core/src/ui/widgets/checkbox.rs
+++ b/crates/core/fission-core/src/ui/widgets/checkbox.rs
@@ -31,6 +31,12 @@ pub struct Checkbox {
     /// Stable identifier exposed on the checkbox's interactive semantics node.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantics_identifier: Option<String>,
+    /// Semantic name submitted by server-rendered HTML forms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Logical form membership for server-rendered HTML submission.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub form_id: Option<String>,
     /// Current checked state.
     pub checked: bool,
     /// Action dispatched when the checkbox is tapped.
@@ -47,6 +53,18 @@ impl Checkbox {
     /// Sets the stable identifier exposed to accessibility and test tooling.
     pub fn semantics_identifier(mut self, identifier: impl Into<String>) -> Self {
         self.semantics_identifier = Some(identifier.into());
+        self
+    }
+
+    /// Sets the successful-control name used by HTML form submission.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Associates this checkbox with one logical form.
+    pub fn form_id(mut self, form_id: impl Into<String>) -> Self {
+        self.form_id = Some(form_id.into());
         self
     }
 
@@ -279,8 +297,8 @@ impl InternalLower for Checkbox {
             max_length: None,
             max_length_enforcement: fission_ir::semantics::MaxLengthEnforcement::Enforced,
             input_formatters: Vec::new(),
-            text_field_name: None,
-            text_form_id: None,
+            text_field_name: self.name.clone(),
+            text_form_id: self.form_id.clone(),
             autofill_group: None,
             required: false,
             min_length: None,

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -32,7 +32,7 @@ store-sqlite-native = [
 [dependencies]
 actix-web = { version = "4.12", optional = true, default-features = false }
 anyhow = "1.0"
-axum = { version = "0.7", optional = true, default-features = false }
+axum = { version = "0.8", optional = true, default-features = false }
 base64 = "0.22"
 bincode = "1.3"
 blake3 = "1.8"

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -53,7 +53,7 @@ moka = { version = "0.12", features = ["sync"] }
 redis = { version = "0.32", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_html_form = { version = "0.4", default-features = false, features = ["de"] }
+serde_html_form = { version = "0.4", default-features = false, features = ["de", "std"] }
 tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 

--- a/crates/shell/fission-shell-server/Cargo.toml
+++ b/crates/shell/fission-shell-server/Cargo.toml
@@ -47,11 +47,13 @@ fission-shell-site = { path = "../fission-shell-site", version = "0.14.1" }
 fission-theme = { path = "../../core/fission-theme", version = "0.14.1" }
 getrandom = { version = "0.2", features = ["std"] }
 futures-lite = { version = "2", optional = true }
+form_urlencoded = "1.2"
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 moka = { version = "0.12", features = ["sync"] }
 redis = { version = "0.32", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_html_form = { version = "0.4", default-features = false, features = ["de"] }
 tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 toml = "0.8"
 

--- a/crates/shell/fission-shell-server/src/action_token.rs
+++ b/crates/shell/fission-shell-server/src/action_token.rs
@@ -15,6 +15,9 @@ pub struct SignedServerAction {
     pub target_node: u128,
     /// Typed action identifier and encoded payload to dispatch.
     pub action: ActionEnvelope,
+    /// Logical typed-form schema bound to this action, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub form_id: Option<String>,
     /// Expiry time as Unix seconds.
     pub expires_unix: u64,
     /// Per-token replay identifier covered by the signature.
@@ -32,6 +35,8 @@ pub struct VerifiedServerAction {
     pub target_node: u128,
     /// Verified action envelope.
     pub action: ActionEnvelope,
+    /// Verified logical typed-form schema, when present.
+    pub form_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -82,14 +87,50 @@ impl ServerActionSigner {
         action: ActionEnvelope,
         ttl: Duration,
     ) -> SignedServerAction {
+        self.sign_envelope_for_form(route_path, target_node, action, None, ttl)
+    }
+
+    pub(crate) fn sign_form_envelope(
+        &self,
+        route_path: impl Into<String>,
+        target_node: u128,
+        action: ActionEnvelope,
+        form_id: impl Into<String>,
+        ttl: Duration,
+    ) -> SignedServerAction {
+        self.sign_envelope_for_form(route_path, target_node, action, Some(form_id.into()), ttl)
+    }
+
+    fn sign_envelope_for_form(
+        &self,
+        route_path: impl Into<String>,
+        target_node: u128,
+        action: ActionEnvelope,
+        form_id: Option<String>,
+        ttl: Duration,
+    ) -> SignedServerAction {
         let route_path = route_path.into();
         let expires_unix = unix_now().saturating_add(ttl.as_secs());
-        let nonce = nonce_for(&route_path, target_node, &action, expires_unix);
-        let signature = self.signature(&route_path, target_node, &action, expires_unix, &nonce);
+        let nonce = nonce_for(
+            &route_path,
+            target_node,
+            &action,
+            form_id.as_deref(),
+            expires_unix,
+        );
+        let signature = self.signature(
+            &route_path,
+            target_node,
+            &action,
+            form_id.as_deref(),
+            expires_unix,
+            &nonce,
+        );
         SignedServerAction {
             route_path,
             target_node,
             action,
+            form_id,
             expires_unix,
             nonce,
             signature,
@@ -105,6 +146,7 @@ impl ServerActionSigner {
             &token.route_path,
             token.target_node,
             &token.action,
+            token.form_id.as_deref(),
             token.expires_unix,
             &token.nonce,
         );
@@ -115,6 +157,7 @@ impl ServerActionSigner {
             route_path: token.route_path.clone(),
             target_node: token.target_node,
             action: token.action.clone(),
+            form_id: token.form_id.clone(),
         })
     }
 
@@ -157,16 +200,25 @@ impl ServerActionSigner {
         route_path: &str,
         target_node: u128,
         action: &ActionEnvelope,
+        form_id: Option<&str>,
         expires_unix: u64,
         nonce: &str,
     ) -> String {
         let mut hasher = blake3::Hasher::new_keyed(&self.key);
-        hasher.update(b"fission.server.action.v1");
+        hasher.update(if form_id.is_some() {
+            b"fission.server.action.v2"
+        } else {
+            b"fission.server.action.v1"
+        });
         hasher.update(route_path.as_bytes());
         hasher.update(&target_node.to_le_bytes());
         hasher.update(&action.id.as_u128().to_le_bytes());
         hasher.update(&(action.payload.len() as u64).to_le_bytes());
         hasher.update(&action.payload);
+        if let Some(form_id) = form_id {
+            hasher.update(&(form_id.len() as u64).to_le_bytes());
+            hasher.update(form_id.as_bytes());
+        }
         hasher.update(&expires_unix.to_le_bytes());
         hasher.update(nonce.as_bytes());
         to_hex(hasher.finalize().as_bytes())
@@ -191,17 +243,26 @@ fn nonce_for(
     route_path: &str,
     target_node: u128,
     action: &ActionEnvelope,
+    form_id: Option<&str>,
     expires_unix: u64,
 ) -> String {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default();
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"fission.server.action.nonce.v1");
+    hasher.update(if form_id.is_some() {
+        b"fission.server.action.nonce.v2"
+    } else {
+        b"fission.server.action.nonce.v1"
+    });
     hasher.update(route_path.as_bytes());
     hasher.update(&target_node.to_le_bytes());
     hasher.update(&action.id.as_u128().to_le_bytes());
     hasher.update(&action.payload);
+    if let Some(form_id) = form_id {
+        hasher.update(&(form_id.len() as u64).to_le_bytes());
+        hasher.update(form_id.as_bytes());
+    }
     hasher.update(&expires_unix.to_le_bytes());
     hasher.update(&now.as_nanos().to_le_bytes());
     hasher.update(&std::process::id().to_le_bytes());
@@ -261,6 +322,25 @@ mod tests {
         let mut tampered = decoded;
         tampered.target_node = 8;
         assert!(signer.verify(&tampered).is_err());
+    }
+
+    #[test]
+    fn signed_form_identity_is_authenticated() {
+        let signer = ServerActionSigner::new("secret");
+        let mut token = signer.sign_form_envelope(
+            "/search",
+            7,
+            AddToCart { sku: "abc".into() }.into(),
+            "search",
+            Duration::from_secs(60),
+        );
+
+        assert_eq!(
+            signer.verify(&token).unwrap().form_id.as_deref(),
+            Some("search")
+        );
+        token.form_id = Some("admin".into());
+        assert!(signer.verify(&token).is_err());
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -1,15 +1,15 @@
 use crate::render::{ServerRequest, ServerResponse, ServerSession};
 use crate::{
-    ProgressiveWorker, ServerJobRegistry, ServerRenderPolicy, VerifiedServerAction, WasmIsland,
-    WebRoute, WebRouteMode,
+    ProgressiveWorker, ServerFormSchema, ServerJobRegistry, ServerRenderPolicy,
+    VerifiedServerAction, WasmIsland, WebRoute, WebRouteMode,
 };
 use anyhow::Result;
 use fission_core::internal::BuildCtx;
 use fission_core::registry::{VideoRegistration, WebRegistration};
 use fission_core::{
-    Action, ActionInput, Effect, Env, GlobalState, MotionDeclaration, NavigationCommand,
-    NavigationRequested, RuntimeEffect, RuntimeResourceDeclaration, RuntimeResourceKind,
-    RuntimeState, View, Widget, WidgetId,
+    Action, ActionEnvelope, ActionId, ActionInput, Effect, Env, GlobalState, MotionDeclaration,
+    NavigationCommand, NavigationRequested, RuntimeEffect, RuntimeResourceDeclaration,
+    RuntimeResourceKind, RuntimeState, View, Widget, WidgetId,
 };
 use fission_i18n::{I18nRegistry, Locale, TranslationBundle};
 use fission_layout::LayoutSize;
@@ -17,7 +17,7 @@ use fission_shell_site::{
     CodeHighlightingOptions, DocumentMetadata, DocumentShellConfig, SitePageElement,
 };
 use fission_theme::{DesignMode, DesignSystem, PackagedFont, Theme};
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -45,6 +45,21 @@ type BrowserPropsResolver = dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<B
     + Send
     + Sync
     + 'static;
+type ServerFormDecoder =
+    dyn Fn(&[(String, String)]) -> Result<ActionEnvelope> + Send + Sync + 'static;
+
+#[derive(Clone)]
+pub(crate) struct ServerFormActionBinding {
+    schema: ServerFormSchema,
+    decode: Arc<ServerFormDecoder>,
+}
+
+impl ServerFormActionBinding {
+    pub(crate) fn decode(&self, submitted: &[(String, String)]) -> Result<ActionEnvelope> {
+        let normalized = self.schema.normalize(submitted)?;
+        (self.decode)(&normalized)
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct ServerRenderedNode {
@@ -261,6 +276,7 @@ pub struct FissionServerApp {
     pub(crate) jobs: ServerJobRegistry,
     pub(crate) routes: Vec<ServerRouteEntry>,
     pub(crate) http_handlers: Vec<ServerHttpHandlerEntry>,
+    pub(crate) form_actions: BTreeMap<(String, ActionId), ServerFormActionBinding>,
     pub(crate) cache_invalidation_endpoints: Vec<CacheInvalidationEndpoint>,
     pub(crate) static_mounts: Vec<StaticMount>,
     #[cfg(feature = "store")]
@@ -305,6 +321,7 @@ impl FissionServerApp {
             jobs: ServerJobRegistry::new(),
             routes: Vec::new(),
             http_handlers: Vec::new(),
+            form_actions: BTreeMap::new(),
             cache_invalidation_endpoints: Vec::new(),
             static_mounts: Vec::new(),
             #[cfg(all(feature = "store", not(feature = "store-sqlite-native")))]
@@ -541,6 +558,39 @@ impl FissionServerApp {
         F: for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static,
     {
         self.http_handler("POST", path, handler)
+    }
+
+    /// Registers a typed decoder for one signed server action form.
+    ///
+    /// Assign the same logical id to each [`fission_core::ui::TextInput`]'s
+    /// `form_id` and to the submit button with `Button::form_id`. The schema
+    /// rejects controls that were not declared
+    /// and enforces scalar, boolean, and repeated-value cardinality before the
+    /// typed form value is deserialized.
+    pub fn form_action<P, A, F>(mut self, schema: ServerFormSchema, create_action: F) -> Self
+    where
+        P: DeserializeOwned + 'static,
+        A: Action,
+        F: Fn(P) -> A + Send + Sync + 'static,
+    {
+        let key = (schema.id.clone(), A::static_id());
+        let form_id = schema.id.clone();
+        let binding = ServerFormActionBinding {
+            schema,
+            decode: Arc::new(move |submitted| {
+                let encoded = form_urlencoded::Serializer::new(String::new())
+                    .extend_pairs(submitted.iter().map(|(name, value)| (name, value)))
+                    .finish();
+                let form = serde_html_form::from_str::<P>(&encoded)
+                    .map_err(|error| anyhow::anyhow!("invalid typed server form: {error}"))?;
+                Ok(create_action(form).into())
+            }),
+        };
+        assert!(
+            self.form_actions.insert(key, binding).is_none(),
+            "server form action `{form_id}` was registered more than once for this action type"
+        );
+        self
     }
 
     /// Adds a bearer-protected endpoint that invalidates configured cache entries.
@@ -864,6 +914,14 @@ impl FissionServerApp {
         self.cache_invalidation_endpoints
             .iter()
             .find(|entry| entry.path == path)
+    }
+
+    pub(crate) fn find_form_action(
+        &self,
+        form_id: &str,
+        action_id: ActionId,
+    ) -> Option<&ServerFormActionBinding> {
+        self.form_actions.get(&(form_id.to_string(), action_id))
     }
 
     pub(crate) fn apply_default_route_mode(&mut self, mode: WebRouteMode) {

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -141,6 +141,8 @@ pub struct ServerHttpContext<'a> {
     pub request: &'a ServerRequest,
     /// Session resolved for the request.
     pub session: &'a ServerSession,
+    /// Parameters captured from a dynamic handler path such as `/api/items/:id`.
+    pub route_params: ServerRouteParams,
 }
 
 /// Request-specific browser and social metadata for one rendered route.
@@ -222,6 +224,7 @@ impl ServerRouteEntry {
 pub(crate) struct ServerHttpHandlerEntry {
     pub method: String,
     pub path: String,
+    pub matcher: ServerRouteMatcher,
     pub handler: Arc<HttpHandler>,
 }
 
@@ -509,7 +512,10 @@ impl FissionServerApp {
         self
     }
 
-    /// Registers a synchronous custom HTTP handler for a method and exact path.
+    /// Registers a synchronous custom HTTP handler for a method and path.
+    ///
+    /// Segments prefixed with `:` capture dynamic route parameters. Exact
+    /// handlers take precedence over dynamic handlers for the same request.
     pub fn http_handler<F>(
         mut self,
         method: impl Into<String>,
@@ -519,9 +525,11 @@ impl FissionServerApp {
     where
         F: for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static,
     {
+        let path = normalize_server_path(&path.into());
         self.http_handlers.push(ServerHttpHandlerEntry {
             method: method.into().to_ascii_uppercase(),
-            path: normalize_server_path(&path.into()),
+            matcher: matcher_for_route_path(&path),
+            path,
             handler: Arc::new(handler),
         });
         self
@@ -823,12 +831,29 @@ impl FissionServerApp {
         &self,
         method: &str,
         path: &str,
-    ) -> Option<&ServerHttpHandlerEntry> {
+    ) -> Option<(&ServerHttpHandlerEntry, ServerRouteParams)> {
         let method = method.to_ascii_uppercase();
         let path = normalize_server_path(path);
         self.http_handlers
             .iter()
-            .find(|entry| entry.method == method && entry.path == path)
+            .filter(|entry| entry.method == method)
+            .find_map(|entry| {
+                matches!(entry.matcher, ServerRouteMatcher::Exact)
+                    .then(|| entry.matcher.match_request(&entry.path, &path))
+                    .flatten()
+                    .map(|params| (entry, params))
+            })
+            .or_else(|| {
+                self.http_handlers
+                    .iter()
+                    .filter(|entry| entry.method == method)
+                    .find_map(|entry| {
+                        matches!(entry.matcher, ServerRouteMatcher::Dynamic { .. })
+                            .then(|| entry.matcher.match_request(&entry.path, &path))
+                            .flatten()
+                            .map(|params| (entry, params))
+                    })
+            })
     }
 
     pub(crate) fn find_cache_invalidation_endpoint(

--- a/crates/shell/fission-shell-server/src/app.rs
+++ b/crates/shell/fission-shell-server/src/app.rs
@@ -17,6 +17,8 @@ use fission_shell_site::{
     CodeHighlightingOptions, DocumentMetadata, DocumentShellConfig, SitePageElement,
 };
 use fission_theme::{DesignMode, DesignSystem, PackagedFont, Theme};
+use serde::Serialize;
+use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU16, Ordering};
@@ -39,6 +41,10 @@ type InitialStateLoader<S> =
     dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<S> + Send + Sync + 'static;
 type HttpHandler =
     dyn for<'a> Fn(&ServerHttpContext<'a>) -> Result<ServerResponse> + Send + Sync + 'static;
+type BrowserPropsResolver = dyn for<'a> Fn(&ServerRenderContext<'a>) -> Result<BTreeMap<String, Value>>
+    + Send
+    + Sync
+    + 'static;
 
 #[derive(Debug)]
 pub(crate) struct ServerRenderedNode {
@@ -145,6 +151,8 @@ pub(crate) struct ServerRouteEntry {
     pub route: WebRoute,
     pub matcher: ServerRouteMatcher,
     pub render: Arc<RouteRenderer>,
+    worker_props: BTreeMap<String, Arc<BrowserPropsResolver>>,
+    island_props: BTreeMap<String, Arc<BrowserPropsResolver>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -177,6 +185,10 @@ pub(crate) struct ServerRouteMatch {
 }
 
 impl ServerRouteEntry {
+    pub(crate) fn has_request_scoped_browser_props(&self) -> bool {
+        !self.worker_props.is_empty() || !self.island_props.is_empty()
+    }
+
     pub(crate) fn match_request(&self, request_path: &str) -> Option<ServerRouteMatch> {
         self.matcher
             .match_request(&self.route.path, request_path)
@@ -184,6 +196,25 @@ impl ServerRouteEntry {
                 path: request_path.to_string(),
                 params,
             })
+    }
+
+    pub(crate) fn browser_artifacts(
+        &self,
+        ctx: &ServerRenderContext<'_>,
+    ) -> Result<(Vec<ProgressiveWorker>, Vec<WasmIsland>)> {
+        let mut workers = self.route.workers.clone();
+        for worker in &mut workers {
+            if let Some(resolve) = self.worker_props.get(&worker.id) {
+                worker.props = resolve(ctx)?;
+            }
+        }
+        let mut islands = self.route.islands.clone();
+        for island in &mut islands {
+            if let Some(resolve) = self.island_props.get(&island.id) {
+                island.props = resolve(ctx)?;
+            }
+        }
+        Ok((workers, islands))
     }
 }
 
@@ -600,6 +631,8 @@ impl FissionServerApp {
                 let state = initial_state(ctx)?;
                 render_widget_node::<S, W>(widget.as_ref(), ctx, state)
             }),
+            worker_props: BTreeMap::new(),
+            island_props: BTreeMap::new(),
         });
         self
     }
@@ -637,6 +670,8 @@ impl FissionServerApp {
                 let state = initial_state(ctx)?;
                 render_widget_node::<S, W>(widget.as_ref(), ctx, state)
             }),
+            worker_props: BTreeMap::new(),
+            island_props: BTreeMap::new(),
         });
         self
     }
@@ -654,6 +689,34 @@ impl FissionServerApp {
         self
     }
 
+    /// Attaches a worker whose public initialization properties are resolved
+    /// independently for every rendered request.
+    pub fn worker_with_props<P, F>(
+        mut self,
+        path: &str,
+        worker: ProgressiveWorker,
+        resolve: F,
+    ) -> Self
+    where
+        P: Serialize,
+        F: for<'a> Fn(&ServerRenderContext<'a>) -> Result<P> + Send + Sync + 'static,
+    {
+        let path = normalize_server_path(path);
+        if let Some(route) = self
+            .routes
+            .iter_mut()
+            .find(|entry| entry.route.path == path)
+        {
+            let id = worker.id.clone();
+            route.route.workers.push(worker);
+            route.worker_props.insert(
+                id,
+                Arc::new(move |ctx| serialize_browser_props(resolve(ctx)?)),
+            );
+        }
+        self
+    }
+
     /// Attaches a WebAssembly island to an existing route.
     pub fn island(mut self, path: &str, island: WasmIsland) -> Self {
         let path = normalize_server_path(path);
@@ -663,6 +726,29 @@ impl FissionServerApp {
             .find(|entry| entry.route.path == path)
         {
             route.route.islands.push(island);
+        }
+        self
+    }
+
+    /// Attaches an island whose public initialization properties are resolved
+    /// independently for every rendered request.
+    pub fn island_with_props<P, F>(mut self, path: &str, island: WasmIsland, resolve: F) -> Self
+    where
+        P: Serialize,
+        F: for<'a> Fn(&ServerRenderContext<'a>) -> Result<P> + Send + Sync + 'static,
+    {
+        let path = normalize_server_path(path);
+        if let Some(route) = self
+            .routes
+            .iter_mut()
+            .find(|entry| entry.route.path == path)
+        {
+            let id = island.id.clone();
+            route.route.islands.push(island);
+            route.island_props.insert(
+                id,
+                Arc::new(move |ctx| serialize_browser_props(resolve(ctx)?)),
+            );
         }
         self
     }
@@ -793,6 +879,13 @@ fn matcher_for_route_path(path: &str) -> ServerRouteMatcher {
         }
     } else {
         ServerRouteMatcher::Exact
+    }
+}
+
+fn serialize_browser_props<P: Serialize>(props: P) -> Result<BTreeMap<String, Value>> {
+    match serde_json::to_value(props)? {
+        Value::Object(props) => Ok(props.into_iter().collect()),
+        _ => anyhow::bail!("browser initialization properties must serialize as a JSON object"),
     }
 }
 

--- a/crates/shell/fission-shell-server/src/form.rs
+++ b/crates/shell/fission-shell-server/src/form.rs
@@ -1,0 +1,183 @@
+use anyhow::{bail, Result};
+use std::collections::BTreeMap;
+
+/// Cardinality and browser-value policy for a submitted server form field.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServerFormFieldKind {
+    /// Zero or one UTF-8 text value.
+    Text,
+    /// An HTML checkbox value; absence is normalized to `false`.
+    Boolean,
+    /// Zero or more UTF-8 values with the same field name.
+    Repeated,
+}
+
+/// One explicitly allowed field in a typed server action form.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerFormField {
+    pub(crate) name: String,
+    pub(crate) kind: ServerFormFieldKind,
+    pub(crate) required: bool,
+    pub(crate) max_length: Option<usize>,
+}
+
+impl ServerFormField {
+    /// Declares a scalar UTF-8 text field.
+    pub fn text(name: impl Into<String>) -> Self {
+        Self::new(name, ServerFormFieldKind::Text)
+    }
+
+    /// Declares a checkbox field. An absent successful control becomes `false`.
+    pub fn boolean(name: impl Into<String>) -> Self {
+        Self::new(name, ServerFormFieldKind::Boolean)
+    }
+
+    /// Declares a field that deliberately accepts repeated values.
+    pub fn repeated(name: impl Into<String>) -> Self {
+        Self::new(name, ServerFormFieldKind::Repeated)
+    }
+
+    fn new(name: impl Into<String>, kind: ServerFormFieldKind) -> Self {
+        let name = name.into();
+        assert!(!name.is_empty(), "server form field names cannot be empty");
+        assert_ne!(name, "token", "`token` is reserved by server action forms");
+        Self {
+            name,
+            kind,
+            required: false,
+            max_length: None,
+        }
+    }
+
+    /// Requires at least one non-empty submitted value.
+    pub fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    /// Limits each submitted value by Unicode scalar count.
+    pub fn max_length(mut self, max_length: usize) -> Self {
+        self.max_length = Some(max_length);
+        self
+    }
+}
+
+/// Explicit allow-list and cardinality schema for one server action form.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerFormSchema {
+    pub(crate) id: String,
+    fields: BTreeMap<String, ServerFormField>,
+}
+
+impl ServerFormSchema {
+    /// Creates a schema matching the logical form id assigned to its controls
+    /// and submit button.
+    pub fn new(id: impl Into<String>) -> Self {
+        let id = id.into();
+        assert!(!id.is_empty(), "server form ids cannot be empty");
+        Self {
+            id,
+            fields: BTreeMap::new(),
+        }
+    }
+
+    /// Adds one allowed field. Duplicate declarations are rejected immediately.
+    pub fn field(mut self, field: ServerFormField) -> Self {
+        let name = field.name.clone();
+        assert!(
+            self.fields.insert(name.clone(), field).is_none(),
+            "server form field `{name}` was declared more than once"
+        );
+        self
+    }
+
+    pub(crate) fn normalize(
+        &self,
+        submitted: &[(String, String)],
+    ) -> Result<Vec<(String, String)>> {
+        let mut values = BTreeMap::<&str, Vec<&str>>::new();
+        for (name, value) in submitted {
+            let Some(field) = self.fields.get(name) else {
+                bail!(
+                    "server form field `{name}` is not declared by schema `{}`",
+                    self.id
+                );
+            };
+            if field.kind != ServerFormFieldKind::Repeated && values.contains_key(name.as_str()) {
+                bail!("server form field `{name}` cannot be repeated");
+            }
+            if let Some(max_length) = field.max_length {
+                if value.chars().count() > max_length {
+                    bail!("server form field `{name}` exceeds its maximum length");
+                }
+            }
+            values.entry(name.as_str()).or_default().push(value);
+        }
+
+        let mut normalized = submitted.to_vec();
+        for field in self.fields.values() {
+            let submitted_values = values.get(field.name.as_str());
+            if field.required
+                && submitted_values
+                    .map_or(true, |values| values.iter().all(|value| value.is_empty()))
+            {
+                bail!("required server form field `{}` is missing", field.name);
+            }
+            if field.kind == ServerFormFieldKind::Boolean {
+                match submitted_values {
+                    None => normalized.push((field.name.clone(), "false".to_string())),
+                    Some(values) if matches!(values.as_slice(), [value] if matches!(*value, "on" | "true" | "false")) =>
+                        {}
+                    Some(_) => bail!("server form field `{}` is not a boolean", field.name),
+                }
+            }
+        }
+        Ok(normalized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> ServerFormSchema {
+        ServerFormSchema::new("search")
+            .field(ServerFormField::text("query").required().max_length(20))
+            .field(ServerFormField::boolean("archived"))
+            .field(ServerFormField::repeated("tag"))
+    }
+
+    #[test]
+    fn schema_accepts_repeated_values_and_normalizes_absent_boolean() {
+        let values = schema()
+            .normalize(&[
+                ("query".into(), "ocean".into()),
+                ("tag".into(), "water".into()),
+                ("tag".into(), "physics".into()),
+            ])
+            .unwrap();
+
+        assert!(values.contains(&("archived".into(), "false".into())));
+        assert_eq!(values.iter().filter(|(name, _)| name == "tag").count(), 2);
+    }
+
+    #[test]
+    fn schema_rejects_unknown_duplicate_invalid_and_oversized_values() {
+        assert!(schema().normalize(&[("other".into(), "x".into())]).is_err());
+        assert!(schema()
+            .normalize(&[
+                ("query".into(), "one".into()),
+                ("query".into(), "two".into())
+            ])
+            .is_err());
+        assert!(schema()
+            .normalize(&[
+                ("query".into(), "ocean".into()),
+                ("archived".into(), "yes".into())
+            ])
+            .is_err());
+        assert!(schema()
+            .normalize(&[("query".into(), "this query is far too long".into())])
+            .is_err());
+    }
+}

--- a/crates/shell/fission-shell-server/src/lib.rs
+++ b/crates/shell/fission-shell-server/src/lib.rs
@@ -11,6 +11,7 @@ mod app;
 mod artifacts;
 mod cache;
 mod config;
+mod form;
 mod jobs;
 mod protocol;
 mod render;
@@ -46,6 +47,7 @@ pub use fission_shell_site::{
     CodeHighlightingOptions, DocumentMetadata, DocumentShellConfig, SitePageElement,
     SitePageElementFilter, SitePageElementPlacement,
 };
+pub use form::{ServerFormField, ServerFormFieldKind, ServerFormSchema};
 pub use jobs::{ServerJobCtx, ServerJobError, ServerJobRegistry};
 pub use protocol::{
     AriaPoliteness, BrowserBridgeOutput, BrowserEventBinding, BrowserEventKind, DomBatch, DomOp,

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -938,8 +938,8 @@ impl ServerRenderer {
                 "server action origin rejected",
             ));
         }
-        let token: SignedServerAction = match self.decode_action_request(&request) {
-            Ok(token) => token,
+        let decoded = match self.decode_action_request(&request) {
+            Ok(decoded) => decoded,
             Err(_) => {
                 return Ok(ServerResponse::text(
                     400,
@@ -948,7 +948,7 @@ impl ServerRenderer {
                 ))
             }
         };
-        let action = match self.action_signer.verify_once(&token) {
+        let verified = match self.action_signer.verify(&decoded.token) {
             Ok(action) => action,
             Err(_) => {
                 return Ok(ServerResponse::text(
@@ -958,6 +958,58 @@ impl ServerRenderer {
                 ))
             }
         };
+        let bound_action = match (&verified.form_id, decoded.fields.as_deref()) {
+            (Some(form_id), Some(fields)) => {
+                let Some(binding) = self.app.find_form_action(form_id, verified.action.id) else {
+                    return Ok(ServerResponse::text(
+                        400,
+                        "text/plain; charset=utf-8",
+                        "server action form schema not registered",
+                    ));
+                };
+                match binding.decode(fields) {
+                    Ok(action) => Some(action),
+                    Err(_) => {
+                        return Ok(ServerResponse::text(
+                            422,
+                            "text/plain; charset=utf-8",
+                            "invalid server action form",
+                        ))
+                    }
+                }
+            }
+            (Some(_), None) => {
+                return Ok(ServerResponse::text(
+                    400,
+                    "text/plain; charset=utf-8",
+                    "typed server action requires a form submission",
+                ))
+            }
+            (None, Some(fields)) if !fields.is_empty() => {
+                return Ok(ServerResponse::text(
+                    400,
+                    "text/plain; charset=utf-8",
+                    "fixed server action does not accept form fields",
+                ))
+            }
+            (None, _) => None,
+        };
+        let mut action = match self.action_signer.verify_once(&decoded.token) {
+            Ok(action) => action,
+            Err(_) => {
+                return Ok(ServerResponse::text(
+                    403,
+                    "text/plain; charset=utf-8",
+                    "server action token rejected",
+                ))
+            }
+        };
+        if let Some(bound_action) = bound_action {
+            if bound_action.id != action.action.id {
+                anyhow::bail!("typed server form changed the signed action identity");
+            }
+            action.action = bound_action;
+        }
         let route_path = normalize_server_path(&action.route_path);
         let Some(route) = self.app.find_route(&route_path) else {
             return Ok(ServerResponse::text(
@@ -992,17 +1044,32 @@ impl ServerRenderer {
         Ok(response)
     }
 
-    fn decode_action_request(&self, request: &ServerRequest) -> Result<SignedServerAction> {
+    fn decode_action_request(&self, request: &ServerRequest) -> Result<DecodedActionRequest> {
         let content_type = header_value(&request.headers, "content-type")
             .map(|value| value.split(';').next().unwrap_or(value).trim())
             .unwrap_or("application/json");
         if content_type.eq_ignore_ascii_case("application/x-www-form-urlencoded") {
-            let body = String::from_utf8_lossy(&request.body);
-            let token = form_value(&body, "token")
-                .ok_or_else(|| anyhow!("server action form is missing token"))?;
-            return self.action_signer.decode(&token);
+            let mut token = None;
+            let mut fields = Vec::new();
+            for (name, value) in parse_form_pairs(&request.body)? {
+                if name == "token" {
+                    if token.replace(value).is_some() {
+                        anyhow::bail!("server action form contains duplicate tokens");
+                    }
+                } else {
+                    fields.push((name, value));
+                }
+            }
+            let token = token.ok_or_else(|| anyhow!("server action form is missing token"))?;
+            return Ok(DecodedActionRequest {
+                token: self.action_signer.decode(&token)?,
+                fields: Some(fields),
+            });
         }
-        serde_json::from_slice(&request.body).map_err(Into::into)
+        Ok(DecodedActionRequest {
+            token: serde_json::from_slice(&request.body)?,
+            fields: None,
+        })
     }
 
     fn action_origin_allowed(&self, request: &ServerRequest) -> bool {
@@ -1356,33 +1423,47 @@ fn asset_request_path(path: &str) -> String {
     out
 }
 
-fn form_value(body: &str, key: &str) -> Option<String> {
-    body.split('&').find_map(|field| {
-        let (candidate, value) = field.split_once('=')?;
-        (candidate == key).then(|| form_decode(value))
-    })
+struct DecodedActionRequest {
+    token: SignedServerAction,
+    fields: Option<Vec<(String, String)>>,
 }
 
-fn form_decode(value: &str) -> String {
-    let bytes = value.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
+fn parse_form_pairs(body: &[u8]) -> Result<Vec<(String, String)>> {
+    if body.is_empty() {
+        return Ok(Vec::new());
+    }
+    body.split(|byte| *byte == b'&')
+        .map(|field| {
+            let Some(separator) = field.iter().position(|byte| *byte == b'=') else {
+                anyhow::bail!("malformed form field");
+            };
+            Ok((
+                form_decode(&field[..separator])?,
+                form_decode(&field[separator + 1..])?,
+            ))
+        })
+        .collect()
+}
+
+fn form_decode(value: &[u8]) -> Result<String> {
+    let mut out = Vec::with_capacity(value.len());
     let mut index = 0;
-    while index < bytes.len() {
-        match bytes[index] {
+    while index < value.len() {
+        match value[index] {
             b'+' => {
                 out.push(b' ');
                 index += 1;
             }
-            b'%' if index + 2 < bytes.len() => {
-                let hi = hex_value(bytes[index + 1]);
-                let lo = hex_value(bytes[index + 2]);
-                if let (Some(hi), Some(lo)) = (hi, lo) {
-                    out.push((hi << 4) | lo);
-                    index += 3;
-                } else {
-                    out.push(bytes[index]);
-                    index += 1;
+            b'%' => {
+                if index + 2 >= value.len() {
+                    anyhow::bail!("incomplete percent escape in form value");
                 }
+                let hi = hex_value(value[index + 1])
+                    .ok_or_else(|| anyhow!("invalid percent escape in form value"))?;
+                let lo = hex_value(value[index + 2])
+                    .ok_or_else(|| anyhow!("invalid percent escape in form value"))?;
+                out.push((hi << 4) | lo);
+                index += 3;
             }
             byte => {
                 out.push(byte);
@@ -1390,7 +1471,7 @@ fn form_decode(value: &str) -> String {
             }
         }
     }
-    String::from_utf8_lossy(&out).into_owned()
+    String::from_utf8(out).context("form value is not valid UTF-8")
 }
 
 fn cookie_value(cookie: &str, key: &str) -> Option<String> {
@@ -1611,6 +1692,7 @@ fn collect_server_action_tokens(
     ttl: Duration,
 ) -> Result<BTreeMap<(fission_ir::WidgetId, u128), String>> {
     let mut tokens = BTreeMap::new();
+    let mut form_ids = BTreeSet::new();
     for node in ir.nodes.values() {
         let Op::Semantics(semantics) = &node.op else {
             continue;
@@ -1631,8 +1713,25 @@ fn collect_server_action_tokens(
                 id: ActionId::from_u128(entry.action_id),
                 payload,
             };
-            let token =
-                signer.sign_envelope(route_path.to_string(), node.id.as_u128(), envelope, ttl);
+            let token = if let Some(form_id) = semantics.text_form_id.as_deref() {
+                if form_id.is_empty() {
+                    anyhow::bail!("server action form ids cannot be empty");
+                }
+                if !form_ids.insert(form_id) {
+                    anyhow::bail!(
+                        "server action form id `{form_id}` belongs to more than one submit action"
+                    );
+                }
+                signer.sign_form_envelope(
+                    route_path.to_string(),
+                    node.id.as_u128(),
+                    envelope,
+                    form_id,
+                    ttl,
+                )
+            } else {
+                signer.sign_envelope(route_path.to_string(), node.id.as_u128(), envelope, ttl)
+            };
             tokens.insert((node.id, entry.action_id), signer.encode(&token)?);
         }
     }
@@ -1755,9 +1854,9 @@ mod tests {
     use super::*;
     use crate::{
         CacheError, CacheTag, InvalidationReport, MokaCache, ProgressiveWorker, RevalidationPolicy,
-        WasmIsland, WebRouteMode,
+        ServerFormField, ServerFormSchema, WasmIsland, WebRouteMode,
     };
-    use fission_core::ui::{Button, SemanticsRegion, Text, TextContent};
+    use fission_core::ui::{Button, Checkbox, SemanticsRegion, Text, TextContent, TextInput};
     use fission_core::{
         Action, ActionId, GlobalState, Handler, JobRef, JobResource, JobSpec, ReducerContext,
         ResourceKey, Role, Widget, WidgetId,
@@ -1989,6 +2088,86 @@ mod tests {
     impl Action for TestAction {
         fn static_id() -> ActionId {
             ActionId::from_name("server-renderer.test-action")
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct FormActionState;
+
+    impl GlobalState for FormActionState {}
+
+    #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+    struct SubmittedSearch {
+        query: String,
+        archived: bool,
+        #[serde(default)]
+        tag: Vec<String>,
+    }
+
+    impl Action for SubmittedSearch {
+        fn static_id() -> ActionId {
+            ActionId::from_name("server-renderer.submitted-search")
+        }
+    }
+
+    static SUBMITTED_SEARCHES: OnceLock<Mutex<Vec<SubmittedSearch>>> = OnceLock::new();
+
+    fn on_submitted_search(_state: &mut FormActionState, action: SubmittedSearch) {
+        SUBMITTED_SEARCHES
+            .get_or_init(|| Mutex::new(Vec::new()))
+            .lock()
+            .unwrap()
+            .push(action);
+    }
+
+    #[derive(Clone)]
+    struct FormActionPage;
+
+    impl From<FormActionPage> for Widget {
+        fn from(_: FormActionPage) -> Self {
+            let (ctx, _) = fission_core::build::current::<FormActionState>();
+            let submit = ctx.bind(
+                SubmittedSearch::default(),
+                on_submitted_search as Handler<FormActionState, SubmittedSearch>,
+            );
+            Column {
+                children: vec![
+                    TextInput {
+                        label: Some("Query".into()),
+                        name: Some("query".into()),
+                        form_id: Some("search".into()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    Checkbox::default()
+                        .name("archived")
+                        .form_id("search")
+                        .into(),
+                    TextInput {
+                        label: Some("Tag one".into()),
+                        name: Some("tag".into()),
+                        form_id: Some("search".into()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    TextInput {
+                        label: Some("Tag two".into()),
+                        name: Some("tag".into()),
+                        form_id: Some("search".into()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    Button {
+                        child: Some(Text::new("Search").into()),
+                        on_press: Some(submit),
+                        ..Default::default()
+                    }
+                    .form_id("search")
+                    .into(),
+                ],
+                ..Default::default()
+            }
+            .into()
         }
     }
 
@@ -3654,6 +3833,138 @@ same_site = "none"
             response_header(&response, "cache-control"),
             Some("no-store")
         );
+    }
+
+    #[test]
+    fn typed_server_form_binds_current_controls_and_enforces_security_contract() {
+        SUBMITTED_SEARCHES
+            .get_or_init(|| Mutex::new(Vec::new()))
+            .lock()
+            .unwrap()
+            .clear();
+        let schema = ServerFormSchema::new("search")
+            .field(ServerFormField::text("query").required().max_length(64))
+            .field(ServerFormField::boolean("archived"))
+            .field(ServerFormField::repeated("tag"));
+        let renderer = ServerRenderer::new(
+            FissionServerApp::new("Test")
+                .form_action::<SubmittedSearch, SubmittedSearch, _>(schema, |form| form)
+                .server_route_widget::<FormActionState, _>(
+                    "/search",
+                    "Search",
+                    None,
+                    FormActionPage,
+                ),
+        )
+        .with_allowed_action_origin("https://app.example");
+
+        let initial_html = renderer
+            .handle(ServerRequest::get("/search"))
+            .unwrap()
+            .body_string();
+        assert!(initial_html.contains("name=\"query\""));
+        assert!(initial_html.contains("form=\"search\""));
+        assert!(initial_html.contains("id=\"search\""));
+
+        let duplicate_token = rendered_form_token(&renderer);
+        let duplicate = encoded_form(&[
+            ("token", duplicate_token.as_str()),
+            ("query", "one"),
+            ("query", "two"),
+        ]);
+        assert_eq!(form_request(&renderer, duplicate, None).status, 422);
+
+        let oversized = format!(
+            "token={}&query={}",
+            rendered_form_token(&renderer),
+            "x".repeat(MAX_SERVER_ACTION_BODY_BYTES)
+        );
+        assert_eq!(form_request(&renderer, oversized, None).status, 413);
+
+        let malformed_token = rendered_form_token(&renderer);
+        let malformed = format!("token={malformed_token}&query=%FF");
+        assert_eq!(form_request(&renderer, malformed, None).status, 400);
+
+        let valid_token = rendered_form_token(&renderer);
+        let valid = encoded_form(&[
+            ("token", valid_token.as_str()),
+            ("query", "naïve 海"),
+            ("archived", "on"),
+            ("tag", "water"),
+            ("tag", "physics"),
+        ]);
+        assert_eq!(
+            form_request(&renderer, valid.clone(), Some("https://evil.example")).status,
+            403
+        );
+        assert_eq!(
+            form_request(&renderer, valid.clone(), Some("https://app.example")).status,
+            303
+        );
+        assert_eq!(
+            SUBMITTED_SEARCHES.get().unwrap().lock().unwrap().last(),
+            Some(&SubmittedSearch {
+                query: "naïve 海".into(),
+                archived: true,
+                tag: vec!["water".into(), "physics".into()],
+            })
+        );
+        assert_eq!(
+            form_request(&renderer, valid, Some("https://app.example")).status,
+            403
+        );
+
+        let absent_boolean_token = rendered_form_token(&renderer);
+        let absent_boolean =
+            encoded_form(&[("token", absent_boolean_token.as_str()), ("query", "open")]);
+        assert_eq!(
+            form_request(&renderer, absent_boolean, Some("https://app.example")).status,
+            303
+        );
+        assert!(
+            !SUBMITTED_SEARCHES
+                .get()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .last()
+                .unwrap()
+                .archived
+        );
+    }
+
+    fn rendered_form_token(renderer: &ServerRenderer) -> String {
+        let html = renderer
+            .handle(ServerRequest::get("/search"))
+            .unwrap()
+            .body_string();
+        html.split("name=\"token\" value=\"")
+            .nth(1)
+            .and_then(|value| value.split('"').next())
+            .unwrap()
+            .to_string()
+    }
+
+    fn encoded_form(fields: &[(&str, &str)]) -> String {
+        form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(fields.iter().copied())
+            .finish()
+    }
+
+    fn form_request(
+        renderer: &ServerRenderer,
+        body: String,
+        origin: Option<&str>,
+    ) -> ServerResponse {
+        let mut request = ServerRequest::post("/__fission/action", body);
+        request.headers.insert(
+            "content-type".into(),
+            "application/x-www-form-urlencoded".into(),
+        );
+        if let Some(origin) = origin {
+            request.headers.insert("origin".into(), origin.into());
+        }
+        renderer.handle(request).unwrap()
     }
 
     #[derive(Debug)]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -2112,7 +2112,11 @@ mod tests {
 
     static SUBMITTED_SEARCHES: OnceLock<Mutex<Vec<SubmittedSearch>>> = OnceLock::new();
 
-    fn on_submitted_search(_state: &mut FormActionState, action: SubmittedSearch) {
+    fn on_submitted_search(
+        _state: &mut FormActionState,
+        action: SubmittedSearch,
+        _ctx: &mut ReducerContext<FormActionState>,
+    ) {
         SUBMITTED_SEARCHES
             .get_or_init(|| Mutex::new(Vec::new()))
             .lock()

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -427,6 +427,11 @@ impl ServerRenderer {
         let session = self.session_for_request(&request)?;
 
         if let WebRouteMode::Revalidated(policy) = &route.route.mode {
+            if route.has_request_scoped_browser_props() {
+                return Err(anyhow!(
+                    "request-scoped browser properties require an uncached server route; use static properties on revalidated routes"
+                ));
+            }
             let route_path = matched_route(route, &request).path;
             let env = self.env_for_route(route, None, &request, &session)?;
             let cache_key = self.cache_key_for_route(&route.route, &request, &env);
@@ -673,7 +678,8 @@ impl ServerRenderer {
             SitePageElementPlacement::BodyEnd,
         );
         if !route.route.workers.is_empty() || !route.route.islands.is_empty() {
-            body_end_html.push(route_manifest_script(&route.route)?);
+            let (workers, islands) = route.browser_artifacts(&ctx)?;
+            body_end_html.push(route_manifest_script(&route.route, &workers, &islands)?);
             body_end_html.push(server_browser_runtime_script());
         }
         let action_tokens = collect_server_action_tokens(
@@ -1638,7 +1644,11 @@ struct RouteManifest<'a> {
     islands: &'a [crate::WasmIsland],
 }
 
-fn route_manifest_script(route: &WebRoute) -> Result<String> {
+fn route_manifest_script(
+    route: &WebRoute,
+    workers: &[crate::ProgressiveWorker],
+    islands: &[crate::WasmIsland],
+) -> Result<String> {
     let mode = match &route.mode {
         WebRouteMode::Static => "static",
         WebRouteMode::Revalidated(_) => "revalidated",
@@ -1649,13 +1659,37 @@ fn route_manifest_script(route: &WebRoute) -> Result<String> {
     let manifest = RouteManifest {
         route: &route.path,
         mode,
-        workers: &route.workers,
-        islands: &route.islands,
+        workers,
+        islands,
     };
-    let json = serde_json::to_string(&manifest)?;
+    let json = escape_script_data(&serde_json::to_string(&manifest)?);
     Ok(format!(
         "<script type=\"application/json\" id=\"fission-route-manifest\">{json}</script>"
     ))
+}
+
+fn escape_script_data(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut escaped = String::with_capacity(value.len() + 1);
+    let mut index = 0;
+    while index < bytes.len() {
+        let is_script_end = index + 8 <= bytes.len()
+            && bytes[index] == b'<'
+            && bytes[index + 1] == b'/'
+            && bytes[index + 2..index + 8].eq_ignore_ascii_case(b"script");
+        if is_script_end {
+            escaped.push_str("<\\/script");
+            index += 8;
+            continue;
+        }
+        let ch = value[index..]
+            .chars()
+            .next()
+            .expect("non-empty string slice has a first character");
+        escaped.push(ch);
+        index += ch.len_utf8();
+    }
+    escaped
 }
 
 fn browser_artifact_preload_links(route: &WebRoute) -> Vec<String> {
@@ -2989,6 +3023,115 @@ same_site = "none"
         assert!(html.contains("src=\"/server-runtime.js\""));
         assert!(html.contains("filters"));
         assert!(html.contains("cart-root"));
+    }
+
+    #[test]
+    fn route_manifest_resolves_isolated_request_props_and_escapes_script_data() {
+        #[derive(Serialize)]
+        struct IslandProps {
+            request_name: String,
+            unsafe_text: &'static str,
+        }
+
+        let app = FissionServerApp::new("Test")
+            .route_widget::<TestState, _>(
+                "/",
+                "Home",
+                None,
+                WebRouteMode::Server(Default::default()),
+                TestPage("Interactive page"),
+            )
+            .worker_with_props(
+                "/",
+                ProgressiveWorker::new("filters", "/workers/filters.wasm"),
+                |ctx| {
+                    Ok(serde_json::json!({
+                        "requestName": ctx.request.headers.get("x-request-name").cloned(),
+                    }))
+                },
+            )
+            .island_with_props(
+                "/",
+                WasmIsland::new("cart", "/islands/cart.wasm", "cart-root"),
+                |ctx| {
+                    Ok(IslandProps {
+                        request_name: ctx
+                            .request
+                            .headers
+                            .get("x-request-name")
+                            .cloned()
+                            .unwrap_or_default(),
+                        unsafe_text: "</sCrIpT><script>bad()</SCRIPT>",
+                    })
+                },
+            );
+        let renderer = ServerRenderer::new(app);
+
+        let mut alpha = ServerRequest::get("/");
+        alpha
+            .headers
+            .insert("x-request-name".to_string(), "alpha".to_string());
+        let alpha = renderer.handle(alpha).unwrap().body_string();
+        let mut beta = ServerRequest::get("/");
+        beta.headers
+            .insert("x-request-name".to_string(), "beta".to_string());
+        let beta = renderer.handle(beta).unwrap().body_string();
+
+        assert!(alpha.contains("requestName"));
+        assert!(alpha.contains("alpha"));
+        assert!(!alpha.contains("beta"));
+        assert!(beta.contains("beta"));
+        assert!(!beta.contains("alpha"));
+        assert!(alpha.contains(r#"<\/script><script>bad()<\/script>"#));
+        assert!(!alpha.contains("</sCrIpT><script>bad()</SCRIPT>"));
+    }
+
+    #[test]
+    fn route_manifest_rejects_non_object_initialization_props() {
+        let app = FissionServerApp::new("Test")
+            .route_widget::<TestState, _>(
+                "/",
+                "Home",
+                None,
+                WebRouteMode::Server(Default::default()),
+                TestPage("Interactive page"),
+            )
+            .island_with_props(
+                "/",
+                WasmIsland::new("cart", "/islands/cart.wasm", "cart-root"),
+                |_| Ok(vec!["not", "an", "object"]),
+            );
+        let error = ServerRenderer::new(app)
+            .handle(ServerRequest::get("/"))
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("must serialize as a JSON object"));
+    }
+
+    #[test]
+    fn revalidated_route_rejects_request_scoped_browser_props() {
+        let app = FissionServerApp::new("Test")
+            .route_widget::<TestState, _>(
+                "/",
+                "Home",
+                None,
+                WebRouteMode::Revalidated(RevalidationPolicy::new(Duration::from_secs(60))),
+                TestPage("Interactive page"),
+            )
+            .island_with_props(
+                "/",
+                WasmIsland::new("cart", "/islands/cart.wasm", "cart-root"),
+                |_| Ok(serde_json::json!({"private": "request data"})),
+            );
+        let error = ServerRenderer::new(app)
+            .handle(ServerRequest::get("/"))
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("require an uncached server route"));
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/render.rs
+++ b/crates/shell/fission-shell-server/src/render.rs
@@ -380,12 +380,15 @@ impl ServerRenderer {
                 return self.handle_cache_invalidation(endpoint, &request);
             }
         }
-        if let Some(handler) = self.app.find_http_handler(&request.method, &request.path) {
+        if let Some((handler, route_params)) =
+            self.app.find_http_handler(&request.method, &request.path)
+        {
             let session = self.session_for_request(&request)?;
             let ctx = ServerHttpContext {
                 project_dir: &self.app.project_dir,
                 request: &request,
                 session: &session,
+                route_params,
             };
             let response = if tokio::runtime::Handle::try_current().is_ok() {
                 std::thread::scope(|scope| {
@@ -2545,6 +2548,61 @@ mod tests {
 
         assert_eq!(response.status, 200);
         assert_eq!(response.body_string(), "stored");
+    }
+
+    #[test]
+    fn http_handlers_match_dynamic_paths_and_capture_parameters() {
+        let app = FissionServerApp::new("Test")
+            .http_handler("GET", "/api/items/:id", |ctx| {
+                Ok(ServerResponse::text(
+                    200,
+                    "text/plain; charset=utf-8",
+                    ctx.route_params.get("id").cloned().unwrap_or_default(),
+                ))
+            })
+            .http_handler("GET", "/api/items/new", |_ctx| {
+                Ok(ServerResponse::text(
+                    200,
+                    "text/plain; charset=utf-8",
+                    "exact",
+                ))
+            });
+        let renderer = ServerRenderer::new(app);
+
+        let dynamic = renderer
+            .handle(ServerRequest::get("/api/items/item-42"))
+            .unwrap();
+        let exact = renderer
+            .handle(ServerRequest::get("/api/items/new"))
+            .unwrap();
+
+        assert_eq!(dynamic.status, 200);
+        assert_eq!(dynamic.body_string(), "item-42");
+        assert_eq!(exact.status, 200);
+        assert_eq!(exact.body_string(), "exact");
+    }
+
+    #[test]
+    fn http_handlers_do_not_match_different_methods_or_shapes() {
+        let app = FissionServerApp::new("Test").http_handler("POST", "/api/items/:id", |_ctx| {
+            Ok(ServerResponse::text(204, "text/plain", ""))
+        });
+        let renderer = ServerRenderer::new(app);
+
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::get("/api/items/item-42"))
+                .unwrap()
+                .status,
+            404
+        );
+        assert_eq!(
+            renderer
+                .handle(ServerRequest::post("/api/items", ""))
+                .unwrap()
+                .status,
+            405
+        );
     }
 
     #[test]

--- a/crates/shell/fission-shell-server/src/route.rs
+++ b/crates/shell/fission-shell-server/src/route.rs
@@ -1,5 +1,7 @@
 use crate::{CacheScope, CacheTag};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -145,6 +147,9 @@ pub struct ProgressiveWorker {
     pub root_node_id: Option<String>,
     /// Human-readable purpose shown by tooling.
     pub description: Option<String>,
+    /// Public initialization properties delivered in the worker boot message.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: BTreeMap<String, Value>,
 }
 
 impl ProgressiveWorker {
@@ -156,6 +161,7 @@ impl ProgressiveWorker {
             entry: None,
             root_node_id: None,
             description: None,
+            props: BTreeMap::new(),
         }
     }
 
@@ -176,6 +182,12 @@ impl ProgressiveWorker {
         self.description = Some(description.into());
         self
     }
+
+    /// Supplies static public initialization properties.
+    pub fn props(mut self, props: BTreeMap<String, Value>) -> Self {
+        self.props = props;
+        self
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -191,6 +203,9 @@ pub struct WasmIsland {
     pub mount_id: String,
     /// Human-readable purpose shown by tooling.
     pub description: Option<String>,
+    /// Public initialization properties delivered in the island boot message.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: BTreeMap<String, Value>,
 }
 
 impl WasmIsland {
@@ -206,6 +221,7 @@ impl WasmIsland {
             entry: None,
             mount_id: mount_id.into(),
             description: None,
+            props: BTreeMap::new(),
         }
     }
 
@@ -218,6 +234,12 @@ impl WasmIsland {
     /// Adds a tooling-facing description.
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Supplies static public initialization properties.
+    pub fn props(mut self, props: BTreeMap<String, Value>) -> Self {
+        self.props = props;
         self
     }
 }

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -2315,6 +2315,9 @@ impl HtmlRenderer<'_> {
         if semantics.autofocus {
             attrs.push_str(" autofocus");
         }
+        if let Some(form_id) = semantics.text_form_id.as_deref() {
+            attrs.push_str(&format!(" form=\"{}\"", escape_attr(form_id)));
+        }
         if let Some(max_length) = semantics.max_length {
             attrs.push_str(&format!(" maxlength=\"{max_length}\""));
         }
@@ -2363,9 +2366,6 @@ impl HtmlRenderer<'_> {
                     escape_attr(group)
                 ));
             }
-            if let Some(form_id) = semantics.text_form_id.as_deref() {
-                attrs.push_str(&format!(" form=\"{}\"", escape_attr(form_id)));
-            }
             if semantics.multiline {
                 let wrap = match semantics.text_wrap_mode {
                     fission_ir::semantics::TextWrapMode::Soft => "soft",
@@ -2412,8 +2412,13 @@ impl HtmlRenderer<'_> {
                 escape_attr(identifier)
             ));
         }
+        let form_id = semantics
+            .text_form_id
+            .as_deref()
+            .map(|form_id| format!(" id=\"{}\"", escape_attr(form_id)))
+            .unwrap_or_default();
         Ok(Some(format!(
-            "<form class=\"fission-site-node fission-server-action-form\" method=\"post\" action=\"{}\" data-fission-node=\"{}\"><input type=\"hidden\" name=\"token\" value=\"{}\"><button class=\"fission-site-node fission-site-semantics fission-server-action\" type=\"submit\"{attrs}>{children}</button></form>",
+            "<form class=\"fission-site-node fission-server-action-form\" method=\"post\" action=\"{}\"{form_id} data-fission-node=\"{}\"><input type=\"hidden\" name=\"token\" value=\"{}\"><button class=\"fission-site-node fission-site-semantics fission-server-action\" type=\"submit\"{attrs}>{children}</button></form>",
             escape_attr(action_path),
             node.id,
             escape_attr(token),

--- a/crates/tools/fission-command-process/Cargo.toml
+++ b/crates/tools/fission-command-process/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fission-command-process"
+version = "0.14.1"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/fission-ui/fission"
+description = "Owned child-process supervision for Fission CLI commands"
+categories = ["command-line-utilities", "development-tools"]
+keywords = ["fission", "cli", "process", "supervision"]
+
+[package.metadata.fission]
+platforms = ["linux", "macos", "windows"]
+
+[dependencies]
+anyhow = "1.0"
+command-group = "5.0"
+
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.3"
+
+[target.'cfg(windows)'.dependencies]
+ctrlc = { version = "3.5", features = ["termination"] }

--- a/crates/tools/fission-command-process/README.md
+++ b/crates/tools/fission-command-process/README.md
@@ -1,0 +1,6 @@
+# fission-command-process
+
+Internal process-tree supervision used by long-running Fission CLI commands.
+
+The public developer interface remains the `fission` binary published by the
+`cargo-fission` crate.

--- a/crates/tools/fission-command-process/src/lib.rs
+++ b/crates/tools/fission-command-process/src/lib.rs
@@ -1,0 +1,346 @@
+//! Owned child-process supervision for Fission CLI commands.
+
+use anyhow::{bail, Context, Result};
+use command_group::{CommandGroup, GroupChild};
+use std::process::{Command, ExitStatus};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+const GRACEFUL_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+static ACTIVE_SUPERVISOR: Mutex<()> = Mutex::new(());
+
+/// A process group (Unix) or Job Object (Windows) owned by one CLI command.
+pub struct SupervisedChild {
+    child: Option<GroupChild>,
+}
+
+impl SupervisedChild {
+    /// Spawns `command` in a new owned process group or Job Object.
+    pub fn spawn(command: &mut Command) -> std::io::Result<Self> {
+        command
+            .group_spawn()
+            .map(|child| Self { child: Some(child) })
+    }
+
+    /// Returns the operating-system identifier for the owned process group.
+    pub fn id(&self) -> Option<u32> {
+        self.child.as_ref().map(GroupChild::id)
+    }
+
+    /// Terminates the owned process tree and reaps its leader.
+    pub fn terminate(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        let Some(mut child) = self.child.take() else {
+            return Ok(None);
+        };
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
+        }
+        child.kill()?;
+        child.wait().map(Some)
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        self.child
+            .as_mut()
+            .expect("supervised child is present while waiting")
+            .try_wait()
+    }
+
+    fn forward_termination(&mut self, request: TerminationRequest) -> std::io::Result<()> {
+        forward_termination(
+            self.child
+                .as_mut()
+                .expect("supervised child is present while forwarding termination"),
+            request,
+        )
+    }
+}
+
+impl Drop for SupervisedChild {
+    fn drop(&mut self) {
+        let _ = self.terminate();
+    }
+}
+
+/// Runs a child process under tree supervision and validates its exit status.
+pub fn run_status(command: &mut Command, label: &str) -> Result<()> {
+    let _active = ACTIVE_SUPERVISOR
+        .lock()
+        .map_err(|_| anyhow::anyhow!("process supervisor lock was poisoned"))?;
+    let signals = termination_signals()?;
+    signals.reset();
+    let mut child =
+        SupervisedChild::spawn(command).with_context(|| format!("failed to run {label}"))?;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            child.child.take();
+            if !status.success() {
+                bail!("{label} failed with {status}");
+            }
+            return Ok(());
+        }
+        if let Some(request) = signals.take() {
+            child.forward_termination(request)?;
+            let deadline = Instant::now() + GRACEFUL_EXIT_TIMEOUT;
+            while Instant::now() < deadline {
+                if child.try_wait()?.is_some() {
+                    child.child.take();
+                    bail!("{label} was interrupted");
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            child.terminate()?;
+            bail!("{label} was interrupted");
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TerminationRequest {
+    #[cfg(unix)]
+    Interrupt,
+    Terminate,
+}
+
+#[cfg(unix)]
+struct TerminationSignals {
+    interrupt: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    terminate: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(unix)]
+impl TerminationSignals {
+    fn reset(&self) {
+        use std::sync::atomic::Ordering;
+        self.interrupt.store(false, Ordering::SeqCst);
+        self.terminate.store(false, Ordering::SeqCst);
+    }
+
+    fn take(&self) -> Option<TerminationRequest> {
+        use std::sync::atomic::Ordering;
+        if self.terminate.swap(false, Ordering::SeqCst) {
+            Some(TerminationRequest::Terminate)
+        } else if self.interrupt.swap(false, Ordering::SeqCst) {
+            Some(TerminationRequest::Interrupt)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(unix)]
+fn termination_signals() -> Result<&'static TerminationSignals> {
+    use signal_hook::consts::signal::{SIGINT, SIGTERM};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    static SIGNALS: OnceLock<TerminationSignals> = OnceLock::new();
+    if let Some(signals) = SIGNALS.get() {
+        return Ok(signals);
+    }
+    let signals = TerminationSignals {
+        interrupt: Arc::new(AtomicBool::new(false)),
+        terminate: Arc::new(AtomicBool::new(false)),
+    };
+    signal_hook::flag::register(SIGINT, signals.interrupt.clone())?;
+    signal_hook::flag::register(SIGTERM, signals.terminate.clone())?;
+    let _ = SIGNALS.set(signals);
+    Ok(SIGNALS
+        .get()
+        .expect("termination signals are initialized before use"))
+}
+
+#[cfg(unix)]
+fn forward_termination(child: &mut GroupChild, request: TerminationRequest) -> std::io::Result<()> {
+    use command_group::{Signal, UnixChildExt};
+
+    let signal = match request {
+        TerminationRequest::Interrupt => Signal::SIGINT,
+        TerminationRequest::Terminate => Signal::SIGTERM,
+    };
+    child.signal(signal)
+}
+
+#[cfg(windows)]
+struct TerminationSignals {
+    requested: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(windows)]
+impl TerminationSignals {
+    fn reset(&self) {
+        self.requested
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn take(&self) -> Option<TerminationRequest> {
+        self.requested
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+            .then_some(TerminationRequest::Terminate)
+    }
+}
+
+#[cfg(windows)]
+fn termination_signals() -> Result<&'static TerminationSignals> {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    static SIGNALS: OnceLock<TerminationSignals> = OnceLock::new();
+    if let Some(signals) = SIGNALS.get() {
+        return Ok(signals);
+    }
+    let requested = Arc::new(AtomicBool::new(false));
+    let signal_requested = requested.clone();
+    ctrlc::set_handler(move || {
+        signal_requested.store(true, std::sync::atomic::Ordering::SeqCst);
+    })?;
+    let _ = SIGNALS.set(TerminationSignals { requested });
+    Ok(SIGNALS
+        .get()
+        .expect("termination signals are initialized before use"))
+}
+
+#[cfg(windows)]
+fn forward_termination(
+    child: &mut GroupChild,
+    _request: TerminationRequest,
+) -> std::io::Result<()> {
+    child.kill()
+}
+
+#[cfg(not(any(unix, windows)))]
+compile_error!("fission-command-process supports Unix and Windows hosts");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::path::PathBuf;
+
+    #[test]
+    fn propagates_successful_and_failed_exit_statuses() {
+        let mut success = fixture_command(0);
+        run_status(&mut success, "successful fixture").unwrap();
+
+        let mut failure = fixture_command(7);
+        let error = run_status(&mut failure, "failed fixture").unwrap_err();
+        assert!(error.to_string().contains("failed fixture failed with"));
+    }
+
+    fn fixture_command(code: i32) -> Command {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("--exact")
+            .arg("tests::exit_fixture")
+            .arg("--ignored")
+            .env("FISSION_PROCESS_FIXTURE_EXIT", code.to_string());
+        command
+    }
+
+    #[test]
+    #[ignore]
+    fn exit_fixture() {
+        let code = std::env::var("FISSION_PROCESS_FIXTURE_EXIT")
+            .unwrap()
+            .parse()
+            .unwrap();
+        std::process::exit(code);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn targeted_parent_termination_releases_owned_descendant_port() {
+        use command_group::{Signal, UnixChildExt};
+        use std::net::TcpListener;
+
+        let probe = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+        let ready = fixture_path("ready");
+        let _ = std::fs::remove_file(&ready);
+        let mut parent = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("tests::supervisor_parent_fixture")
+            .arg("--ignored")
+            .env("FISSION_PROCESS_FIXTURE_PORT", port.to_string())
+            .env("FISSION_PROCESS_FIXTURE_READY", &ready)
+            .spawn()
+            .unwrap();
+        if !wait_until(Duration::from_secs(5), || ready.exists()) {
+            let _ = parent.kill();
+            let _ = parent.wait();
+            panic!("descendant did not bind its fixture port");
+        }
+
+        parent.signal(Signal::SIGTERM).unwrap();
+        if !wait_until(Duration::from_secs(5), || {
+            parent.try_wait().unwrap().is_some()
+        }) {
+            let _ = parent.kill();
+            let _ = parent.wait();
+            panic!("supervisor did not exit after targeted termination");
+        }
+        assert!(TcpListener::bind(("127.0.0.1", port)).is_ok());
+        let _ = std::fs::remove_file(ready);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[ignore]
+    fn supervisor_parent_fixture() {
+        let port = std::env::var("FISSION_PROCESS_FIXTURE_PORT").unwrap();
+        let ready = std::env::var_os("FISSION_PROCESS_FIXTURE_READY").unwrap();
+        let mut descendant = Command::new(std::env::current_exe().unwrap());
+        descendant
+            .arg("--exact")
+            .arg("tests::port_holder_fixture")
+            .arg("--ignored")
+            .env("FISSION_PROCESS_FIXTURE_PORT", port)
+            .env("FISSION_PROCESS_FIXTURE_READY", ready);
+
+        let error = run_status(&mut descendant, "port holder fixture").unwrap_err();
+        assert!(error.to_string().contains("was interrupted"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[ignore]
+    fn port_holder_fixture() {
+        let port = std::env::var("FISSION_PROCESS_FIXTURE_PORT")
+            .unwrap()
+            .parse::<u16>()
+            .unwrap();
+        let _listener = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+        std::fs::write(
+            std::env::var_os("FISSION_PROCESS_FIXTURE_READY").unwrap(),
+            b"ready",
+        )
+        .unwrap();
+        loop {
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    }
+
+    #[cfg(unix)]
+    fn wait_until(timeout: Duration, mut ready: impl FnMut() -> bool) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if ready() {
+                return true;
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        }
+        false
+    }
+
+    #[cfg(unix)]
+    fn fixture_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "fission-command-process-{label}-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ))
+    }
+}

--- a/crates/tools/fission-command-run/Cargo.toml
+++ b/crates/tools/fission-command-run/Cargo.toml
@@ -17,6 +17,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 fission-command-core = { path = "../fission-command-core", version = "0.14.1" }
+fission-command-process = { path = "../fission-command-process", version = "0.14.1" }
 fission-command-server = { path = "../fission-command-server", version = "0.14.1" }
 fission-command-site = { path = "../fission-command-site", version = "0.14.1" }
 fission-test-driver = { path = "../fission-test-driver", version = "0.14.1" }

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -11,6 +11,7 @@ use fission_command_core::{
     test_macos_native_modules, test_windows_native_modules, variant_output_path, FissionProject,
     MacosNativeBundleMode, MacosPackageConfig, NativeVariant, PlatformCapability, Target,
 };
+use fission_command_process::run_status;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::env;
@@ -19,7 +20,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{self, IsTerminal, Read, Seek, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 #[derive(Clone, Debug, Serialize)]
@@ -431,12 +432,8 @@ fn browser_test_site(project_dir: &Path) -> Result<()> {
 
 fn browser_test_server(project_dir: &Path) -> Result<()> {
     let port = free_local_port()?;
-    let mut child = ServerChild::new(fission_command_server::spawn_serve(
-        project_dir,
-        false,
-        "127.0.0.1".to_string(),
-        port,
-    )?);
+    let mut child =
+        fission_command_server::spawn_serve(project_dir, false, "127.0.0.1".to_string(), port)?;
     let url = format!("http://127.0.0.1:{port}/");
     wait_for_http(&url, Duration::from_secs(60))?;
     let report = fission_test_driver::run_browser_smoke(
@@ -446,31 +443,8 @@ fn browser_test_server(project_dir: &Path) -> Result<()> {
         "SSR browser smoke passed: title=\"{}\" body_text_len={}",
         report.title, report.body_text_len
     );
-    child.kill();
+    child.terminate()?;
     Ok(())
-}
-
-struct ServerChild {
-    child: Option<Child>,
-}
-
-impl ServerChild {
-    fn new(child: Child) -> Self {
-        Self { child: Some(child) }
-    }
-
-    fn kill(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
-    }
-}
-
-impl Drop for ServerChild {
-    fn drop(&mut self) {
-        self.kill();
-    }
 }
 
 struct StaticTestServer {
@@ -1891,16 +1865,6 @@ where
     command.current_dir(project_dir);
     configure(&mut command);
     run_status(&mut command, relative_script)
-}
-
-fn run_status(command: &mut Command, label: &str) -> Result<()> {
-    let status = command
-        .status()
-        .with_context(|| format!("failed to run {label}"))?;
-    if !status.success() {
-        bail!("{label} failed with {status}");
-    }
-    Ok(())
 }
 
 fn command_for_script(script: &Path) -> Result<Command> {

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -16,5 +16,6 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0"
+fission-command-process = { path = "../fission-command-process", version = "0.14.1" }
 serde_json = "1.0"
 toml = "0.8"

--- a/crates/tools/fission-command-server/Cargo.toml
+++ b/crates/tools/fission-command-server/Cargo.toml
@@ -16,4 +16,5 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0"
+serde_json = "1.0"
 toml = "0.8"

--- a/crates/tools/fission-command-server/src/lib.rs
+++ b/crates/tools/fission-command-server/src/lib.rs
@@ -1,9 +1,10 @@
 use anyhow::{bail, Context, Result};
+use fission_command_process::{run_status, SupervisedChild};
 use serde_json::Value;
 use std::collections::BTreeSet;
 use std::net::TcpListener;
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 
 pub fn check(project_dir: &Path, release: bool) -> Result<()> {
     ensure_server_entry_configured(project_dir)?;
@@ -22,7 +23,12 @@ pub fn routes(project_dir: &Path) -> Result<()> {
     run_server_builder(project_dir, false, "routes", &[])
 }
 
-pub fn spawn_serve(project_dir: &Path, release: bool, host: String, port: u16) -> Result<Child> {
+pub fn spawn_serve(
+    project_dir: &Path,
+    release: bool,
+    host: String,
+    port: u16,
+) -> Result<SupervisedChild> {
     ensure_server_entry_configured(project_dir)?;
     ensure_server_address_available(&host, port)?;
     artifacts(project_dir, release, true).context("failed to build server browser artifacts")?;
@@ -205,7 +211,7 @@ fn spawn_server_builder(
     release: bool,
     command_name: &str,
     extra_args: &[&str],
-) -> Result<Child> {
+) -> Result<SupervisedChild> {
     let manifest_path = project_dir.join("Cargo.toml");
     if !manifest_path.exists() {
         bail!(
@@ -233,7 +239,7 @@ fn spawn_server_builder(
         command.arg(arg);
     }
     command.stdout(Stdio::null()).stderr(Stdio::null());
-    command.spawn().context("failed to spawn server app")
+    SupervisedChild::spawn(&mut command).context("failed to spawn server app")
 }
 
 fn run_server_builder(
@@ -268,11 +274,7 @@ fn run_server_builder(
     for arg in extra_args {
         command.arg(arg);
     }
-    let status = command.status().context("failed to run server app")?;
-    if !status.success() {
-        bail!("server app failed with {status}");
-    }
-    Ok(())
+    run_status(&mut command, "server app")
 }
 
 fn build_server_binary(project_dir: &Path, release: bool) -> Result<()> {
@@ -298,11 +300,7 @@ fn build_server_binary(project_dir: &Path, release: bool) -> Result<()> {
     if release {
         command.arg("--release");
     }
-    let status = command.status().context("failed to build server app")?;
-    if !status.success() {
-        bail!("server app build failed with {status}");
-    }
-    Ok(())
+    run_status(&mut command, "server app build")
 }
 
 #[cfg(test)]

--- a/crates/tools/fission-command-server/src/lib.rs
+++ b/crates/tools/fission-command-server/src/lib.rs
@@ -1,4 +1,6 @@
 use anyhow::{bail, Context, Result};
+use serde_json::Value;
+use std::collections::BTreeSet;
 use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
@@ -59,10 +61,9 @@ fn ensure_server_address_available(host: &str, port: u16) -> Result<()> {
 
 pub fn artifacts(project_dir: &Path, release: bool, compile: bool) -> Result<()> {
     ensure_server_entry_configured(project_dir)?;
-    let package_name = package_name(project_dir)?;
-    let features = package_features(project_dir)?;
-    let mut args = vec!["--package-name", package_name.as_str()];
-    if features.iter().any(|feature| feature == "browser") {
+    let package = server_package(project_dir)?;
+    let mut args = vec!["--package-name", package.name.as_str()];
+    if package.features.contains("browser") {
         args.push("--package-no-default-features");
         args.push("--package-feature");
         args.push("browser");
@@ -91,31 +92,112 @@ fn ensure_server_entry_configured(project_dir: &Path) -> Result<()> {
     }
 }
 
-fn package_name(project_dir: &Path) -> Result<String> {
-    let path = project_dir.join("Cargo.toml");
-    let data = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let value: toml::Value =
-        toml::from_str(&data).with_context(|| format!("failed to parse {}", path.display()))?;
-    value
-        .get("package")
-        .and_then(|package| package.get("name"))
-        .and_then(|name| name.as_str())
-        .map(ToString::to_string)
-        .ok_or_else(|| anyhow::anyhow!("{} is missing [package].name", path.display()))
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ServerPackage {
+    name: String,
+    features: BTreeSet<String>,
 }
 
-fn package_features(project_dir: &Path) -> Result<Vec<String>> {
-    let path = project_dir.join("Cargo.toml");
+fn configured_server_package(project_dir: &Path) -> Result<Option<String>> {
+    let path = project_dir.join("fission.toml");
     let data = std::fs::read_to_string(&path)
         .with_context(|| format!("failed to read {}", path.display()))?;
     let value: toml::Value =
         toml::from_str(&data).with_context(|| format!("failed to parse {}", path.display()))?;
     Ok(value
+        .get("server")
+        .and_then(|server| server.get("package"))
+        .and_then(|package| package.as_str())
+        .map(ToString::to_string))
+}
+
+fn server_package(project_dir: &Path) -> Result<ServerPackage> {
+    let manifest_path = project_dir.join("Cargo.toml");
+    if !manifest_path.exists() {
+        bail!("{} is missing", manifest_path.display());
+    }
+    let manifest_path = manifest_path
+        .canonicalize()
+        .with_context(|| format!("failed to resolve {}", manifest_path.display()))?;
+    let output = Command::new("cargo")
+        .arg("metadata")
+        .arg("--no-deps")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .current_dir(project_dir)
+        .output()
+        .context("failed to run cargo metadata for the server package")?;
+    if !output.status.success() {
+        bail!(
+            "cargo metadata failed for {}: {}",
+            manifest_path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let metadata: Value = serde_json::from_slice(&output.stdout)
+        .context("failed to parse cargo metadata for the server package")?;
+    select_server_package(
+        &metadata,
+        &manifest_path,
+        configured_server_package(project_dir)?.as_deref(),
+    )
+}
+
+fn select_server_package(
+    metadata: &Value,
+    root_manifest_path: &Path,
+    configured_name: Option<&str>,
+) -> Result<ServerPackage> {
+    let workspace_members = metadata
+        .get("workspace_members")
+        .and_then(Value::as_array)
+        .context("cargo metadata omitted workspace_members")?;
+    let packages = metadata
+        .get("packages")
+        .and_then(Value::as_array)
+        .context("cargo metadata omitted packages")?;
+    let selected = packages.iter().find(|package| {
+        let is_workspace_member = package.get("id").is_some_and(|id| {
+            workspace_members
+                .iter()
+                .any(|workspace_id| workspace_id == id)
+        });
+        if !is_workspace_member {
+            return false;
+        }
+        if let Some(name) = configured_name {
+            package.get("name").and_then(Value::as_str) == Some(name)
+        } else {
+            package
+                .get("manifest_path")
+                .and_then(Value::as_str)
+                .is_some_and(|path| Path::new(path) == root_manifest_path)
+        }
+    });
+    let selected = match (selected, configured_name) {
+        (Some(package), _) => package,
+        (None, Some(name)) => bail!(
+            "[server].package `{name}` is not a package in the Cargo workspace rooted at {}",
+            root_manifest_path.display()
+        ),
+        (None, None) => bail!(
+            "{} is a virtual Cargo workspace; set [server].package to the server package name",
+            root_manifest_path.display()
+        ),
+    };
+    let name = selected
+        .get("name")
+        .and_then(Value::as_str)
+        .context("selected Cargo package is missing its name")?
+        .to_string();
+    let features = selected
         .get("features")
-        .and_then(|features| features.as_table())
+        .and_then(Value::as_object)
         .map(|features| features.keys().cloned().collect())
-        .unwrap_or_default())
+        .unwrap_or_default();
+    Ok(ServerPackage { name, features })
 }
 
 fn spawn_server_builder(
@@ -135,11 +217,14 @@ fn spawn_server_builder(
         .canonicalize()
         .with_context(|| format!("failed to resolve {}", manifest_path.display()))?;
     let mut command = Command::new("cargo");
+    let package = server_package(project_dir)?;
     command.current_dir(project_dir);
     command
         .arg("run")
         .arg("--manifest-path")
-        .arg(&manifest_path);
+        .arg(&manifest_path)
+        .arg("--package")
+        .arg(&package.name);
     if release {
         command.arg("--release");
     }
@@ -168,11 +253,14 @@ fn run_server_builder(
         .canonicalize()
         .with_context(|| format!("failed to resolve {}", manifest_path.display()))?;
     let mut command = Command::new("cargo");
+    let package = server_package(project_dir)?;
     command.current_dir(project_dir);
     command
         .arg("run")
         .arg("--manifest-path")
-        .arg(&manifest_path);
+        .arg(&manifest_path)
+        .arg("--package")
+        .arg(&package.name);
     if release {
         command.arg("--release");
     }
@@ -199,11 +287,14 @@ fn build_server_binary(project_dir: &Path, release: bool) -> Result<()> {
         .canonicalize()
         .with_context(|| format!("failed to resolve {}", manifest_path.display()))?;
     let mut command = Command::new("cargo");
+    let package = server_package(project_dir)?;
     command.current_dir(project_dir);
     command
         .arg("build")
         .arg("--manifest-path")
-        .arg(&manifest_path);
+        .arg(&manifest_path)
+        .arg("--package")
+        .arg(&package.name);
     if release {
         command.arg("--release");
     }
@@ -238,30 +329,52 @@ mod tests {
     }
 
     #[test]
-    fn reads_package_name_and_browser_feature_for_artifact_shims() {
-        let dir = temp_project("fission-server-config-package");
-        fs::write(
-            dir.join("Cargo.toml"),
-            r#"[package]
-name = "server-app"
-version = "0.1.0"
-edition = "2021"
+    fn selects_configured_virtual_workspace_package_and_its_features() {
+        let metadata = serde_json::json!({
+            "workspace_members": ["path+file:///workspace/apps/server#server-app@0.1.0"],
+            "packages": [
+                {
+                    "id": "path+file:///workspace/apps/server#server-app@0.1.0",
+                    "name": "server-app",
+                    "manifest_path": "/workspace/apps/server/Cargo.toml",
+                    "features": {"browser": [], "server": []}
+                },
+                {
+                    "id": "registry+https://example.invalid/dependency#1.0.0",
+                    "name": "dependency",
+                    "manifest_path": "/registry/dependency/Cargo.toml",
+                    "features": {}
+                }
+            ]
+        });
 
-[features]
-default = ["server"]
-server = []
-browser = []
-"#,
+        let package = select_server_package(
+            &metadata,
+            Path::new("/workspace/Cargo.toml"),
+            Some("server-app"),
         )
         .unwrap();
 
-        assert_eq!(package_name(&dir).unwrap(), "server-app");
-        assert!(package_features(&dir)
-            .unwrap()
-            .iter()
-            .any(|feature| feature == "browser"));
+        assert_eq!(package.name, "server-app");
+        assert!(package.features.contains("browser"));
+    }
 
-        let _ = fs::remove_dir_all(&dir);
+    #[test]
+    fn virtual_workspace_requires_explicit_server_package() {
+        let metadata = serde_json::json!({
+            "workspace_members": ["server-id"],
+            "packages": [{
+                "id": "server-id",
+                "name": "server-app",
+                "manifest_path": "/workspace/apps/server/Cargo.toml",
+                "features": {}
+            }]
+        });
+
+        let error =
+            select_server_package(&metadata, Path::new("/workspace/Cargo.toml"), None).unwrap_err();
+
+        assert!(error.to_string().contains("set [server].package"));
     }
 
     #[test]

--- a/crates/tools/fission-command-site/Cargo.toml
+++ b/crates/tools/fission-command-site/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://fission.rs"
 readme = "README.md"
 [dependencies]
 anyhow = "1.0"
+fission-command-process = { path = "../fission-command-process", version = "0.14.1" }
 fission-shell-site = { path = "../../shell/fission-shell-site", version = "0.14.1" }
 serde_json = "1"
 toml = "0.8"

--- a/crates/tools/fission-command-site/src/lib.rs
+++ b/crates/tools/fission-command-site/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use fission_command_process::run_status;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, BufRead, Write};
@@ -210,16 +211,6 @@ fn run_site_builder(
         }
     }
     run_status(&mut command, "site builder")
-}
-
-fn run_status(command: &mut Command, label: &str) -> Result<()> {
-    let status = command
-        .status()
-        .with_context(|| format!("failed to run {label}"))?;
-    if !status.success() {
-        bail!("{label} failed with {status}");
-    }
-    Ok(())
 }
 
 fn handle_http_request(mut stream: TcpStream, root: &Path, spa_fallback: bool) -> Result<()> {

--- a/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
+++ b/documentation/content/docs/guides/server-site-caching-jobs-actions.mdx
@@ -215,6 +215,45 @@ pub fn on_add_to_cart(state: &mut StoreState, slug: String) {
 
 Do not expose arbitrary Rust functions as HTTP actions. Keep actions narrow and typed. A small action describes what happened; a reducer updates state and can request any follow-up work through jobs or services.
 
+When the action needs values entered after rendering, give its controls and
+submit button one logical form id, then register an explicit typed schema on the
+server app:
+
+```rust
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+struct SearchSubmitted {
+    query: String,
+    archived: bool,
+    #[serde(default)]
+    tag: Vec<String>,
+}
+
+impl Action for SearchSubmitted {
+    fn static_id() -> ActionId {
+        ActionId::from_name("store::SearchSubmitted")
+    }
+}
+
+let schema = ServerFormSchema::new("catalog-search")
+    .field(ServerFormField::text("query").required().max_length(200))
+    .field(ServerFormField::boolean("archived"))
+    .field(ServerFormField::repeated("tag"));
+
+FissionServerApp::new("Store")
+    .form_action::<SearchSubmitted, SearchSubmitted, _>(schema, |form| form)
+    // Add routes after registering the form action.
+```
+
+Set `name` and `form_id` on each `TextInput`, and call
+`.name("archived").form_id("catalog-search")` on a `Checkbox`. Associate the
+submit button with `.form_id("catalog-search")`. Fission keeps the route,
+target node, action type, expiry, nonce, and form schema inside the signed
+token; submitted controls can only populate the already-authorized action type.
+Unknown fields, duplicate scalar values, invalid booleans, malformed UTF-8 or
+percent encoding, schema violations, oversized bodies, wrong origins, and
+replayed tokens are rejected. Use `ServerFormField::repeated` only where the
+typed action deliberately accepts a sequence.
+
 ## 6. Keep cached pages and actions separate
 
 Do not cache a full page that contains signed server action forms. The action token is request-specific and short lived; putting it into a public revalidated cache would either replay the same token for different users or leave users with expired controls. Fission rejects that combination.

--- a/documentation/content/docs/guides/server-sites.mdx
+++ b/documentation/content/docs/guides/server-sites.mdx
@@ -22,6 +22,8 @@ app_id = "rs.fission.examples.pokemon_card_store"
 
 [server]
 entry = "pokemon_card_store::pokemon_card_store_server"
+# Required when this fission.toml sits beside a virtual workspace Cargo.toml.
+package = "pokemon-card-store"
 default_route_mode = "server_private"
 render_pass_limit = 4
 ```

--- a/documentation/content/reference/config/fission-toml.mdx
+++ b/documentation/content/reference/config/fission-toml.mdx
@@ -477,6 +477,7 @@ Client-side search is optional. When enabled, the build writes a local search in
 | Field | Type | Required | Default | Meaning |
 | --- | --- | --- | --- | --- |
 | `entry` | string | Yes for server commands | none | Rust path to the function that returns the `FissionServerApp`, such as `pokemon_card_store::pokemon_card_store_server`. The top-level CLI reads this field and generates/runs the server binary entrypoint. |
+| `package` | string | Required for virtual Cargo workspaces | root package | Cargo workspace package that owns the server entrypoint. Server commands pass this name to Cargo explicitly and use its feature declarations when building browser artifacts. |
 | `default_locale` | string | No | `en` | Locale written to the rendered HTML `lang` attribute unless a route or future locale layer overrides it. |
 | `default_route_mode` | string | No | app default | Route mode applied to routes declared through the default server route helper. Accepted values are `static`, `server`, `dynamic`, `server_private`, `private`, `revalidated`, `client_app`, and `client`. `dynamic` is an alias for `server`; `private` is an alias for `server_private`. |
 | `render_pass_limit` | integer | No | `4` | Maximum render passes allowed while jobs/resources settle before the server returns HTML. `fission server check`, `fission server serve`, and the server binary read this value. |


### PR DESCRIPTION
## Summary

- bind request-scoped worker and island props without leaking cached request data
- route dynamic custom HTTP handlers through the same matcher and expose captured params
- update the optional Axum adapter to Axum 0.8
- select an explicit server package for virtual Cargo workspaces
- supervise CLI-owned child process trees across Unix and Windows
- bind schema-validated HTML controls into signed typed SSR actions
- keep Fission development builds on the requested isolated Debian target with two jobs and reduced debug data

## Architecture and security

- Signed route, node, action type, form identity, expiry, nonce, origin and replay protections remain authoritative.
- Submitted controls replace only the payload of the already-signed action type after explicit field/cardinality validation.
- Request-scoped browser props are rejected on revalidated routes, preventing private request data from entering shared cached HTML.
- Child supervision is confined to CLI tooling; the new command-group, signal-hook and ctrlc dependencies do not enter application runtime graphs.

## Validation

- cargo fmt --all -- --check
- command dependency boundary check
- published dependency boundary check
- exact-commit focused Rust tests and optional Axum adapter check submitted through Zrunner

Closes #209
Closes #210
Closes #211
Closes #212
Closes #213
Closes #214