### PR TITLE
Fix Windows text scale settings construction

### DIFF
--- a/crates/shell/fission-shell-winit/src/platform_text_scale.rs
+++ b/crates/shell/fission-shell-winit/src/platform_text_scale.rs
@@ -115,7 +115,7 @@ fn platform_factor(_event_loop: &ActiveEventLoop) -> Option<f32> {
 fn platform_factor(_event_loop: &ActiveEventLoop) -> Option<f32> {
     use windows::UI::ViewManagement::UISettings;
 
-    UISettings::GetForCurrentView()
+    UISettings::new()
         .and_then(|settings| settings.TextScaleFactor())
         .ok()
         .map(|percentage| percentage as f32 / 100.0)


### PR DESCRIPTION
## Summary

- construct UISettings through the activation-factory constructor exposed by the pinned generated bindings
- preserve the existing TextScaleFactor fallback behavior

## Validation

- exact source inspection against the pinned Windows bindings confirms UISettings::new and TextScaleFactor are available
- focused Windows cargo-fission build verification is in progress on the release VM