### PR TITLE
Fix relative project paths in Web CLI preflight

### DIFF
--- a/crates/tools/fission-command-core/src/web_storage.rs
+++ b/crates/tools/fission-command-core/src/web_storage.rs
@@ -170,15 +170,7 @@ fn validate_web_sqlite_assets(root: &Path) -> Result<()> {
 
 fn resolved_web_sqlite_enabled(root: &Path) -> Result<bool> {
     let manifest_path = root.join("Cargo.toml");
-    let output = Command::new("cargo")
-        .arg("metadata")
-        .arg("--format-version")
-        .arg("1")
-        .arg("--filter-platform")
-        .arg(WEB_TARGET)
-        .arg("--manifest-path")
-        .arg(&manifest_path)
-        .current_dir(root)
+    let output = cargo_metadata_command(&manifest_path)
         .output()
         .context("failed to inspect the Web Cargo dependency graph")?;
     if !output.status.success() {
@@ -188,10 +180,20 @@ fn resolved_web_sqlite_enabled(root: &Path) -> Result<bool> {
 
     let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)
         .context("failed to parse the Web Cargo dependency graph")?;
-    let manifest_path = manifest_path
-        .canonicalize()
-        .with_context(|| format!("failed to resolve {}", manifest_path.display()))?;
-    Ok(metadata.web_sqlite_enabled_for(&manifest_path))
+    Ok(metadata.web_sqlite_enabled_for_root())
+}
+
+fn cargo_metadata_command(manifest_path: &Path) -> Command {
+    let mut command = Command::new("cargo");
+    command
+        .arg("metadata")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--filter-platform")
+        .arg(WEB_TARGET)
+        .arg("--manifest-path")
+        .arg(manifest_path);
+    command
 }
 
 #[derive(Debug, Deserialize)]
@@ -201,14 +203,11 @@ struct CargoMetadata {
 }
 
 impl CargoMetadata {
-    fn web_sqlite_enabled_for(&self, manifest_path: &Path) -> bool {
+    fn web_sqlite_enabled_for_root(&self) -> bool {
         let Some(resolve) = &self.resolve else {
             return false;
         };
-        let Some(root_id) = self.packages.iter().find_map(|package| {
-            paths_refer_to_same_file(&package.manifest_path, manifest_path)
-                .then_some(package.id.as_str())
-        }) else {
+        let Some(root_id) = resolve.root.as_deref() else {
             return false;
         };
 
@@ -249,11 +248,11 @@ impl CargoMetadata {
 struct CargoPackage {
     id: String,
     name: String,
-    manifest_path: PathBuf,
 }
 
 #[derive(Debug, Deserialize)]
 struct CargoResolve {
+    root: Option<String>,
     nodes: Vec<CargoNode>,
 }
 
@@ -264,13 +263,6 @@ struct CargoNode {
     dependencies: Vec<String>,
     #[serde(default)]
     features: Vec<String>,
-}
-
-fn paths_refer_to_same_file(left: &Path, right: &Path) -> bool {
-    match (left.canonicalize(), right.canonicalize()) {
-        (Ok(left), Ok(right)) => left == right,
-        _ => left == right,
-    }
 }
 
 #[cfg(test)]
@@ -416,25 +408,19 @@ mod tests {
 
     #[test]
     fn dependency_detection_ignores_unreachable_workspace_packages() {
-        let root = TestDir::new("unreachable-provider");
-        let app_manifest = root.path().join("Cargo.toml");
-        fs::write(&app_manifest, "[package]\nname='app'\nversion='0.1.0'\n").unwrap();
-        let sqlite_manifest = root.path().join("sqlite.toml");
-        fs::write(&sqlite_manifest, "").unwrap();
         let metadata = CargoMetadata {
             packages: vec![
                 CargoPackage {
                     id: "app".into(),
                     name: "app".into(),
-                    manifest_path: app_manifest.clone(),
                 },
                 CargoPackage {
                     id: "sqlite".into(),
                     name: "fission-store-sqlite".into(),
-                    manifest_path: sqlite_manifest,
                 },
             ],
             resolve: Some(CargoResolve {
+                root: Some("app".into()),
                 nodes: vec![
                     CargoNode {
                         id: "app".into(),
@@ -450,30 +436,24 @@ mod tests {
             }),
         };
 
-        assert!(!metadata.web_sqlite_enabled_for(&app_manifest));
+        assert!(!metadata.web_sqlite_enabled_for_root());
     }
 
     #[test]
     fn dependency_detection_finds_reachable_web_provider() {
-        let root = TestDir::new("reachable-provider");
-        let app_manifest = root.path().join("Cargo.toml");
-        fs::write(&app_manifest, "[package]\nname='app'\nversion='0.1.0'\n").unwrap();
-        let sqlite_manifest = root.path().join("sqlite.toml");
-        fs::write(&sqlite_manifest, "").unwrap();
         let metadata = CargoMetadata {
             packages: vec![
                 CargoPackage {
                     id: "app".into(),
                     name: "app".into(),
-                    manifest_path: app_manifest.clone(),
                 },
                 CargoPackage {
                     id: "sqlite".into(),
                     name: "fission-store-sqlite".into(),
-                    manifest_path: sqlite_manifest,
                 },
             ],
             resolve: Some(CargoResolve {
+                root: Some("app".into()),
                 nodes: vec![
                     CargoNode {
                         id: "app".into(),
@@ -489,7 +469,30 @@ mod tests {
             }),
         };
 
-        assert!(metadata.web_sqlite_enabled_for(&app_manifest));
+        assert!(metadata.web_sqlite_enabled_for_root());
+    }
+
+    #[test]
+    fn cargo_metadata_does_not_rebase_a_relative_manifest_twice() {
+        let command = cargo_metadata_command(Path::new("crates/apollo/Cargo.toml"));
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(command.get_current_dir(), None);
+        assert_eq!(
+            args,
+            [
+                "metadata",
+                "--format-version",
+                "1",
+                "--filter-platform",
+                WEB_TARGET,
+                "--manifest-path",
+                "crates/apollo/Cargo.toml",
+            ]
+        );
     }
 
     #[test]

--- a/crates/tools/fission-command-core/src/web_storage.rs
+++ b/crates/tools/fission-command-core/src/web_storage.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
@@ -268,6 +268,7 @@ struct CargoNode {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;

--- a/crates/tools/fission-command-run/src/lib.rs
+++ b/crates/tools/fission-command-run/src/lib.rs
@@ -1207,12 +1207,7 @@ fn build_web_with_test_control(
     cargo_features: &[String],
     cargo_no_default_features: bool,
 ) -> Result<()> {
-    let project_dir = fs::canonicalize(project_dir).with_context(|| {
-        format!(
-            "failed to resolve project directory {}",
-            project_dir.display()
-        )
-    })?;
+    let project_dir = absolute_path(project_dir)?;
     let out_dir = project_dir.join("platforms/web/pkg");
     let mut command = web_build_command(
         &project_dir,
@@ -1225,6 +1220,17 @@ fn build_web_with_test_control(
         command.env("FISSION_WEB_TEST_CONTROL", "1");
     }
     run_status(&mut command, "web build")
+}
+
+/// Makes a path independent of subsequent child-process working directories
+/// without resolving symlinks or mapped drives through the filesystem.
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(env::current_dir()
+        .context("failed to resolve the current directory")?
+        .join(path))
 }
 
 fn web_build_command(
@@ -2540,6 +2546,16 @@ mod tests {
                 "fixtures,diagnostics",
             ]
         );
+    }
+
+    #[test]
+    fn web_build_keeps_an_absolute_project_path_lexical() {
+        let project_dir = env::current_dir()
+            .expect("current directory")
+            .join("path-that-need-not-exist")
+            .join("..");
+
+        assert_eq!(absolute_path(&project_dir).unwrap(), project_dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop rebasing a relative `--manifest-path` by also changing Cargo metadata's working directory
- use Cargo metadata's declared root package ID for Web storage dependency traversal instead of canonical filesystem paths
- replace Web build path canonicalization with lexical absolutization so mapped-drive paths remain intact

## Regression coverage
- asserts `crates/apollo/Cargo.toml` is passed exactly once with no child working-directory override
- asserts absolute Web project paths are preserved lexically
- retains reachable/unreachable Web SQLite dependency graph coverage

## Validation
- `cargo fmt --all`
- `cargo test --locked -j 2 -p fission-command-core -p fission-command-run` (74 tests plus doc tests passed)