### PR TITLE
fix(site): isolate blog pagination by template

### DIFF
--- a/crates/shell/fission-shell-site/src/build.rs
+++ b/crates/shell/fission-shell-site/src/build.rs
@@ -1983,6 +1983,56 @@ href = "/docs/reference/"
     }
 
     #[test]
+    fn blog_pagination_does_not_leak_into_documentation_mounts() {
+        let temp = std::env::temp_dir().join(format!(
+            "fission-site-mixed-content-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(temp.join("content/docs")).unwrap();
+        fs::create_dir_all(temp.join("content/blog")).unwrap();
+        fs::write(
+            temp.join("content/docs/index.md"),
+            "---\ntitle: Documentation\n---\n# Documentation\n\nStart here.",
+        )
+        .unwrap();
+        for index in 1..=9 {
+            fs::write(
+                temp.join(format!("content/blog/2026-06-{index:02}-post.md")),
+                format!("---\ntitle: Post {index}\n---\n# Post {index}\n\nPost body."),
+            )
+            .unwrap();
+        }
+
+        let mut options = SiteBuildOptions::for_project(&temp, "Test site");
+        options.content_routes = vec![
+            SiteContentRouteConfig {
+                path: "/docs".to_string(),
+                source: temp.join("content/docs"),
+                template: Some("fission::site::documentation".to_string()),
+                sidebar: None,
+            },
+            SiteContentRouteConfig {
+                path: "/journal".to_string(),
+                source: temp.join("content/blog"),
+                template: Some("fission::site::blog".to_string()),
+                sidebar: None,
+            },
+        ];
+
+        let report = build_content_site(&options).unwrap();
+        assert!(report
+            .routes
+            .iter()
+            .any(|route| route.path == "/journal/page/2/"));
+        let docs = fs::read_to_string(temp.join("target/fission/site/docs/index.html")).unwrap();
+        assert!(!docs.contains("docs/page/2/"));
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
     fn content_header_widget_replaces_the_default_content_header() {
         let temp = std::env::temp_dir().join(format!(
             "fission-site-content-header-test-{}",

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -1440,7 +1440,7 @@ fn is_blog_post_route(route: &ContentRoute) -> bool {
 }
 
 fn is_blog_index_route(route: &ContentRoute) -> bool {
-    route.path == route.mount_path || blog_page_number(route).is_some()
+    is_blog_route(route) && (route.path == route.mount_path || blog_page_number(route).is_some())
 }
 
 fn blog_page_number(route: &ContentRoute) -> Option<usize> {
@@ -1831,6 +1831,19 @@ mod tests {
         assert_eq!(blog_page_number(&invalid_page), None);
         assert_eq!(blog_page_path("/journal/", 1), "/journal/");
         assert_eq!(blog_page_path("/journal/", 3), "/journal/page/3/");
+    }
+
+    #[test]
+    fn documentation_mounts_are_never_blog_indexes() {
+        let mut index = test_blog_route("/docs/");
+        index.mount_path = "/docs/".to_string();
+        index.template = Some("fission::site::documentation".to_string());
+        let mut page_like_path = index.clone();
+        page_like_path.path = "/docs/page/2/".to_string();
+
+        assert!(!is_blog_index_route(&index));
+        assert!(!is_blog_index_route(&page_like_path));
+        assert!(!is_blog_post_route(&index));
     }
 
     #[test]

--- a/crates/shell/fission-shell-site/src/document.rs
+++ b/crates/shell/fission-shell-site/src/document.rs
@@ -1525,12 +1525,13 @@ fn blog_page_link(label: &str, mount_path: &str, page: Option<usize>, tokens: &T
 }
 
 fn is_blog_taxonomy_route(route: &ContentRoute) -> bool {
-    route
-        .path
-        .starts_with(&format!("{}categories/", route.mount_path))
-        || route
+    is_blog_route(route)
+        && (route
             .path
-            .starts_with(&format!("{}tags/", route.mount_path))
+            .starts_with(&format!("{}categories/", route.mount_path))
+            || route
+                .path
+                .starts_with(&format!("{}tags/", route.mount_path)))
 }
 
 fn ordered_blog_routes<'a>(routes: &'a [ContentRoute]) -> Vec<&'a ContentRoute> {
@@ -1840,9 +1841,12 @@ mod tests {
         index.template = Some("fission::site::documentation".to_string());
         let mut page_like_path = index.clone();
         page_like_path.path = "/docs/page/2/".to_string();
+        let mut category_path = index.clone();
+        category_path.path = "/docs/categories/layout/".to_string();
 
         assert!(!is_blog_index_route(&index));
         assert!(!is_blog_index_route(&page_like_path));
+        assert!(!is_blog_taxonomy_route(&category_path));
         assert!(!is_blog_post_route(&index));
     }
 


### PR DESCRIPTION
## Summary

- require the explicit fission::site::blog template before treating a content mount root, /page/<n>/ path, or taxonomy path as a blog route
- keep documentation and other content mounts on their own renderer even when a separate blog contains enough posts for pagination
- add unit coverage for documentation mount and taxonomy classification plus an end-to-end mixed docs/blog static-site build with a real second blog page

## Failure fixed

The website deployment for main generated this invalid link:

    documentation/dist/site/docs/index.html -> ../docs/page/2/

The blog route classifiers recognized content paths by shape without first establishing that the route used the blog template. Blog index and taxonomy classification now share the same explicit template boundary already used for blog posts.

## Validation

- rustfmt --edition 2021 --check passed for both changed Rust files
- cargo test --locked --jobs 2 -p fission-shell-site --lib passed through zrunner: 83 passed, 0 failed
- the exact failed deployment package command passed through zrunner: 900 routes rendered and validated, then 1,418 files packaged
- verified /blog/page/2/index.html exists and /docs/index.html contains no docs/page/2 link
