### PR TITLE
Redesign the documentation site around developer value

### DIFF
--- a/crates/shell/fission-shell-site/src/blog_routes.rs
+++ b/crates/shell/fission-shell-site/src/blog_routes.rs
@@ -1,0 +1,261 @@
+use crate::build::{load_sidebar, SiteBuildOptions};
+use crate::document::{extract_page_links, ContentRoute, SidebarLink, BLOG_PAGE_SIZE};
+use crate::site::normalize_site_path;
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub(crate) fn add_generated_blog_routes(
+    options: &SiteBuildOptions,
+    routes: &mut Vec<ContentRoute>,
+) -> Result<()> {
+    for config in &options.content_routes {
+        let prefix = normalize_site_path(&config.path);
+        if prefix != "/blog/" {
+            continue;
+        }
+        let posts = routes
+            .iter()
+            .filter(|route| {
+                route.path.starts_with(&prefix)
+                    && route.path != prefix
+                    && !is_blog_taxonomy_path(&route.path)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if posts.is_empty() {
+            continue;
+        }
+        let sidebar = load_sidebar(config.sidebar.as_deref())?;
+        add_blog_index(routes, &posts, &sidebar, &prefix);
+        add_blog_pages(routes, &posts, &sidebar, &prefix);
+        add_blog_taxonomy_routes(routes, &posts, &sidebar);
+    }
+    Ok(())
+}
+
+fn add_blog_index(
+    routes: &mut Vec<ContentRoute>,
+    posts: &[ContentRoute],
+    sidebar: &[SidebarLink],
+    prefix: &str,
+) {
+    if routes.iter().any(|route| route.path == prefix) {
+        return;
+    }
+    let body = blog_landing_markdown(posts);
+    routes.push(ContentRoute {
+        path: prefix.to_string(),
+        title: "Blog".to_string(),
+        description: Some(
+            "Technical posts, release notes, and product updates from Fission.".to_string(),
+        ),
+        locale: None,
+        headings: extract_page_links(&body),
+        sidebar: sidebar.to_vec(),
+        tags: Vec::new(),
+        categories: Vec::new(),
+        show_adjacent_posts: false,
+        body,
+        source_path: PathBuf::from("<generated-blog-index>"),
+        rendered: None,
+    });
+}
+
+fn add_blog_pages(
+    routes: &mut Vec<ContentRoute>,
+    posts: &[ContentRoute],
+    sidebar: &[SidebarLink],
+    prefix: &str,
+) {
+    for page in 2..=posts.len().div_ceil(BLOG_PAGE_SIZE) {
+        let path = format!("{prefix}page/{page}/");
+        if routes.iter().any(|route| route.path == path) {
+            continue;
+        }
+        let body = blog_landing_markdown(posts);
+        routes.push(ContentRoute {
+            path,
+            title: format!("Blog — page {page}"),
+            description: Some(format!(
+                "Technical posts, release notes, and product updates from Fission, page {page}."
+            )),
+            locale: None,
+            headings: extract_page_links(&body),
+            sidebar: sidebar.to_vec(),
+            tags: Vec::new(),
+            categories: Vec::new(),
+            show_adjacent_posts: false,
+            body,
+            source_path: PathBuf::from(format!("<generated-blog-page-{page}>")),
+            rendered: None,
+        });
+    }
+}
+
+fn add_blog_taxonomy_routes(
+    routes: &mut Vec<ContentRoute>,
+    posts: &[ContentRoute],
+    sidebar: &[SidebarLink],
+) {
+    for category in unique_taxonomy_values(posts, BlogTaxonomyKind::Category) {
+        let path = blog_taxonomy_route(BlogTaxonomyKind::Category, &category);
+        if routes.iter().any(|route| route.path == path) {
+            continue;
+        }
+        let body = format!("# {category}\n\nPosts filed under the {category} category.\n");
+        routes.push(ContentRoute {
+            path,
+            title: format!("{category} posts"),
+            description: Some(format!("Posts filed under the {category} category.")),
+            locale: None,
+            headings: extract_page_links(&body),
+            sidebar: sidebar.to_vec(),
+            tags: Vec::new(),
+            categories: vec![category.clone()],
+            show_adjacent_posts: false,
+            body,
+            source_path: PathBuf::from(format!(
+                "<generated-blog-category-{}>",
+                taxonomy_slug(&category)
+            )),
+            rendered: None,
+        });
+    }
+
+    for tag in unique_taxonomy_values(posts, BlogTaxonomyKind::Tag) {
+        let path = blog_taxonomy_route(BlogTaxonomyKind::Tag, &tag);
+        if routes.iter().any(|route| route.path == path) {
+            continue;
+        }
+        let body = format!("# #{tag}\n\nPosts tagged #{tag}.\n");
+        routes.push(ContentRoute {
+            path,
+            title: format!("#{tag} posts"),
+            description: Some(format!("Posts tagged #{tag}.")),
+            locale: None,
+            headings: extract_page_links(&body),
+            sidebar: sidebar.to_vec(),
+            tags: vec![tag.clone()],
+            categories: Vec::new(),
+            show_adjacent_posts: false,
+            body,
+            source_path: PathBuf::from(format!("<generated-blog-tag-{}>", taxonomy_slug(&tag))),
+            rendered: None,
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BlogTaxonomyKind {
+    Category,
+    Tag,
+}
+
+fn unique_taxonomy_values(posts: &[ContentRoute], kind: BlogTaxonomyKind) -> Vec<String> {
+    let mut values = posts
+        .iter()
+        .flat_map(|route| match kind {
+            BlogTaxonomyKind::Category => route.categories.iter(),
+            BlogTaxonomyKind::Tag => route.tags.iter(),
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    values.sort_by_key(|value| value.to_ascii_lowercase());
+    values.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+    values
+}
+
+fn blog_taxonomy_route(kind: BlogTaxonomyKind, value: &str) -> String {
+    let segment = match kind {
+        BlogTaxonomyKind::Category => "categories",
+        BlogTaxonomyKind::Tag => "tags",
+    };
+    normalize_site_path(&format!("/blog/{segment}/{}", taxonomy_slug(value)))
+}
+
+fn taxonomy_slug(value: &str) -> String {
+    let mut out = String::new();
+    let mut previous_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            previous_dash = false;
+        } else if !previous_dash && !out.is_empty() {
+            out.push('-');
+            previous_dash = true;
+        }
+    }
+    let slug = out.trim_matches('-');
+    if slug.is_empty() {
+        "untitled".to_string()
+    } else {
+        slug.to_string()
+    }
+}
+
+fn is_blog_taxonomy_path(path: &str) -> bool {
+    path.starts_with("/blog/categories/") || path.starts_with("/blog/tags/")
+}
+
+fn blog_landing_markdown(posts: &[ContentRoute]) -> String {
+    let mut posts = posts.to_vec();
+    posts.sort_by(|a, b| {
+        b.source_path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or(&b.path)
+            .cmp(
+                a.source_path
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or(&a.path),
+            )
+    });
+
+    let mut tags = posts
+        .iter()
+        .flat_map(|route| route.tags.iter().cloned())
+        .collect::<Vec<_>>();
+    tags.sort();
+    tags.dedup();
+    let mut categories = posts
+        .iter()
+        .flat_map(|route| route.categories.iter().cloned())
+        .collect::<Vec<_>>();
+    categories.sort();
+    categories.dedup();
+
+    let mut body = String::from(
+        "# Blog\n\nTechnical posts, release notes, and product updates from the Fission team.\n\n",
+    );
+    if !categories.is_empty() {
+        body.push_str("## Categories\n\n");
+        body.push_str(&categories.join(", "));
+        body.push_str("\n\n");
+    }
+    if !tags.is_empty() {
+        body.push_str("## Tags\n\n");
+        body.push_str(&tags.join(", "));
+        body.push_str("\n\n");
+    }
+    body.push_str("## Latest posts\n\n");
+    for route in posts {
+        body.push_str(&format!("- [{}]({})", route.title, route.path));
+        if let Some(description) = &route.description {
+            body.push_str(&format!(" — {description}"));
+        }
+        body.push('\n');
+    }
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn taxonomy_slugs_are_stable() {
+        assert_eq!(taxonomy_slug("Release notes"), "release-notes");
+        assert_eq!(taxonomy_slug("  "), "untitled");
+    }
+}

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1,3 +1,8 @@
+use crate::build_support::{
+    escape_attr, escape_text, first_h1, normalize_site_asset_href, normalize_site_link_href,
+    page_asset_href_for_route, resolve_project_path, search_script_href_for_route,
+    stylesheet_href_for_route, title_from_path, validate_generated_internal_links,
+};
 use crate::document::{
     extract_page_links, ContentRoute, DocumentationPage, SidebarLink, SiteNavLink, SitePageState,
 };
@@ -676,217 +681,11 @@ fn load_content_routes(
             });
         }
     }
-    add_generated_blog_routes(options, &mut routes)?;
+    crate::blog_routes::add_generated_blog_routes(options, &mut routes)?;
     if routes.is_empty() && site_has_content_routes(options) {
         bail!("configured site content routes contain no .md or .mdx files");
     }
     Ok(routes)
-}
-
-fn add_generated_blog_routes(
-    options: &SiteBuildOptions,
-    routes: &mut Vec<ContentRoute>,
-) -> Result<()> {
-    for config in &options.content_routes {
-        let prefix = normalize_site_path(&config.path);
-        if prefix != "/blog/" {
-            continue;
-        }
-        let posts = routes
-            .iter()
-            .filter(|route| {
-                route.path.starts_with(&prefix)
-                    && route.path != prefix
-                    && !is_blog_taxonomy_path(&route.path)
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        if posts.is_empty() {
-            continue;
-        }
-        let sidebar = load_sidebar(config.sidebar.as_deref())?;
-        if !routes.iter().any(|route| route.path == prefix) {
-            let body = blog_landing_markdown(&posts);
-            routes.push(ContentRoute {
-                path: prefix.clone(),
-                title: "Blog".to_string(),
-                description: Some(
-                    "Technical posts, release notes, and product updates from Fission.".to_string(),
-                ),
-                locale: None,
-                headings: extract_page_links(&body),
-                sidebar: sidebar.clone(),
-                tags: Vec::new(),
-                categories: Vec::new(),
-                show_adjacent_posts: false,
-                body,
-                source_path: PathBuf::from("<generated-blog-index>"),
-                rendered: None,
-            });
-        }
-        add_generated_blog_taxonomy_routes(routes, &posts, &sidebar);
-    }
-    Ok(())
-}
-
-fn add_generated_blog_taxonomy_routes(
-    routes: &mut Vec<ContentRoute>,
-    posts: &[ContentRoute],
-    sidebar: &[SidebarLink],
-) {
-    let categories = unique_taxonomy_values(posts, BlogTaxonomyKind::Category);
-    for category in categories {
-        let path = blog_taxonomy_route(BlogTaxonomyKind::Category, &category);
-        if routes.iter().any(|route| route.path == path) {
-            continue;
-        }
-        let body = format!("# {category}\n\nPosts filed under the {category} category.\n");
-        routes.push(ContentRoute {
-            path,
-            title: format!("{category} posts"),
-            description: Some(format!("Posts filed under the {category} category.")),
-            locale: None,
-            headings: extract_page_links(&body),
-            sidebar: sidebar.to_vec(),
-            tags: Vec::new(),
-            categories: vec![category.clone()],
-            show_adjacent_posts: false,
-            body,
-            source_path: PathBuf::from(format!(
-                "<generated-blog-category-{}>",
-                taxonomy_slug(&category)
-            )),
-            rendered: None,
-        });
-    }
-
-    let tags = unique_taxonomy_values(posts, BlogTaxonomyKind::Tag);
-    for tag in tags {
-        let path = blog_taxonomy_route(BlogTaxonomyKind::Tag, &tag);
-        if routes.iter().any(|route| route.path == path) {
-            continue;
-        }
-        let body = format!("# #{tag}\n\nPosts tagged #{tag}.\n");
-        routes.push(ContentRoute {
-            path,
-            title: format!("#{tag} posts"),
-            description: Some(format!("Posts tagged #{tag}.")),
-            locale: None,
-            headings: extract_page_links(&body),
-            sidebar: sidebar.to_vec(),
-            tags: vec![tag.clone()],
-            categories: Vec::new(),
-            show_adjacent_posts: false,
-            body,
-            source_path: PathBuf::from(format!("<generated-blog-tag-{}>", taxonomy_slug(&tag))),
-            rendered: None,
-        });
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum BlogTaxonomyKind {
-    Category,
-    Tag,
-}
-
-fn unique_taxonomy_values(posts: &[ContentRoute], kind: BlogTaxonomyKind) -> Vec<String> {
-    let mut values = posts
-        .iter()
-        .flat_map(|route| match kind {
-            BlogTaxonomyKind::Category => route.categories.iter(),
-            BlogTaxonomyKind::Tag => route.tags.iter(),
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    values.sort_by_key(|value| value.to_ascii_lowercase());
-    values.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
-    values
-}
-
-fn blog_taxonomy_route(kind: BlogTaxonomyKind, value: &str) -> String {
-    let segment = match kind {
-        BlogTaxonomyKind::Category => "categories",
-        BlogTaxonomyKind::Tag => "tags",
-    };
-    normalize_site_path(&format!("/blog/{segment}/{}", taxonomy_slug(value)))
-}
-
-fn taxonomy_slug(value: &str) -> String {
-    let mut out = String::new();
-    let mut previous_dash = false;
-    for ch in value.chars().flat_map(char::to_lowercase) {
-        if ch.is_ascii_alphanumeric() {
-            out.push(ch);
-            previous_dash = false;
-        } else if !previous_dash && !out.is_empty() {
-            out.push('-');
-            previous_dash = true;
-        }
-    }
-    let slug = out.trim_matches('-');
-    if slug.is_empty() {
-        "untitled".to_string()
-    } else {
-        slug.to_string()
-    }
-}
-
-fn is_blog_taxonomy_path(path: &str) -> bool {
-    path.starts_with("/blog/categories/") || path.starts_with("/blog/tags/")
-}
-
-fn blog_landing_markdown(posts: &[ContentRoute]) -> String {
-    let mut posts = posts.to_vec();
-    posts.sort_by(|a, b| {
-        b.source_path
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .unwrap_or(&b.path)
-            .cmp(
-                a.source_path
-                    .file_stem()
-                    .and_then(|value| value.to_str())
-                    .unwrap_or(&a.path),
-            )
-    });
-
-    let mut tags = posts
-        .iter()
-        .flat_map(|route| route.tags.iter().cloned())
-        .collect::<Vec<_>>();
-    tags.sort();
-    tags.dedup();
-
-    let mut categories = posts
-        .iter()
-        .flat_map(|route| route.categories.iter().cloned())
-        .collect::<Vec<_>>();
-    categories.sort();
-    categories.dedup();
-
-    let mut body = String::from(
-        "# Blog\n\nTechnical posts, release notes, and product updates from the Fission team.\n\n",
-    );
-    if !categories.is_empty() {
-        body.push_str("## Categories\n\n");
-        body.push_str(&categories.join(", "));
-        body.push_str("\n\n");
-    }
-    if !tags.is_empty() {
-        body.push_str("## Tags\n\n");
-        body.push_str(&tags.join(", "));
-        body.push_str("\n\n");
-    }
-    body.push_str("## Latest posts\n\n");
-    for route in posts {
-        body.push_str(&format!("- [{}]({})", route.title, route.path));
-        if let Some(description) = &route.description {
-            body.push_str(&format!(" — {description}"));
-        }
-        body.push('\n');
-    }
-    body
 }
 
 fn strip_mdx_control_markers(markdown: &str) -> String {
@@ -900,7 +699,7 @@ fn strip_mdx_control_markers(markdown: &str) -> String {
         .join("\n")
 }
 
-fn load_sidebar(path: Option<&Path>) -> Result<Vec<SidebarLink>> {
+pub(crate) fn load_sidebar(path: Option<&Path>) -> Result<Vec<SidebarLink>> {
     let Some(path) = path else {
         return Ok(Vec::new());
     };
@@ -1437,59 +1236,6 @@ fn resolve_markdown_target_file(path: &Path) -> Option<PathBuf> {
     None
 }
 
-fn stylesheet_href_for_route(route_path: &str) -> String {
-    let depth = route_path
-        .trim_matches('/')
-        .split('/')
-        .filter(|segment| !segment.is_empty())
-        .count();
-    if depth == 0 {
-        "site.css".to_string()
-    } else {
-        format!("{}site.css", "../".repeat(depth))
-    }
-}
-
-fn search_script_href_for_route(route_path: &str, search_path: &str) -> String {
-    let target = format!(
-        "/{}/search.js",
-        search_path.trim_matches('/').trim_end_matches('/')
-    );
-    relative_href_for_route(route_path, &target)
-}
-
-fn page_asset_href_for_route(route_path: &str, href: &str) -> String {
-    if href.starts_with('/') {
-        relative_href_for_route(route_path, href)
-    } else {
-        href.to_string()
-    }
-}
-
-fn relative_href_for_route(current_route_path: &str, target: &str) -> String {
-    let suffix_start = target
-        .find('#')
-        .or_else(|| target.find('?'))
-        .unwrap_or(target.len());
-    let (path, suffix) = target.split_at(suffix_start);
-    let depth = current_route_path
-        .trim_matches('/')
-        .split('/')
-        .filter(|segment| !segment.is_empty())
-        .count();
-    let prefix = "../".repeat(depth);
-    let trimmed = path.trim_start_matches('/');
-    if trimmed.is_empty() {
-        if prefix.is_empty() {
-            format!("./{suffix}")
-        } else {
-            format!("{prefix}{suffix}")
-        }
-    } else {
-        format!("{prefix}{trimmed}{suffix}")
-    }
-}
-
 fn canonical_url_for_route(options: &SiteBuildOptions, route_path: &str) -> Option<String> {
     let base = options.base_url.as_ref()?;
     let path = normalize_site_path(route_path);
@@ -1554,155 +1300,6 @@ fn page_elements_for_route(
         .collect()
 }
 
-fn validate_generated_internal_links(output_dir: &Path) -> Result<()> {
-    let mut html_files = Vec::new();
-    collect_generated_html_files(output_dir, &mut html_files)?;
-    let mut missing = Vec::new();
-    for html_file in html_files {
-        let html = fs::read_to_string(&html_file)
-            .with_context(|| format!("failed to read generated HTML {}", html_file.display()))?;
-        for target in extract_html_attr_values(&html, "href")
-            .into_iter()
-            .chain(extract_html_attr_values(&html, "src"))
-        {
-            if generated_link_target_exists(output_dir, &html_file, &target) {
-                continue;
-            }
-            missing.push(format!("{} -> {}", html_file.display(), target));
-            if missing.len() >= 10 {
-                break;
-            }
-        }
-        if missing.len() >= 10 {
-            break;
-        }
-    }
-    if missing.is_empty() {
-        Ok(())
-    } else {
-        bail!(
-            "static site generated links that do not resolve:\n{}",
-            missing.join("\n")
-        )
-    }
-}
-
-fn collect_generated_html_files(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    if !root.exists() {
-        return Ok(());
-    }
-    for entry in fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))? {
-        let entry = entry?;
-        let path = entry.path();
-        if entry.file_type()?.is_dir() {
-            collect_generated_html_files(&path, out)?;
-        } else if path.extension().and_then(|value| value.to_str()) == Some("html") {
-            out.push(path);
-        }
-    }
-    Ok(())
-}
-
-fn extract_html_attr_values(html: &str, attr: &str) -> Vec<String> {
-    let needle = format!("{attr}=\"");
-    let mut values = Vec::new();
-    let mut rest = html;
-    while let Some(start) = rest.find(&needle) {
-        let after_start = &rest[start + needle.len()..];
-        let Some(end) = after_start.find('"') else {
-            break;
-        };
-        values.push(unescape_basic_attr(&after_start[..end]));
-        rest = &after_start[end + 1..];
-    }
-    values
-}
-
-fn generated_link_target_exists(output_dir: &Path, source: &Path, target: &str) -> bool {
-    if target.is_empty()
-        || target.starts_with('#')
-        || target.starts_with("http://")
-        || target.starts_with("https://")
-        || target.starts_with("mailto:")
-        || target.starts_with("tel:")
-        || target.starts_with("data:")
-    {
-        return true;
-    }
-    let target = target.split(['#', '?']).next().unwrap_or(target).trim();
-    if target.is_empty() {
-        return true;
-    }
-    let path = if target.starts_with('/') {
-        output_dir.join(target.trim_start_matches('/'))
-    } else {
-        source.parent().unwrap_or(output_dir).join(target)
-    };
-    generated_target_path_exists(path)
-}
-
-fn generated_target_path_exists(path: PathBuf) -> bool {
-    if path.is_file() {
-        return true;
-    }
-    if path.is_dir() && path.join("index.html").is_file() {
-        return true;
-    }
-    if path.extension().is_none() && path.join("index.html").is_file() {
-        return true;
-    }
-    false
-}
-
-fn unescape_basic_attr(value: &str) -> String {
-    value
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-        .replace("&amp;", "&")
-}
-
-fn first_h1(markdown: &str) -> Option<String> {
-    markdown
-        .lines()
-        .find_map(|line| line.strip_prefix("# ").map(str::trim))
-        .filter(|line| !line.is_empty())
-        .map(ToString::to_string)
-}
-
-fn title_from_path(path: &Path) -> String {
-    path.file_stem()
-        .and_then(|value| value.to_str())
-        .unwrap_or("Untitled")
-        .split(['-', '_'])
-        .filter(|part| !part.is_empty())
-        .map(|part| {
-            let mut chars = part.chars();
-            match chars.next() {
-                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-                None => String::new(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn resolve_project_path(project_dir: &Path, path: PathBuf) -> PathBuf {
-    if path.is_absolute() {
-        path
-    } else {
-        project_dir.join(path)
-    }
-}
-
-fn normalize_site_link_href(value: &str) -> String {
-    let value = value.trim();
-    if is_absolute_href(value) || value.starts_with('#') {
-        value.to_string()
-    } else {
-        normalize_site_path(value)
-    }
-}
-
 fn normalize_project_site_nav_link(link: ProjectSiteNavLink) -> SiteNavLink {
     SiteNavLink {
         title: link.title,
@@ -1713,42 +1310,6 @@ fn normalize_project_site_nav_link(link: ProjectSiteNavLink) -> SiteNavLink {
             .map(normalize_project_site_nav_link)
             .collect(),
     }
-}
-
-fn normalize_site_asset_href(value: &str) -> String {
-    let value = value.trim();
-    if is_absolute_href(value) || value.starts_with("data:") {
-        return value.to_string();
-    }
-    let mut out = if value.starts_with('/') {
-        value.to_string()
-    } else {
-        format!("/{value}")
-    };
-    while out.contains("//") {
-        out = out.replace("//", "/");
-    }
-    out
-}
-
-fn is_absolute_href(value: &str) -> bool {
-    value.starts_with("http://")
-        || value.starts_with("https://")
-        || value.starts_with("mailto:")
-        || value.starts_with("tel:")
-}
-
-fn escape_text(value: &str) -> String {
-    value
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-}
-
-fn escape_attr(value: &str) -> String {
-    escape_text(value)
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/crates/shell/fission-shell-site/src/build_support.rs
+++ b/crates/shell/fission-shell-site/src/build_support.rs
@@ -1,0 +1,234 @@
+use crate::site::normalize_site_path;
+use anyhow::{bail, Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn stylesheet_href_for_route(route_path: &str) -> String {
+    let depth = route_depth(route_path);
+    if depth == 0 {
+        "site.css".to_string()
+    } else {
+        format!("{}site.css", "../".repeat(depth))
+    }
+}
+
+pub(crate) fn search_script_href_for_route(route_path: &str, search_path: &str) -> String {
+    let target = format!(
+        "/{}/search.js",
+        search_path.trim_matches('/').trim_end_matches('/')
+    );
+    relative_href_for_route(route_path, &target)
+}
+
+pub(crate) fn page_asset_href_for_route(route_path: &str, href: &str) -> String {
+    if href.starts_with('/') {
+        relative_href_for_route(route_path, href)
+    } else {
+        href.to_string()
+    }
+}
+
+fn relative_href_for_route(current_route_path: &str, target: &str) -> String {
+    let suffix_start = target
+        .find('#')
+        .or_else(|| target.find('?'))
+        .unwrap_or(target.len());
+    let (path, suffix) = target.split_at(suffix_start);
+    let prefix = "../".repeat(route_depth(current_route_path));
+    let trimmed = path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        if prefix.is_empty() {
+            format!("./{suffix}")
+        } else {
+            format!("{prefix}{suffix}")
+        }
+    } else {
+        format!("{prefix}{trimmed}{suffix}")
+    }
+}
+
+fn route_depth(route_path: &str) -> usize {
+    route_path
+        .trim_matches('/')
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .count()
+}
+
+pub(crate) fn validate_generated_internal_links(output_dir: &Path) -> Result<()> {
+    let mut html_files = Vec::new();
+    collect_generated_html_files(output_dir, &mut html_files)?;
+    let mut missing = Vec::new();
+    for html_file in html_files {
+        let html = fs::read_to_string(&html_file)
+            .with_context(|| format!("failed to read generated HTML {}", html_file.display()))?;
+        for target in extract_html_attr_values(&html, "href")
+            .into_iter()
+            .chain(extract_html_attr_values(&html, "src"))
+        {
+            if generated_link_target_exists(output_dir, &html_file, &target) {
+                continue;
+            }
+            missing.push(format!("{} -> {}", html_file.display(), target));
+            if missing.len() >= 10 {
+                break;
+            }
+        }
+        if missing.len() >= 10 {
+            break;
+        }
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "static site generated links that do not resolve:\n{}",
+            missing.join("\n")
+        )
+    }
+}
+
+fn collect_generated_html_files(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            collect_generated_html_files(&path, out)?;
+        } else if path.extension().and_then(|value| value.to_str()) == Some("html") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn extract_html_attr_values(html: &str, attr: &str) -> Vec<String> {
+    let needle = format!("{attr}=\"");
+    let mut values = Vec::new();
+    let mut rest = html;
+    while let Some(start) = rest.find(&needle) {
+        let after_start = &rest[start + needle.len()..];
+        let Some(end) = after_start.find('"') else {
+            break;
+        };
+        values.push(unescape_basic_attr(&after_start[..end]));
+        rest = &after_start[end + 1..];
+    }
+    values
+}
+
+fn generated_link_target_exists(output_dir: &Path, source: &Path, target: &str) -> bool {
+    if target.is_empty()
+        || target.starts_with('#')
+        || target.starts_with("http://")
+        || target.starts_with("https://")
+        || target.starts_with("mailto:")
+        || target.starts_with("tel:")
+        || target.starts_with("data:")
+    {
+        return true;
+    }
+    let target = target.split(['#', '?']).next().unwrap_or(target).trim();
+    if target.is_empty() {
+        return true;
+    }
+    let path = if target.starts_with('/') {
+        output_dir.join(target.trim_start_matches('/'))
+    } else {
+        source.parent().unwrap_or(output_dir).join(target)
+    };
+    generated_target_path_exists(path)
+}
+
+fn generated_target_path_exists(path: PathBuf) -> bool {
+    path.is_file()
+        || (path.is_dir() && path.join("index.html").is_file())
+        || (path.extension().is_none() && path.join("index.html").is_file())
+}
+
+fn unescape_basic_attr(value: &str) -> String {
+    value
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")
+}
+
+pub(crate) fn first_h1(markdown: &str) -> Option<String> {
+    markdown
+        .lines()
+        .find_map(|line| line.strip_prefix("# ").map(str::trim))
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+}
+
+pub(crate) fn title_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("Untitled")
+        .split(['-', '_'])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub(crate) fn resolve_project_path(project_dir: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        project_dir.join(path)
+    }
+}
+
+pub(crate) fn normalize_site_link_href(value: &str) -> String {
+    let value = value.trim();
+    if is_absolute_href(value) || value.starts_with('#') {
+        value.to_string()
+    } else {
+        normalize_site_path(value)
+    }
+}
+
+pub(crate) fn normalize_site_asset_href(value: &str) -> String {
+    let value = value.trim();
+    if is_absolute_href(value) || value.starts_with("data:") {
+        return value.to_string();
+    }
+    let mut out = if value.starts_with('/') {
+        value.to_string()
+    } else {
+        format!("/{value}")
+    };
+    while out.contains("//") {
+        out = out.replace("//", "/");
+    }
+    out
+}
+
+fn is_absolute_href(value: &str) -> bool {
+    value.starts_with("http://")
+        || value.starts_with("https://")
+        || value.starts_with("mailto:")
+        || value.starts_with("tel:")
+}
+
+pub(crate) fn escape_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+pub(crate) fn escape_attr(value: &str) -> String {
+    escape_text(value)
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -121,14 +121,28 @@ impl DocumentationPage<'_> {
                 .into(),
             );
         }
+        let mut actions = Vec::new();
         if self.theme_switching {
-            children.push(theme_toggle(tokens));
+            actions.push(theme_toggle(tokens));
             // Re-enable when the translated documentation corpus is substantial enough
             // for switching locale here to preserve the reader's current destination.
             // children.push(locale_switcher(tokens));
         }
         if self.search_enabled {
-            children.push(search_trigger(tokens));
+            actions.push(search_trigger(tokens));
+        }
+        if !actions.is_empty() {
+            children.push(
+                Row {
+                    children: actions,
+                    gap: Some(tokens.spacing.m),
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::End,
+                    semantics: Some(site_semantics("site-doc-actions")),
+                    ..Default::default()
+                }
+                .into(),
+            );
         }
         Container::new(Row {
             children,
@@ -402,6 +416,12 @@ impl DocumentationPage<'_> {
         let mut children = vec![
             Container::new(Column {
                 children: vec![
+                    Text::new("Fission journal")
+                        .size(tokens.typography.font_size_xs)
+                        .family(tokens.typography.font_family_mono.clone())
+                        .weight(tokens.typography.font_weight_bold)
+                        .color(tokens.colors.primary)
+                        .into(),
                     Text::new("How Fission is built, tested, and released.")
                         .size(tokens.typography.heading1_size)
                         .family(tokens.typography.font_family_serif.clone())

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -24,6 +24,8 @@ pub(crate) struct ContentRoute {
     pub rendered: Option<String>,
 }
 
+pub(crate) const BLOG_PAGE_SIZE: usize = 6;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// One navigation link, optionally containing a nested dropdown/tree.
 pub struct SiteNavLink {
@@ -386,16 +388,21 @@ impl DocumentationPage<'_> {
 
     fn blog_index_article(&self, tokens: &Tokens) -> Widget {
         let posts = ordered_blog_routes(self.all_routes);
-        let featured = posts.first().copied();
+        let page = blog_page_number(&self.route.path).unwrap_or(1);
+        let page_count = posts.len().div_ceil(BLOG_PAGE_SIZE).max(1);
+        let page_start = (page.saturating_sub(1) * BLOG_PAGE_SIZE).min(posts.len());
+        let page_end = (page_start + BLOG_PAGE_SIZE).min(posts.len());
+        let page_posts = &posts[page_start..page_end];
+        let featured = (page == 1).then(|| page_posts.first().copied()).flatten();
         let mut post_cards = Vec::new();
-        for route in posts.iter().skip(usize::from(featured.is_some())) {
+        for route in page_posts.iter().skip(usize::from(featured.is_some())) {
             post_cards.push(blog_post_card(route, false, tokens));
         }
 
         let mut children = vec![
             Container::new(Column {
                 children: vec![
-                    Text::new("Notes from every surface.")
+                    Text::new("How Fission is built, tested, and released.")
                         .size(tokens.typography.heading1_size)
                         .family(tokens.typography.font_family_serif.clone())
                         .weight(tokens.typography.font_weight_bold)
@@ -406,7 +413,7 @@ impl DocumentationPage<'_> {
                         .color(tokens.colors.heading)
                         .semantics_identifier("site-blog-index-title")
                         .into(),
-                    Text::new("Engineering stories, release notes, and practical guides for building production Rust applications.")
+                    Text::new("Release notes explain what changed and who it helps. Engineering articles document the decisions behind Fission's application model, platform boundaries, rendering, testing, and production tooling.")
                         .size(tokens.typography.body_large_size)
                         .line_height(
                             tokens.typography.body_large_size
@@ -463,6 +470,10 @@ impl DocumentationPage<'_> {
                 })
                 .into(),
             );
+        }
+
+        if page_count > 1 {
+            children.push(blog_index_pagination(page, page_count, tokens));
         }
 
         Column {
@@ -783,6 +794,9 @@ impl DocumentationPage<'_> {
     fn content_adjacent_pages(&self, tokens: &Tokens) -> Option<Widget> {
         let prefix = section_prefix(&self.route.path);
         let mut routes = Vec::<&ContentRoute>::new();
+        if let Some(route) = self.all_routes.iter().find(|route| route.path == prefix) {
+            routes.push(route);
+        }
         for item in &self.route.sidebar {
             if item.group || item.level < 2 || routes.iter().any(|route| route.path == item.href) {
                 continue;
@@ -1360,11 +1374,82 @@ fn is_blog_route(path: &str) -> bool {
 }
 
 fn is_blog_post_route(path: &str) -> bool {
-    is_blog_route(path) && path != "/blog/" && !is_blog_taxonomy_route(path)
+    is_blog_route(path) && !is_blog_index_route(path) && !is_blog_taxonomy_route(path)
 }
 
 fn is_blog_index_route(path: &str) -> bool {
-    path == "/blog/"
+    path == "/blog/" || blog_page_number(path).is_some()
+}
+
+fn blog_page_number(path: &str) -> Option<usize> {
+    let page = path
+        .strip_prefix("/blog/page/")?
+        .trim_end_matches('/')
+        .parse::<usize>()
+        .ok()?;
+    (page >= 2).then_some(page)
+}
+
+fn blog_page_path(page: usize) -> String {
+    if page <= 1 {
+        "/blog/".to_string()
+    } else {
+        format!("/blog/page/{page}/")
+    }
+}
+
+fn blog_index_pagination(page: usize, page_count: usize, tokens: &Tokens) -> Widget {
+    SemanticBlogPagination {
+        previous: page.checked_sub(1).filter(|value| *value >= 1),
+        next: (page < page_count).then_some(page + 1),
+        page,
+        page_count,
+    }
+    .into_widget(tokens)
+}
+
+struct SemanticBlogPagination {
+    previous: Option<usize>,
+    next: Option<usize>,
+    page: usize,
+    page_count: usize,
+}
+
+impl SemanticBlogPagination {
+    fn into_widget(self, tokens: &Tokens) -> Widget {
+        Row {
+            children: vec![
+                blog_page_link("← Previous page", self.previous, tokens),
+                Text::new(format!("Page {} of {}", self.page, self.page_count))
+                    .size(tokens.typography.font_size_xs)
+                    .family(tokens.typography.font_family_mono.clone())
+                    .color(tokens.colors.text_muted)
+                    .into(),
+                blog_page_link("Next page →", self.next, tokens),
+            ],
+            gap: Some(tokens.spacing.l),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::SpaceBetween,
+            semantics: Some(site_semantics("site-blog-pagination")),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+fn blog_page_link(label: &str, page: Option<usize>, tokens: &Tokens) -> Widget {
+    let mut text = Text::new(label.to_string())
+        .size(tokens.typography.label_large_size)
+        .weight(tokens.typography.font_weight_bold)
+        .color(if page.is_some() {
+            tokens.colors.text_link
+        } else {
+            tokens.colors.text_muted.with_alpha(110)
+        });
+    if let Some(page) = page {
+        text = text.semantics_identifier(format!("site-route:{}", blog_page_path(page)));
+    }
+    text.into()
 }
 
 fn is_blog_taxonomy_route(path: &str) -> bool {
@@ -1643,5 +1728,17 @@ mod tests {
         assert_eq!(links[0].title, "Install Rust");
         assert_eq!(links[0].anchor, "install-rust");
         assert_eq!(links[1].title, "Add target");
+    }
+
+    #[test]
+    fn blog_page_routes_are_indexes_not_posts() {
+        assert!(is_blog_index_route("/blog/"));
+        assert!(is_blog_index_route("/blog/page/2/"));
+        assert!(!is_blog_post_route("/blog/page/2/"));
+        assert!(is_blog_post_route("/blog/2026/09/07/example/"));
+        assert_eq!(blog_page_number("/blog/page/4/"), Some(4));
+        assert_eq!(blog_page_number("/blog/page/1/"), None);
+        assert_eq!(blog_page_path(1), "/blog/");
+        assert_eq!(blog_page_path(3), "/blog/page/3/");
     }
 }

--- a/crates/shell/fission-shell-site/src/lib.rs
+++ b/crates/shell/fission-shell-site/src/lib.rs
@@ -5,8 +5,10 @@
 //! the HTML renderer. This crate does not provide an HTML-first page model or a
 //! replacement router.
 
+mod blog_routes;
 mod browser_island;
 mod build;
+mod build_support;
 mod document;
 mod document_config;
 mod front_matter;

--- a/documentation/content/docs/index.mdx
+++ b/documentation/content/docs/index.mdx
@@ -1,0 +1,43 @@
+---
+title: Documentation
+description: Build, test, package, and ship a Fission application through one guided path.
+---
+
+# Build and ship with Fission.
+
+Fission documentation follows the work of creating a real product: get an application running, understand its ownership boundaries, build the interface, verify each target, and ship the resulting artifacts.
+
+## Start with a running application
+
+The [Quickstart](/docs/learn/quickstart/) creates a Fission application and puts it on screen. It explains each command and the files you will edit next, so the first result is working software rather than a tour of framework terminology.
+
+- [Open the Quickstart](/docs/learn/quickstart/)
+- [Understand the application model](/docs/learn/overview/)
+
+## Follow the delivery path
+
+| Stage | What you will accomplish | Start here |
+| --- | --- | --- |
+| Start | Create an application, inspect its project shape, and add the targets you need. | [Quickstart](/docs/learn/quickstart/) |
+| Learn | Understand state, actions, reducers, retained widgets, shells, and the rendering pipeline. | [Learn Fission](/docs/learn/overview/) |
+| Build | Compose responsive interfaces, connect services, and request platform capabilities explicitly. | [Layout and widgets](/docs/guides/layout-and-widgets/) |
+| Verify | Test shared behaviour and qualify input, rendering, accessibility, and packaging on real targets. | [Test and debug](/docs/test-and-debug/overview/) |
+| Ship | Build, sign, release, distribute, and retain evidence for the artifact customers receive. | [Release and distribute](/docs/release-and-distribute/overview/) |
+
+## Find guidance by task
+
+### Build an interface
+
+Use the [layout and widgets guide](/docs/guides/layout-and-widgets/) for retained composition, then add [responsive behaviour](/docs/learn/responsive-ui/) and a typed [design system](/docs/guides/design-system/).
+
+### Manage application state
+
+Read [state, handles, and providers](/docs/guides/state-handles-and-providers/) to choose the correct owner, then use [resources and async](/docs/guides/resources-and-async/) for work outside pure component conversion.
+
+### Add platform behaviour
+
+Start with the [capability matrix](/docs/capabilities/matrix/) and use the target shell as the explicit boundary for host-specific lifecycle, input, accessibility, and delivery work.
+
+### Diagnose and ship
+
+Follow [testing and diagnostics](/docs/guides/testing-and-diagnostics/) during development, then use [build and package](/docs/build-and-package/overview/) and the [release checklist](/docs/release-and-distribute/app-release-checklist/) for the shipped form.

--- a/documentation/fission.toml
+++ b/documentation/fission.toml
@@ -20,7 +20,7 @@ description = "Build, test, package, and release production Rust apps across mac
 logo = "/img/fission-mark.svg"
 favicon = "/img/fission-mark.svg"
 asset_dirs = ["static"]
-css_files = ["site/overrides.css"]
+css_files = ["site/overrides.css", "site/value-redesign.css"]
 
 [site.code_highlighting]
 enabled = true
@@ -37,6 +37,10 @@ placement = "body-end"
 file = "site/crates-enhancement.html"
 route_prefixes = ["/crates/", "/es/crates/"]
 
+[[site.elements]]
+placement = "body-end"
+file = "site/value-enhancement.html"
+
 [distribution.github_pages.production]
 owner = "fission-ui"
 repo = "fission"
@@ -50,87 +54,11 @@ workflow = "publish-website.yml"
 production_branch = "main"
 
 [[site.nav]]
-title = "Menu"
-href = "/"
-
-[[site.nav.children]]
-title = "Platform"
-href = "/product/overview/"
-
-[[site.nav.children]]
-title = "Documentation"
-href = "/docs/learn/overview/"
-
-[[site.nav.children]]
-title = "Crates"
-href = "/crates/"
-
-[[site.nav.children]]
-title = "Blog"
-href = "/blog/"
-
-[[site.nav]]
-title = "Platform"
-href = "/product/overview/"
-
-[[site.nav.children]]
-title = "Platform overview"
-href = "/product/overview/"
-
-[[site.nav.children]]
-title = "Cross-platform apps"
-href = "/product/cross-platform-apps/"
-
-[[site.nav.children]]
-title = "Static sites"
-href = "/product/static-sites/"
-
-[[site.nav.children]]
-title = "Server-rendered sites"
-href = "/product/server-rendered-sites/"
-
-[[site.nav.children]]
-title = "Terminal apps"
-href = "/product/terminal-apps/"
-
-[[site.nav.children]]
-title = "Charts"
-href = "/product/charts/"
-
-[[site.nav.children]]
-title = "Production lifecycle"
-href = "/product/production-lifecycle/"
-
-[[site.nav.children]]
-title = "Developer tools"
-href = "/product/developer-tools/"
-
-[[site.nav.children]]
-title = "Design systems"
-href = "/product/design-systems/"
-
-[[site.nav]]
 title = "Docs"
-href = "/docs/learn/overview/"
+href = "/docs/"
 
-[[site.nav.children]]
-title = "Quickstart"
-href = "/docs/learn/quickstart/"
-
-[[site.nav.children]]
-title = "Learn Fission"
-href = "/docs/learn/overview/"
-
-[[site.nav.children]]
-title = "Guides"
-href = "/docs/guides/layout-and-widgets/"
-
-[[site.nav.children]]
-title = "Cookbook"
-href = "/docs/cookbook/add-platform-targets/"
-
-[[site.nav.children]]
-title = "API reference"
+[[site.nav]]
+title = "Reference"
 href = "/reference/overview/overview/"
 
 [[site.nav]]

--- a/documentation/i18n/en-GB.json
+++ b/documentation/i18n/en-GB.json
@@ -8,7 +8,7 @@
   "site.hero.body": "Build, test, package, and release production apps in Rust—from native windows and mobile devices to the web, terminal, and server.",
   "site.hero.start": "Start building →",
   "site.hero.crates": "Explore crates",
-  "crates.eyebrow": "Community registry",
-  "crates.title": "Crates for every surface.",
-  "crates.body": "Discover libraries built directly on Fission. The directory refreshes from crates.io every six hours."
+  "crates.eyebrow": "Crate atlas",
+  "crates.title": "Find what your Fission app needs next.",
+  "crates.body": "Discover widgets, platform capabilities, data services, jobs, and developer tools from the Fission team and community. Search the ecosystem here instead of reconstructing it from crates.io results."
 }

--- a/documentation/i18n/es-ES.json
+++ b/documentation/i18n/es-ES.json
@@ -8,7 +8,7 @@
   "site.hero.body": "Crea, prueba, empaqueta y publica aplicaciones de producción en Rust: desde ventanas nativas y dispositivos móviles hasta la web, el terminal y el servidor.",
   "site.hero.start": "Empieza a crear →",
   "site.hero.crates": "Explorar crates",
-  "crates.eyebrow": "Registro de la comunidad",
-  "crates.title": "Crates para cada plataforma.",
-  "crates.body": "Descubre bibliotecas creadas directamente sobre Fission. El directorio se actualiza desde crates.io cada seis horas."
+  "crates.eyebrow": "Atlas de crates",
+  "crates.title": "Encuentra lo que tu aplicación Fission necesita ahora.",
+  "crates.body": "Descubre widgets, capacidades de plataforma, servicios de datos, trabajos y herramientas de desarrollo del equipo de Fission y de la comunidad. Busca aquí en todo el ecosistema sin reconstruirlo desde los resultados de crates.io."
 }

--- a/documentation/site/crates-enhancement.html
+++ b/documentation/site/crates-enhancement.html
@@ -18,7 +18,7 @@
     appearance: none;
     min-height: 2.35rem;
     border: 1px solid var(--atlas-line, currentColor);
-    border-radius: 0.65rem;
+    border-radius: 0;
     background: var(--atlas-surface, transparent);
     color: var(--atlas-muted, inherit);
     cursor: pointer;
@@ -152,6 +152,43 @@
       return selected;
     };
 
+    const upgradeCategoryFilters = (root, onChange) => {
+      root.querySelectorAll(`[${SEMANTICS}^="crate-category-filter:"]`).forEach((host) => {
+        const category = semanticSuffix(host, "crate-category-filter:");
+        if (!category) return;
+        const existingShell = host.closest(".fission-site-box");
+        const replaceTarget = existingShell && existingShell !== root ? existingShell : host;
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "fission-crate-filter-button fission-crate-category-button";
+        button.dataset.category = category;
+        button.dataset.active = String(category === "all");
+        button.setAttribute("aria-pressed", String(category === "all"));
+        button.textContent = host.textContent.trim();
+        button.addEventListener("click", () => {
+          root.querySelectorAll(".fission-crate-category-button").forEach((peer) => {
+            const active = peer === button;
+            peer.dataset.active = String(active);
+            peer.setAttribute("aria-pressed", String(active));
+          });
+          onChange(category);
+        });
+        replaceTarget.replaceWith(button);
+      });
+    };
+
+    const categoryTerms = {
+      widgets: ["widget", "interface", "ui", "chart", "icon", "theme"],
+      capabilities: ["capability", "platform", "map", "camera", "media", "device"],
+      services: ["service", "storage", "store", "sqlite", "data", "network", "http"],
+      jobs: ["job", "automation", "worker", "build", "site", "server", "shell"],
+      tooling: ["tool", "test", "diagnostic", "debug", "cli", "command", "development"],
+    };
+
+    const matchesCategory = (searchableText, category) =>
+      category === "all"
+      || (categoryTerms[category] || []).some((term) => searchableText.includes(term));
+
     const upgradeSortControl = (root, onChange) => {
       const host = root.querySelector(`[${SEMANTICS}="crate-sort"]`);
       if (!host) return null;
@@ -187,6 +224,7 @@
       searchInputs.forEach((input) => {
         input.classList.add("fission-crate-search-input");
         input.setAttribute("aria-label", messages.searchLabel);
+        input.setAttribute("placeholder", messages.searchLabel);
         input.setAttribute("autocomplete", "off");
         input.setAttribute("spellcheck", "false");
       });
@@ -249,6 +287,7 @@
       const state = {
         query: "",
         platforms: new Set(),
+        category: "all",
         sort: "updated",
       };
 
@@ -258,7 +297,7 @@
           const matchesPlatforms = Array.from(state.platforms).every((platform) =>
             platforms.has(platform),
           );
-          return matchesQuery && matchesPlatforms;
+          return matchesQuery && matchesPlatforms && matchesCategory(searchableText, state.category);
         });
 
         cards.sort((left, right) => {
@@ -280,6 +319,10 @@
 
       state.platforms = upgradePlatformFilters(root, (platforms) => {
         state.platforms = new Set(platforms);
+        apply();
+      });
+      upgradeCategoryFilters(root, (category) => {
+        state.category = category;
         apply();
       });
       upgradeSortControl(results, (sort) => {

--- a/documentation/site/docs-sidebar.toml
+++ b/documentation/site/docs-sidebar.toml
@@ -1,7 +1,7 @@
 [[items]]
-title = "Docs"
-href = "/docs/intro/"
-level = 0
+title = "Documentation overview"
+href = "/docs/"
+level = 1
 
 [[items]]
 title = "Start"

--- a/documentation/site/value-enhancement.html
+++ b/documentation/site/value-enhancement.html
@@ -1,0 +1,54 @@
+<script>
+  (() => {
+    const tabs = [...document.querySelectorAll('[data-fission-semantics^="site-value-home-audience-tab:"]')];
+    const panels = [...document.querySelectorAll('[data-fission-semantics^="site-value-home-audience-panel:"]')];
+    if (tabs.length && panels.length) {
+      const keyOf = (node) => node.dataset.fissionSemantics.split(':')[1];
+      const select = (key, focus) => {
+        tabs.forEach((tab) => {
+          const selected = keyOf(tab) === key;
+          tab.setAttribute('role', 'tab');
+          tab.setAttribute('aria-selected', String(selected));
+          tab.tabIndex = selected ? 0 : -1;
+          tab.dataset.active = String(selected);
+          if (selected && focus) tab.focus();
+        });
+        panels.forEach((panel) => {
+          const selected = keyOf(panel) === key;
+          panel.setAttribute('role', 'tabpanel');
+          panel.hidden = !selected;
+        });
+      };
+      const initial = tabs.find((tab) => tab.dataset.fissionSemantics.endsWith(':true')) || tabs[0];
+      tabs.forEach((tab, index) => {
+        tab.addEventListener('click', () => select(keyOf(tab), false));
+        tab.addEventListener('keydown', (event) => {
+          if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+          event.preventDefault();
+          let next = index;
+          if (event.key === 'ArrowLeft') next = (index - 1 + tabs.length) % tabs.length;
+          if (event.key === 'ArrowRight') next = (index + 1) % tabs.length;
+          if (event.key === 'Home') next = 0;
+          if (event.key === 'End') next = tabs.length - 1;
+          select(keyOf(tabs[next]), true);
+        });
+      });
+      tabs[0].parentElement?.setAttribute('role', 'tablist');
+      select(keyOf(initial), false);
+    }
+
+    const observer = 'IntersectionObserver' in window
+      ? new IntersectionObserver((entries, current) => {
+          entries.forEach((entry) => {
+            if (!entry.isIntersecting) return;
+            entry.target.classList.add('is-visible');
+            current.unobserve(entry.target);
+          });
+        }, { threshold: 0.08 })
+      : null;
+    document.querySelectorAll('[data-fission-semantics^="site-value-home-"]').forEach((node) => {
+      if (observer) observer.observe(node);
+      else node.classList.add('is-visible');
+    });
+  })();
+</script>

--- a/documentation/site/value-redesign.css
+++ b/documentation/site/value-redesign.css
@@ -7,8 +7,10 @@
   --ink-soft: #595964;
   --line: #d7d5cd;
   --line-strong: #aaa89f;
-  --accent: #ff4f24;
-  --accent-ink: #c62d0a;
+  --accent: #4f5bec;
+  --accent-ink: #4d4ac8;
+  --accent-violet: #7048de;
+  --accent-gradient: linear-gradient(135deg, #4f5bec 0%, #7048de 100%);
   --code: #12121a;
   --code-ink: #f5f2e9;
   --editorial-max: 88rem;
@@ -36,7 +38,7 @@
   --atlas-radius-sm: 0;
   --atlas-radius: 0;
   --atlas-radius-lg: 0;
-  --atlas-gradient: var(--accent);
+  --atlas-gradient: var(--accent-gradient);
   --fs-color-primary: var(--accent);
   --fs-color-primary-hover: var(--accent-ink);
   --fs-color-primary-subtle: var(--atlas-surface-2);
@@ -62,8 +64,10 @@
   --ink-soft: #aaa8b0;
   --line: #34333c;
   --line-strong: #56545f;
-  --accent: #ff6842;
-  --accent-ink: #ff886b;
+  --accent: #8491ff;
+  --accent-ink: #ad9fff;
+  --accent-violet: #b08bff;
+  --accent-gradient: linear-gradient(135deg, #8491ff 0%, #b08bff 100%);
   --code: #08080d;
   --code-ink: #f5f2e9;
 }
@@ -168,27 +172,68 @@ body::before {
   white-space: nowrap;
 }
 
+/* Fragment links all resolve to the home document, so generated current-page
+   state cannot distinguish their section. Only reveal the marker on intent. */
+.fission-site-main-nav .fission-site-nav-label .fission-site-route-link[aria-current="page"]::after {
+  opacity: 0;
+  transform: scaleX(0.5);
+}
+
+.fission-site-main-nav .fission-site-nav-label .fission-site-route-link:hover::after,
+.fission-site-main-nav .fission-site-nav-label .fission-site-route-link:focus-visible::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
 .fission-site-main-nav .fission-site-route-link:hover,
 .fission-site-doc-nav .fission-site-route-link:hover,
-.fission-site-main-nav .fission-site-route-link[aria-current="page"],
 .fission-site-doc-nav .fission-site-route-link[aria-current="page"] {
   color: var(--accent) !important;
 }
 
 .fission-site-home-actions,
-.fission-site-doc-header > .fission-site-row > .fission-site-row:last-child {
+.fission-site-doc-actions {
   grid-column: 3;
   justify-self: end;
+}
+
+.fission-site-doc-actions > .fission-site-row {
+  flex-wrap: nowrap !important;
+}
+
+.fission-site-search-trigger {
+  min-width: 11.5rem;
+  justify-content: space-between !important;
+  padding: 0.55rem 0.75rem !important;
+  border: 1px solid var(--line) !important;
+  background: var(--paper-bright) !important;
+}
+
+.fission-site-search-trigger:hover {
+  border-color: var(--line-strong) !important;
+}
+
+/* The configured mark already contains the F. Keep the visible wordmark from
+   repeating it while retaining the full accessible site title. */
+.fission-site-doc-header > .fission-site-row > .fission-site-row:has(.fission-site-img) .fission-site-text-run {
+  font-size: 0 !important;
+}
+
+.fission-site-doc-header > .fission-site-row > .fission-site-row:has(.fission-site-img) .fission-site-text-run::after {
+  color: var(--ink);
+  content: "ission";
+  font-size: 1.1rem;
+  font-weight: 650;
 }
 
 .fission-site-home-actions > .fission-site-row > .fission-site-box:last-child {
   border: 1px solid var(--ink) !important;
   border-radius: 0 !important;
-  background: transparent !important;
+  background: var(--accent-gradient) !important;
 }
 
 .fission-site-home-actions > .fission-site-row > .fission-site-box:last-child:hover {
-  background: var(--ink) !important;
+  filter: saturate(1.08) brightness(0.96);
 }
 
 .fission-site-home-actions > .fission-site-row > .fission-site-box:last-child:hover .fission-site-text-run {
@@ -238,8 +283,8 @@ body::before {
 
 .fission-site-value-home-hero-main > .fission-site-row {
   display: grid !important;
-  grid-template-columns: minmax(0, 1.1fr) minmax(25rem, 0.9fr);
-  gap: clamp(3rem, 8vw, 8rem) !important;
+  grid-template-columns: minmax(0, 1.28fr) minmax(24rem, 0.72fr);
+  gap: clamp(2.5rem, 5vw, 5rem) !important;
   width: 100% !important;
 }
 
@@ -267,9 +312,9 @@ body::before {
 
 [data-fission-semantics="site-heading-1:top"],
 [data-fission-semantics="site-heading-1:top"] .fission-site-text-run {
-  max-width: 13ch !important;
+  max-width: 16ch !important;
   color: var(--ink) !important;
-  font-size: clamp(4.1rem, 8vw, 8rem) !important;
+  font-size: clamp(4.1rem, 7vw, 7.6rem) !important;
   font-weight: 580 !important;
   line-height: 0.98 !important;
   letter-spacing: -0.06em !important;
@@ -281,28 +326,69 @@ body::before {
 
 .fission-site-value-home-map-stage {
   position: relative;
-  min-height: 30rem;
+  aspect-ratio: 1 / 1.05;
+  min-height: 0;
   overflow: hidden;
-  border: 1px solid var(--line) !important;
-  background: var(--paper-bright);
+  border: 0 !important;
+  border-bottom: 1px solid var(--line) !important;
+  background: transparent;
 }
 
 .fission-site-value-home-map-stage::before,
 .fission-site-value-home-map-stage::after {
   position: absolute;
-  inset: 13% 7%;
+  z-index: 0;
+  top: 50%;
+  left: 50%;
+  width: 83%;
+  height: 83%;
   border: 1px solid var(--line);
   border-radius: 50%;
   content: "";
   pointer-events: none;
+  transform: translate(-50%, -50%);
 }
 
 .fission-site-value-home-map-stage::after {
-  inset: 25% 17%;
+  width: 50%;
+  height: 50%;
+}
+
+.fission-site-value-home-map-stage > .fission-site-column {
+  position: absolute;
+  inset: 0;
+}
+
+.fission-site-value-home-map-stage > .fission-site-column::before,
+.fission-site-value-home-map-stage > .fission-site-column::after {
+  position: absolute;
+  z-index: 0;
+  top: 50%;
+  left: 50%;
+  background: var(--line);
+  content: "";
+  transform: translate(-50%, -50%);
+}
+
+.fission-site-value-home-map-stage > .fission-site-column::before {
+  width: 1px;
+  height: 100%;
+}
+
+.fission-site-value-home-map-stage > .fission-site-column::after {
+  width: 100%;
+  height: 1px;
 }
 
 .fission-site-value-home-map-core {
-  z-index: 2;
+  position: absolute;
+  z-index: 3;
+  top: 50%;
+  left: 50%;
+  width: 5.8rem !important;
+  height: 7.4rem;
+  padding: 1rem !important;
+  transform: translate(-50%, -50%);
   border: 0 !important;
   border-radius: 0 !important;
   background: var(--ink) !important;
@@ -312,13 +398,44 @@ body::before {
   filter: brightness(0) invert(1);
 }
 
-.fission-site-value-home-map-targets {
-  z-index: 2;
+.fission-site-value-home-map-core > .fission-site-column {
+  align-items: center !important;
+  justify-content: center !important;
 }
 
-.fission-site-value-home-map-targets > .fission-site-row > .fission-site-box {
-  border-radius: 0 !important;
+[data-fission-semantics^="site-value-home-map-target:"] {
+  position: absolute;
+  z-index: 2;
+  width: auto !important;
+  padding: 0.2rem 0.45rem !important;
   background: var(--paper) !important;
+  color: var(--ink-soft);
+  font-family: "DM Mono", ui-monospace, monospace;
+}
+
+[data-fission-semantics^="site-value-home-map-target:"]::before {
+  display: inline-block;
+  width: 0.38rem;
+  height: 0.38rem;
+  margin-right: 0.45rem;
+  border-radius: 50%;
+  background: var(--accent-gradient);
+  content: "";
+}
+
+[data-fission-semantics="site-value-home-map-target:macos"] { top: 10%; left: 42%; }
+[data-fission-semantics="site-value-home-map-target:web"] { top: 24%; right: 5%; }
+[data-fission-semantics="site-value-home-map-target:ios"] { right: 10%; bottom: 22%; }
+[data-fission-semantics="site-value-home-map-target:linux"] { bottom: 7%; left: 38%; }
+[data-fission-semantics="site-value-home-map-target:android"] { bottom: 23%; left: 4%; }
+[data-fission-semantics="site-value-home-map-target:windows"] { top: 23%; left: 2%; }
+[data-fission-semantics="site-value-home-map-target:terminal"] { top: 43%; right: 0; }
+[data-fission-semantics="site-value-home-map-target:static"] { right: 24%; bottom: 4%; }
+[data-fission-semantics="site-value-home-map-target:ssr"] { bottom: 42%; left: 1%; }
+
+.fission-site-value-home-map-caption > .fission-site-row {
+  padding-bottom: 0.9rem;
+  border-bottom: 1px solid var(--line);
 }
 
 .fission-site-value-home-hero-proof > .fission-site-row {
@@ -382,13 +499,21 @@ body::before {
 }
 
 .fission-site-value-home-section-heading > .fission-site-row,
-.fission-site-value-home-audience-heading > .fission-site-row,
-.fission-site-value-home-approach-intro > .fission-site-row,
 .fission-site-value-home-comparison-heading > .fission-site-row {
   display: grid !important;
-  grid-template-columns: minmax(12rem, 0.44fr) minmax(0, 1fr);
-  gap: clamp(2rem, 8vw, 8rem) !important;
+  grid-template-columns: minmax(10rem, 0.36fr) minmax(0, 1fr);
+  gap: 2rem !important;
   width: 100% !important;
+}
+
+.fission-site-value-home-audience-heading > .fission-site-row,
+.fission-site-value-home-approach-intro > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 0.6fr);
+  gap: clamp(2rem, 8vw, 8rem) !important;
+  align-items: end !important;
+  width: 78% !important;
+  margin-left: 22%;
 }
 
 .fission-site-value-home-section-heading {
@@ -506,7 +631,7 @@ body::before {
   border: 0 !important;
   background: var(--code) !important;
   color: var(--code-ink) !important;
-  box-shadow: 1.2rem 1.2rem 0 color-mix(in srgb, var(--accent) 75%, transparent);
+  box-shadow: 1.2rem 1.2rem 0 color-mix(in srgb, var(--accent-violet) 75%, transparent);
 }
 
 .fission-site-value-home-quickstart .fission-site-code-block {
@@ -536,14 +661,84 @@ body::before {
 }
 
 [data-fission-semantics="crate-directory-copy"] {
-  max-width: 62rem;
+  max-width: none;
 }
 
-[data-fission-semantics="crate-directory-copy"] > .fission-site-column > .fission-site-box:nth-child(2) .fission-site-text-run {
+[data-fission-semantics="crate-directory-copy"] > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(10rem, 0.32fr) minmax(0, 1fr);
+  gap: clamp(2rem, 7vw, 8rem) !important;
+  width: 100% !important;
+}
+
+[data-fission-semantics="crate-directory-copy"] > .fission-site-row > .fission-site-box:first-child {
+  padding-top: 1rem;
+  font-family: "DM Mono", ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-fission-semantics="crate-directory-copy"] > .fission-site-row > .fission-site-box:nth-child(2) > .fission-site-column > .fission-site-box:first-child .fission-site-text-run {
   font-size: clamp(3.8rem, 8vw, 7.5rem) !important;
   font-weight: 560 !important;
   line-height: 0.96 !important;
   letter-spacing: -0.06em !important;
+}
+
+[data-fission-semantics="crate-featured"] {
+  width: min(100%, var(--editorial-max)) !important;
+  padding: clamp(3rem, 6vw, 6rem) var(--editorial-gutter) !important;
+  border: 0 !important;
+  border-top: 1px solid var(--ink) !important;
+  border-bottom: 1px solid var(--ink) !important;
+  background: transparent !important;
+}
+
+[data-fission-semantics="crate-featured"] > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.72fr);
+  gap: clamp(3rem, 8vw, 9rem) !important;
+  width: 100% !important;
+}
+
+[data-fission-semantics="crate-featured"] > .fission-site-row > .fission-site-box:first-child .fission-site-text-run {
+  max-width: 48rem;
+}
+
+[data-fission-semantics="crate-featured-actions"] > .fission-site-row > .fission-site-box:first-child {
+  padding: 0.85rem 1.25rem !important;
+  background: var(--accent-gradient) !important;
+}
+
+[data-fission-semantics="crate-featured-visual"] {
+  position: relative;
+  display: grid !important;
+  min-height: 28rem;
+  overflow: hidden;
+  place-items: center;
+  background:
+    radial-gradient(circle at 72% 28%, color-mix(in srgb, var(--accent) 55%, transparent) 0 0.45rem, transparent 0.5rem),
+    linear-gradient(132deg, transparent 37%, color-mix(in srgb, var(--paper) 75%, transparent) 38% 42%, transparent 43%),
+    linear-gradient(28deg, transparent 58%, color-mix(in srgb, var(--paper) 78%, transparent) 59% 63%, transparent 64%),
+    color-mix(in srgb, var(--accent) 13%, #cfe6d0);
+}
+
+[data-fission-semantics="crate-featured-visual"]::before {
+  position: absolute;
+  top: 18%;
+  right: 16%;
+  bottom: -12%;
+  left: 48%;
+  border-radius: 48% 52% 0 0;
+  background: color-mix(in srgb, var(--accent) 23%, #9accc8);
+  content: "";
+}
+
+[data-fission-semantics="crate-featured-visual"] > .fission-site-column {
+  z-index: 1;
+  max-width: 17rem;
+  padding: 1.2rem !important;
+  background: color-mix(in srgb, var(--paper) 86%, transparent);
 }
 
 [data-fission-semantics="crate-searchbox"] {
@@ -555,7 +750,35 @@ body::before {
   box-shadow: none !important;
 }
 
+[data-fission-semantics="crate-searchbox"] .fission-site-control {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+[data-fission-semantics="crate-searchbox"] .fission-site-control-label,
+[data-fission-semantics="crate-searchbox"] .fission-site-input ~ .fission-site-node {
+  display: none !important;
+}
+
+[data-fission-semantics="crate-searchbox"] .fission-site-input {
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0 !important;
+  border: 0 !important;
+  outline: 0;
+  background: transparent !important;
+  color: var(--ink) !important;
+  font: inherit;
+}
+
+[data-fission-semantics="crate-searchbox"] .fission-site-input::placeholder {
+  color: var(--ink-soft);
+  opacity: 1;
+}
+
 [data-fission-semantics="crate-platform-legend"],
+[data-fission-semantics="crate-category-legend"],
 [data-fission-semantics="crate-results"] {
   width: min(calc(100% - 2 * var(--editorial-gutter)), var(--editorial-max)) !important;
 }
@@ -567,6 +790,16 @@ body::before {
   border-radius: 0 !important;
   background: transparent !important;
   box-shadow: none !important;
+}
+
+[data-fission-semantics="crate-category-legend"] {
+  padding: 4rem 0 1.2rem !important;
+  border: 0 !important;
+  background: transparent !important;
+}
+
+[data-fission-semantics="crate-category-legend"] > .fission-site-row {
+  justify-content: flex-start !important;
 }
 
 [data-fission-semantics^="crate-platform-filter:"] {
@@ -768,8 +1001,8 @@ body::before {
 
 /* Blog journal */
 .fission-site-blog-layout {
-  width: min(100%, var(--editorial-max)) !important;
-  max-width: var(--editorial-max) !important;
+  width: min(100%, 96rem) !important;
+  max-width: 96rem !important;
   padding: clamp(5rem, 9vw, 9rem) var(--editorial-gutter) var(--editorial-space) !important;
 }
 
@@ -786,6 +1019,15 @@ body::before {
   max-width: none !important;
 }
 
+.fission-site-blog-layout .fission-site-blog-post {
+  width: min(100%, 68rem) !important;
+  max-width: 68rem !important;
+}
+
+.fission-site-blog-post-title .fission-site-text-run {
+  max-width: 18ch !important;
+}
+
 .fission-site-blog-index-title .fission-site-text-run {
   max-width: 12ch;
   font-size: clamp(4rem, 8vw, 7.2rem) !important;
@@ -795,8 +1037,31 @@ body::before {
 }
 
 .fission-site-blog-index-hero {
-  max-width: 70rem;
+  max-width: none;
+  margin-inline: 0 !important;
   padding-bottom: clamp(4rem, 7vw, 7rem) !important;
+  text-align: left !important;
+}
+
+.fission-site-blog-index-hero > .fission-site-column {
+  display: grid !important;
+  grid-template-columns: minmax(10rem, 0.32fr) minmax(0, 1fr);
+  gap: 1.5rem clamp(2rem, 7vw, 8rem) !important;
+  align-items: start !important;
+}
+
+.fission-site-blog-index-hero > .fission-site-column > .fission-site-box:first-child {
+  grid-column: 1;
+  grid-row: 1 / 3;
+  padding-top: 0.8rem;
+  font-family: "DM Mono", ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.fission-site-blog-index-hero > .fission-site-column > .fission-site-box:nth-child(2),
+.fission-site-blog-index-hero > .fission-site-column > .fission-site-box:nth-child(3) {
+  grid-column: 2;
 }
 
 .fission-site-blog-featured-card,
@@ -812,15 +1077,73 @@ body::before {
 }
 
 .fission-site-blog-featured-card {
+  padding: clamp(3rem, 5vw, 5rem) 0 !important;
   border-top-color: var(--ink) !important;
+  border-bottom: 1px solid var(--ink) !important;
 }
 
-.fission-site-blog-featured-card::after {
-  display: none;
+.fission-site-blog-featured-card > .fission-site-column {
+  display: grid !important;
+  grid-template-columns: minmax(8rem, 0.25fr) minmax(0, 1fr) minmax(15rem, 0.45fr);
+  gap: 1.2rem clamp(2rem, 5vw, 5rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-blog-featured-card > .fission-site-column > .fission-site-box:first-child {
+  grid-column: 1;
+  grid-row: 1 / 6;
+}
+
+.fission-site-blog-featured-card > .fission-site-column > .fission-site-box:not(:first-child) {
+  grid-column: 2;
+}
+
+.fission-site-blog-featured-card > .fission-site-column::after {
+  display: grid;
+  grid-column: 3;
+  grid-row: 1 / 6;
+  min-height: 20rem;
+  place-items: center;
+  border-block: 1px solid var(--line);
+  background:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 2.5rem 2.5rem;
+  color: var(--ink-soft);
+  content: "shared source  →  shipped product";
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .fission-site-blog-post-list > .fission-site-column {
   display: block !important;
+}
+
+.fission-site-blog-card > .fission-site-column {
+  display: grid !important;
+  grid-template-columns: minmax(8rem, 0.25fr) minmax(0, 1fr) auto;
+  gap: 0.8rem clamp(1.5rem, 5vw, 5rem) !important;
+  align-items: start !important;
+  width: 100% !important;
+}
+
+.fission-site-blog-card > .fission-site-column > .fission-site-box:first-child {
+  grid-column: 1;
+  grid-row: 1 / 5;
+}
+
+.fission-site-blog-card > .fission-site-column > .fission-site-box:nth-child(2),
+.fission-site-blog-card > .fission-site-column > .fission-site-box:nth-child(3),
+.fission-site-blog-card > .fission-site-column > .fission-site-box:nth-child(4) {
+  grid-column: 2;
+}
+
+.fission-site-blog-card > .fission-site-column > .fission-site-box:last-child {
+  grid-column: 3;
+  grid-row: 1 / 5;
 }
 
 .fission-site-blog-card h2 .fission-site-text-run,
@@ -837,9 +1160,17 @@ body::before {
   border-bottom: 1px solid var(--ink);
 }
 
-/* Product pages and footer use the same restrained editorial language. */
+/* Product pages carry the homepage's editorial system into the retained
+   routes: one continuous story, not a stack of unrelated dashboard cards. */
 .fission-site-product-page {
+  width: 100% !important;
+  max-width: none !important;
+  padding: 0 0 var(--editorial-space) !important;
   background: var(--paper) !important;
+}
+
+.fission-site-product-page > .fission-site-column {
+  gap: 0 !important;
 }
 
 .fission-site-product-hero,
@@ -852,13 +1183,153 @@ body::before {
   box-shadow: none !important;
 }
 
+.fission-site-product-hero,
+.fission-site-product-nav-strip,
 .fission-site-product-feature-showcase,
 .fission-site-product-detail-showcase,
 .fission-site-product-workflow,
 .fission-site-product-proof {
+  box-sizing: border-box;
+  width: min(100%, var(--editorial-max)) !important;
+  margin: 0 auto !important;
+}
+
+.fission-site-product-hero {
+  min-height: calc(78svh - 5rem);
+  padding: clamp(5rem, 9vw, 9rem) var(--editorial-gutter) !important;
+}
+
+.fission-site-product-hero > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1.12fr) minmax(22rem, 0.88fr);
+  gap: clamp(3rem, 7vw, 8rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-product-hero-title .fission-site-text-run {
+  max-width: 15ch !important;
+  font-size: clamp(3.8rem, 7vw, 7rem) !important;
+  font-weight: 560 !important;
+  line-height: 0.96 !important;
+  letter-spacing: -0.06em !important;
+}
+
+.fission-site-product-hero-body .fission-site-text-run {
+  max-width: 43rem;
+  font-size: clamp(1.1rem, 1.55vw, 1.34rem) !important;
+  line-height: 1.62 !important;
+}
+
+.fission-site-product-hero > .fission-site-row > .fission-site-box:last-child {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(1.5rem, 3vw, 2.5rem) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-product-hero > .fission-site-row > .fission-site-box:last-child::before {
+  position: absolute;
+  inset: 1.25rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--line));
+  border-radius: 50%;
+  content: "";
+  pointer-events: none;
+}
+
+.fission-site-product-nav-strip {
+  overflow-x: auto;
+  padding: 1rem var(--editorial-gutter) !important;
+  border: 0 !important;
+  border-top: 1px solid var(--ink) !important;
+  border-bottom: 1px solid var(--line) !important;
+  background: transparent !important;
+}
+
+.fission-site-product-nav-strip > .fission-site-row {
+  justify-content: flex-start !important;
+  flex-wrap: nowrap !important;
+}
+
+.fission-site-product-nav-strip > .fission-site-row > .fission-site-box {
+  flex: 0 0 auto;
+  padding: 0.45rem 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-product-feature-showcase,
+.fission-site-product-detail-showcase,
+.fission-site-product-workflow,
+.fission-site-product-proof {
+  padding: var(--editorial-space) var(--editorial-gutter) !important;
   border: 0 !important;
   border-top: 1px solid var(--line) !important;
   background: transparent !important;
+}
+
+.fission-site-product-feature-showcase > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(15rem, 0.52fr) minmax(0, 1fr);
+  gap: clamp(3rem, 8vw, 9rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-product-feature-showcase > .fission-site-row > .fission-site-row,
+.fission-site-product-detail-showcase > .fission-site-column > .fission-site-row,
+.fission-site-product-workflow > .fission-site-column > .fission-site-row:last-child {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0 !important;
+  width: 100% !important;
+  border-top: 1px solid var(--ink);
+}
+
+[data-fission-semantics="site-product-feature-card"],
+[data-fission-semantics="site-product-detail-card"],
+[data-fission-semantics="site-product-workflow-step"] {
+  width: 100% !important;
+  min-height: 18rem;
+  padding: 1.8rem clamp(1.25rem, 2.5vw, 2.5rem) 2.5rem !important;
+  border: 0 !important;
+  border-right: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+[data-fission-semantics="site-product-feature-card"]:last-child,
+[data-fission-semantics="site-product-detail-card"]:last-child,
+[data-fission-semantics="site-product-workflow-step"]:last-child {
+  border-right: 0 !important;
+}
+
+.fission-site-product-detail-showcase > .fission-site-column,
+.fission-site-product-workflow > .fission-site-column {
+  gap: clamp(3rem, 6vw, 6rem) !important;
+}
+
+.fission-site-product-detail-showcase > .fission-site-column > .fission-site-box:first-child {
+  max-width: 66rem;
+}
+
+.fission-site-product-workflow > .fission-site-column > .fission-site-row:first-child {
+  display: grid !important;
+  grid-template-columns: minmax(12rem, 0.36fr) minmax(0, 1fr);
+  gap: clamp(2rem, 7vw, 7rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-product-proof {
+  border-top-color: var(--ink) !important;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--accent) 7%, transparent), transparent 52%),
+    transparent !important;
+}
+
+.fission-site-product-proof > .fission-site-row {
+  gap: clamp(3rem, 8vw, 9rem) !important;
 }
 
 .fission-site-footer {
@@ -926,6 +1397,15 @@ body::before {
     max-width: 42rem;
   }
 
+  .fission-site-product-hero > .fission-site-row,
+  .fission-site-product-feature-showcase > .fission-site-row {
+    grid-template-columns: 1fr;
+  }
+
+  .fission-site-product-hero > .fission-site-row > .fission-site-box:last-child {
+    max-width: 44rem;
+  }
+
   .fission-site-doc-layout > .fission-site-row {
     grid-template-columns: 14rem minmax(0, 1fr) !important;
     gap: 2.5rem !important;
@@ -958,6 +1438,10 @@ body::before {
 
   .fission-site-doc-header .fission-site-doc-nav {
     margin-left: auto;
+  }
+
+  .fission-site-doc-actions {
+    margin-left: 0;
   }
 
   .fission-site-doc-header .fission-site-doc-nav > .fission-site-row > .fission-site-nav-item:not(:first-child) {
@@ -1016,7 +1500,7 @@ body::before {
   }
 
   .fission-site-value-home-map-stage {
-    min-height: 24rem;
+    aspect-ratio: 1 / 1;
   }
 
   .fission-site-value-home-hero-proof > .fission-site-row {
@@ -1031,6 +1515,12 @@ body::before {
   .fission-site-value-home-audience-switcher > .fission-site-row {
     grid-template-columns: 1fr;
     gap: 2rem !important;
+  }
+
+  .fission-site-value-home-audience-heading > .fission-site-row,
+  .fission-site-value-home-approach-intro > .fission-site-row {
+    width: 100% !important;
+    margin-left: 0;
   }
 
   .fission-site-value-home-outcome > .fission-site-row {
@@ -1093,6 +1583,23 @@ body::before {
     font-size: clamp(3.1rem, 14vw, 4.5rem) !important;
   }
 
+  [data-fission-semantics="crate-directory-copy"] > .fission-site-row > .fission-site-box:nth-child(2) > .fission-site-column > .fission-site-box:first-child .fission-site-text-run {
+    font-size: clamp(3.1rem, 14vw, 4.5rem) !important;
+  }
+
+  [data-fission-semantics="crate-directory-copy"] > .fission-site-row,
+  [data-fission-semantics="crate-featured"] > .fission-site-row {
+    grid-template-columns: 1fr;
+  }
+
+  [data-fission-semantics="crate-featured"] {
+    padding: 4rem 1.25rem !important;
+  }
+
+  [data-fission-semantics="crate-featured-visual"] {
+    min-height: 20rem;
+  }
+
   .fission-site-doc-layout {
     width: 100% !important;
     padding: 2.5rem 1.25rem 5rem !important;
@@ -1111,6 +1618,60 @@ body::before {
 
   .fission-site-blog-index-title .fission-site-text-run {
     font-size: clamp(3.4rem, 15vw, 4.8rem) !important;
+  }
+
+  .fission-site-blog-index-hero > .fission-site-column,
+  .fission-site-blog-featured-card > .fission-site-column,
+  .fission-site-blog-card > .fission-site-column {
+    grid-template-columns: 1fr;
+  }
+
+  .fission-site-blog-index-hero > .fission-site-column > .fission-site-box:first-child,
+  .fission-site-blog-index-hero > .fission-site-column > .fission-site-box:nth-child(2),
+  .fission-site-blog-index-hero > .fission-site-column > .fission-site-box:nth-child(3),
+  .fission-site-blog-featured-card > .fission-site-column > .fission-site-box:first-child,
+  .fission-site-blog-featured-card > .fission-site-column > .fission-site-box:not(:first-child),
+  .fission-site-blog-featured-card > .fission-site-column::after,
+  .fission-site-blog-card > .fission-site-column > .fission-site-box:first-child,
+  .fission-site-blog-card > .fission-site-column > .fission-site-box:nth-child(2),
+  .fission-site-blog-card > .fission-site-column > .fission-site-box:nth-child(3),
+  .fission-site-blog-card > .fission-site-column > .fission-site-box:nth-child(4),
+  .fission-site-blog-card > .fission-site-column > .fission-site-box:last-child {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .fission-site-product-hero,
+  .fission-site-product-nav-strip,
+  .fission-site-product-feature-showcase,
+  .fission-site-product-detail-showcase,
+  .fission-site-product-workflow,
+  .fission-site-product-proof {
+    padding-right: 1.25rem !important;
+    padding-left: 1.25rem !important;
+  }
+
+  .fission-site-product-hero {
+    min-height: 0;
+    padding-top: 4rem !important;
+    padding-bottom: 4rem !important;
+  }
+
+  .fission-site-product-feature-showcase > .fission-site-row > .fission-site-row,
+  .fission-site-product-detail-showcase > .fission-site-column > .fission-site-row,
+  .fission-site-product-workflow > .fission-site-column > .fission-site-row:last-child,
+  .fission-site-product-workflow > .fission-site-column > .fission-site-row:first-child {
+    grid-template-columns: 1fr;
+  }
+
+  [data-fission-semantics="site-product-feature-card"],
+  [data-fission-semantics="site-product-detail-card"],
+  [data-fission-semantics="site-product-workflow-step"] {
+    min-height: 0;
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+    border-right: 0 !important;
+    border-bottom: 1px solid var(--line) !important;
   }
 
   .fission-site-footer {

--- a/documentation/site/value-redesign.css
+++ b/documentation/site/value-redesign.css
@@ -1,0 +1,1137 @@
+/* Approved value-led editorial redesign. This final layer intentionally overrides
+   the older atlas presentation while preserving Fission's generated structure. */
+:root {
+  --paper: #f7f6f1;
+  --paper-bright: #fdfcf8;
+  --ink: #101018;
+  --ink-soft: #595964;
+  --line: #d7d5cd;
+  --line-strong: #aaa89f;
+  --accent: #ff4f24;
+  --accent-ink: #c62d0a;
+  --code: #12121a;
+  --code-ink: #f5f2e9;
+  --editorial-max: 88rem;
+  --editorial-gutter: clamp(1.25rem, 4vw, 4.5rem);
+  --editorial-space: clamp(6rem, 11vw, 11rem);
+  --atlas-bg: var(--paper);
+  --atlas-surface: var(--paper-bright);
+  --atlas-surface-2: color-mix(in srgb, var(--paper) 82%, var(--ink) 3%);
+  --atlas-surface-3: color-mix(in srgb, var(--paper) 72%, var(--ink) 7%);
+  --atlas-ink: var(--ink);
+  --atlas-muted: var(--ink-soft);
+  --atlas-faint: color-mix(in srgb, var(--ink-soft) 78%, transparent);
+  --atlas-line: var(--line);
+  --atlas-line-strong: var(--line-strong);
+  --atlas-blue: var(--accent);
+  --atlas-blue-hover: var(--accent-ink);
+  --atlas-violet: var(--accent);
+  --atlas-code: var(--code);
+  --atlas-code-ink: var(--code-ink);
+  --atlas-header: color-mix(in srgb, var(--paper) 90%, transparent);
+  --atlas-content: var(--editorial-max);
+  --atlas-reading: 48rem;
+  --atlas-shadow-sm: none;
+  --atlas-shadow: none;
+  --atlas-radius-sm: 0;
+  --atlas-radius: 0;
+  --atlas-radius-lg: 0;
+  --atlas-gradient: var(--accent);
+  --fs-color-primary: var(--accent);
+  --fs-color-primary-hover: var(--accent-ink);
+  --fs-color-primary-subtle: var(--atlas-surface-2);
+  --fs-color-secondary: var(--accent);
+  --fs-color-text-link: var(--accent-ink);
+  --fs-color-focus-ring: var(--accent);
+  --fs-color-background: var(--paper);
+  --fs-color-surface: var(--paper-bright);
+  --fs-color-surface-raised: var(--paper-bright);
+  --fs-color-surface-sunken: var(--atlas-surface-2);
+  --fs-color-heading: var(--ink);
+  --fs-color-text-primary: var(--ink);
+  --fs-color-text-secondary: var(--ink-soft);
+  --fs-color-text-muted: var(--atlas-faint);
+  --fs-color-border: var(--line);
+  --fs-color-border-strong: var(--line-strong);
+}
+
+:root[data-theme="dark"] {
+  --paper: #101017;
+  --paper-bright: #16161f;
+  --ink: #f5f2e9;
+  --ink-soft: #aaa8b0;
+  --line: #34333c;
+  --line-strong: #56545f;
+  --accent: #ff6842;
+  --accent-ink: #ff886b;
+  --code: #08080d;
+  --code-ink: #f5f2e9;
+}
+
+html {
+  background: var(--paper);
+  scroll-padding-top: 6rem;
+}
+
+body {
+  overflow-x: hidden;
+  background: var(--paper) !important;
+  color: var(--ink);
+  font-family: "Space Grotesk", Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  letter-spacing: -0.012em;
+}
+
+body::before {
+  background-image: radial-gradient(color-mix(in srgb, var(--ink) 10%, transparent) 0.65px, transparent 0.65px) !important;
+  background-size: 5px 5px !important;
+  opacity: 0.12;
+  mask-image: none !important;
+}
+
+::selection {
+  background: var(--accent);
+  color: white;
+}
+
+:focus-visible {
+  outline-color: var(--accent);
+  outline-offset: 4px;
+}
+
+.fission-site-root,
+.fission-site-root > .fission-site-column,
+.fission-site-root > .fission-site-column > .fission-site-box {
+  background: transparent !important;
+}
+
+/* Header */
+.fission-site-home-header,
+.fission-site-doc-header {
+  position: sticky !important;
+  z-index: 900;
+  top: 0;
+  min-height: 5rem;
+  padding: 0.75rem var(--editorial-gutter) !important;
+  border: 0 !important;
+  border-bottom: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: color-mix(in srgb, var(--paper) 90%, transparent) !important;
+  box-shadow: none !important;
+  backdrop-filter: blur(18px) saturate(140%);
+}
+
+.fission-site-home-header > .fission-site-row,
+.fission-site-doc-header > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(9rem, 1fr) auto minmax(9rem, 1fr);
+  gap: 1.5rem !important;
+  align-items: center !important;
+  width: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.fission-site-home-header [data-fission-semantics="site-route:/"],
+.fission-site-footer [data-fission-semantics="site-route:/"],
+.fission-site-doc-header > .fission-site-row > .fission-site-row:has(.fission-site-img) {
+  gap: 0 !important;
+}
+
+.fission-site-home-header [data-fission-semantics="site-route:/"] .fission-site-img,
+.fission-site-doc-header .fission-site-img,
+.fission-site-footer [data-fission-semantics="site-route:/"] .fission-site-img {
+  width: 1.7rem !important;
+  height: 2rem !important;
+  margin-right: 0.65rem;
+}
+
+.fission-site-main-nav,
+.fission-site-doc-nav {
+  grid-column: 2;
+}
+
+.fission-site-main-nav > .fission-site-row,
+.fission-site-doc-nav > .fission-site-row {
+  gap: clamp(1rem, 2.4vw, 2.2rem) !important;
+  flex-wrap: nowrap !important;
+}
+
+.fission-site-main-nav .fission-site-route-link,
+.fission-site-doc-nav .fission-site-route-link {
+  color: var(--ink-soft) !important;
+  font-size: 0.84rem;
+  font-weight: 560;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.fission-site-main-nav .fission-site-route-link:hover,
+.fission-site-doc-nav .fission-site-route-link:hover,
+.fission-site-main-nav .fission-site-route-link[aria-current="page"],
+.fission-site-doc-nav .fission-site-route-link[aria-current="page"] {
+  color: var(--accent) !important;
+}
+
+.fission-site-home-actions,
+.fission-site-doc-header > .fission-site-row > .fission-site-row:last-child {
+  grid-column: 3;
+  justify-self: end;
+}
+
+.fission-site-home-actions > .fission-site-row > .fission-site-box:last-child {
+  border: 1px solid var(--ink) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-home-actions > .fission-site-row > .fission-site-box:last-child:hover {
+  background: var(--ink) !important;
+}
+
+.fission-site-home-actions > .fission-site-row > .fission-site-box:last-child:hover .fission-site-text-run {
+  color: var(--paper) !important;
+}
+
+.fission-site-theme-toggle,
+.fission-site-search-trigger,
+.fission-site-sidebar-toggle {
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.fission-site-mobile-global-menu {
+  display: none !important;
+}
+
+/* Homepage */
+.fission-site-value-home-hero,
+.fission-site-value-home-why,
+.fission-site-value-home-outcomes,
+.fission-site-value-home-audience,
+.fission-site-value-home-approach,
+.fission-site-value-home-comparison,
+.fission-site-value-home-start {
+  box-sizing: border-box;
+  width: min(100%, var(--editorial-max)) !important;
+  margin-inline: auto;
+  padding-inline: var(--editorial-gutter) !important;
+}
+
+/* Generated retained rows can carry a full-viewport width on their immediate
+   child. Let CSS grid own that width when the editorial layout establishes
+   columns, otherwise a later column can extend the page horizontally. */
+[data-fission-semantics^="site-value-home-"] > .fission-site-row > .fission-site-box,
+[data-fission-semantics^="site-value-home-"] > .fission-site-row > .fission-site-semantics {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+}
+
+.fission-site-value-home-hero {
+  min-height: calc(100svh - 5rem);
+  padding-top: clamp(4rem, 8vw, 8rem) !important;
+  padding-bottom: 2rem !important;
+}
+
+.fission-site-value-home-hero-main > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1.1fr) minmax(25rem, 0.9fr);
+  gap: clamp(3rem, 8vw, 8rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-value-home-hero-copy > .fission-site-column {
+  gap: 1.5rem !important;
+}
+
+.fission-site-value-home-eyebrow .fission-site-text-run,
+.fission-site-value-home-eyebrow {
+  font-family: "DM Mono", ui-monospace, monospace !important;
+  font-size: 0.68rem !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase;
+}
+
+.fission-site-value-home-eyebrow::before {
+  display: inline-block;
+  width: 1.8rem;
+  height: 1px;
+  margin-right: 0.7rem;
+  background: var(--accent);
+  content: "";
+  vertical-align: middle;
+}
+
+[data-fission-semantics="site-heading-1:top"],
+[data-fission-semantics="site-heading-1:top"] .fission-site-text-run {
+  max-width: 13ch !important;
+  color: var(--ink) !important;
+  font-size: clamp(4.1rem, 8vw, 8rem) !important;
+  font-weight: 580 !important;
+  line-height: 0.98 !important;
+  letter-spacing: -0.06em !important;
+}
+
+.fission-site-value-home-product-map {
+  width: 100% !important;
+}
+
+.fission-site-value-home-map-stage {
+  position: relative;
+  min-height: 30rem;
+  overflow: hidden;
+  border: 1px solid var(--line) !important;
+  background: var(--paper-bright);
+}
+
+.fission-site-value-home-map-stage::before,
+.fission-site-value-home-map-stage::after {
+  position: absolute;
+  inset: 13% 7%;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  content: "";
+  pointer-events: none;
+}
+
+.fission-site-value-home-map-stage::after {
+  inset: 25% 17%;
+}
+
+.fission-site-value-home-map-core {
+  z-index: 2;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--ink) !important;
+}
+
+.fission-site-value-home-map-core .fission-site-img {
+  filter: brightness(0) invert(1);
+}
+
+.fission-site-value-home-map-targets {
+  z-index: 2;
+}
+
+.fission-site-value-home-map-targets > .fission-site-row > .fission-site-box {
+  border-radius: 0 !important;
+  background: var(--paper) !important;
+}
+
+.fission-site-value-home-hero-proof > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  width: 100% !important;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--line);
+}
+
+.fission-site-value-home-hero-proof > .fission-site-row > .fission-site-box {
+  padding: 1.1rem 1rem !important;
+  border-right: 1px solid var(--line) !important;
+}
+
+.fission-site-value-home-hero-proof > .fission-site-row > .fission-site-box:last-child {
+  border-right: 0 !important;
+  text-align: right;
+}
+
+.fission-site-value-home-why,
+.fission-site-value-home-outcomes,
+.fission-site-value-home-audience,
+.fission-site-value-home-approach,
+.fission-site-value-home-comparison,
+.fission-site-value-home-start {
+  padding-top: var(--editorial-space) !important;
+  padding-bottom: var(--editorial-space) !important;
+  border-top: 1px solid var(--line);
+}
+
+.fission-site-value-home-why > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: 0.22fr minmax(0, 1fr);
+  gap: 0 !important;
+  width: 100% !important;
+}
+
+.fission-site-value-home-why-copy {
+  max-width: 60rem;
+}
+
+.fission-site-value-home-why-copy > .fission-site-column > .fission-site-box:nth-child(2) .fission-site-text-run,
+.fission-site-value-home-audience-heading > .fission-site-row > .fission-site-box:first-child .fission-site-text-run,
+.fission-site-value-home-approach-intro > .fission-site-row > .fission-site-box:first-child .fission-site-text-run,
+.fission-site-value-home-comparison-heading > .fission-site-row > .fission-site-box:last-child .fission-site-text-run,
+.fission-site-value-home-start-copy > .fission-site-column > .fission-site-box:nth-child(2) .fission-site-text-run {
+  color: var(--ink) !important;
+  font-size: clamp(3rem, 6vw, 6.2rem) !important;
+  font-weight: 540 !important;
+  line-height: 0.98 !important;
+  letter-spacing: -0.055em !important;
+}
+
+[data-fission-semantics^="site-anchor:"] .fission-site-text-run,
+[data-fission-semantics^="site-anchor:"] {
+  font-family: "DM Mono", ui-monospace, monospace !important;
+  font-size: 0.65rem !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase;
+}
+
+.fission-site-value-home-section-heading > .fission-site-row,
+.fission-site-value-home-audience-heading > .fission-site-row,
+.fission-site-value-home-approach-intro > .fission-site-row,
+.fission-site-value-home-comparison-heading > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(12rem, 0.44fr) minmax(0, 1fr);
+  gap: clamp(2rem, 8vw, 8rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-value-home-section-heading {
+  margin-bottom: clamp(4rem, 8vw, 8rem);
+}
+
+.fission-site-value-home-outcome > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: 3rem minmax(0, 1fr) minmax(10rem, 0.38fr);
+  gap: clamp(1.5rem, 4vw, 4rem) !important;
+  width: 100% !important;
+  padding: 2.4rem 0 !important;
+  border-top: 1px solid var(--line);
+}
+
+.fission-site-value-home-outcome:last-child > .fission-site-row {
+  border-bottom: 1px solid var(--ink);
+}
+
+.fission-site-value-home-outcome > .fission-site-row > .fission-site-box:last-child {
+  text-align: right;
+}
+
+.fission-site-value-home-audience-switcher > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: 14rem minmax(0, 1fr);
+  gap: clamp(2rem, 7vw, 7rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-value-home-audience-tabs button {
+  justify-content: flex-start !important;
+  width: 100% !important;
+  padding: 1rem 0 !important;
+  border: 0 !important;
+  border-bottom: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: var(--ink-soft) !important;
+  text-align: left;
+  cursor: pointer;
+}
+
+.fission-site-value-home-audience-tabs button[data-active="true"] {
+  color: var(--accent) !important;
+}
+
+.fission-site-value-home-audience-panel > .fission-site-column > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: 100% !important;
+}
+
+.fission-site-value-home-audience-panel > .fission-site-column > .fission-site-row > .fission-site-box {
+  min-width: 0 !important;
+  border: 0 !important;
+  border-top: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-value-home-approach-steps > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: 100% !important;
+  border-top: 1px solid var(--ink);
+}
+
+.fission-site-value-home-approach-step {
+  min-height: 22rem;
+  padding: 1.5rem clamp(1.5rem, 3vw, 3rem) 2rem 0 !important;
+  border-right: 1px solid var(--line);
+}
+
+.fission-site-value-home-approach-step + .fission-site-value-home-approach-step {
+  padding-left: clamp(1.5rem, 3vw, 3rem) !important;
+}
+
+.fission-site-value-home-approach-step:last-child {
+  border-right: 0;
+}
+
+.fission-site-value-home-comparison-row > .fission-site-row,
+.fission-site-value-home-comparison-labels > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: 78% !important;
+  margin-left: 22%;
+  border-top: 1px solid var(--line);
+}
+
+.fission-site-value-home-comparison-labels > .fission-site-row {
+  border-top-color: var(--ink);
+}
+
+.fission-site-value-home-comparison-row > .fission-site-row > .fission-site-box,
+.fission-site-value-home-comparison-labels > .fission-site-row > .fission-site-box {
+  padding: 1.7rem 1.5rem !important;
+}
+
+.fission-site-value-home-comparison-row > .fission-site-row > .fission-site-box + .fission-site-box,
+.fission-site-value-home-comparison-labels > .fission-site-row > .fission-site-box + .fission-site-box {
+  border-left: 1px solid var(--line) !important;
+}
+
+.fission-site-value-home-start > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: clamp(3rem, 8vw, 9rem) !important;
+  width: 100% !important;
+}
+
+.fission-site-value-home-quickstart {
+  overflow: hidden;
+  border: 0 !important;
+  background: var(--code) !important;
+  color: var(--code-ink) !important;
+  box-shadow: 1.2rem 1.2rem 0 color-mix(in srgb, var(--accent) 75%, transparent);
+}
+
+.fission-site-value-home-quickstart .fission-site-code-block {
+  margin: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+/* Crate marketplace */
+[data-fission-semantics="crate-directory-page"] {
+  background: var(--paper) !important;
+}
+
+[data-fission-semantics="crate-directory-hero"] {
+  width: min(100%, var(--editorial-max)) !important;
+  padding: clamp(5rem, 9vw, 9rem) var(--editorial-gutter) !important;
+  border-bottom: 1px solid var(--line);
+}
+
+[data-fission-semantics="crate-directory-hero"] > .fission-site-row {
+  display: block !important;
+}
+
+[data-fission-semantics="crate-directory-hero"] .fission-site-platform-atlas {
+  display: none !important;
+}
+
+[data-fission-semantics="crate-directory-copy"] {
+  max-width: 62rem;
+}
+
+[data-fission-semantics="crate-directory-copy"] > .fission-site-column > .fission-site-box:nth-child(2) .fission-site-text-run {
+  font-size: clamp(3.8rem, 8vw, 7.5rem) !important;
+  font-weight: 560 !important;
+  line-height: 0.96 !important;
+  letter-spacing: -0.06em !important;
+}
+
+[data-fission-semantics="crate-searchbox"] {
+  max-width: 48rem;
+  min-height: 3.7rem;
+  border: 1px solid var(--line-strong) !important;
+  border-radius: 0 !important;
+  background: var(--paper-bright) !important;
+  box-shadow: none !important;
+}
+
+[data-fission-semantics="crate-platform-legend"],
+[data-fission-semantics="crate-results"] {
+  width: min(calc(100% - 2 * var(--editorial-gutter)), var(--editorial-max)) !important;
+}
+
+[data-fission-semantics="crate-platform-legend"] {
+  padding: 1.2rem 0 !important;
+  border: 0 !important;
+  border-bottom: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+[data-fission-semantics^="crate-platform-filter:"] {
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+[data-fission-semantics^="crate-platform-filter:"][data-active="true"] {
+  border-color: var(--ink) !important;
+  color: var(--accent) !important;
+}
+
+[data-fission-semantics="crate-results"] {
+  padding: clamp(3rem, 6vw, 6rem) 0 var(--editorial-space) !important;
+}
+
+[data-fission-semantics="crate-card"],
+[data-fission-semantics^="crate-card:"] {
+  min-height: 18rem;
+  border: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: var(--paper-bright) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+[data-fission-semantics="crate-card"]::after,
+[data-fission-semantics^="crate-card:"]::after {
+  display: none;
+}
+
+[data-fission-semantics="crate-card"]:hover,
+[data-fission-semantics^="crate-card:"]:hover {
+  border-color: var(--ink) !important;
+  box-shadow: inset 0 3px 0 var(--accent) !important;
+}
+
+.fission-crate-sort,
+[data-fission-semantics="crate-install"],
+[data-fission-semantics="crate-metadata"],
+[data-fission-semantics="crate-platform-support"] {
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+/* Documentation: retained three-column reading layout. */
+.fission-site-doc-layout {
+  width: min(100%, 100rem) !important;
+  max-width: 100rem !important;
+  padding: 2.5rem var(--editorial-gutter) 7rem !important;
+}
+
+.fission-site-doc-layout > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: 14.5rem minmax(0, 1fr) 11.5rem !important;
+  gap: clamp(2rem, 4vw, 5rem) !important;
+  align-items: start !important;
+}
+
+.fission-site-doc-sidebar,
+.fission-site-doc-toc {
+  position: relative;
+  align-self: stretch;
+  padding: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-doc-sidebar {
+  padding-right: 1.4rem !important;
+  border-right: 1px solid var(--line);
+}
+
+.fission-site-doc-sidebar > .fission-site-column,
+.fission-site-doc-toc > .fission-site-column {
+  position: sticky;
+  top: 7.5rem;
+  max-height: calc(100svh - 9rem);
+  overflow-y: auto;
+  padding: 0 !important;
+}
+
+.fission-site-doc-sidebar > .fission-site-column > .fission-site-box,
+.fission-site-doc-toc > .fission-site-column > .fission-site-box {
+  width: 100% !important;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-doc-sidebar .fission-site-sidebar-item > .fission-site-column > .fission-site-box {
+  padding: 0.4rem 0 0.4rem 0.8rem !important;
+  border: 0 !important;
+  border-left: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-doc-sidebar [data-fission-site-sidebar-group="true"] {
+  margin-top: 1.5rem;
+}
+
+.fission-site-doc-sidebar [data-fission-site-sidebar-group="true"] > .fission-site-column > .fission-site-box {
+  padding-left: 0 !important;
+  border-left: 0 !important;
+}
+
+.fission-site-doc-sidebar [data-fission-site-sidebar-active="true"] > .fission-site-column > .fission-site-box {
+  border-left-color: var(--accent) !important;
+  color: var(--accent) !important;
+}
+
+.fission-site-doc-sidebar [data-fission-site-sidebar-active="true"]::before {
+  display: none;
+}
+
+.fission-site-doc-main {
+  width: 100% !important;
+  max-width: 55rem !important;
+}
+
+.fission-site-doc-main > .fission-site-column > .fission-site-box {
+  padding: 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+}
+
+.fission-site-doc-main h1,
+.fission-site-doc-main h1 .fission-site-text-run,
+.fission-site-blog-post-title .fission-site-text-run {
+  max-width: 13ch;
+  color: var(--ink) !important;
+  font-size: clamp(3.4rem, 6vw, 6.2rem) !important;
+  font-weight: 560 !important;
+  line-height: 0.98 !important;
+  letter-spacing: -0.055em !important;
+}
+
+.fission-site-doc-main h2,
+.fission-site-doc-main h2 .fission-site-text-run {
+  color: var(--ink) !important;
+  font-size: clamp(2.2rem, 4vw, 3.8rem) !important;
+  font-weight: 550 !important;
+  line-height: 1 !important;
+}
+
+.fission-site-doc-main h3,
+.fission-site-doc-main h3 .fission-site-text-run {
+  color: var(--ink) !important;
+}
+
+.fission-site-doc-main p,
+.fission-site-doc-main li {
+  color: var(--ink-soft) !important;
+  font-size: 1.03rem !important;
+  line-height: 1.78 !important;
+}
+
+.fission-site-doc-main a {
+  color: var(--accent-ink) !important;
+}
+
+.fission-site-doc-toc {
+  padding-left: 1.2rem !important;
+  border-left: 1px solid var(--line);
+}
+
+.fission-site-doc-toc .fission-site-text-run {
+  color: var(--ink-soft) !important;
+  font-size: 0.74rem !important;
+  line-height: 1.35 !important;
+}
+
+.fission-site-code-block,
+.fission-site-doc-main pre {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--code) !important;
+  box-shadow: none !important;
+}
+
+.fission-site-markdown-table-wrap {
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.fission-site-doc-adjacent-pages {
+  margin-top: 5rem;
+  border-top: 1px solid var(--ink);
+}
+
+.fission-site-doc-adjacent-pages > .fission-site-row > .fission-site-box {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+/* Blog journal */
+.fission-site-blog-layout {
+  width: min(100%, var(--editorial-max)) !important;
+  max-width: var(--editorial-max) !important;
+  padding: clamp(5rem, 9vw, 9rem) var(--editorial-gutter) var(--editorial-space) !important;
+}
+
+.fission-site-blog-layout > .fission-site-row {
+  display: block !important;
+}
+
+.fission-site-blog-layout .fission-site-doc-sidebar,
+.fission-site-blog-rail {
+  display: none !important;
+}
+
+.fission-site-blog-layout .fission-site-doc-main {
+  max-width: none !important;
+}
+
+.fission-site-blog-index-title .fission-site-text-run {
+  max-width: 12ch;
+  font-size: clamp(4rem, 8vw, 7.2rem) !important;
+  font-weight: 560 !important;
+  line-height: 0.95 !important;
+  letter-spacing: -0.06em !important;
+}
+
+.fission-site-blog-index-hero {
+  max-width: 70rem;
+  padding-bottom: clamp(4rem, 7vw, 7rem) !important;
+}
+
+.fission-site-blog-featured-card,
+.fission-site-blog-card {
+  min-height: 0 !important;
+  padding: clamp(2rem, 4vw, 3rem) 0 !important;
+  border: 0 !important;
+  border-top: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fission-site-blog-featured-card {
+  border-top-color: var(--ink) !important;
+}
+
+.fission-site-blog-featured-card::after {
+  display: none;
+}
+
+.fission-site-blog-post-list > .fission-site-column {
+  display: block !important;
+}
+
+.fission-site-blog-card h2 .fission-site-text-run,
+.fission-site-blog-featured-card h2 .fission-site-text-run {
+  font-size: clamp(1.9rem, 3.8vw, 3.4rem) !important;
+  line-height: 1 !important;
+  letter-spacing: -0.045em !important;
+}
+
+.fission-site-blog-pagination {
+  margin-top: 2rem;
+  padding: 2rem 0 !important;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--ink);
+}
+
+/* Product pages and footer use the same restrained editorial language. */
+.fission-site-product-page {
+  background: var(--paper) !important;
+}
+
+.fission-site-product-hero,
+.fission-site-product-nav-strip,
+.fission-site-product-feature-showcase,
+.fission-site-product-detail-showcase,
+.fission-site-product-workflow,
+.fission-site-product-proof {
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.fission-site-product-feature-showcase,
+.fission-site-product-detail-showcase,
+.fission-site-product-workflow,
+.fission-site-product-proof {
+  border: 0 !important;
+  border-top: 1px solid var(--line) !important;
+  background: transparent !important;
+}
+
+.fission-site-footer {
+  width: 100% !important;
+  padding: clamp(5rem, 9vw, 8rem) var(--editorial-gutter) 2rem !important;
+  border: 0 !important;
+  border-top: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  background: var(--paper) !important;
+  box-shadow: none !important;
+}
+
+.fission-site-footer > .fission-site-column {
+  width: min(100%, var(--editorial-max)) !important;
+  margin-inline: auto;
+}
+
+.fission-site-footer > .fission-site-column > .fission-site-row {
+  display: grid !important;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(2rem, 7vw, 7rem) !important;
+  width: 100% !important;
+  padding-bottom: 4rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.fission-site-footer > .fission-site-column > .fission-site-row > .fission-site-box {
+  width: auto !important;
+}
+
+.fission-site-footer .fission-site-route-link,
+.fission-site-footer .fission-site-markdown-link {
+  color: var(--ink-soft) !important;
+}
+
+.fission-site-footer .fission-site-route-link:hover,
+.fission-site-footer .fission-site-markdown-link:hover {
+  color: var(--accent) !important;
+}
+
+.fission-site-footer > .fission-site-column > .fission-site-box:last-child {
+  width: 100% !important;
+  padding-top: 3rem !important;
+  border: 0 !important;
+  background: transparent !important;
+}
+
+@media (max-width: 64rem) {
+  .fission-site-home-header > .fission-site-row,
+  .fission-site-doc-header > .fission-site-row {
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .fission-site-main-nav > .fission-site-row,
+  .fission-site-doc-nav > .fission-site-row {
+    gap: 1rem !important;
+  }
+
+  .fission-site-value-home-hero-main > .fission-site-row,
+  .fission-site-value-home-start > .fission-site-row {
+    grid-template-columns: 1fr;
+  }
+
+  .fission-site-value-home-product-map {
+    max-width: 42rem;
+  }
+
+  .fission-site-doc-layout > .fission-site-row {
+    grid-template-columns: 14rem minmax(0, 1fr) !important;
+    gap: 2.5rem !important;
+  }
+
+  .fission-site-doc-toc {
+    display: none !important;
+  }
+}
+
+@media (max-width: 60rem) {
+  .fission-site-home-header > .fission-site-row,
+  .fission-site-doc-header > .fission-site-row {
+    display: flex !important;
+    justify-content: space-between !important;
+  }
+
+  .fission-site-home-header .fission-site-main-nav {
+    display: none !important;
+  }
+
+  .fission-site-mobile-global-menu {
+    display: block !important;
+    margin-left: auto;
+  }
+
+  .fission-site-home-actions {
+    display: none !important;
+  }
+
+  .fission-site-doc-header .fission-site-doc-nav {
+    margin-left: auto;
+  }
+
+  .fission-site-doc-header .fission-site-doc-nav > .fission-site-row > .fission-site-nav-item:not(:first-child) {
+    display: none !important;
+  }
+
+  .fission-site-doc-layout > .fission-site-row {
+    display: block !important;
+  }
+
+  .fission-site-doc-sidebar {
+    position: fixed !important;
+    z-index: 1001;
+    top: 0;
+    left: 0;
+    width: min(22rem, 88vw) !important;
+    height: 100dvh;
+    max-height: 100dvh;
+    padding: 1.5rem !important;
+    overflow-y: auto;
+    border-right: 1px solid var(--line);
+    background: var(--paper-bright) !important;
+    transform: translateX(-105%);
+    transition: transform 180ms ease;
+  }
+
+  .fission-site-sidebar-open .fission-site-doc-sidebar {
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 45rem) {
+  .fission-site-home-header,
+  .fission-site-doc-header {
+    min-height: 5rem;
+    padding-inline: 1.25rem !important;
+  }
+
+  .fission-site-value-home-hero,
+  .fission-site-value-home-why,
+  .fission-site-value-home-outcomes,
+  .fission-site-value-home-audience,
+  .fission-site-value-home-approach,
+  .fission-site-value-home-comparison,
+  .fission-site-value-home-start {
+    padding-inline: 1.25rem !important;
+  }
+
+  .fission-site-value-home-hero {
+    padding-top: 4rem !important;
+  }
+
+  [data-fission-semantics="site-heading-1:top"],
+  [data-fission-semantics="site-heading-1:top"] .fission-site-text-run {
+    font-size: clamp(3.2rem, 15vw, 4.6rem) !important;
+  }
+
+  .fission-site-value-home-map-stage {
+    min-height: 24rem;
+  }
+
+  .fission-site-value-home-hero-proof > .fission-site-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .fission-site-value-home-why > .fission-site-row,
+  .fission-site-value-home-section-heading > .fission-site-row,
+  .fission-site-value-home-audience-heading > .fission-site-row,
+  .fission-site-value-home-approach-intro > .fission-site-row,
+  .fission-site-value-home-comparison-heading > .fission-site-row,
+  .fission-site-value-home-audience-switcher > .fission-site-row {
+    grid-template-columns: 1fr;
+    gap: 2rem !important;
+  }
+
+  .fission-site-value-home-outcome > .fission-site-row {
+    grid-template-columns: 2.4rem minmax(0, 1fr);
+    gap: 1rem !important;
+  }
+
+  .fission-site-value-home-outcome > .fission-site-row > .fission-site-box:last-child {
+    grid-column: 2;
+    text-align: left;
+  }
+
+  .fission-site-value-home-audience-tabs > .fission-site-column {
+    flex-direction: row !important;
+    overflow-x: auto;
+  }
+
+  .fission-site-value-home-audience-tabs button {
+    width: auto !important;
+    flex: 0 0 auto;
+    padding-right: 1.5rem !important;
+  }
+
+  .fission-site-value-home-audience-panel > .fission-site-column > .fission-site-row,
+  .fission-site-value-home-approach-steps > .fission-site-row {
+    grid-template-columns: 1fr;
+  }
+
+  .fission-site-value-home-approach-step,
+  .fission-site-value-home-approach-step + .fission-site-value-home-approach-step {
+    min-height: 0;
+    padding: 1.5rem 0 3rem !important;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .fission-site-value-home-comparison-row > .fission-site-row,
+  .fission-site-value-home-comparison-labels > .fission-site-row {
+    grid-template-columns: 1fr;
+    width: 100% !important;
+    margin-left: 0;
+  }
+
+  .fission-site-value-home-comparison-row > .fission-site-row > .fission-site-box,
+  .fission-site-value-home-comparison-labels > .fission-site-row > .fission-site-box {
+    padding: 1.3rem 0 !important;
+  }
+
+  .fission-site-value-home-comparison-row > .fission-site-row > .fission-site-box + .fission-site-box,
+  .fission-site-value-home-comparison-labels > .fission-site-row > .fission-site-box + .fission-site-box {
+    border-top: 1px dashed var(--line) !important;
+    border-left: 0 !important;
+  }
+
+  [data-fission-semantics="crate-directory-hero"] {
+    padding: 4rem 1.25rem !important;
+  }
+
+  [data-fission-semantics="crate-directory-copy"] > .fission-site-column > .fission-site-box:nth-child(2) .fission-site-text-run {
+    font-size: clamp(3.1rem, 14vw, 4.5rem) !important;
+  }
+
+  .fission-site-doc-layout {
+    width: 100% !important;
+    padding: 2.5rem 1.25rem 5rem !important;
+  }
+
+  .fission-site-doc-main h1,
+  .fission-site-doc-main h1 .fission-site-text-run,
+  .fission-site-blog-post-title .fission-site-text-run {
+    font-size: clamp(2.9rem, 13vw, 4rem) !important;
+  }
+
+  .fission-site-blog-layout {
+    width: 100% !important;
+    padding: 4rem 1.25rem 6rem !important;
+  }
+
+  .fission-site-blog-index-title .fission-site-text-run {
+    font-size: clamp(3.4rem, 15vw, 4.8rem) !important;
+  }
+
+  .fission-site-footer {
+    padding-inline: 1.25rem !important;
+  }
+
+  .fission-site-footer > .fission-site-column > .fission-site-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3rem 1.5rem !important;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .fission-site-js [data-fission-semantics^="site-value-home-"] {
+    opacity: 0;
+    transform: translateY(1rem);
+    transition: opacity 500ms ease, transform 500ms ease;
+  }
+
+  .fission-site-js [data-fission-semantics^="site-value-home-"].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/documentation/src/components/crates.rs
+++ b/documentation/src/components/crates.rs
@@ -31,41 +31,204 @@ impl From<CrateDirectoryPage> for Widget {
         } else {
             HomePageNav.into()
         };
+        let featured = page
+            .crates
+            .iter()
+            .find(|item| item.name == "fission-maps")
+            .cloned();
+        let mut children = vec![navigation, CrateDirectoryHero { crate_count }.into()];
+        if let Some(item) = featured {
+            children.push(FeaturedCrate { item }.into());
+        }
+        children.extend([
+            CategoryLegend.into(),
+            PlatformLegend.into(),
+            Container::new(Column {
+                children: vec![
+                    CrateDirectoryToolbar { crate_count }.into(),
+                    CrateResults {
+                        crates: page.crates,
+                    }
+                    .into(),
+                ],
+                gap: Some(tokens.spacing.l),
+                semantics: Some(site_semantics("crate-results")),
+                ..Default::default()
+            })
+            .width_length(Length::clamp(
+                Length::points(280.0),
+                Length::percent(100.0),
+                Length::points(1304.0),
+            ))
+            .padding_lengths([
+                Length::points(tokens.spacing.xxl),
+                Length::points(tokens.spacing.xl),
+                Length::points(tokens.spacing.xxxxl),
+                Length::points(tokens.spacing.xl),
+            ])
+            .into(),
+        ]);
         Container::new(Column {
-            children: vec![
-                navigation,
-                CrateDirectoryHero { crate_count }.into(),
-                PlatformLegend.into(),
-                Container::new(Column {
-                    children: vec![
-                        CrateDirectoryToolbar { crate_count }.into(),
-                        CrateResults {
-                            crates: page.crates,
-                        }
-                        .into(),
-                    ],
-                    gap: Some(tokens.spacing.l),
-                    semantics: Some(site_semantics("crate-results")),
-                    ..Default::default()
-                })
-                .width_length(Length::clamp(
-                    Length::points(280.0),
-                    Length::percent(100.0),
-                    Length::points(1304.0),
-                ))
-                .padding_lengths([
-                    Length::points(tokens.spacing.xxl),
-                    Length::points(tokens.spacing.xl),
-                    Length::points(tokens.spacing.xxxxl),
-                    Length::points(tokens.spacing.xl),
-                ])
-                .into(),
-            ],
+            children,
             gap: Some(0.0),
             semantics: Some(site_semantics("crate-directory-page")),
             ..Default::default()
         })
         .bg_fill(page_fill(tokens))
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct FeaturedCrate {
+    item: RegistryCrate,
+}
+
+impl From<FeaturedCrate> for Widget {
+    fn from(featured: FeaturedCrate) -> Widget {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        let item = featured.item;
+        let href = format!("/crates/{}/", item.name);
+        Container::new(SemanticRow::new(
+            "crate-featured",
+            vec![
+                Column {
+                    children: vec![
+                        Text::new("Featured community capability")
+                            .size(tokens.typography.font_size_xs)
+                            .family(tokens.typography.font_family_mono.clone())
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.primary)
+                            .into(),
+                        Text::new(item.name.clone())
+                            .size(tokens.typography.font_size_lg)
+                            .family(tokens.typography.font_family_mono.clone())
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                        Text::new("Put native Apple maps inside a Fission application.")
+                            .size(tokens.typography.heading1_size)
+                            .weight(tokens.typography.font_weight_bold)
+                            .line_height(
+                                tokens.typography.heading1_size
+                                    * tokens.typography.line_height_heading,
+                            )
+                            .color(tokens.colors.heading)
+                            .into(),
+                        Text::new(item.description)
+                            .size(tokens.typography.body_large_size)
+                            .line_height(
+                                tokens.typography.body_large_size
+                                    * tokens.typography.line_height_relaxed,
+                            )
+                            .color(tokens.colors.text_secondary)
+                            .max_width(680.0)
+                            .into(),
+                        SemanticRow::new(
+                            "crate-featured-actions",
+                            vec![
+                                Text::new("View package  ↗")
+                                    .size(tokens.typography.label_large_size)
+                                    .weight(tokens.typography.font_weight_bold)
+                                    .color(tokens.colors.on_primary)
+                                    .semantics_identifier(format!("site-route:{href}"))
+                                    .into(),
+                                Text::new(format!("cargo add {}", item.name))
+                                    .size(tokens.typography.font_size_sm)
+                                    .family(tokens.typography.font_family_mono.clone())
+                                    .color(tokens.colors.text_link)
+                                    .into(),
+                            ],
+                            Some(tokens.spacing.l),
+                            FlexWrap::Wrap,
+                            AlignItems::Center,
+                            JustifyContent::Start,
+                        )
+                        .into(),
+                    ],
+                    gap: Some(tokens.spacing.l),
+                    ..Default::default()
+                }
+                .into(),
+                Column {
+                    children: vec![Container::new(
+                        Text::new("Native maps\nwhere they belong.")
+                            .size(tokens.typography.heading_size)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .text_align(TextAlign::Center),
+                    )
+                    .into()],
+                    semantics: Some(site_semantics("crate-featured-visual")),
+                    ..Default::default()
+                }
+                .into(),
+            ],
+            Some(tokens.spacing.xxxl),
+            FlexWrap::NoWrap,
+            AlignItems::Stretch,
+            JustifyContent::SpaceBetween,
+        ))
+        .width_length(Length::clamp(
+            Length::points(280.0),
+            Length::percent(100.0),
+            Length::points(1400.0),
+        ))
+        .padding_lengths([
+            Length::points(tokens.spacing.xxxl),
+            Length::points(tokens.spacing.xl),
+            Length::points(tokens.spacing.xxxl),
+            Length::points(tokens.spacing.xl),
+        ])
+        .border(tokens.colors.border_strong, 1.0)
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CategoryLegend;
+
+impl From<CategoryLegend> for Widget {
+    fn from(_legend: CategoryLegend) -> Widget {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        let categories = [
+            ("All", "all"),
+            ("Widgets", "widgets"),
+            ("Capabilities", "capabilities"),
+            ("Services & data", "services"),
+            ("Jobs & automation", "jobs"),
+            ("Tooling", "tooling"),
+        ];
+        Container::new(Row {
+            children: categories
+                .into_iter()
+                .map(|(label, id)| {
+                    Container::new(
+                        Text::new(label)
+                            .size(tokens.typography.font_size_sm)
+                            .weight(tokens.typography.font_weight_medium)
+                            .color(tokens.colors.text_secondary)
+                            .semantics_identifier(format!("crate-category-filter:{id}")),
+                    )
+                    .padding([10.0, 14.0, 10.0, 14.0])
+                    .border(tokens.colors.border, 1.0)
+                    .into()
+                })
+                .collect(),
+            gap: Some(tokens.spacing.s),
+            wrap: FlexWrap::Wrap,
+            justify_content: JustifyContent::Center,
+            semantics: Some(site_semantics("crate-category-legend")),
+            ..Default::default()
+        })
+        .width_length(Length::clamp(
+            Length::points(280.0),
+            Length::percent(100.0),
+            Length::points(1304.0),
+        ))
+        .padding_lengths(Length::all(Length::points(tokens.spacing.m)))
         .into()
     }
 }
@@ -181,38 +344,46 @@ impl From<CrateHeroContent> for Widget {
         } else {
             format!("{} indexed crates", hero.crate_count)
         };
-        Container::new(Column {
-            children: vec![
+        SemanticRow::new(
+            "crate-directory-copy",
+            vec![
                 Text::new(TextContent::Key("crates.eyebrow".into()))
                     .size(tokens.typography.font_size_sm)
                     .weight(tokens.typography.font_weight_bold)
                     .color(tokens.colors.primary)
                     .into(),
-                Text::new(TextContent::Key("crates.title".into()))
-                    .size(if hero.compact { 46.0 } else { 68.0 })
-                    .line_height(if hero.compact { 48.0 } else { 70.0 })
-                    .weight(tokens.typography.font_weight_bold)
-                    .color(tokens.colors.heading)
-                    .max_width(760.0)
-                    .into(),
-                Text::new(TextContent::Key("crates.body".into()))
-                    .size(if hero.compact { 17.0 } else { 20.0 })
-                    .line_height(if hero.compact { 27.0 } else { 32.0 })
-                    .color(tokens.colors.text_secondary)
-                    .max_width(700.0)
-                    .into(),
-                CrateSearchBox.into(),
-                Text::new(indexed_count)
-                    .size(tokens.typography.font_size_sm)
-                    .weight(tokens.typography.font_weight_bold)
-                    .color(tokens.colors.secondary)
-                    .into(),
+                Column {
+                    children: vec![
+                        Text::new(TextContent::Key("crates.title".into()))
+                            .size(if hero.compact { 46.0 } else { 68.0 })
+                            .line_height(if hero.compact { 48.0 } else { 70.0 })
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .max_width(900.0)
+                            .into(),
+                        Text::new(TextContent::Key("crates.body".into()))
+                            .size(if hero.compact { 17.0 } else { 20.0 })
+                            .line_height(if hero.compact { 27.0 } else { 32.0 })
+                            .color(tokens.colors.text_secondary)
+                            .max_width(740.0)
+                            .into(),
+                        CrateSearchBox.into(),
+                        Text::new(indexed_count)
+                            .size(tokens.typography.font_size_sm)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.secondary)
+                            .into(),
+                    ],
+                    gap: Some(tokens.spacing.l),
+                    ..Default::default()
+                }
+                .into(),
             ],
-            gap: Some(tokens.spacing.m),
-            semantics: Some(site_semantics("crate-directory-copy")),
-            ..Default::default()
-        })
-        .width_length(Length::percent(100.0))
+            Some(tokens.spacing.xxxl),
+            FlexWrap::Wrap,
+            AlignItems::Start,
+            JustifyContent::SpaceBetween,
+        )
         .into()
     }
 }

--- a/documentation/src/components/footer.rs
+++ b/documentation/src/components/footer.rs
@@ -30,7 +30,7 @@ impl From<DocsFooter> for Widget {
                             "Build",
                             &[
                                 ("Quickstart", "/docs/learn/quickstart/"),
-                                ("Documentation", "/docs/learn/overview/"),
+                                ("Documentation", "/docs/"),
                                 ("Guides", "/docs/guides/layout-and-widgets/"),
                                 ("Cookbook", "/docs/cookbook/add-platform-targets/"),
                             ],

--- a/documentation/src/components/home.rs
+++ b/documentation/src/components/home.rs
@@ -1,7 +1,10 @@
 use super::home_nav::HomePageNav;
-use super::home_sections::{ChartsSection, FinalCta, HomePageHero, ModelSection, ProofStrip};
 use super::home_widgets::page_fill;
 use super::state::DocsState;
+use super::value_home::{
+    AudienceSection, ComparisonSection, HomePageHero, HowItWorksSection, OutcomesSection,
+    StartSection, WhySection,
+};
 use fission::op::{AlignItems, JustifyContent};
 use fission::prelude::*;
 use std::sync::Arc;
@@ -46,10 +49,12 @@ impl From<HomePage> for Widget {
                     children: vec![Container::new(Column {
                         children: vec![
                             HomePageHero.into(),
-                            ProofStrip.into(),
-                            ChartsSection.into(),
-                            ModelSection.into(),
-                            FinalCta.into(),
+                            WhySection.into(),
+                            OutcomesSection.into(),
+                            AudienceSection.into(),
+                            HowItWorksSection.into(),
+                            ComparisonSection.into(),
+                            StartSection.into(),
                         ],
                         gap: Some(0.0),
                         align_items: AlignItems::Center,

--- a/documentation/src/components/home_nav.rs
+++ b/documentation/src/components/home_nav.rs
@@ -1,5 +1,5 @@
 use super::brand_logo::BrandLogo;
-use super::home_widgets::{nav_inset, ExternalNavLink, SearchPill, ThemeToggle};
+use super::home_widgets::{nav_inset, Cta, ThemeToggle};
 use super::state::DocsState;
 use fission::op::{AlignItems, Fill, FlexWrap, JustifyContent};
 use fission::prelude::*;
@@ -11,92 +11,26 @@ struct NavItem {
     children: &'static [NavItem],
 }
 
-const PRODUCT_CHILDREN: &[NavItem] = &[
-    NavItem {
-        label: "Platform overview",
-        href: "/product/overview/",
-        children: &[],
-    },
-    NavItem {
-        label: "Cross-platform apps",
-        href: "/product/cross-platform-apps/",
-        children: &[],
-    },
-    NavItem {
-        label: "Static sites",
-        href: "/product/static-sites/",
-        children: &[],
-    },
-    NavItem {
-        label: "Server-rendered sites",
-        href: "/product/server-rendered-sites/",
-        children: &[],
-    },
-    NavItem {
-        label: "Terminal apps",
-        href: "/product/terminal-apps/",
-        children: &[],
-    },
-    NavItem {
-        label: "Charts",
-        href: "/product/charts/",
-        children: &[],
-    },
-    NavItem {
-        label: "Production lifecycle",
-        href: "/product/production-lifecycle/",
-        children: &[],
-    },
-    NavItem {
-        label: "Developer tools",
-        href: "/product/developer-tools/",
-        children: &[],
-    },
-    NavItem {
-        label: "Design systems",
-        href: "/product/design-systems/",
-        children: &[],
-    },
-];
-
-const DOCS_CHILDREN: &[NavItem] = &[
-    NavItem {
-        label: "Quickstart",
-        href: "/docs/learn/quickstart/",
-        children: &[],
-    },
-    NavItem {
-        label: "Learn Fission",
-        href: "/docs/learn/overview/",
-        children: &[],
-    },
-    NavItem {
-        label: "Guides",
-        href: "/docs/guides/layout-and-widgets/",
-        children: &[],
-    },
-    NavItem {
-        label: "Cookbook",
-        href: "/docs/cookbook/add-platform-targets/",
-        children: &[],
-    },
-    NavItem {
-        label: "API reference",
-        href: "/reference/overview/overview/",
-        children: &[],
-    },
-];
-
 const NAV_ITEMS: &[NavItem] = &[
     NavItem {
-        label: "Platform",
-        href: "/product/overview/",
-        children: PRODUCT_CHILDREN,
+        label: "Why Fission",
+        href: "/#why",
+        children: &[],
+    },
+    NavItem {
+        label: "Who it helps",
+        href: "/#value",
+        children: &[],
+    },
+    NavItem {
+        label: "How it works",
+        href: "/#approach",
+        children: &[],
     },
     NavItem {
         label: "Docs",
-        href: "/docs/learn/overview/",
-        children: DOCS_CHILDREN,
+        href: "/docs/",
+        children: &[],
     },
     NavItem {
         label: "Crates",
@@ -112,23 +46,23 @@ const NAV_ITEMS: &[NavItem] = &[
 
 const MOBILE_MENU_CHILDREN: &[NavItem] = &[
     NavItem {
-        label: "Platform",
-        href: "/product/overview/",
+        label: "Why Fission",
+        href: "/#why",
+        children: &[],
+    },
+    NavItem {
+        label: "Who it helps",
+        href: "/#value",
+        children: &[],
+    },
+    NavItem {
+        label: "How it works",
+        href: "/#approach",
         children: &[],
     },
     NavItem {
         label: "Documentation",
-        href: "/docs/learn/overview/",
-        children: &[],
-    },
-    NavItem {
-        label: "Quickstart",
-        href: "/docs/learn/quickstart/",
-        children: &[],
-    },
-    NavItem {
-        label: "API reference",
-        href: "/reference/overview/overview/",
+        href: "/docs/",
         children: &[],
     },
     NavItem {
@@ -145,7 +79,7 @@ const MOBILE_MENU_CHILDREN: &[NavItem] = &[
 
 const MOBILE_NAV_ITEMS: &[NavItem] = &[NavItem {
     label: "Menu",
-    href: "/product/overview/",
+    href: "/",
     children: MOBILE_MENU_CHILDREN,
 }];
 
@@ -205,13 +139,8 @@ impl From<HomePageNav> for Widget {
                 .into(),
                 Row {
                     children: vec![
-                        ExternalNavLink::new("GitHub", "https://github.com/fission-ui/fission")
-                            .into(),
                         ThemeToggle.into(),
-                        // Re-enable once Spanish covers enough routes for switching here
-                        // to retain the visitor's current destination.
-                        // super::home_widgets::LocaleSwitcher.into(),
-                        SearchPill.into(),
+                        Cta::new("Start building", "/docs/learn/quickstart/", false).into(),
                     ],
                     gap: Some(tokens.spacing.m),
                     justify_content: JustifyContent::End,

--- a/documentation/src/components/home_widgets.rs
+++ b/documentation/src/components/home_widgets.rs
@@ -4,9 +4,15 @@ use fission::prelude::*;
 use fission::{Role, Semantics};
 
 pub(super) fn site_semantics(identifier: impl Into<String>) -> Semantics {
+    let identifier = identifier.into();
+    let identifier = if identifier.starts_with("value-home-") {
+        format!("site-{identifier}")
+    } else {
+        identifier
+    };
     Semantics {
         role: Role::Generic,
-        identifier: Some(identifier.into()),
+        identifier: Some(identifier),
         ..Semantics::default()
     }
 }

--- a/documentation/src/components/marketing.rs
+++ b/documentation/src/components/marketing.rs
@@ -301,8 +301,8 @@ impl MarketingPageKind {
         match self {
             MarketingPageKind::Overview => PageCopy {
                 eyebrow: "Fission platform",
-                title: "A Rust application platform for the full product lifecycle.",
-                body: "Build the interface, run it on real targets, test and debug it, package artifacts, prepare release content, publish through stores and hosts, and keep receipts for automation.",
+                title: "Keep the product together from first build to release.",
+                body: "Build the interface once, run that product on real targets, and carry the same project model through testing, packaging, signing, stores, and hosting. Teams spend their time improving one product instead of coordinating several implementations.",
                 primary_label: "Start docs",
                 primary_href: "/docs/intro/",
                 secondary_label: "See release workflow",
@@ -312,12 +312,12 @@ impl MarketingPageKind {
                 proof_cta_label: "Start with the platform model",
                 proof_cta_href: "/docs/intro/",
                 feature_label: "Platform shape",
-                feature_title: "The product architecture stays together.",
-                feature_body: "Fission is organized around one explicit app model and the host/lifecycle tools needed to take that model from first run to release.",
+                feature_title: "One place to make product decisions.",
+                feature_body: "State, interface, platform boundaries, and delivery configuration stay visible in one Rust project, so a change can be reviewed and proven as one coherent piece of work.",
                 features: OVERVIEW_FEATURES,
                 details_label: "How it fits",
-                details_title: "A framework boundary for the whole application lifecycle.",
-                details_body: "The overview page connects the major targets. Use the deeper product pages when you need the details for a specific output or workflow.",
+                details_title: "Share what is product logic. Isolate what is genuinely platform-specific.",
+                details_body: "Fission shares behavior and interface intent while each shell owns its real operating-system boundary. That keeps reuse honest and platform work explicit.",
                 details: OVERVIEW_DETAILS,
                 workflow_label: "Lifecycle path",
                 workflow_title: "From project setup to release receipts.",
@@ -325,8 +325,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::CrossPlatformApps => PageCopy {
                 eyebrow: "Cross-platform apps",
-                title: "One Rust app model across every Fission target.",
-                body: "Fission keeps state, reducers, widgets, resources, jobs, services, design systems, and charts shared while shells host the product on each platform.",
+                title: "Support more platforms without maintaining more versions of your product.",
+                body: "A workflow implemented in shared Rust reaches macOS, Windows, Linux, Web, Android, and iOS. Platform shells still own lifecycle, input, packaging, and other host concerns, so teams share product behavior without pretending every platform is identical.",
                 primary_label: "Read shell guide",
                 primary_href: "/docs/guides/platform-shells-cli-and-testing/",
                 secondary_label: "Browse targets",
@@ -336,12 +336,12 @@ impl MarketingPageKind {
                 proof_cta_label: "Read target expectations",
                 proof_cta_href: "/reference/platform/targets/",
                 feature_label: "Host coverage",
-                feature_title: "Each app target has a concrete responsibility.",
-                feature_body: "Cross-platform does not mean pretending every host is the same. Fission keeps product behavior shared while validating the parts that belong to each platform.",
+                feature_title: "Add reach, not another product codebase.",
+                feature_body: "Desktop gives a fast development loop; mobile and Web prove their own input, lifecycle, rendering, and delivery boundaries against the same underlying application.",
                 features: CROSS_FEATURES,
                 details_label: "Target model",
-                details_title: "Use the fastest loop until the host itself matters.",
-                details_body: "macOS, Windows, Linux, Web, Android, iOS, Terminal, Static site, and SSR should all be tested as real outputs. The right target depends on the behavior you are proving.",
+                details_title: "Use the fastest loop, then prove the shipped host.",
+                details_body: "Work quickly on the most convenient target, then exercise browser, emulator, simulator, device, or desktop packages whenever that platform boundary affects the user experience.",
                 details: CROSS_DETAILS,
                 workflow_label: "Run loop",
                 workflow_title: "Move between hosts without rewriting product code.",
@@ -349,8 +349,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::TerminalApps => PageCopy {
                 eyebrow: "Terminal",
-                title: "Build terminal apps without leaving Fission.",
-                body: "Terminal is for production command tools, setup flows, diagnostics, admin panels, and developer workflows that need an interactive shell target.",
+                title: "Give command-line workflows a real application structure.",
+                body: "Build setup flows, diagnostics, administration, and developer tools with screens, state, navigation, progress, and non-blocking work—using the same application model as graphical targets.",
                 primary_label: "Build a terminal app",
                 primary_href: "/docs/guides/terminal-user-interfaces/",
                 secondary_label: "Try fission ui",
@@ -373,8 +373,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::StaticSites => PageCopy {
                 eyebrow: "Static sites",
-                title: "Generate SEO-friendly static sites from Fission widgets and content.",
-                body: "Use custom widget routes for marketing pages and Markdown content routes for documentation, reference, blogs, and changelogs.",
+                title: "Publish fast, crawlable sites without creating a second frontend stack.",
+                body: "Use Fission widgets for designed pages and Markdown routes for documentation, references, blogs, and changelogs. The result is portable HTML, CSS, metadata, and search that any static host can serve.",
                 primary_label: "Read static site guide",
                 primary_href: "/docs/guides/static-sites/",
                 secondary_label: "View this site structure",
@@ -397,8 +397,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::ServerSites => PageCopy {
                 eyebrow: "Server-rendered sites",
-                title: "Render dynamic web products with the same Fission app model.",
-                body: "Use the server shell for ecommerce, dashboards, portals, account pages, and other routes that need request-time data, sessions, signed actions, cache policy, workers, or focused islands.",
+                title: "Serve dynamic web journeys without rebuilding the product in another framework.",
+                body: "Use the same Fission components for ecommerce, dashboards, portals, and account pages, then choose request-time data, session privacy, cache policy, workers, or focused islands only where the route needs them.",
                 primary_label: "Build a server site",
                 primary_href: "/docs/guides/server-sites/",
                 secondary_label: "Read server security",
@@ -421,8 +421,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::ProductionLifecycle => PageCopy {
                 eyebrow: "Production lifecycle",
-                title: "Package, sign, release, distribute, and track the output.",
-                body: "Fission treats post-build work as a platform feature: readiness checks, artifact manifests, release content, credentials, stores, static hosts, tracks, rollouts, and receipts.",
+                title: "Make release day a repeatable engineering workflow.",
+                body: "Catch missing release inputs early, create verifiable packages, sign the right artifacts, publish through stores and hosts, and leave receipts that CI and teammates can inspect.",
                 primary_label: "Open release docs",
                 primary_href: "/docs/release-and-distribute/overview/",
                 secondary_label: "Lifecycle details",
@@ -445,8 +445,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::DeveloperTools => PageCopy {
                 eyebrow: "Developer tools",
-                title: "Make the Fission runtime observable while you build.",
-                body: "The developer tools direction is inspection, diagnostics, profiling, screenshots, device workflow, and IDE integration around the same explicit app model.",
+                title: "Trace a user action all the way to shipped output.",
+                body: "Inspect state, reducers, layout, semantics, paint, resources, and device logs through the model the application actually runs. Diagnose the product without learning a separate hidden tooling model.",
                 primary_label: "Read testing docs",
                 primary_href: "/docs/test-and-debug/overview/",
                 secondary_label: "Open reference",
@@ -469,8 +469,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::DesignSystems => PageCopy {
                 eyebrow: "Design systems",
-                title: "Bring a real design system into Rust UI code.",
-                body: "Fission reads design system package JSON at build time and generates typed theme code for widgets, charts, shells, and product targets.",
+                title: "Keep design decisions consistent across every shipped surface.",
+                body: "Turn Design System Package JSON into typed Rust at build time, then let widgets, charts, and shells consume the same colors, spacing, typography, variants, and interaction states.",
                 primary_label: "Read design guide",
                 primary_href: "/docs/guides/design-system/",
                 secondary_label: "Theme docs",
@@ -493,8 +493,8 @@ impl MarketingPageKind {
             },
             MarketingPageKind::Charts => PageCopy {
                 eyebrow: "Charts",
-                title: "Beautiful data visualization as a first-class product feature.",
-                body: "Fission Charts is the native charting layer for dashboards, analytics, finance, maps, networks, dynamic data, and 3D-ready visuals.",
+                title: "Help people understand product data without embedding another UI stack.",
+                body: "Build dashboards, analytics, finance views, maps, and networks from typed Rust data. Charts share the product's theme, interaction model, tests, and target delivery instead of behaving like a foreign embed.",
                 primary_label: "Browse catalog",
                 primary_href: "/docs/charts/catalog/",
                 secondary_label: "Chart reference",
@@ -884,6 +884,7 @@ impl From<DetailCard> for Widget {
                 NavLink::new(card.copy.link_label, card.copy.href).into(),
             ],
             gap: Some(tokens.spacing.m),
+            semantics: Some(site_semantics("site-product-detail-card")),
             ..Default::default()
         })
         .width(tokens.spacing.xxxxl * 3.25)
@@ -929,6 +930,7 @@ impl From<FeatureCard> for Widget {
                     .into(),
             ],
             gap: Some(tokens.spacing.m),
+            semantics: Some(site_semantics("site-product-feature-card")),
             ..Default::default()
         })
         .width(tokens.spacing.xxxxl * 3.1)
@@ -1037,6 +1039,7 @@ impl From<WorkflowStep> for Widget {
                     .into(),
             ],
             gap: Some(tokens.spacing.s),
+            semantics: Some(site_semantics("site-product-workflow-step")),
             ..Default::default()
         })
         .width(tokens.spacing.xxxxl * 3.05)

--- a/documentation/src/components/mod.rs
+++ b/documentation/src/components/mod.rs
@@ -8,6 +8,7 @@ mod home_widgets;
 mod localized;
 mod marketing;
 mod state;
+mod value_home;
 
 pub(crate) use crates::{CrateDetailPage, CrateDirectoryPage};
 pub(crate) use footer::DocsFooter;

--- a/documentation/src/components/value_home.rs
+++ b/documentation/src/components/value_home.rs
@@ -1,0 +1,902 @@
+use super::home_widgets::{site_semantics, Cta, NavLink, SemanticColumn, SemanticRow};
+use super::state::DocsState;
+use fission::op::{AlignItems, Fill, FlexWrap, JustifyContent, TextAlign};
+use fission::prelude::*;
+
+#[derive(Clone, Debug)]
+pub(super) struct HomePageHero;
+
+impl From<HomePageHero> for Widget {
+    fn from(_component: HomePageHero) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-hero",
+            vec![
+                SemanticRow::new(
+                    "value-home-hero-main",
+                    vec![HeroCopy.into(), ProductMap.into()],
+                    Some(tokens.spacing.xxxl),
+                    FlexWrap::NoWrap,
+                    AlignItems::Center,
+                    JustifyContent::SpaceBetween,
+                )
+                .into(),
+                HeroProof.into(),
+            ],
+            Some(tokens.spacing.xxl),
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HeroCopy;
+
+impl From<HeroCopy> for Widget {
+    fn from(_copy: HeroCopy) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-hero-copy",
+            vec![
+                Eyebrow::new("A Rust application platform").into(),
+                Text::new("Build one Rust product.\nShip it everywhere.")
+                    .size(76.0)
+                    .line_height(75.0)
+                    .weight(tokens.typography.font_weight_bold)
+                    .color(tokens.colors.heading)
+                    .max_width(760.0)
+                    .semantics_identifier("site-heading-1:top")
+                    .into(),
+                Text::new("Fission keeps application state, interface code, platform integrations, tests, and release workflow in one Rust codebase. Add native, mobile, web, terminal, and server targets without maintaining a separate product implementation for each one.")
+                    .size(tokens.typography.body_large_size)
+                    .line_height(tokens.typography.body_large_size * tokens.typography.line_height_relaxed)
+                    .color(tokens.colors.text_secondary)
+                    .max_width(680.0)
+                    .into(),
+                Row {
+                    children: vec![
+                        Cta::new("Build your first app  ↗", "/docs/learn/quickstart/", true).into(),
+                        NavLink::new("See why teams choose Fission  ↓", "/#why").into(),
+                    ],
+                    gap: Some(tokens.spacing.l),
+                    wrap: FlexWrap::Wrap,
+                    align_items: AlignItems::Center,
+                    ..Default::default()
+                }
+                .into(),
+            ],
+            Some(tokens.spacing.l),
+            AlignItems::Start,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ProductMap;
+
+impl From<ProductMap> for Widget {
+    fn from(_map: ProductMap) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        let targets = [
+            "macOS", "Web", "iOS", "Linux", "Android", "Windows", "Terminal", "Static", "SSR",
+        ]
+        .into_iter()
+        .map(|label| PlatformTarget { label }.into())
+        .collect();
+        SemanticColumn::new(
+            "value-home-product-map",
+            vec![
+                SemanticColumn::new(
+                    "value-home-map-caption",
+                    vec![
+                        Text::new("One product model")
+                            .size(tokens.typography.font_size_xs)
+                            .family(tokens.typography.font_family_mono.clone())
+                            .color(tokens.colors.text_muted)
+                            .into(),
+                        Text::new("Every surface that matters")
+                            .size(tokens.typography.font_size_base)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                    ],
+                    Some(tokens.spacing.xs),
+                    AlignItems::Start,
+                )
+                .into(),
+                Container::new(Column {
+                    children: vec![
+                        Container::new(Column {
+                            children: vec![
+                                Image::asset("/img/fission-mark.svg")
+                                    .size(42.0, 50.0)
+                                    .into(),
+                                Text::new("your product")
+                                    .size(tokens.typography.font_size_xs)
+                                    .family(tokens.typography.font_family_mono.clone())
+                                    .color(tokens.colors.on_primary)
+                                    .into(),
+                            ],
+                            gap: Some(tokens.spacing.s),
+                            align_items: AlignItems::Center,
+                            semantics: Some(site_semantics("value-home-map-core")),
+                            ..Default::default()
+                        })
+                        .padding_all(tokens.spacing.l)
+                        .bg_fill(Fill::Solid(tokens.colors.primary))
+                        .into(),
+                        Row {
+                            children: targets,
+                            gap: Some(tokens.spacing.s),
+                            wrap: FlexWrap::Wrap,
+                            justify_content: JustifyContent::Center,
+                            semantics: Some(site_semantics("value-home-map-targets")),
+                            ..Default::default()
+                        }
+                        .into(),
+                    ],
+                    gap: Some(tokens.spacing.l),
+                    align_items: AlignItems::Center,
+                    semantics: Some(site_semantics("value-home-map-stage")),
+                    ..Default::default()
+                })
+                .padding_all(tokens.spacing.l)
+                .border(tokens.colors.border, 1.0)
+                .into(),
+            ],
+            Some(tokens.spacing.m),
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PlatformTarget {
+    label: &'static str,
+}
+
+impl From<PlatformTarget> for Widget {
+    fn from(target: PlatformTarget) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        Container::new(
+            Text::new(target.label)
+                .size(tokens.typography.font_size_xs)
+                .family(tokens.typography.font_family_mono.clone())
+                .color(tokens.colors.text_secondary),
+        )
+        .padding([
+            tokens.spacing.s,
+            tokens.spacing.s,
+            tokens.spacing.xs,
+            tokens.spacing.xs,
+        ])
+        .border(tokens.colors.border, 1.0)
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HeroProof;
+
+impl From<HeroProof> for Widget {
+    fn from(_proof: HeroProof) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticRow::new(
+            "value-home-hero-proof",
+            [
+                "One language",
+                "One application model",
+                "Platform-native delivery",
+                "Apache-2.0 licensed",
+            ]
+            .into_iter()
+            .map(|label| {
+                Text::new(label)
+                    .size(tokens.typography.font_size_xs)
+                    .family(tokens.typography.font_family_mono.clone())
+                    .color(tokens.colors.text_secondary)
+                    .into()
+            })
+            .collect(),
+            Some(0.0),
+            FlexWrap::Wrap,
+            AlignItems::Center,
+            JustifyContent::SpaceBetween,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct WhySection;
+
+impl From<WhySection> for Widget {
+    fn from(_section: WhySection) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticRow::new(
+            "value-home-why",
+            vec![
+                SectionIndex::new("01 / WHY FISSION", "why").into(),
+                SemanticColumn::new(
+                    "value-home-why-copy",
+                    vec![
+                        Text::new("A Fission application has one shared source of product behaviour.")
+                            .size(tokens.typography.font_size_base)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                        Text::new("One codebase should mean one place to make product decisions.")
+                            .size(tokens.typography.heading1_size)
+                            .line_height(tokens.typography.heading1_size * tokens.typography.line_height_heading)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                        Text::new("State changes, navigation, widgets, services, and design rules are expressed once. Platform shells still own the details that genuinely differ—windows, lifecycle, input, signing, and distribution. A product change stays a product change instead of becoming a coordination job across several application teams.")
+                            .size(tokens.typography.body_large_size)
+                            .line_height(tokens.typography.body_large_size * tokens.typography.line_height_relaxed)
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                    ],
+                    Some(tokens.spacing.l),
+                    AlignItems::Start,
+                )
+                .into(),
+            ],
+            Some(tokens.spacing.xxxl),
+            FlexWrap::NoWrap,
+            AlignItems::Start,
+            JustifyContent::Start,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct OutcomesSection;
+
+impl From<OutcomesSection> for Widget {
+    fn from(_section: OutcomesSection) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-outcomes",
+            vec![
+                SemanticRow::new(
+                    "value-home-section-heading",
+                    vec![
+                        Eyebrow::new("The practical difference").into(),
+                        Text::new("What a shared application model changes in practice.")
+                            .size(tokens.typography.heading2_size)
+                            .line_height(tokens.typography.heading2_size * tokens.typography.line_height_heading)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                    ],
+                    Some(tokens.spacing.xl),
+                    FlexWrap::NoWrap,
+                    AlignItems::Start,
+                    JustifyContent::SpaceBetween,
+                )
+                .into(),
+                Outcome::new("01", "Add a target without starting another application", "The same state, reducers, widgets, and services can reach desktop, mobile, browser, terminal, and server surfaces. Teams implement platform-specific work only where the platform actually requires it.", "Shared implementation → more supported targets").into(),
+                Outcome::new("02", "Fix behaviour once, then test each real target", "Shared behaviour is tested at its source. Target tests then verify the boundaries that differ, including input, rendering, accessibility, lifecycle, and packaging.", "Shared tests → less behavioural drift").into(),
+                Outcome::new("03", "Keep release work inside the engineering system", "Fission carries target configuration into builds, packages, signing checks, and distribution workflows. Release knowledge remains reviewable and repeatable instead of living in disconnected scripts.", "Explicit delivery → fewer manual hand-offs").into(),
+            ],
+            Some(0.0),
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Outcome {
+    number: &'static str,
+    title: &'static str,
+    body: &'static str,
+    result: &'static str,
+}
+
+impl Outcome {
+    fn new(
+        number: &'static str,
+        title: &'static str,
+        body: &'static str,
+        result: &'static str,
+    ) -> Self {
+        Self {
+            number,
+            title,
+            body,
+            result,
+        }
+    }
+}
+
+impl From<Outcome> for Widget {
+    fn from(outcome: Outcome) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticRow::new(
+            "value-home-outcome",
+            vec![
+                Text::new(outcome.number)
+                    .size(tokens.typography.font_size_xs)
+                    .family(tokens.typography.font_family_mono.clone())
+                    .color(tokens.colors.primary)
+                    .into(),
+                Column {
+                    children: vec![
+                        Text::new(outcome.title)
+                            .size(tokens.typography.heading_size)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                        Text::new(outcome.body)
+                            .size(tokens.typography.body_medium_size)
+                            .line_height(
+                                tokens.typography.body_medium_size
+                                    * tokens.typography.line_height_relaxed,
+                            )
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                    ],
+                    gap: Some(tokens.spacing.m),
+                    ..Default::default()
+                }
+                .into(),
+                Text::new(outcome.result)
+                    .size(tokens.typography.font_size_sm)
+                    .family(tokens.typography.font_family_mono.clone())
+                    .color(tokens.colors.primary)
+                    .text_align(TextAlign::Right)
+                    .into(),
+            ],
+            Some(tokens.spacing.xl),
+            FlexWrap::NoWrap,
+            AlignItems::Start,
+            JustifyContent::SpaceBetween,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct AudienceSection;
+
+impl From<AudienceSection> for Widget {
+    fn from(_section: AudienceSection) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-audience",
+            vec![
+                SectionIndex::new("02 / VALUE AT EVERY SCALE", "value").into(),
+                SemanticRow::new(
+                    "value-home-audience-heading",
+                    vec![
+                        Text::new("The same foundation solves different problems at each scale.")
+                            .size(tokens.typography.heading2_size)
+                            .line_height(tokens.typography.heading2_size * tokens.typography.line_height_heading)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                        Text::new("Developers, delivery teams, and organisations all benefit from removing duplicate application implementations, but in concrete and different ways.")
+                            .size(tokens.typography.body_large_size)
+                            .line_height(tokens.typography.body_large_size * tokens.typography.line_height_relaxed)
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                    ],
+                    Some(tokens.spacing.xxxl),
+                    FlexWrap::NoWrap,
+                    AlignItems::Start,
+                    JustifyContent::SpaceBetween,
+                )
+                .into(),
+                SemanticRow::new(
+                    "value-home-audience-switcher",
+                    vec![AudienceTabs.into(), AudiencePanels.into()],
+                    Some(tokens.spacing.xxxl),
+                    FlexWrap::NoWrap,
+                    AlignItems::Start,
+                    JustifyContent::Start,
+                )
+                .into(),
+            ],
+            Some(tokens.spacing.xxl),
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AudienceTabs;
+
+impl From<AudienceTabs> for Widget {
+    fn from(_tabs: AudienceTabs) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-audience-tabs",
+            [
+                ("developers", "Developers", true),
+                ("teams", "Teams", false),
+                ("organisations", "Organisations", false),
+            ]
+            .into_iter()
+            .map(|(key, label, active)| {
+                Button {
+                    child: Some(Text::new(label).into()),
+                    semantics: Some(site_semantics(format!(
+                        "value-home-audience-tab:{key}:{active}"
+                    ))),
+                    variant: ButtonVariant::Ghost,
+                    ..Default::default()
+                }
+                .into()
+            })
+            .collect(),
+            Some(tokens.spacing.s),
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AudiencePanels;
+
+impl From<AudiencePanels> for Widget {
+    fn from(_panels: AudiencePanels) -> Self {
+        SemanticColumn::new(
+            "value-home-audience-panels",
+            vec![
+                AudiencePanel::new("developers", true, "For developers", "Use Rust from state changes to rendered output.", "Work with one language and trace one pipeline through actions, reducers, layout, input, rendering, and platform effects. You can investigate the application without switching between unrelated UI frameworks and state models.", &["Carry one set of skills across every supported surface.", "Trace behaviour through explicit state, actions, layout, input, and rendering.", "Use strong types to catch drift before customers do."], "Learn the application model  ↗", "/docs/learn/overview/").into(),
+                AudiencePanel::new("teams", false, "For teams", "Review one product change instead of several translations.", "Design, engineering, QA, and release work against the same application structure. A new workflow is implemented once, then its platform-specific boundaries are reviewed and tested explicitly.", &["Align around one source of product behaviour.", "Reuse tests and design intent across target boundaries.", "Review changes as coherent product changes, not parallel rewrites."], "See how teams stay aligned  ↗", "/product/design-systems/").into(),
+                AudiencePanel::new("organisations", false, "For organisations", "Support more platforms without duplicating the organisation.", "Platform coverage becomes a capability of the product team rather than a set of isolated codebases with separate ownership, release knowledge, and maintenance schedules.", &["Reduce duplicated implementation and coordination overhead.", "Keep release evidence and platform delivery in one operating model.", "Retain control with an open-source foundation and inspectable architecture."], "Explore the production journey  ↗", "/product/production-lifecycle/").into(),
+            ],
+            None,
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AudiencePanel {
+    key: &'static str,
+    active: bool,
+    label: &'static str,
+    title: &'static str,
+    body: &'static str,
+    points: &'static [&'static str],
+    link: &'static str,
+    href: &'static str,
+}
+
+impl AudiencePanel {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        key: &'static str,
+        active: bool,
+        label: &'static str,
+        title: &'static str,
+        body: &'static str,
+        points: &'static [&'static str],
+        link: &'static str,
+        href: &'static str,
+    ) -> Self {
+        Self {
+            key,
+            active,
+            label,
+            title,
+            body,
+            points,
+            link,
+            href,
+        }
+    }
+}
+
+impl From<AudiencePanel> for Widget {
+    fn from(panel: AudiencePanel) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            format!("value-home-audience-panel:{}:{}", panel.key, panel.active),
+            vec![
+                Text::new(panel.label)
+                    .size(tokens.typography.font_size_xs)
+                    .family(tokens.typography.font_family_mono.clone())
+                    .color(tokens.colors.primary)
+                    .into(),
+                Text::new(panel.title)
+                    .size(tokens.typography.heading2_size)
+                    .line_height(
+                        tokens.typography.heading2_size * tokens.typography.line_height_heading,
+                    )
+                    .weight(tokens.typography.font_weight_bold)
+                    .color(tokens.colors.heading)
+                    .into(),
+                Text::new(panel.body)
+                    .size(tokens.typography.body_large_size)
+                    .line_height(
+                        tokens.typography.body_large_size * tokens.typography.line_height_relaxed,
+                    )
+                    .color(tokens.colors.text_secondary)
+                    .into(),
+                Row {
+                    children: panel
+                        .points
+                        .iter()
+                        .map(|point| {
+                            Container::new(
+                                Text::new(*point)
+                                    .size(tokens.typography.body_medium_size)
+                                    .line_height(
+                                        tokens.typography.body_medium_size
+                                            * tokens.typography.line_height_normal,
+                                    )
+                                    .color(tokens.colors.text_secondary),
+                            )
+                            .padding([tokens.spacing.m, 0.0, tokens.spacing.m, tokens.spacing.m])
+                            .border(tokens.colors.border, 1.0)
+                            .flex_grow(1.0)
+                            .into()
+                        })
+                        .collect(),
+                    gap: Some(tokens.spacing.l),
+                    wrap: FlexWrap::NoWrap,
+                    align_items: AlignItems::Stretch,
+                    ..Default::default()
+                }
+                .into(),
+                NavLink::new(panel.link, panel.href).into(),
+            ],
+            Some(tokens.spacing.l),
+            AlignItems::Start,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct HowItWorksSection;
+
+impl From<HowItWorksSection> for Widget {
+    fn from(_section: HowItWorksSection) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-approach",
+            vec![
+                SectionIndex::new("03 / THE APPROACH", "approach").into(),
+                SemanticRow::new(
+                    "value-home-approach-intro",
+                    vec![
+                        Text::new("The product model is shared.\nThe platform boundary stays explicit.")
+                            .size(tokens.typography.heading2_size)
+                            .line_height(tokens.typography.heading2_size * tokens.typography.line_height_heading)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                        Text::new("Fission does not pretend every platform is identical. It shares application behaviour and UI intent, then gives each shell responsibility for the operating-system and delivery work that cannot honestly be shared.")
+                            .size(tokens.typography.body_large_size)
+                            .line_height(tokens.typography.body_large_size * tokens.typography.line_height_relaxed)
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                    ],
+                    Some(tokens.spacing.xxxl),
+                    FlexWrap::NoWrap,
+                    AlignItems::End,
+                    JustifyContent::SpaceBetween,
+                )
+                .into(),
+                SemanticRow::new(
+                    "value-home-approach-steps",
+                    vec![
+                        ApproachStep::new("01", "Write the application in Rust", "Define state, reducers, retained widgets, services, and design-system values together.").into(),
+                        ApproachStep::new("02", "Connect target shells", "Use native ownership for windows, events, lifecycle, accessibility, and host capabilities.").into(),
+                        ApproachStep::new("03", "Build and test the shipped form", "Exercise the actual target, then package, validate, sign, and distribute its artifact.").into(),
+                    ],
+                    Some(0.0),
+                    FlexWrap::NoWrap,
+                    AlignItems::Stretch,
+                    JustifyContent::SpaceBetween,
+                )
+                .into(),
+            ],
+            Some(tokens.spacing.xxl),
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ApproachStep {
+    number: &'static str,
+    title: &'static str,
+    body: &'static str,
+}
+
+impl ApproachStep {
+    fn new(number: &'static str, title: &'static str, body: &'static str) -> Self {
+        Self {
+            number,
+            title,
+            body,
+        }
+    }
+}
+
+impl From<ApproachStep> for Widget {
+    fn from(step: ApproachStep) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-approach-step",
+            vec![
+                Text::new(step.number)
+                    .size(tokens.typography.font_size_xs)
+                    .family(tokens.typography.font_family_mono.clone())
+                    .color(tokens.colors.primary)
+                    .into(),
+                Text::new(step.title)
+                    .size(tokens.typography.heading_size)
+                    .weight(tokens.typography.font_weight_bold)
+                    .color(tokens.colors.heading)
+                    .into(),
+                Text::new(step.body)
+                    .size(tokens.typography.body_medium_size)
+                    .line_height(
+                        tokens.typography.body_medium_size * tokens.typography.line_height_relaxed,
+                    )
+                    .color(tokens.colors.text_secondary)
+                    .into(),
+            ],
+            Some(tokens.spacing.m),
+            AlignItems::Start,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ComparisonSection;
+
+impl From<ComparisonSection> for Widget {
+    fn from(_section: ComparisonSection) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticColumn::new(
+            "value-home-comparison",
+            vec![
+                SemanticRow::new(
+                    "value-home-comparison-heading",
+                    vec![
+                        SectionIndex::new("04 / THE OPERATING DIFFERENCE", "comparison").into(),
+                        Text::new("What changes when the application is shared?")
+                            .size(tokens.typography.heading2_size)
+                            .line_height(
+                                tokens.typography.heading2_size
+                                    * tokens.typography.line_height_heading,
+                            )
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                    ],
+                    Some(tokens.spacing.xxxl),
+                    FlexWrap::NoWrap,
+                    AlignItems::Start,
+                    JustifyContent::SpaceBetween,
+                )
+                .into(),
+                ComparisonRow::new(
+                    "Separate framework for each target",
+                    "One Fission application",
+                    true,
+                )
+                .into(),
+                ComparisonRow::new(
+                    "Product behaviour is translated between codebases.",
+                    "State, actions, reducers, and interface intent have one source.",
+                    false,
+                )
+                .into(),
+                ComparisonRow::new(
+                    "Platform teams discover drift late in parallel QA.",
+                    "Shared behaviour is tested once; target boundaries are qualified explicitly.",
+                    false,
+                )
+                .into(),
+                ComparisonRow::new(
+                    "Release knowledge lives in separate tools and hand-offs.",
+                    "Build, packaging, signing, and distribution remain part of one workflow.",
+                    false,
+                )
+                .into(),
+            ],
+            Some(0.0),
+            AlignItems::Stretch,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ComparisonRow {
+    separate: &'static str,
+    fission: &'static str,
+    labels: bool,
+}
+
+impl ComparisonRow {
+    fn new(separate: &'static str, fission: &'static str, labels: bool) -> Self {
+        Self {
+            separate,
+            fission,
+            labels,
+        }
+    }
+}
+
+impl From<ComparisonRow> for Widget {
+    fn from(row: ComparisonRow) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticRow::new(
+            if row.labels {
+                "value-home-comparison-labels"
+            } else {
+                "value-home-comparison-row"
+            },
+            vec![
+                Text::new(row.separate)
+                    .size(if row.labels {
+                        tokens.typography.font_size_xs
+                    } else {
+                        tokens.typography.body_medium_size
+                    })
+                    .line_height(
+                        tokens.typography.body_medium_size * tokens.typography.line_height_normal,
+                    )
+                    .color(tokens.colors.text_secondary)
+                    .into(),
+                Text::new(row.fission)
+                    .size(if row.labels {
+                        tokens.typography.font_size_xs
+                    } else {
+                        tokens.typography.body_medium_size
+                    })
+                    .line_height(
+                        tokens.typography.body_medium_size * tokens.typography.line_height_normal,
+                    )
+                    .weight(tokens.typography.font_weight_semibold)
+                    .color(if row.labels {
+                        tokens.colors.primary
+                    } else {
+                        tokens.colors.text_primary
+                    })
+                    .into(),
+            ],
+            Some(0.0),
+            FlexWrap::NoWrap,
+            AlignItems::Stretch,
+            JustifyContent::Start,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct StartSection;
+
+impl From<StartSection> for Widget {
+    fn from(_section: StartSection) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        SemanticRow::new(
+            "value-home-start",
+            vec![
+                SemanticColumn::new(
+                    "value-home-start-copy",
+                    vec![
+                        SectionIndex::new("05 / START", "start").into(),
+                        Text::new("Start with a running app, then follow the real delivery path.")
+                            .size(tokens.typography.heading2_size)
+                            .line_height(tokens.typography.heading2_size * tokens.typography.line_height_heading)
+                            .weight(tokens.typography.font_weight_bold)
+                            .color(tokens.colors.heading)
+                            .into(),
+                        Text::new("The quickstart creates an application, runs it, and explains the model you will extend. From there, the documentation follows development, testing, packaging, and release in order.")
+                            .size(tokens.typography.body_large_size)
+                            .line_height(tokens.typography.body_large_size * tokens.typography.line_height_relaxed)
+                            .color(tokens.colors.text_secondary)
+                            .into(),
+                        Cta::new("Open the quickstart  ↗", "/docs/learn/quickstart/", true).into(),
+                    ],
+                    Some(tokens.spacing.l),
+                    AlignItems::Start,
+                )
+                .into(),
+                Column {
+                    children: vec![MarkdownViewer {
+                        markdown: "```sh\ncargo install fission\nfission create my-app\ncd my-app\nfission run\n```\n\nReady: one Rust application, ready for its first target."
+                            .to_string(),
+                        show_scrollbar: false,
+                    }
+                    .into()],
+                    semantics: Some(site_semantics("value-home-quickstart")),
+                    ..Default::default()
+                }
+                .into(),
+            ],
+            Some(tokens.spacing.xxxl),
+            FlexWrap::NoWrap,
+            AlignItems::Center,
+            JustifyContent::SpaceBetween,
+        )
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Eyebrow {
+    label: &'static str,
+}
+
+impl Eyebrow {
+    fn new(label: &'static str) -> Self {
+        Self { label }
+    }
+}
+
+impl From<Eyebrow> for Widget {
+    fn from(eyebrow: Eyebrow) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        Text::new(eyebrow.label)
+            .size(tokens.typography.font_size_xs)
+            .family(tokens.typography.font_family_mono.clone())
+            .color(tokens.colors.text_secondary)
+            .semantics_identifier("site-value-home-eyebrow")
+            .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SectionIndex {
+    label: &'static str,
+    anchor: &'static str,
+}
+
+impl SectionIndex {
+    fn new(label: &'static str, anchor: &'static str) -> Self {
+        Self { label, anchor }
+    }
+}
+
+impl From<SectionIndex> for Widget {
+    fn from(index: SectionIndex) -> Self {
+        let (_ctx, view) = fission::build::current::<DocsState>();
+        let tokens = &view.env().theme.tokens;
+        Text::new(index.label)
+            .size(tokens.typography.font_size_xs)
+            .family(tokens.typography.font_family_mono.clone())
+            .color(tokens.colors.text_muted)
+            .semantics_identifier(format!("site-anchor:{}", index.anchor))
+            .into()
+    }
+}

--- a/documentation/src/components/value_home.rs
+++ b/documentation/src/components/value_home.rs
@@ -82,16 +82,36 @@ impl From<ProductMap> for Widget {
     fn from(_map: ProductMap) -> Self {
         let (_ctx, view) = fission::build::current::<DocsState>();
         let tokens = &view.env().theme.tokens;
-        let targets = [
-            "macOS", "Web", "iOS", "Linux", "Android", "Windows", "Terminal", "Static", "SSR",
-        ]
-        .into_iter()
-        .map(|label| PlatformTarget { label }.into())
-        .collect();
+        let mut map_children = vec![Container::new(Column {
+            children: vec![
+                Image::asset("/img/fission-mark.svg")
+                    .size(42.0, 50.0)
+                    .into(),
+                Text::new("your product")
+                    .size(tokens.typography.font_size_xs)
+                    .family(tokens.typography.font_family_mono.clone())
+                    .color(tokens.colors.on_primary)
+                    .into(),
+            ],
+            gap: Some(tokens.spacing.s),
+            align_items: AlignItems::Center,
+            semantics: Some(site_semantics("value-home-map-core")),
+            ..Default::default()
+        })
+        .padding_all(tokens.spacing.l)
+        .bg_fill(Fill::Solid(tokens.colors.primary))
+        .into()];
+        map_children.extend(
+            [
+                "macOS", "Web", "iOS", "Linux", "Android", "Windows", "Terminal", "Static", "SSR",
+            ]
+            .into_iter()
+            .map(|label| PlatformTarget { label }.into()),
+        );
         SemanticColumn::new(
             "value-home-product-map",
             vec![
-                SemanticColumn::new(
+                SemanticRow::new(
                     "value-home-map-caption",
                     vec![
                         Text::new("One product model")
@@ -105,48 +125,18 @@ impl From<ProductMap> for Widget {
                             .color(tokens.colors.heading)
                             .into(),
                     ],
-                    Some(tokens.spacing.xs),
-                    AlignItems::Start,
+                    Some(tokens.spacing.m),
+                    FlexWrap::NoWrap,
+                    AlignItems::Center,
+                    JustifyContent::SpaceBetween,
                 )
                 .into(),
-                Container::new(Column {
-                    children: vec![
-                        Container::new(Column {
-                            children: vec![
-                                Image::asset("/img/fission-mark.svg")
-                                    .size(42.0, 50.0)
-                                    .into(),
-                                Text::new("your product")
-                                    .size(tokens.typography.font_size_xs)
-                                    .family(tokens.typography.font_family_mono.clone())
-                                    .color(tokens.colors.on_primary)
-                                    .into(),
-                            ],
-                            gap: Some(tokens.spacing.s),
-                            align_items: AlignItems::Center,
-                            semantics: Some(site_semantics("value-home-map-core")),
-                            ..Default::default()
-                        })
-                        .padding_all(tokens.spacing.l)
-                        .bg_fill(Fill::Solid(tokens.colors.primary))
-                        .into(),
-                        Row {
-                            children: targets,
-                            gap: Some(tokens.spacing.s),
-                            wrap: FlexWrap::Wrap,
-                            justify_content: JustifyContent::Center,
-                            semantics: Some(site_semantics("value-home-map-targets")),
-                            ..Default::default()
-                        }
-                        .into(),
-                    ],
-                    gap: Some(tokens.spacing.l),
-                    align_items: AlignItems::Center,
-                    semantics: Some(site_semantics("value-home-map-stage")),
-                    ..Default::default()
-                })
-                .padding_all(tokens.spacing.l)
-                .border(tokens.colors.border, 1.0)
+                SemanticColumn::new(
+                    "value-home-map-stage",
+                    map_children,
+                    Some(0.0),
+                    AlignItems::Stretch,
+                )
                 .into(),
             ],
             Some(tokens.spacing.m),
@@ -165,19 +155,17 @@ impl From<PlatformTarget> for Widget {
     fn from(target: PlatformTarget) -> Self {
         let (_ctx, view) = fission::build::current::<DocsState>();
         let tokens = &view.env().theme.tokens;
-        Container::new(
-            Text::new(target.label)
+        let slug = target.label.to_ascii_lowercase().replace(' ', "-");
+        SemanticColumn::new(
+            format!("value-home-map-target:{slug}"),
+            vec![Text::new(target.label)
                 .size(tokens.typography.font_size_xs)
                 .family(tokens.typography.font_family_mono.clone())
-                .color(tokens.colors.text_secondary),
+                .color(tokens.colors.text_secondary)
+                .into()],
+            Some(0.0),
+            AlignItems::Center,
         )
-        .padding([
-            tokens.spacing.s,
-            tokens.spacing.s,
-            tokens.spacing.xs,
-            tokens.spacing.xs,
-        ])
-        .border(tokens.colors.border, 1.0)
         .into()
     }
 }
@@ -833,7 +821,7 @@ impl From<StartSection> for Widget {
                 .into(),
                 Column {
                     children: vec![MarkdownViewer {
-                        markdown: "```sh\ncargo install fission\nfission create my-app\ncd my-app\nfission run\n```\n\nReady: one Rust application, ready for its first target."
+                        markdown: "```sh\ncargo install cargo-fission\nfission init my-app\ncd my-app\nfission run\n```\n\nReady: one Rust application, ready for its first target."
                             .to_string(),
                         show_scrollbar: false,
                     }

--- a/documentation/src/main.rs
+++ b/documentation/src/main.rs
@@ -134,11 +134,11 @@ fn atlas_theme(mode: DesignMode) -> Theme {
     let colors = &mut tokens.colors;
     match mode {
         DesignMode::Light => {
-            colors.primary = rgb(255, 79, 36);
+            colors.primary = rgb(79, 91, 236);
             colors.on_primary = Color::WHITE;
-            colors.primary_hover = rgb(198, 45, 10);
-            colors.primary_subtle = rgb(239, 235, 226);
-            colors.secondary = rgb(255, 79, 36);
+            colors.primary_hover = rgb(103, 70, 214);
+            colors.primary_subtle = rgb(236, 237, 252);
+            colors.secondary = rgb(112, 72, 222);
             colors.on_secondary = Color::WHITE;
             colors.surface = rgb(253, 252, 248);
             colors.on_surface = rgb(16, 16, 24);
@@ -152,16 +152,16 @@ fn atlas_theme(mode: DesignMode) -> Theme {
             colors.text_primary = rgb(16, 16, 24);
             colors.text_secondary = rgb(89, 89, 100);
             colors.text_muted = rgb(112, 110, 119);
-            colors.text_link = rgb(198, 45, 10);
+            colors.text_link = rgb(77, 74, 200);
             colors.heading = rgb(16, 16, 24);
-            colors.focus_ring = rgb(255, 79, 36);
+            colors.focus_ring = rgb(79, 91, 236);
         }
         DesignMode::Dark => {
-            colors.primary = rgb(255, 104, 66);
+            colors.primary = rgb(132, 145, 255);
             colors.on_primary = rgb(16, 16, 23);
-            colors.primary_hover = rgb(255, 136, 107);
-            colors.primary_subtle = rgb(38, 30, 31);
-            colors.secondary = rgb(255, 104, 66);
+            colors.primary_hover = rgb(176, 139, 255);
+            colors.primary_subtle = rgb(35, 34, 64);
+            colors.secondary = rgb(176, 139, 255);
             colors.on_secondary = rgb(16, 16, 23);
             colors.surface = rgb(22, 22, 31);
             colors.on_surface = rgb(245, 242, 233);
@@ -175,9 +175,9 @@ fn atlas_theme(mode: DesignMode) -> Theme {
             colors.text_primary = rgb(245, 242, 233);
             colors.text_secondary = rgb(170, 168, 176);
             colors.text_muted = rgb(125, 123, 132);
-            colors.text_link = rgb(255, 136, 107);
+            colors.text_link = rgb(173, 159, 255);
             colors.heading = rgb(245, 242, 233);
-            colors.focus_ring = rgb(255, 104, 66);
+            colors.focus_ring = rgb(132, 145, 255);
         }
     }
     tokens.typography.font_family_sans =

--- a/documentation/src/main.rs
+++ b/documentation/src/main.rs
@@ -35,9 +35,9 @@ fn site_app() -> FissionSite {
         )
         .route_widget::<DocsState, _>(
             "/",
-            "Fission",
+            "Fission — One Rust application across every surface",
             Some(
-                "Build, test, package, and release production Rust apps across macOS, Windows, Linux, Web, Android, iOS, Terminal, Static site, and SSR targets."
+                "Fission helps Rust teams turn one product model into native, mobile, web, terminal, and server experiences without rebuilding the organisation around every target."
                     .to_string(),
             ),
             RoutedHomePage::new("/"),
@@ -134,50 +134,50 @@ fn atlas_theme(mode: DesignMode) -> Theme {
     let colors = &mut tokens.colors;
     match mode {
         DesignMode::Light => {
-            colors.primary = rgb(49, 87, 232);
+            colors.primary = rgb(255, 79, 36);
             colors.on_primary = Color::WHITE;
-            colors.primary_hover = rgb(39, 71, 199);
-            colors.primary_subtle = rgb(244, 241, 255);
-            colors.secondary = rgb(121, 84, 238);
+            colors.primary_hover = rgb(198, 45, 10);
+            colors.primary_subtle = rgb(239, 235, 226);
+            colors.secondary = rgb(255, 79, 36);
             colors.on_secondary = Color::WHITE;
-            colors.surface = Color::WHITE;
-            colors.on_surface = rgb(17, 17, 38);
-            colors.surface_raised = Color::WHITE;
-            colors.surface_sunken = rgb(244, 241, 255);
-            colors.background = rgb(251, 251, 254);
-            colors.on_background = rgb(17, 17, 38);
-            colors.border = rgb(222, 219, 237);
-            colors.border_strong = rgb(199, 194, 220);
-            colors.divider = rgb(222, 219, 237);
-            colors.text_primary = rgb(17, 17, 38);
-            colors.text_secondary = rgb(102, 101, 122);
-            colors.text_muted = rgb(112, 110, 131);
-            colors.text_link = rgb(49, 87, 232);
-            colors.heading = rgb(17, 17, 38);
-            colors.focus_ring = rgb(121, 84, 238);
+            colors.surface = rgb(253, 252, 248);
+            colors.on_surface = rgb(16, 16, 24);
+            colors.surface_raised = rgb(253, 252, 248);
+            colors.surface_sunken = rgb(239, 235, 226);
+            colors.background = rgb(247, 246, 241);
+            colors.on_background = rgb(16, 16, 24);
+            colors.border = rgb(215, 213, 205);
+            colors.border_strong = rgb(170, 168, 159);
+            colors.divider = rgb(215, 213, 205);
+            colors.text_primary = rgb(16, 16, 24);
+            colors.text_secondary = rgb(89, 89, 100);
+            colors.text_muted = rgb(112, 110, 119);
+            colors.text_link = rgb(198, 45, 10);
+            colors.heading = rgb(16, 16, 24);
+            colors.focus_ring = rgb(255, 79, 36);
         }
         DesignMode::Dark => {
-            colors.primary = rgb(130, 150, 255);
-            colors.on_primary = rgb(11, 11, 24);
-            colors.primary_hover = rgb(154, 171, 255);
-            colors.primary_subtle = rgb(25, 23, 46);
-            colors.secondary = rgb(171, 145, 255);
-            colors.on_secondary = rgb(11, 11, 24);
-            colors.surface = rgb(19, 19, 36);
-            colors.on_surface = rgb(245, 243, 255);
-            colors.surface_raised = rgb(25, 23, 46);
-            colors.surface_sunken = rgb(25, 23, 46);
-            colors.background = rgb(11, 11, 24);
-            colors.on_background = rgb(245, 243, 255);
-            colors.border = rgb(48, 45, 73);
-            colors.border_strong = rgb(73, 68, 100);
-            colors.divider = rgb(48, 45, 73);
-            colors.text_primary = rgb(245, 243, 255);
-            colors.text_secondary = rgb(176, 174, 194);
-            colors.text_muted = rgb(141, 138, 159);
-            colors.text_link = rgb(130, 150, 255);
-            colors.heading = rgb(245, 243, 255);
-            colors.focus_ring = rgb(171, 145, 255);
+            colors.primary = rgb(255, 104, 66);
+            colors.on_primary = rgb(16, 16, 23);
+            colors.primary_hover = rgb(255, 136, 107);
+            colors.primary_subtle = rgb(38, 30, 31);
+            colors.secondary = rgb(255, 104, 66);
+            colors.on_secondary = rgb(16, 16, 23);
+            colors.surface = rgb(22, 22, 31);
+            colors.on_surface = rgb(245, 242, 233);
+            colors.surface_raised = rgb(22, 22, 31);
+            colors.surface_sunken = rgb(30, 29, 37);
+            colors.background = rgb(16, 16, 23);
+            colors.on_background = rgb(245, 242, 233);
+            colors.border = rgb(52, 51, 60);
+            colors.border_strong = rgb(86, 84, 95);
+            colors.divider = rgb(52, 51, 60);
+            colors.text_primary = rgb(245, 242, 233);
+            colors.text_secondary = rgb(170, 168, 176);
+            colors.text_muted = rgb(125, 123, 132);
+            colors.text_link = rgb(255, 136, 107);
+            colors.heading = rgb(245, 242, 233);
+            colors.focus_ring = rgb(255, 104, 66);
         }
     }
     tokens.typography.font_family_sans =


### PR DESCRIPTION
## Summary

- replace the documentation homepage with the approved value-led editorial design
- carry the same visual system through product, blog, documentation, and reference routes
- turn the crate directory into a searchable marketplace backed by the published crate index
- add paginated blog indexes and retain the full existing footer directory
- use the Fission blue-to-violet identity and correct the quickstart command to `cargo install cargo-fission`

## Validation

- `cargo test --locked -p fission-shell-site --lib --jobs 2` (78 passed)
- generated all 900 static routes with the published 36-crate database
- generated internal-link validation passed
- browser QA at 1440x1000 and 390x844 across home, crates, blog, docs, intro, and cross-platform product routes; no horizontal overflow
- crate search narrowed the real catalogue from 36 entries to `fission-maps`

## Isolation

This branch is based on `main` and contains no gaming commits or prototype files.