### PR TITLE
docs: finish responsive site fidelity and neutral shell defaults

### DIFF
--- a/crates/shell/fission-shell-site/assets/search.js
+++ b/crates/shell/fission-shell-site/assets/search.js
@@ -100,9 +100,9 @@
     dialog.hidden = true;
     dialog.innerHTML =
       '<div class="fission-site-search-backdrop" data-fission-search-close></div>' +
-      '<section class="fission-site-search-panel" role="dialog" aria-modal="true" aria-label="Search documentation">' +
+      '<section class="fission-site-search-panel" role="dialog" aria-modal="true" aria-label="Search this site">' +
       '<div class="fission-site-search-input-wrap">' +
-      '<input class="fission-site-search-input" data-fission-search-input placeholder="Search Fission docs" autocomplete="off" spellcheck="false">' +
+      '<input class="fission-site-search-input" data-fission-search-input placeholder="Search this site" autocomplete="off" spellcheck="false">' +
       '<kbd>Esc</kbd>' +
       '</div>' +
       '<div class="fission-site-search-results" data-fission-search-results></div>' +
@@ -120,7 +120,7 @@
     state.results = results;
     state.selected = 0;
     if (!query) {
-      target.innerHTML = '<p class="fission-site-search-empty">Start typing to search the generated documentation index.</p>';
+      target.innerHTML = '<p class="fission-site-search-empty">Start typing to search this site.</p>';
       return;
     }
     if (!results.length) {

--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1659,6 +1659,7 @@ mod tests {
         assert!(html.contains("fission-site-nav-menu"));
         assert!(html.contains("Resources"));
         assert!(html.contains("Documentation"));
+        assert!(html.contains("aria-label=\"Search this site\""));
         let css = fs::read_to_string(temp.join("target/fission/site/site.css")).unwrap();
         assert!(css.contains(":root"));
         assert!(css.contains(".fs_"));
@@ -1669,7 +1670,10 @@ mod tests {
         );
         assert!(temp.join("target/fission/site/sitemap.xml").exists());
         assert!(temp.join("target/fission/site/robots.txt").exists());
-        assert!(temp.join("target/fission/site/search/search.js").exists());
+        let search_script =
+            fs::read_to_string(temp.join("target/fission/site/search/search.js")).unwrap();
+        assert!(search_script.contains("placeholder=\"Search this site\""));
+        assert!(!search_script.contains("Fission docs"));
         assert!(temp
             .join("target/fission/site/search/manifest.json")
             .exists());

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -618,14 +618,12 @@ impl DocumentationPage<'_> {
         children.push(
             Container::new(Column {
                 children: vec![
-                    Text::new(
-                        blog_date_label(self.route).unwrap_or_else(|| "Fission blog".to_string()),
-                    )
-                    .size(tokens.typography.font_size_sm)
-                    .family(tokens.typography.font_family_mono.clone())
-                    .weight(tokens.typography.font_weight_bold)
-                    .color(tokens.colors.primary)
-                    .into(),
+                    Text::new(blog_date_label(self.route).unwrap_or_else(|| "Blog".to_string()))
+                        .size(tokens.typography.font_size_sm)
+                        .family(tokens.typography.font_family_mono.clone())
+                        .weight(tokens.typography.font_weight_bold)
+                        .color(tokens.colors.primary)
+                        .into(),
                     Text::new(self.route.title.clone())
                         .size(tokens.typography.heading2_size)
                         .family(tokens.typography.font_family_serif.clone())
@@ -1706,7 +1704,7 @@ fn blog_excerpt(route: &ContentRoute) -> String {
                 && *line != "<!-- truncate -->"
         })
         .next()
-        .unwrap_or("Read the latest Fission update.")
+        .unwrap_or("Read the latest update.")
         .chars()
         .take(220)
         .collect()
@@ -1833,6 +1831,13 @@ mod tests {
         assert_eq!(blog_page_number(&invalid_page), None);
         assert_eq!(blog_page_path("/journal/", 1), "/journal/");
         assert_eq!(blog_page_path("/journal/", 3), "/journal/page/3/");
+    }
+
+    #[test]
+    fn blog_excerpt_fallback_is_site_neutral() {
+        let route = test_blog_route("/journal/2026/09/07/example/");
+
+        assert_eq!(blog_excerpt(&route), "Read the latest update.");
     }
 
     fn test_blog_route(path: &str) -> ContentRoute {

--- a/crates/shell/fission-shell-site/src/html.rs
+++ b/crates/shell/fission-shell-site/src/html.rs
@@ -2050,7 +2050,7 @@ impl HtmlRenderer<'_> {
             if identifier == "site-search-trigger" {
                 let children = self.render_children(&node.children, &HashSet::new())?;
                 return Ok(format!(
-                    "<button class=\"fission-site-node fission-site-search-trigger\" type=\"button\" aria-label=\"Search documentation\" data-fission-search-trigger data-fission-node=\"{}\">{children}</button>",
+                    "<button class=\"fission-site-node fission-site-search-trigger\" type=\"button\" aria-label=\"Search this site\" data-fission-search-trigger data-fission-node=\"{}\">{children}</button>",
                     node.id
                 ));
             }

--- a/documentation/content/docs/guides/static-site-custom-pages.mdx
+++ b/documentation/content/docs/guides/static-site-custom-pages.mdx
@@ -163,20 +163,6 @@ template = "fission::site::blog"
 
 Use `fission::site::documentation` when you want to record the default content-page intent explicitly.
 
-## What you should have working
-
-After this guide, you should be able to explain where `Static site custom pages` fits in the Fission lifecycle, identify the file or component you changed, run the relevant `fission` command, and verify the result in a real target or test.
-
-## Common mistakes to check
-
-| Symptom | What to check first |
-| --- | --- |
-| The app compiles but nothing changes | Confirm the component is actually used by the route or shell target you are running. |
-| An action fires but state does not update | Confirm the reducer is registered with the same action value that the UI dispatches. |
-| A platform feature reports unsupported | Confirm the target has the capability in `fission.toml` and the shell registered the provider. |
-| The page works on one target but not another | Run `fission doctor`, then inspect target-specific configuration and feature flags. |
-| Tests are hard to write | Split the product rule into a reducer test first, then add a UI or shell smoke test for the integration. |
-
 ## 7. Keep the page static by default
 
 A custom static page should be useful before JavaScript loads. Theme switching, sidebar expansion, search, code highlighting, and small document-level scripts are fine. Continuous runtime state, device APIs, and app-like flows belong in a Fission web app, a server route, or a focused island.
@@ -206,3 +192,17 @@ fission site build --project-dir . --release
 ```
 
 Open the generated `index.html` and `site.css` if the page looks wrong. The HTML should contain the real content, not a blank app shell. That is what keeps the site crawlable and shareable.
+
+## What you should have working
+
+After this guide, you should have a custom widget route, site-owned content chrome, project CSS loaded after the generic shell styles, and any progressive enhancement limited to the routes that need it. You should also be able to build the site and inspect the generated HTML without changing `fission-shell-site`.
+
+## Common mistakes to check
+
+| Symptom | What to check first |
+| --- | --- |
+| The app compiles but nothing changes | Confirm the component is registered with `route_widget` or `content_header_widget` in the site passed to `build_from_cli`. |
+| The override loses to a shell style | Confirm the stylesheet is listed in `site.css_files`, then target a stable semantics identifier owned by your component. |
+| A script affects unrelated pages | Add `route_prefixes` or `routes` to its `[[site.elements]]` filter. |
+| Blog indexes are not generated | Set `template = "fission::site::blog"` on that content mount. The mount name alone does not opt in. |
+| The generated page is blank without JavaScript | Keep primary content in retained widgets or Markdown; use document elements only for progressive enhancement. |

--- a/documentation/site/value-redesign.css
+++ b/documentation/site/value-redesign.css
@@ -1037,7 +1037,8 @@ body::before {
 }
 
 .fission-site-blog-index-hero {
-  max-width: none;
+  width: 100% !important;
+  max-width: none !important;
   margin-inline: 0 !important;
   padding-bottom: clamp(4rem, 7vw, 7rem) !important;
   text-align: left !important;
@@ -1201,14 +1202,14 @@ body::before {
 
 .fission-site-product-hero > .fission-site-row {
   display: grid !important;
-  grid-template-columns: minmax(0, 1.12fr) minmax(22rem, 0.88fr);
-  gap: clamp(3rem, 7vw, 8rem) !important;
+  grid-template-columns: minmax(0, 1.35fr) minmax(20rem, 0.65fr);
+  gap: clamp(2rem, 5vw, 5rem) !important;
   width: 100% !important;
 }
 
 .fission-site-product-hero-title .fission-site-text-run {
-  max-width: 15ch !important;
-  font-size: clamp(3.8rem, 7vw, 7rem) !important;
+  max-width: 17ch !important;
+  font-size: clamp(3.8rem, 4.8vw, 5rem) !important;
   font-weight: 560 !important;
   line-height: 0.96 !important;
   letter-spacing: -0.06em !important;
@@ -1657,6 +1658,19 @@ body::before {
     padding-bottom: 4rem !important;
   }
 
+  .fission-site-product-hero > .fission-site-row > .fission-site-box:first-child,
+  .fission-site-product-hero > .fission-site-row > .fission-site-box:first-child > .fission-site-column,
+  .fission-site-product-hero-title,
+  .fission-site-product-hero-body {
+    width: calc(100vw - 7.25rem) !important;
+    min-width: 0 !important;
+    max-width: calc(100vw - 7.25rem) !important;
+  }
+
+  .fission-site-product-hero-title .fission-site-text-run {
+    font-size: clamp(3rem, 13vw, 3.5rem) !important;
+  }
+
   .fission-site-product-feature-showcase > .fission-site-row > .fission-site-row,
   .fission-site-product-detail-showcase > .fission-site-column > .fission-site-row,
   .fission-site-product-workflow > .fission-site-column > .fission-site-row:last-child,
@@ -1772,21 +1786,46 @@ body::before {
   top: 50%;
   left: 50%;
   width: 5.8rem !important;
-  height: 7.4rem !important;
-  padding: 1rem !important;
+  height: auto !important;
+  overflow: visible !important;
+  padding: 0 !important;
   border: 0 !important;
   border-radius: 0 !important;
-  background: var(--ink) !important;
+  background: transparent !important;
   transform: translate(-50%, -50%);
 }
 
 .fission-site-value-home-map-core {
   position: static !important;
   width: 100% !important;
-  height: 100% !important;
+  height: auto !important;
   padding: 0 !important;
   background: transparent !important;
   transform: none !important;
+}
+
+.fission-site-value-home-map-core > .fission-site-column {
+  gap: 0.55rem !important;
+}
+
+.fission-site-value-home-map-core > .fission-site-column > .fission-site-box:first-child {
+  display: grid !important;
+  width: 5.8rem !important;
+  height: 5.8rem !important;
+  place-items: center;
+  padding: 1.35rem !important;
+  background: var(--ink) !important;
+}
+
+.fission-site-value-home-map-core > .fission-site-column > .fission-site-box:last-child {
+  width: max-content !important;
+  align-self: center;
+  background: var(--paper) !important;
+  color: var(--ink-soft) !important;
+}
+
+.fission-site-value-home-map-core > .fission-site-column > .fission-site-box:last-child .fission-site-text-run {
+  color: var(--ink-soft) !important;
 }
 
 [data-fission-semantics="crate-directory-title"] .fission-site-text-run,
@@ -1905,16 +1944,21 @@ body::before {
 
 @media (max-width: 45rem) {
   .fission-site-value-home-hero { padding-top: 2.5rem !important; }
-  .fission-site-mobile-global-menu .fission-site-nav-item > .fission-site-box {
+  .fission-site-mobile-global-menu > .fission-site-row > .fission-site-nav-item > .fission-site-column > .fission-site-nav-label > .fission-site-row {
+    display: grid !important;
     width: 2.6rem !important;
-    height: 2.6rem;
+    height: 2.6rem !important;
     overflow: hidden;
+    place-items: center;
     padding: 0 !important;
     border: 1px solid var(--line-strong) !important;
     border-radius: 0 !important;
-    font-size: 0 !important;
+    background: transparent !important;
   }
-  .fission-site-mobile-global-menu .fission-site-nav-item > .fission-site-box::before {
+  .fission-site-mobile-global-menu > .fission-site-row > .fission-site-nav-item > .fission-site-column > .fission-site-nav-label > .fission-site-row > * {
+    display: none !important;
+  }
+  .fission-site-mobile-global-menu > .fission-site-row > .fission-site-nav-item > .fission-site-column > .fission-site-nav-label > .fission-site-row::before {
     color: var(--ink);
     content: "☰";
     font-size: 1rem;


### PR DESCRIPTION
## Summary

- finish the documentation site's desktop and mobile fidelity fixes after rendered-browser comparison with the approved prototype
- correct the marketplace map tile, wide blog and product layouts, mobile navigation, and narrow product hero clipping in the Fission-owned stylesheet
- remove Fission-branded blog and search fallback copy from the generic static-site shell
- clarify how third-party sites verify route, chrome, CSS, script, and blog-template overrides without changing the shell

## Architecture boundary

All Fission-specific visuals and responsive behavior remain in `documentation/site/value-redesign.css`, using the public override path merged in #217. Shell changes are deliberately site-neutral: generic blog fallbacks and search UI no longer assume they are rendering Fission's own documentation. A third party uses the same `route_widget`, `content_header_widget`, `footer_widget`, `css_files`, `site.elements`, design-system, and explicit content-template surfaces documented in the guide.

## Validation

- final SHA `f68e2649`: Android package smoke passed
- final SHA `f68e2649`: iOS simulator/device compile and package passed
- final SHA `f68e2649`: Web/wasm builds and Chromium conformance passed
- final SHA `f68e2649`: CLI platform script tests passed
- `rustfmt --check` passed for all changed Rust files
- desktop/mobile browser QA completed against the real retained DOM at 1440×1000 and 390×844
- local release site check is running through zrunner on the persistent project target; no shared build was interrupted
